### PR TITLE
Enables fec by default.

### DIFF
--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -180,6 +180,13 @@ Moderator.prototype.createConferenceIq =  function () {
                 value: true
             }).up();
     //}
+    if (options.enableFec !== false) {
+        elem.c(
+            'property', {
+                name: 'enableFec',
+                value: true
+            }).up();
+    }
     if (options.openSctp !== undefined) {
         elem.c(
             'property', {


### PR DESCRIPTION
Adds "enableFec=true" to the conference creation IQ (unless
config.enableFec is set to false).