### PR TITLE
Share start muted policy if user became moderator

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -942,6 +942,8 @@ function setupListeners(conference) {
 
     conference.room.addListener(XMPPEvents.LOCAL_ROLE_CHANGED, function (role) {
         conference.eventEmitter.emit(JitsiConferenceEvents.USER_ROLE_CHANGED, conference.myUserId(), role);
+        // if local user became moderator then he should share startMutedPolicy with others
+        conference.setStartMutedPolicy(conference.startMutedPolicy);
     });
     conference.room.addListener(XMPPEvents.MUC_ROLE_CHANGED, conference.onUserRoleChanged.bind(conference));
 


### PR DESCRIPTION
Modarator shares start muted policy with other participants. 
So when moderator left the room and new user became moderator he should also start sharing start muted policy.
