### PR TITLE
Fixes crash on "this.rtc" being "undefined" when JitsiLocalTrack.atta…

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -175,6 +175,14 @@ JitsiLocalTrack.prototype.isMuted = function () {
  */
 JitsiLocalTrack.prototype._setRTC = function (rtc) {
     this.rtc = rtc;
+    // We want to keep up with postponed events which should have been fired
+    // on "attach" call, but for local track we not always have the conference
+    // before attaching. However this may result in duplicated events if they
+    // have been triggered on "attach" already.
+    for(var i = 0; i < this.containers.length; i++)
+    {
+        this._maybeFireTrackAttached(this.containers[i]);
+    }
 };
 
 /**

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -151,6 +151,18 @@ JitsiTrack.prototype.getUsageLabel = function () {
 };
 
 /**
+ * Eventually will trigger RTCEvents.TRACK_ATTACHED event.
+ * @param container the video/audio container to which this stream is attached
+ *        and for which event will be fired.
+ * @private
+ */
+JitsiTrack.prototype._maybeFireTrackAttached = function (container) {
+    if (this.rtc && container) {
+        this.rtc.eventEmitter.emit(RTCEvents.TRACK_ATTACHED, this, container);
+    }
+};
+
+/**
  * Mutes the track.
  */
 JitsiTrack.prototype.mute = function () {
@@ -194,10 +206,10 @@ JitsiTrack.prototype.attach = function (container) {
     }
     this.containers.push(container);
 
-    this.rtc.eventEmitter.emit(RTCEvents.TRACK_ATTACHED, this, container);
+    this._maybeFireTrackAttached(container);
 
     return container;
-}
+};
 
 /**
  * Removes the track from the passed HTML container.


### PR DESCRIPTION
…ch is called before it's added to the conference.

The fix is not perfect as we are not tracking TRACK_ATTACHED events that have been already fired when "attach" method was called, so it may result in duplicated events. Currently this is internal event and used only by CallStats where that duplication will not hurt. But if you think we should handle it more gracefully let me know.