### PR TITLE
Fix logic inversion in Settings.prototype.save

### DIFF
--- a/modules/settings/Settings.js
+++ b/modules/settings/Settings.js
@@ -55,7 +55,7 @@ function Settings(conferenceID) {
 }
 
 Settings.prototype.save = function () {
-    if(!supportsLocalStorage())
+    if(supportsLocalStorage())
         window.localStorage.setItem(this.conferenceID, JSON.stringify(this.confSettings));
 }
 


### PR DESCRIPTION
This fixes "machine UID mismatch or empty" when using authenticated conference.
(machineUID come from Settings.userId)

Fixing this hide the fact that there is 2 different Settings object
coming from 2 calls to initJitsiConference (when using authenticated conference)

There is also another Settings module in jitsi-meet, with a userId ...

Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>