### PR TITLE
Fixes undefined error in getResourceBySSRC

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -319,8 +319,8 @@ RTC.prototype.setAudioLevel = function (resource, audioLevel) {
  * @param ssrc the ssrc to check.
  */
 RTC.prototype.getResourceBySSRC = function (ssrc) {
-    if(ssrc == this.localVideo.getSSRC()
-        || ssrc == this.localAudio.getSSRC()) {
+    if((this.localVideo && ssrc == this.localVideo.getSSRC())
+        || (this.localAudio && ssrc == this.localAudio.getSSRC())) {
         return Strophe.getResourceFromJid(this.room.myroomjid);
     }
 


### PR DESCRIPTION
Fixes undefined error in getResourceBySSRC when local video or audio track is stopped, reported to happen sometimes with desktop sharing.