### PR TITLE
Fixes asynchronous error handling when chrome.webstore.install throws…

### DIFF
--- a/JitsiTrackErrors.js
+++ b/JitsiTrackErrors.js
@@ -23,5 +23,7 @@ module.exports = {
     },
     UNSUPPORTED_RESOLUTION: "gum.unsupported_resolution",
     FIREFOX_EXTENSION_NEEDED: "gum.firefox_extension_needed",
+    CHROME_EXTENSION_INSTALLATION_ERROR:
+        "gum.chrome_extension_installation_error",
     GENERAL: "gum.general"
 };

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -192,23 +192,31 @@ var ScreenObtainer = {
                     'Changes will take effect after next Chrome restart.');
             }
 
-            chrome.webstore.install(
-                getWebStoreInstallUrl(this.options),
-                function (arg) {
-                    logger.log("Extension installed successfully", arg);
-                    chromeExtInstalled = true;
-                    // We need to give a moment for the endpoint to become
-                    // available
-                    window.setTimeout(function () {
-                        doGetStreamFromExtension(self.options, streamCallback,
-                            failCallback);
-                    }, 500);
-                },
-                function (arg) {
-                    logger.log("Failed to install the extension", arg);
-                    failCallback(arg);
-                }
-            );
+            try {
+                chrome.webstore.install(
+                    getWebStoreInstallUrl(this.options),
+                    function (arg) {
+                        logger.log("Extension installed successfully", arg);
+                        chromeExtInstalled = true;
+                        // We need to give a moment for the endpoint to become
+                        // available
+                        window.setTimeout(function () {
+                            doGetStreamFromExtension(self.options,
+                                streamCallback, failCallback);
+                        }, 500);
+                    },
+                    function (arg) {
+                        logger.log("Failed to install the extension", arg);
+                        failCallback(arg);
+                    }
+                );
+            } catch(e) {
+                failCallback({
+                    type: "jitsiError",
+                    errorObject:
+                        JitsiTrackErrors.CHROME_EXTENSION_INSTALLATION_ERROR
+                });
+            }
         }
     }
 };


### PR DESCRIPTION
Before the fix, if you execute this code in Chrome without the extension installed (and without a trusted domain for an inline installation)

```
          JitsiMeetJS.createLocalTracks({
            resolution: '720',
            devices: ['video', 'desktop']
          }).then(tracks => {
            resolve();
          }).catch(err => {
            // this never gets called
          });
```
after the fix:
```
          JitsiMeetJS.createLocalTracks({
            resolution: '720',
            devices: ['video', 'desktop']
          }).then(tracks => {
            resolve();
          }).catch(err => {
              alert('this gets called and you can run your error handling code');
          });
```

