### PR TITLE
Set video src to empty string instead of null on #detach()

### DIFF
--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -192,7 +192,7 @@ JitsiTrack.prototype.detach = function (container) {
     {
         if(!container)
         {
-            require("./RTCUtils").setVideoSrc(this.containers[i], null);
+            require("./RTCUtils").setVideoSrc(this.containers[i], '');
         }
         if(!container || $(this.containers[i]).is($(container)))
         {
@@ -201,7 +201,7 @@ JitsiTrack.prototype.detach = function (container) {
     }
 
     if(container) {
-        require("./RTCUtils").setVideoSrc(container, null);
+        require("./RTCUtils").setVideoSrc(container, '');
     }
 }
 


### PR DESCRIPTION
Previously, when setting `src` to `null` on jQuery elements, the `src` attribute was just removed.  

Now that it's set on plain DOM elements the `src` is actually set to string "null" which performs a network request for resource "null".

Setting the video `src` to empty string on plain DOM elements stops the old stream and does not initiate a network request.