### PR TITLE
Uses sendIceCandidates instead of sendIceCandidate as the rest of the…

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -340,7 +340,7 @@ JingleSessionPC.prototype.sendIceCandidate = function (candidate) {
                 this.drip_container.push(candidate);
                 return;
             } else {
-                self.sendIceCandidate([candidate]);
+                self.sendIceCandidates([candidate]);
             }
         }
     } else {


### PR DESCRIPTION
… code suggests was the intention.

Note though that the modified code doesn't get executed by Meet, I'm fixing a supposed mistake which got me scratching my head.

sendIceCandidate (i.e the single case) accepts an ICE candidate as an argument
sendIceCandidates (i.e. the plural case) accepts an array of ICE candidates as an argument

Consequently, it doesn't make sense for sendIceCandidate to call itself with an array argument. Besides, the if clause uses the plural case, so it's very likely that the else clause wants to use the plural case as well.