### PR TITLE
Monitor device list changes

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -21,7 +21,6 @@ modules/statistics/LocalStatsCollector.js
 modules/connectionquality/connectionquality.js
 modules/RTC/adapter.screenshare.js
 modules/statistics/statistics.js
-modules/RTC/RTC.js
 modules/RTC/RTCUtils.js
 modules/RTC/DataChannels.js
 modules/RTC/JitsiLocalTrack.js

--- a/.jshintignore
+++ b/.jshintignore
@@ -21,7 +21,6 @@ modules/statistics/LocalStatsCollector.js
 modules/connectionquality/connectionquality.js
 modules/RTC/adapter.screenshare.js
 modules/statistics/statistics.js
-modules/RTC/RTCUtils.js
 modules/RTC/DataChannels.js
 modules/RTC/JitsiLocalTrack.js
 modules/RTC/JitsiRemoteTrack.js

--- a/.jshintrc
+++ b/.jshintrc
@@ -15,5 +15,6 @@
     "newcap": true, // true: Require capitalization of all constructor functions e.g. `new F()`
     "maxlen": 80, // {int} Max number of characters per line
     "latedef": false, //This option prohibits the use of a variable before it was defined
-    "laxbreak": true //Ignore line breaks around "=", "==", "&&", etc.
+    "laxbreak": true, //Ignore line breaks around "=", "==", "&&", etc.
+    "globals": { "Promise": true, "$": true, "Strophe": true }
 }

--- a/JitsiLibraryEvents.js
+++ b/JitsiLibraryEvents.js
@@ -1,0 +1,12 @@
+/**
+ * Enumeration with the events for the library.
+ * @type {{string: string}}
+ */
+var JitsiLibraryEvents = {
+    /**
+     * Indicates that list of physical audio or video devices changed.
+     */
+    DEVICES_LIST_CHANGED: "library.devicesListChanged"
+};
+
+module.exports = JitsiLibraryEvents;

--- a/doc/API.md
+++ b/doc/API.md
@@ -62,20 +62,29 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
         3. cameraDeviceId - the deviceID for the video device that is going to be used
         4. micDeviceId - the deviceID for the audio device that is going to be used
 
-* ```JitsiMeetJS.enumerateDevices(callback)``` - returns list of the available devices as a parameter to the callback function. Every device is a object with the following format:
+* ```JitsiMeetJS.isDesktopSharingEnabled()``` - returns true if desktop sharing is supported and false otherwise. NOTE: that method can be used after ```JitsiMeetJS.init(options)``` is completed otherwise the result will be always null.
+
+* ```JitsiMeetJS.getDevicesList()``` - returns object `{ audio: [], video: [] }` with available audio and video devices. Every device is a object with the following format:
     - label - the name of the device
     - kind - "audioinput" or "videoinput"
     - deviceId - the id of the device.
 
-* ```JitsiMeetJS.isDeviceListAvailable()```- returns true if retrieving the device list is support and false - otherwise.
+* ```JitsiMeetJS.on(event, listener)``` - Subscribes the passed listener to the event.
+    - event - one of the events from ```JitsiMeetJS.events.library``` object.
+    - listener - handler for the event.
 
-* ```JitsiMeetJS.isDesktopSharingEnabled()``` - returns true if desktop sharing is supported and false otherwise. NOTE: that method can be used after ```JitsiMeetJS.init(options)``` is completed otherwise the result will be always null.
+* ```JitsiMeetJS.off(event, listener)``` - Removes event listener.
+    - event - the event
+    - listener - the listener that will be removed.
 
 * ```JitsiMeetJS.events``` - JS object that contains all events used by the API. You will need that JS object when you try to subscribe for connection or conference events.
     We have two event types - connection and conference. You can access the events with the following code ```JitsiMeetJS.events.<event_type>.<event_name>```.
     For example if you want to use the conference event that is fired when somebody leave conference you can use the following code - ```JitsiMeetJS.events.conference.USER_LEFT```.
     We support the following events:
-    1. conference
+    1. library
+        - DEVICES_LIST_CHANGED - notifies that list of available physical audio or video devices changed
+
+    2. conference
         - TRACK_ADDED - stream received. (parameters - JitsiTrack)
         - TRACK_REMOVED - stream removed. (parameters - JitsiTrack)
         - TRACK_MUTE_CHANGED - JitsiTrack was muted or unmuted. (parameters - JitsiTrack)
@@ -101,13 +110,13 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
         - CONNECTION_STATS - New local connection statistics are received. (parameters - stats(object))
         - AUTH_STATUS_CHANGED - notifies that authentication is enabled or disabled, or local user authenticated (logged in). (parameters - isAuthEnabled(boolean), authIdentity(string))
 
