### PR TITLE
Syncs mute/unmute calls.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -889,8 +889,15 @@ function setupListeners(conference) {
 
     conference.room.addListener(XMPPEvents.AUDIO_MUTED_BY_FOCUS,
         function (value) {
-            conference.rtc.setAudioMute(value);
-            conference.isMutedByFocus = true;
+            // set isMutedByFocus when setAudioMute Promise ends
+            conference.rtc.setAudioMute(value).then(
+                function() {
+                    conference.isMutedByFocus = true;
+                },
+                function() {
+                    logger.warn(
+                        "Error while audio muting due to focus request");
+                });
         }
     );
 

--- a/JitsiTrackErrors.js
+++ b/JitsiTrackErrors.js
@@ -32,5 +32,6 @@ module.exports = {
     CHROME_EXTENSION_USER_CANCELED:
         "gum.chrome_extension_user_canceled",
     GENERAL: "gum.general",
-    TRACK_IS_DISPOSED: "track.track_is_disposed"
+    TRACK_IS_DISPOSED: "track.track_is_disposed",
+    TRACK_MUTE_UNMUTE_IN_PROGRESS: "track.mute_unmute_inprogress"
 };

--- a/doc/API.md
+++ b/doc/API.md
@@ -309,12 +309,11 @@ We have the following methods for controling the tracks:
 1. getType() - returns string with the type of the track( "video" for the video tracks and "audio" for the audio tracks)
 
 
-2. mute() - mutes the track.
+2. mute() - mutes the track. Returns Promise.
 
    Note: This method is implemented only for the local tracks.
 
-
-3. unmute() - unmutes the track.
+3. unmute() - unmutes the track. Returns Promise.
 
    Note: This method is implemented only for the local tracks.
 

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -41,24 +41,7 @@ JitsiLocalTrack.prototype.constructor = JitsiLocalTrack;
  * @returns {Promise}
  */
 JitsiLocalTrack.prototype.mute = function () {
-    return new Promise(function (resolve, reject) {
-
-        if(this.inMuteOrUnmuteProcess) {
-            reject(new Error(JitsiTrackErrors.TRACK_MUTE_UNMUTE_IN_PROGRESS));
-            return;
-        }
-        this.inMuteOrUnmuteProcess = true;
-
-        this._setMute(true,
-            function(){
-                this.inMuteOrUnmuteProcess = false;
-                resolve();
-            }.bind(this),
-            function(status){
-                this.inMuteOrUnmuteProcess = false;
-                reject(status);
-            }.bind(this));
-    }.bind(this));
+    return createMuteUnmutePromise(this, true);
 }
 
 /**
@@ -67,6 +50,16 @@ JitsiLocalTrack.prototype.mute = function () {
  * @returns {Promise}
  */
 JitsiLocalTrack.prototype.unmute = function () {
+    return createMuteUnmutePromise(this, false);
+}
+
+/**
+ * Creates Promise for mute/unmute operation.
+ * @param track the track that will be muted/unmuted
+ * @param mute whether to mute or unmute the track
+ */
+function createMuteUnmutePromise(track, mute)
+{
     return new Promise(function (resolve, reject) {
 
         if(this.inMuteOrUnmuteProcess) {
@@ -75,7 +68,7 @@ JitsiLocalTrack.prototype.unmute = function () {
         }
         this.inMuteOrUnmuteProcess = true;
 
-        this._setMute(false,
+        this._setMute(mute,
             function(){
                 this.inMuteOrUnmuteProcess = false;
                 resolve();
@@ -84,7 +77,7 @@ JitsiLocalTrack.prototype.unmute = function () {
                 this.inMuteOrUnmuteProcess = false;
                 reject(status);
             }.bind(this));
-    }.bind(this));
+    }.bind(track));
 }
 
 /**

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -181,6 +181,8 @@ JitsiLocalTrack.prototype._setMute = function (mute, resolve, reject) {
                             type: "unmute",
                             ssrc: self.ssrc,
                             msid: self.getMSID()});
+                }).catch(function (error) {
+                    reject(error);
                 });
         }
     }

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -29,7 +29,7 @@ function JitsiLocalTrack(stream, videoType,
             this.dontFireRemoveEvent = false;
         }.bind(this));
     this.initialMSID = this.getMSID();
-    this.inMuteOrUnmuteProcess = false;
+    this.inMuteOrUnmuteProgress = false;
 }
 
 JitsiLocalTrack.prototype = Object.create(JitsiTrack.prototype);
@@ -62,19 +62,19 @@ function createMuteUnmutePromise(track, mute)
 {
     return new Promise(function (resolve, reject) {
 
-        if(this.inMuteOrUnmuteProcess) {
+        if(this.inMuteOrUnmuteProgress) {
             reject(new Error(JitsiTrackErrors.TRACK_MUTE_UNMUTE_IN_PROGRESS));
             return;
         }
-        this.inMuteOrUnmuteProcess = true;
+        this.inMuteOrUnmuteProgress = true;
 
         this._setMute(mute,
             function(){
-                this.inMuteOrUnmuteProcess = false;
+                this.inMuteOrUnmuteProgress = false;
                 resolve();
             }.bind(this),
             function(status){
-                this.inMuteOrUnmuteProcess = false;
+                this.inMuteOrUnmuteProgress = false;
                 reject(status);
             }.bind(this));
     }.bind(track));

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -147,20 +147,6 @@ JitsiTrack.prototype._maybeFireTrackAttached = function (container) {
 };
 
 /**
- * Mutes the track.
- */
-JitsiTrack.prototype.mute = function () {
-    this._setMute(true);
-}
-
-/**
- * Unmutes the stream.
- */
-JitsiTrack.prototype.unmute = function () {
-    this._setMute(false);
-}
-
-/**
  * Attaches the MediaStream of this track to an HTML container.
  * Adds the container to the list of containers that are displaying the track.
  * Note that Temasys plugin will replace original audio/video element with

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -198,7 +198,7 @@ RTC.prototype.setAudioMute = function (value) {
             continue;
         }
         // this is a Promise
-        mutePromises.push(stream.mute(value));
+        mutePromises.push(value ? stream.mute() : stream.unmute());
     }
     // we return a Promise from all Promises so we can wait for their execution
     return Promise.all(mutePromises);

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -191,17 +191,17 @@ RTC.prototype.getLocalVideoStream = function () {
  * @returns {Promise}
  */
 RTC.prototype.setAudioMute = function (value) {
-    var mutes = [];
+    var mutePromises = [];
     for(var i = 0; i < this.localStreams.length; i++) {
         var stream = this.localStreams[i];
         if(stream.getType() !== "audio") {
             continue;
         }
         // this is a Promise
-        mutes.push(stream.mute(value));
+        mutePromises.push(stream.mute(value));
     }
     // we return a Promise from all Promises so we can wait for their execution
-    return Promise.all(mutes);
+    return Promise.all(mutePromises);
 }
 
 RTC.prototype.removeLocalStream = function (stream) {

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -188,15 +188,20 @@ RTC.prototype.getLocalVideoStream = function () {
 /**
  * Set mute for all local audio streams attached to the conference.
  * @param value the mute value
+ * @returns {Promise}
  */
 RTC.prototype.setAudioMute = function (value) {
+    var mutes = [];
     for(var i = 0; i < this.localStreams.length; i++) {
         var stream = this.localStreams[i];
         if(stream.getType() !== "audio") {
             continue;
         }
-        stream._setMute(value);
+        // this is a Promise
+        mutes.push(stream.mute(value));
     }
+    // we return a Promise from all Promises so we can wait for their execution
+    return Promise.all(mutes);
 }
 
 RTC.prototype.removeLocalStream = function (stream) {


### PR DESCRIPTION
Returns Promise from mute/unmute and ignores requests while mute/unmuting is in progress. Moves mute/unmute methods to JitsiLocalTrack as said in API docs.