### PR TITLE
Fail if user is trying to add second video track to the conference

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -275,9 +275,14 @@ JitsiConference.prototype.setSubject = function (subject) {
  * Adds JitsiLocalTrack object to the conference.
  * @param track the JitsiLocalTrack object.
  * @returns {Promise<JitsiLocalTrack>}
+ * @throws will throw and error if track is video track
+ * and there is already another video track in the conference.
  */
 JitsiConference.prototype.addTrack = function (track) {
     if (track.isVideoTrack()) {
+        if (this.rtc.getLocalVideoStream()) {
+            throw new Error("cannot add second video track to the conference");
+        }
         this.removeCommand("videoType");
         this.sendCommand("videoType", {
             value: track.videoType,

--- a/doc/API.md
+++ b/doc/API.md
@@ -247,10 +247,10 @@ The object represents a conference. We have the following methods to control the
 16. removeCommandListener(command) - removes the listeners for the specified command
     - command - the name of the command
 
-17. addTrack(track) - Adds JitsiLocalTrack object to the conference.
+17. addTrack(track) - Adds JitsiLocalTrack object to the conference. Throws an error if adding second video stream. Returns Promise.
     - track - the JitsiLocalTrack
 
-18. removeTrack(track) - Removes JitsiLocalTrack object to the conference.
+18. removeTrack(track) - Removes JitsiLocalTrack object to the conference. Returns Promise.
     - track - the JitsiLocalTrack
 
 19. isDTMFSupported() - Check if at least one user supports DTMF.
@@ -319,7 +319,7 @@ We have the following methods for controling the tracks:
 
 6. detach(container) - removes the track from the container.
 
-7. stop() - stop sending the track to the other participants in the conference.
+7. stop() - stop sending the track to the other participants in the conference. Returns Promise.
 
    Note: This method is implemented only for the local tracks.
 

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -1,3 +1,4 @@
+/* global Promise */
 var JitsiTrack = require("./JitsiTrack");
 var RTCBrowserType = require("./RTCBrowserType");
 var JitsiTrackEvents = require('../../JitsiTrackEvents');
@@ -126,16 +127,22 @@ JitsiLocalTrack.prototype._setMute = function (mute) {
 /**
  * Stops sending the media track. And removes it from the HTML.
  * NOTE: Works for local tracks only.
+ * @returns {Promise}
  */
 JitsiLocalTrack.prototype.stop = function () {
-    if(this.conference){
-        this.conference.removeTrack(this);
+    var promise = Promise.resolve();
+
+    if (this.conference){
+        promise = this.conference.removeTrack(this);
     }
-    if(!this.stream)
-        return;
-    RTCUtils.stopMediaStream(this.stream);
-    this.detach();
-}
+
+    if (this.stream) {
+        RTCUtils.stopMediaStream(this.stream);
+        this.detach();
+    }
+
+    return promise;
+};
 
 /**
  * Returns <tt>true</tt> - if the stream is muted

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -142,11 +142,19 @@ RTC.prototype.addLocalStream = function (stream) {
     this.localStreams.push(stream);
     stream._setRTC(this);
 
-    if (stream.type == "audio") {
+    if (stream.isAudioTrack()) {
         this.localAudio = stream;
     } else {
         this.localVideo = stream;
     }
+};
+
+/**
+ * Get local video track.
+ * @returns {JitsiLocalTrack}
+ */
+RTC.prototype.getLocalVideoStream = function () {
+    return this.localVideo;
 };
 
 /**
@@ -163,10 +171,18 @@ RTC.prototype.setAudioMute = function (value) {
     }
 }
 
-RTC.prototype.removeLocalStream = function (track) {
-    var pos = this.localStreams.indexOf(track);
-    if (pos > -1) {
-        this.localStreams.splice(pos, 1);
+RTC.prototype.removeLocalStream = function (stream) {
+    var pos = this.localStreams.indexOf(stream);
+    if (pos === -1) {
+        return;
+    }
+
+    this.localStreams.splice(pos, 1);
+
+    if (stream.isAudioTrack()) {
+        this.localAudio = null;
+    } else {
+        this.localVideo = null;
     }
 };
 


### PR DESCRIPTION
Currently jitsi doesn't support multiple video streams, so fail if that happens.