### PR TITLE
Store session settings userId and callStatsUserName globally (was per-conference)

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -18,7 +18,6 @@ modules/xmpp/ChatRoom.js
 modules/xmpp/ChatRoom.js
 modules/statistics/RTPStatsCollector.js
 modules/statistics/LocalStatsCollector.js
-modules/settings/Settings.js
 modules/connectionquality/connectionquality.js
 modules/RTC/adapter.screenshare.js
 modules/statistics/statistics.js

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -34,7 +34,7 @@ function JitsiConference(options) {
     this.xmpp = this.connection.xmpp;
     this.eventEmitter = new EventEmitter();
     var confID = this.options.name  + '@' + this.xmpp.options.hosts.muc;
-    this.settings = new Settings(confID);
+    this.settings = new Settings();
     this.room = this.xmpp.createRoom(this.options.name, this.options.config,
         this.settings);
     this.room.updateDeviceAvailability(RTC.getDeviceAvailability());

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -970,6 +970,7 @@ function setupListeners(conference) {
     conference.room.addListener(AuthenticationEvents.IDENTITY_UPDATED, function (authEnabled, authIdentity) {
         conference.authEnabled = authEnabled;
         conference.authIdentity = authIdentity;
+        conference.eventEmitter.emit(JitsiConferenceEvents.AUTH_STATUS_CHANGED, authEnabled, authIdentity);
     });
 
     conference.room.addListener(XMPPEvents.MESSAGE_RECEIVED, function (jid, displayName, txt, myJid, ts) {

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -119,7 +119,11 @@ var JitsiConferenceEvents = {
     /**
      * Indicates that available devices changed.
      */
-    AVAILABLE_DEVICES_CHANGED: "conference.availableDevicesChanged"
+    AVAILABLE_DEVICES_CHANGED: "conference.availableDevicesChanged",
+    /**
+     * Indicates that authentication status changed.
+     */
+    AUTH_STATUS_CHANGED: "conference.auth_status_changed"
 };
 
 module.exports = JitsiConferenceEvents;

--- a/doc/API.md
+++ b/doc/API.md
@@ -99,6 +99,7 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
         - STARTED_MUTED - notifies that the local user has started muted
         - AVAILABLE_DEVICES_CHANGED - notifies that available participant devices changed (camera or microphone was added or removed) (parameters - id(string), devices(JS object with 2 properties - audio(boolean), video(boolean)))
         - CONNECTION_STATS - New local connection statistics are received. (parameters - stats(object))
+        - AUTH_STATUS_CHANGED - notifies that authentication is enabled or disabled, or local user authenticated (logged in). (parameters - isAuthEnabled(boolean), authIdentity(string))
 
     2. connection
         - CONNECTION_FAILED - indicates that the server connection failed.


### PR DESCRIPTION
* store session settings userId and callStatsUserName globally (was per-conference)
* move sessionId reading/storing into Settings.js
* propagate conference event AUTH_STATUS_CHANGE

fixes https://github.com/jitsi/lib-jitsi-meet/issues/18