-    2. connection
+    3. connection
         - CONNECTION_FAILED - indicates that the server connection failed.
         - CONNECTION_ESTABLISHED - indicates that we have successfully established server connection.
         - CONNECTION_DISCONNECTED - indicates that we are disconnected.
         - WRONG_STATE - indicates that the user has performed action that can't be executed because the connection is in wrong state.
 
-    3. tracks
+    4. tracks
         - LOCAL_TRACK_STOPPED - indicates that a local track was stopped. This
         event can be fired when ```dispose()``` method is called or for other reasons.
 

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -172,6 +172,14 @@ RTC.getDeviceAvailability = function () {
     return RTCUtils.getDeviceAvailability();
 };
 
+/**
+ * Get list of physical audio and video devices.
+ * @returns {{audio: [], video: []}}
+ */
+RTC.getDevicesList = function () {
+    return RTCUtils.getDevicesList();
+};
+
 RTC.prototype.addLocalStream = function (stream) {
     this.localStreams.push(stream);
     stream._setRTC(this);
@@ -257,29 +265,6 @@ RTC.getStreamID = function (stream) {
 
 RTC.getVideoSrc = function (element) {
     return RTCUtils.getVideoSrc(element);
-};
-
-/**
- * Returns true if retrieving the the list of input devices is supported and
- * false if not.
- */
-RTC.isDeviceListAvailable = function () {
-    return RTCUtils.isDeviceListAvailable();
-};
-
-/**
- * Returns true if changing the camera / microphone device is supported and
- * false if not.
- */
-RTC.isDeviceChangeAvailable = function () {
-    return RTCUtils.isDeviceChangeAvailable();
-};
-/**
- * Allows to receive list of available cameras/microphones.
- * @param {function} callback would receive array of devices as an argument
- */
-RTC.enumerateDevices = function (callback) {
-    RTCUtils.enumerateDevices(callback);
 };
 
 RTC.setVideoSrc = function (element, src) {

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -1,4 +1,3 @@
-/* global APP */
 var EventEmitter = require("events");
 var RTCBrowserType = require("./RTCBrowserType");
 var RTCUtils = require("./RTCUtils.js");
@@ -10,7 +9,7 @@ var MediaStreamType = require("../../service/RTC/MediaStreamTypes");
 var RTCEvents = require("../../service/RTC/RTCEvents.js");
 
 function createLocalTracks(streams, options) {
-    var newStreams = []
+    var newStreams = [];
     var deviceId = null;
     for (var i = 0; i < streams.length; i++) {
         if (streams[i].type === 'audio') {
@@ -75,19 +74,25 @@ function RTC(room, options) {
  * @param {Object} [options] optional parameters
  * @param {Array} options.devices the devices that will be requested
  * @param {string} options.resolution resolution constraints
- * @param {bool} options.dontCreateJitsiTrack if <tt>true</tt> objects with the following structure {stream: the Media Stream,
- * type: "audio" or "video", videoType: "camera" or "desktop"}
- * will be returned trough the Promise, otherwise JitsiTrack objects will be returned.
+ * @param {bool} options.dontCreateJitsiTrack if <tt>true</tt> objects
+ * with the following structure
+ * { stream: the Media Stream,
+ *   type: "audio" or "video",
+ *   videoType: "camera" or "desktop" }
+ * will be returned trough the Promise,
+ * otherwise JitsiTrack objects will be returned.
  * @param {string} options.cameraDeviceId
  * @param {string} options.micDeviceId
  * @returns {*} Promise object that will receive the new JitsiTracks
  */
 
 RTC.obtainAudioAndVideoPermissions = function (options) {
-    return RTCUtils.obtainAudioAndVideoPermissions(options).then(function (streams) {
+    return RTCUtils.obtainAudioAndVideoPermissions(
+        options
+    ).then(function (streams) {
         return createLocalTracks(streams, options);
     });
-}
+};
 
 RTC.prototype.onIncommingCall = function(event) {
     if(this.options.config.openSctp)
@@ -100,18 +105,19 @@ RTC.prototype.onIncommingCall = function(event) {
             if(this.localStreams[i].isMuted() &&
                 this.localStreams[i].getType() === "video") {
                 /**
-                 * Handles issues when the stream is added before the peerconnection is created.
-                 * The peerconnection is created when second participant enters the call. In
-                 * that use case the track doesn't have information about it's ssrcs and no
-                 * jingle packets are sent. That can cause inconsistant behavior later.
+                 * Handles issues when the stream is added before the
+                 * peerconnection is created.The peerconnection is created when
+                 * second participant enters the call. In that use case the
+                 * track doesn't have information about it's ssrcs and no jingle
+                 * packets are sent. That can cause inconsistant behavior later.
                  *
                  * For example:
-                 * If we mute the stream and than second participant enter it's remote SDP won't
-                 * include that track. On unmute we are not sending any jingle packets which
-                 * will brake the unmute.
+                 * If we mute the stream and than second participant enter it's
+                 * remote SDP won't include that track. On unmute we are not
+                 * sending any jingle packets which will brake the unmute.
                  *
-                 * In order to solve issues like the above one here we have to generate the ssrc
-                 * information for the track .
+                 * In order to solve issues like the above one here we have
+                 * to generate the ssrc information for the track.
                  */
                 this.localStreams[i]._setSSRC(
                     this.room.generateNewStreamSSRCInfo());
@@ -120,22 +126,22 @@ RTC.prototype.onIncommingCall = function(event) {
                     type: "addMuted",
                     ssrc: this.localStreams[i].ssrc,
                     msid: this.localStreams[i].initialMSID
-                }
+                };
             }
             this.room.addStream(this.localStreams[i].getOriginalStream(),
                 function () {}, ssrcInfo, true);
         }
-}
+};
 
 RTC.prototype.selectedEndpoint = function (id) {
     if(this.dataChannels)
         this.dataChannels.handleSelectedEndpointEvent(id);
-}
+};
 
 RTC.prototype.pinEndpoint = function (id) {
     if(this.dataChannels)
         this.dataChannels.handlePinnedEndpointEvent(id);
-}
+};
 
 RTC.prototype.addListener = function (type, listener) {
     this.eventEmitter.on(type, listener);
@@ -147,24 +153,24 @@ RTC.prototype.removeListener = function (eventType, listener) {
 
 RTC.addListener = function (eventType, listener) {
     RTCUtils.addListener(eventType, listener);
-}
+};
 
 RTC.removeListener = function (eventType, listener) {
-    RTCUtils.removeListener(eventType, listener)
-}
+    RTCUtils.removeListener(eventType, listener);
+};
 
 RTC.isRTCReady = function () {
     return RTCUtils.isRTCReady();
-}
+};
 
 RTC.init = function (options) {
     this.options = options || {};
     return RTCUtils.init(this.options);
-}
+};
 
 RTC.getDeviceAvailability = function () {
     return RTCUtils.getDeviceAvailability();
-}
+};
 
 RTC.prototype.addLocalStream = function (stream) {
     this.localStreams.push(stream);
@@ -202,7 +208,7 @@ RTC.prototype.setAudioMute = function (value) {
     }
     // we return a Promise from all Promises so we can wait for their execution
     return Promise.all(mutePromises);
-}
+};
 
 RTC.prototype.removeLocalStream = function (stream) {
     var pos = this.localStreams.indexOf(stream);
@@ -267,7 +273,7 @@ RTC.isDeviceListAvailable = function () {
  */
 RTC.isDeviceChangeAvailable = function () {
     return RTCUtils.isDeviceChangeAvailable();
-}
+};
 /**
  * Allows to receive list of available cameras/microphones.
  * @param {function} callback would receive array of devices as an argument
@@ -312,10 +318,13 @@ RTC.prototype.switchVideoStreams = function (newStream) {
 };
 
 RTC.prototype.setAudioLevel = function (resource, audioLevel) {
-    if(!resource)
+    if (!resource || !this.remoteStreams[resource]) {
         return;
-    if(this.remoteStreams[resource] && this.remoteStreams[resource][JitsiTrack.AUDIO])
-        this.remoteStreams[resource][JitsiTrack.AUDIO].setAudioLevel(audioLevel);
+    }
+    var audioTrack = this.remoteStreams[resource][JitsiTrack.AUDIO];
+    if (audioTrack) {
+        audioTrack.setAudioLevel(audioLevel);
+    }
 };
 
 /**

--- a/service/RTC/RTCEvents.js
+++ b/service/RTC/RTCEvents.js
@@ -5,6 +5,7 @@ var RTCEvents = {
     DOMINANTSPEAKER_CHANGED: "rtc.dominantspeaker_changed",
     LASTN_ENDPOINT_CHANGED: "rtc.lastn_endpoint_changed",
     AVAILABLE_DEVICES_CHANGED: "rtc.available_devices_changed",
+    DEVICES_LIST_CHANGED: "rtc.devices_list_changed",
     FAKE_VIDEO_TRACK_CREATED: "rtc.fake_video_track_created",
     TRACK_ATTACHED: "rtc.track_attached"
 };


### PR DESCRIPTION
* monitor device list changes and trigger DEVICES_LIST_CHANGED on `JitsiMeetJS`
* so now `JitsiMeetJS` is event bus
* provide single method `JitsiMeetJS.getDevicesList()` which returns available devices. If browser do not support `navigator.mediaDevices.enumerateDevices` or `MediaStreamTrack.getSource` it always returns empty lists.