### PR TITLE
Ssrc remove

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -802,6 +802,12 @@ JingleSessionPC.prototype.removeSource = function (elem) {
                 var ssrcLines = SDPUtil.find_lines(media, 'a=ssrc:' + ssrc);
                 if (ssrcLines.length)
                     self.removessrc[idx] += ssrcLines.join("\r\n")+"\r\n";
+                // Clear any pending 'source-add' for this SSRC 
+                if (self.addssrc[idx]) {
+                    self.addssrc[idx]
+                        = self.addssrc[idx].replace(
+                            new RegExp('^a=ssrc:'+ssrc+' .*\r\n', 'gm'), '');
+                }
             });
             self.removessrc[idx] += lines;
         });

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -783,6 +783,7 @@ JingleSessionPC.prototype.removeSource = function (elem) {
                 lines += 'a=ssrc-group:' + semantics + ' ' + ssrcs.join(' ') + '\r\n';
             }
         });
+        var ssrcs = [];
         var tmp = $(content).find('source[xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]'); // can handle both >source and >description>source
         tmp.each(function () {
             var ssrc = $(this).attr('ssrc');
@@ -791,18 +792,17 @@ JingleSessionPC.prototype.removeSource = function (elem) {
                 logger.error("Got remove stream request for my own ssrc: "+ssrc);
                 return;
             }
-            $(this).find('>parameter').each(function () {
-                lines += 'a=ssrc:' + ssrc + ' ' + $(this).attr('name');
-                if ($(this).attr('value') && $(this).attr('value').length)
-                    lines += ':' + $(this).attr('value');
-                lines += '\r\n';
-            });
+            ssrcs.push(ssrc);
         });
         sdp.media.forEach(function(media, idx) {
             if (!SDPUtil.find_line(media, 'a=mid:' + name))
                 return;
-            sdp.media[idx] += lines;
             if (!self.removessrc[idx]) self.removessrc[idx] = '';
+            ssrcs.forEach(function(ssrc) {
+                var ssrcLines = SDPUtil.find_lines(media, 'a=ssrc:' + ssrc);
+                if (ssrcLines.length)
+                    self.removessrc[idx] += ssrcLines.join("\r\n")+"\r\n";
+            });
             self.removessrc[idx] += lines;
         });
         sdp.raw = sdp.session + sdp.media.join('');


### PR DESCRIPTION
The goal of this PR is to make source-remove notifications simpler. That is they will no longer contain SSRC parameters, but only the SSRC value after https://github.com/jitsi/jicofo/pull/73. The client should remove all lines related to that SSRC instead of trying to match the lines for given parameters.

This will fix the issue where we're leaking FF and Chrome recvonly streams which do not come with mslabel. Then later Chrome adds mslabel and msid with 'default' value. Jicofo doesn't know about that changes, so these are not included in source-remove notification.

It will also simplify implementation of lipsync stream merge feature in jicofo, as it will not have to track the peers that received merged or separate version of A/V stream.