### PR TITLE
Better onicecandidate

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -355,6 +355,9 @@ JingleSessionPC.prototype.sendIceCandidate = function (candidate) {
                 return;
             } else {
                 self.sendIceCandidates([candidate]);
+                // FIXME this.lasticecandidate is going to be set to true
+                // bellow and that seems wrong. The execution doesn't come here
+                // with the default values at the time of this writing.
             }
         }
     } else {


### PR DESCRIPTION
(Well, it's a matter of subjective opinion whether it's better.)

1. The check whether to discard ICE candidates was suboptimal and harder to read.
2. The check for event was partial and could still potentially allow the throw of an exception.
3. There's a branch of the code which could potentially lead to seemingly undesired behavior. Luckily, we don't execute that branch of the code. Anyway, I believe it's better to have a FIXME there (because I don't want to spend time fixing the problem now).