### PR TITLE
Lipsync

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -171,7 +171,7 @@ JitsiConference.prototype.getExternalAuthUrl = function (urlForPopup) {
  */
 JitsiConference.prototype.getLocalTracks = function () {
     if (this.rtc) {
-        return this.rtc.localStreams.slice();
+        return this.rtc.localTracks.slice();
     } else {
         return [];
     }
@@ -304,7 +304,7 @@ JitsiConference.prototype.addTrack = function (track) {
         throw new Error(JitsiTrackErrors.TRACK_IS_DISPOSED);
     }
     if (track.isVideoTrack()) {
-        if (this.rtc.getLocalVideoStream()) {
+        if (this.rtc.getLocalVideoTrack()) {
             throw new Error("cannot add second video track to the conference");
         }
         this.removeCommand("videoType");
@@ -328,7 +328,7 @@ JitsiConference.prototype.addTrack = function (track) {
 
     return new Promise(function (resolve) {
         this.room.addStream(track.getOriginalStream(), function () {
-            this.rtc.addLocalStream(track);
+            this.rtc.addLocalTrack(track);
             if (track.startMuted) {
                 track.mute();
             }
@@ -398,7 +398,7 @@ JitsiConference.prototype.removeTrack = function (track) {
 
     if(!this.room){
         if(this.rtc) {
-            this.rtc.removeLocalStream(track);
+            this.rtc.removeLocalTrack(track);
             this.eventEmitter.emit(JitsiConferenceEvents.TRACK_REMOVED, track);
         }
         return Promise.resolve();
@@ -408,7 +408,7 @@ JitsiConference.prototype.removeTrack = function (track) {
             track._setSSRC(null);
             //FIXME: This dependacy is not necessary. This is quick fix.
             track._setConference(this);
-            this.rtc.removeLocalStream(track);
+            this.rtc.removeLocalTrack(track);
             track.removeEventListener(JitsiTrackEvents.TRACK_MUTE_CHANGED,
                 track.muteHandler);
             track.removeEventListener(JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED,
@@ -566,7 +566,7 @@ JitsiConference.prototype.onMemberLeft = function (jid) {
     var participant = this.participants[id];
     delete this.participants[id];
 
-    this.rtc.removeRemoteStream(id);
+    this.rtc.removeRemoteTrack(id);
 
     this.eventEmitter.emit(JitsiConferenceEvents.USER_LEFT, id, participant);
 };
@@ -901,19 +901,17 @@ function setupListeners(conference) {
         }
     });
 
-    conference.room.addListener(XMPPEvents.REMOTE_STREAM_RECEIVED,
+    conference.room.addListener(XMPPEvents.REMOTE_TRACK_ADDED,
         function (data, sid, thessrc) {
-            var track = conference.rtc.createRemoteStream(data, sid, thessrc);
+            var track = conference.rtc.createRemoteTrack(data, sid, thessrc);
             if (track) {
                 conference.onTrackAdded(track);
             }
         }
     );
-    conference.room.addListener(XMPPEvents.REMOTE_STREAM_REMOVED,
+    conference.room.addListener(XMPPEvents.REMOTE_TRACK_REMOVED,
         function (streamId) {
-            var participants = conference.getParticipants();
-            for(var j = 0; j < participants.length; j++) {
-                var participant = participants[j];
+            conference.getParticipants().forEach(function(participant) {
                 var tracks = participant.getTracks();
                 for(var i = 0; i < tracks.length; i++) {
                     if(tracks[i] && tracks[i].stream &&
@@ -924,7 +922,7 @@ function setupListeners(conference) {
                         return;
                     }
                 }
-            }
+            });
         }
     );
     conference.rtc.addListener(RTCEvents.FAKE_VIDEO_TRACK_CREATED,

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -902,20 +902,21 @@ function setupListeners(conference) {
     });
 
     conference.room.addListener(XMPPEvents.REMOTE_TRACK_ADDED,
-        function (data, sid, thessrc) {
-            var track = conference.rtc.createRemoteTrack(data, sid, thessrc);
+        function (data) {
+            var track = conference.rtc.createRemoteTrack(data);
             if (track) {
                 conference.onTrackAdded(track);
             }
         }
     );
     conference.room.addListener(XMPPEvents.REMOTE_TRACK_REMOVED,
-        function (streamId) {
+        function (streamId, trackId) {
             conference.getParticipants().forEach(function(participant) {
                 var tracks = participant.getTracks();
                 for(var i = 0; i < tracks.length; i++) {
-                    if(tracks[i] && tracks[i].stream &&
-                        RTC.getStreamID(tracks[i].stream) == streamId){
+                    if(tracks[i]
+                        && tracks[i].getStreamId() == streamId
+                        && tracks[i].getTrackId() == trackId) {
                         var track = participant._tracks.splice(i, 1)[0];
                         conference.eventEmitter.emit(
                             JitsiConferenceEvents.TRACK_REMOVED, track);

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -566,7 +566,7 @@ JitsiConference.prototype.onMemberLeft = function (jid) {
     var participant = this.participants[id];
     delete this.participants[id];
 
-    this.rtc.removeRemoteTrack(id);
+    this.rtc.removeRemoteTracks(id);
 
     this.eventEmitter.emit(JitsiConferenceEvents.USER_LEFT, id, participant);
 };

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -7,6 +7,7 @@ var JitsiConferenceErrors = require("./JitsiConferenceErrors");
 var JitsiTrackEvents = require("./JitsiTrackEvents");
 var JitsiTrackErrors = require("./JitsiTrackErrors");
 var Logger = require("jitsi-meet-logger");
+var MediaType = require("./service/RTC/MediaType");
 var RTC = require("./modules/RTC/RTC");
 var RTCUIHelper = require("./modules/RTC/RTCUIHelper");
 var Statistics = require("./modules/statistics/statistics");
@@ -102,7 +103,7 @@ var LibJitsiMeet = {
                     for(var i = 0; i < tracks.length; i++) {
                         var track = tracks[i];
                         var mStream = track.getOriginalStream();
-                        if(track.getType() === "audio"){
+                        if(track.getType() === MediaType.AUDIO){
                             Statistics.startLocalStats(mStream,
                                 track.setAudioLevel.bind(track));
                             track.addEventListener(

--- a/modules/DTMF/JitsiDTMFManager.js
+++ b/modules/DTMF/JitsiDTMFManager.js
@@ -1,11 +1,12 @@
 var logger = require("jitsi-meet-logger").getLogger(__filename);
 
 function JitsiDTMFManager (localAudio, peerConnection) {
-    var tracks = localAudio._getTracks();
-    if (!tracks.length) {
+    var audioTrack = localAudio.getTrack();
+    if (!audioTrack) {
         throw new Error("Failed to initialize DTMFSender: no audio track.");
     }
-    this.dtmfSender = peerConnection.peerconnection.createDTMFSender(tracks[0]);
+    this.dtmfSender
+        = peerConnection.peerconnection.createDTMFSender(audioTrack);
     logger.debug("Initialized DTMFSender");
 }
 

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -47,7 +47,7 @@ JitsiLocalTrack.prototype.mute = function () {
 };
 
 /**
- * Unmutes the stream. Will reject the Promise if there is mute/unmute operation
+ * Unmutes the track. Will reject the Promise if there is mute/unmute operation
  * in progress.
  * @returns {Promise}
  */
@@ -229,6 +229,7 @@ JitsiLocalTrack.prototype.dispose = function () {
  * and <tt>false</tt> otherwise.
  */
 JitsiLocalTrack.prototype.isMuted = function () {
+    // this.stream will be null when we mute local video on Chrome
     if (!this.stream)
         return true;
     var tracks = [];

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -42,7 +42,7 @@ JitsiLocalTrack.prototype.constructor = JitsiLocalTrack;
  */
 JitsiLocalTrack.prototype.mute = function () {
     return createMuteUnmutePromise(this, true);
-}
+};
 
 /**
  * Unmutes the stream. Will reject the Promise if there is mute/unmute operation
@@ -51,7 +51,7 @@ JitsiLocalTrack.prototype.mute = function () {
  */
 JitsiLocalTrack.prototype.unmute = function () {
     return createMuteUnmutePromise(this, false);
-}
+};
 
 /**
  * Creates Promise for mute/unmute operation.
@@ -82,7 +82,8 @@ function createMuteUnmutePromise(track, mute)
 
 /**
  * Mutes / unmutes the track.
- * @param mute {boolean} if true the track will be muted. Otherwise the track will be unmuted.
+ * @param mute {boolean} if true the track will be muted. Otherwise the track
+ * will be unmuted.
  */
 JitsiLocalTrack.prototype._setMute = function (mute, resolve, reject) {
     if (this.isMuted() === mute) {
@@ -186,7 +187,7 @@ JitsiLocalTrack.prototype._setMute = function (mute, resolve, reject) {
                 });
         }
     }
-}
+};
 
 /**
  * Stops sending the media track. And removes it from the HTML.
@@ -256,7 +257,7 @@ JitsiLocalTrack.prototype._setRTC = function (rtc) {
  */
 JitsiLocalTrack.prototype._setSSRC = function (ssrc) {
     this.ssrc = ssrc;
-}
+};
 
 
 //FIXME: This dependacy is not necessary. This is quick fix.
@@ -267,7 +268,7 @@ JitsiLocalTrack.prototype._setSSRC = function (ssrc) {
  */
 JitsiLocalTrack.prototype._setConference = function(conference) {
     this.conference = conference;
-}
+};
 
 /**
  * Gets the SSRC of this local track if it's available already or <tt>null</tt>
@@ -290,6 +291,6 @@ JitsiLocalTrack.prototype.getSSRC = function () {
  */
 JitsiLocalTrack.prototype.isLocal = function () {
     return true;
-}
+};
 
 module.exports = JitsiLocalTrack;

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -4,6 +4,7 @@ var RTCBrowserType = require("./RTCBrowserType");
 var JitsiTrackEvents = require('../../JitsiTrackEvents');
 var JitsiTrackErrors = require("../../JitsiTrackErrors");
 var RTCUtils = require("./RTCUtils");
+var VideoType = require('../../service/RTC/VideoType');
 
 /**
  * Represents a single media track (either audio or video).
@@ -110,7 +111,7 @@ JitsiLocalTrack.prototype._setMute = function (mute, resolve, reject) {
     }.bind(this);
 
     if ((window.location.protocol != "https:") ||
-        (isAudio) || this.videoType === "desktop" ||
+        (isAudio) || this.videoType === VideoType.DESKTOP ||
         // FIXME FF does not support 'removeStream' method used to mute
         RTCBrowserType.isFirefox()) {
 
@@ -141,9 +142,9 @@ JitsiLocalTrack.prototype._setMute = function (mute, resolve, reject) {
                 resolution: self.resolution
             };
             if (isAudio) {
-              streamOptions['micDeviceId'] = self.deviceId;
-          } else if(self.videoType === 'camera') {
-              streamOptions['cameraDeviceId'] = self.deviceId;
+                streamOptions['micDeviceId'] = self.deviceId;
+            } else if(self.videoType === VideoType.CAMERA) {
+                streamOptions['cameraDeviceId'] = self.deviceId;
             }
             RTCUtils.obtainAudioAndVideoPermissions(streamOptions)
                 .then(function (streams) {

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -95,7 +95,7 @@ JitsiLocalTrack.prototype._setMute = function (mute, resolve, reject) {
         resolve();
         return;
     }
-    var isAudio = this.type === JitsiTrack.AUDIO;
+    var isAudio = this.isAudioTrack();
     this.dontFireRemoveEvent = false;
 
     var setStreamToNull = false;
@@ -220,7 +220,7 @@ JitsiLocalTrack.prototype.isMuted = function () {
     if (!this.stream)
         return true;
     var tracks = [];
-    var isAudio = this.type === JitsiTrack.AUDIO;
+    var isAudio = this.isAudioTrack();
     if (isAudio) {
         tracks = this.stream.getAudioTracks();
     } else {

--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -48,7 +48,8 @@ JitsiRemoteTrack.prototype.setMute = function (value) {
 
 /**
  * Returns the current muted status of the track.
- * @returns {boolean|*|JitsiRemoteTrack.muted} <tt>true</tt> if the track is muted and <tt>false</tt> otherwise.
+ * @returns {boolean|*|JitsiRemoteTrack.muted} <tt>true</tt> if the track is
+ * muted and <tt>false</tt> otherwise.
  */
 JitsiRemoteTrack.prototype.isMuted = function () {
     return this.muted;
@@ -85,7 +86,7 @@ JitsiRemoteTrack.prototype._setVideoType = function (type) {
         return;
     this.videoType = type;
     this.eventEmitter.emit(JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED, type);
-}
+};
 
 delete JitsiRemoteTrack.prototype.dispose;
 

--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -4,26 +4,22 @@ var JitsiTrackEvents = require("../../JitsiTrackEvents");
 /**
  * Represents a single media track (either audio or video).
  * @param RTC the rtc instance.
- * @param data object with the stream and some details about it(participant id, video type, etc.)
- * @param sid sid for the Media Stream
- * @param ssrc ssrc for the Media Stream
- * @param eventEmitter the event emitter
+ * @param ownerJid the MUC JID of the track owner
+ * @param stream WebRTC MediaStream, parent of the track
+ * @param track underlying WebRTC MediaStreamTrack for new JitsiRemoteTrack
+ * @param mediaType the MediaType of the JitsiRemoteTrack
+ * @param videoType the VideoType of the JitsiRemoteTrack
+ * @param ssrc the SSRC number of the Media Stream
+ * @param muted intial muted state of the JitsiRemoteTrack
  * @constructor
  */
-function JitsiRemoteTrack(RTC, data, sid, ssrc) {
-    JitsiTrack.call(this, RTC, data.stream,
-        function () {}, data.jitsiTrackType);
+function JitsiRemoteTrack(RTC, ownerJid, stream, track, mediaType, videoType,
+                          ssrc, muted) {    
+    JitsiTrack.call(
+        this, RTC, stream, track, function () {}, mediaType, videoType, ssrc);
     this.rtc = RTC;
-    this.sid = sid;
-    this.stream = data.stream;
-    this.peerjid = data.peerjid;
-    this.videoType = data.videoType;
-    this.ssrc = ssrc;
-    this.muted = false;
-    if((this.isAudioTrack() && data.audiomuted)
-      || (this.isVideoTrack() && data.videomuted)) {
-        this.muted = true;
-    }
+    this.peerjid = ownerJid;
+    this.muted = muted;
 }
 
 JitsiRemoteTrack.prototype = Object.create(JitsiTrack.prototype);

--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -20,8 +20,8 @@ function JitsiRemoteTrack(RTC, data, sid, ssrc) {
     this.videoType = data.videoType;
     this.ssrc = ssrc;
     this.muted = false;
-    if((this.type === JitsiTrack.AUDIO && data.audiomuted)
-      || (this.type === JitsiTrack.VIDEO && data.videomuted)) {
+    if((this.isAudioTrack() && data.audiomuted)
+      || (this.isVideoTrack() && data.videomuted)) {
         this.muted = true;
     }
 }

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -5,6 +5,7 @@ var RTCEvents = require("../../service/RTC/RTCEvents");
 var RTCUtils = require("./RTCUtils");
 var JitsiTrackEvents = require("../../JitsiTrackEvents");
 var EventEmitter = require("events");
+var MediaType = require("../../service/RTC/MediaType");
 
 /**
  * This implements 'onended' callback normally fired by WebRTC after the stream
@@ -63,8 +64,8 @@ function JitsiTrack(rtc, stream, streamInactiveHandler, jitsiTrackType)
     this.eventEmitter = new EventEmitter();
     this.audioLevel = -1;
     this.type = jitsiTrackType || ((this.stream.getVideoTracks().length > 0)?
-        JitsiTrack.VIDEO : JitsiTrack.AUDIO);
-    if(this.type == JitsiTrack.AUDIO) {
+        MediaType.VIDEO : MediaType.AUDIO);
+    if(this.isAudioTrack()) {
         this._getTracks = function () {
             return this.stream? this.stream.getAudioTracks() : [];
         }.bind(this);
@@ -83,18 +84,6 @@ function JitsiTrack(rtc, stream, streamInactiveHandler, jitsiTrackType)
 }
 
 /**
- * JitsiTrack video type.
- * @type {string}
- */
-JitsiTrack.VIDEO = "video";
-
-/**
- * JitsiTrack audio type.
- * @type {string}
- */
-JitsiTrack.AUDIO = "audio";
-
-/**
  * Returns the type (audio or video) of this track.
  */
 JitsiTrack.prototype.getType = function() {
@@ -105,14 +94,14 @@ JitsiTrack.prototype.getType = function() {
  * Check if this is audiotrack.
  */
 JitsiTrack.prototype.isAudioTrack = function () {
-    return this.getType() === JitsiTrack.AUDIO;
+    return this.getType() === MediaType.AUDIO;
 };
 
 /**
  * Check if this is videotrack.
  */
 JitsiTrack.prototype.isVideoTrack = function () {
-    return this.getType() === JitsiTrack.VIDEO;
+    return this.getType() === MediaType.VIDEO;
 };
 
 /**
@@ -128,7 +117,7 @@ JitsiTrack.prototype.getOriginalStream = function() {
  * @returns {string}
  */
 JitsiTrack.prototype.getUsageLabel = function () {
-    if (this.type == JitsiTrack.AUDIO) {
+    if (this.isAudioTrack()) {
         return "mic";
     } else {
         return this.videoType ? this.videoType : "default";

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -119,7 +119,7 @@ JitsiTrack.prototype.isVideoTrack = function () {
  */
 JitsiTrack.prototype.getOriginalStream = function() {
     return this.stream;
-}
+};
 
 /**
  * Return meaningful usage label for this track depending on it's media and
@@ -203,14 +203,14 @@ JitsiTrack.prototype.detach = function (container) {
     if(container) {
         require("./RTCUtils").setVideoSrc(container, null);
     }
-}
+};
 
 /**
  * Dispose sending the media track. And removes it from the HTML.
  * NOTE: Works for local tracks only.
  */
 JitsiTrack.prototype.dispose = function () {
-}
+};
 
 /**
  * Returns true if this is a video track and the source of the video is a
@@ -218,11 +218,11 @@ JitsiTrack.prototype.dispose = function () {
  */
 JitsiTrack.prototype.isScreenSharing = function(){
 
-}
+};
 
 /**
  * Returns id of the track.
- * @returns {string} id of the track or null if this is fake track.
+ * @returns {string|null} id of the track or null if this is fake track.
  */
 JitsiTrack.prototype._getId = function () {
     var tracks = this.stream.getTracks();
@@ -233,7 +233,7 @@ JitsiTrack.prototype._getId = function () {
 
 /**
  * Returns id of the track.
- * @returns {string} id of the track or null if this is fake track.
+ * @returns {string|null} id of the track or null if this is fake track.
  */
 JitsiTrack.prototype.getId = function () {
     if(this.stream)
@@ -264,7 +264,7 @@ JitsiTrack.prototype.isActive = function () {
 JitsiTrack.prototype.on = function (eventId, handler) {
     if(this.eventEmitter)
         this.eventEmitter.on(eventId, handler);
-}
+};
 
 /**
  * Removes event listener
@@ -274,7 +274,7 @@ JitsiTrack.prototype.on = function (eventId, handler) {
 JitsiTrack.prototype.off = function (eventId, handler) {
     if(this.eventEmitter)
         this.eventEmitter.removeListener(eventId, handler);
-}
+};
 
 // Common aliases for event emitter
 JitsiTrack.prototype.addEventListener = JitsiTrack.prototype.on;
@@ -291,7 +291,7 @@ JitsiTrack.prototype.setAudioLevel = function (audioLevel) {
             audioLevel);
         this.audioLevel = audioLevel;
     }
- }
+ };
 
 /**
  * Returns the msid of the stream attached to the JitsiTrack object or null if
@@ -302,6 +302,6 @@ JitsiTrack.prototype.getMSID = function () {
     return (!this.stream || !this.stream.id || !(tracks = this._getTracks()) ||
         !tracks.length || !(track = tracks[0]) || !track.id)?
             null : this.stream.id + " " + track.id;
-}
+};
 
 module.exports = JitsiTrack;

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -1,9 +1,10 @@
+/* global __filename, module */
 var logger = require("jitsi-meet-logger").getLogger(__filename);
 var RTCBrowserType = require("./RTCBrowserType");
 var RTCEvents = require("../../service/RTC/RTCEvents");
+var RTCUtils = require("./RTCUtils");
 var JitsiTrackEvents = require("../../JitsiTrackEvents");
 var EventEmitter = require("events");
-var RTC = require("./RTCUtils");
 
 /**
  * This implements 'onended' callback normally fired by WebRTC after the stream
@@ -172,7 +173,7 @@ JitsiTrack.prototype.attach = function (container) {
             containerSel.show();
         }
         container
-            = require("./RTCUtils").attachMediaStream(container, this.stream);
+            = RTCUtils.attachMediaStream(container, this.stream);
     }
     this.containers.push(container);
 
@@ -192,7 +193,7 @@ JitsiTrack.prototype.detach = function (container) {
     {
         if(!container)
         {
-            require("./RTCUtils").setVideoSrc(this.containers[i], null);
+            RTCUtils.setVideoSrc(this.containers[i], null);
         }
         if(!container || $(this.containers[i]).is($(container)))
         {
@@ -201,7 +202,7 @@ JitsiTrack.prototype.detach = function (container) {
     }
 
     if(container) {
-        require("./RTCUtils").setVideoSrc(container, null);
+        RTCUtils.setVideoSrc(container, null);
     }
 };
 
@@ -237,7 +238,7 @@ JitsiTrack.prototype._getId = function () {
  */
 JitsiTrack.prototype.getId = function () {
     if(this.stream)
-        return RTC.getStreamID(this.stream);
+        return RTCUtils.getStreamID(this.stream);
     else
         return null;
 };

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -105,7 +105,7 @@ JitsiTrack.prototype.isVideoTrack = function () {
 };
 
 /**
- * Returns the RTCMediaStream from the browser (?).
+ * Returns the WebRTC MediaStream instance.
  */
 JitsiTrack.prototype.getOriginalStream = function() {
     return this.stream;

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -264,8 +264,13 @@ RTC.prototype.createRemoteTrack = function (data, sid, thessrc) {
     return remoteTrack;
 };
 
-RTC.prototype.removeRemoteTrack = function (resource) {
-    // FIXME this clears both audio and video tracks!
+/**
+ * Removes all JitsiRemoteTracks associated with given MUC nickname (resource
+ * part of the JID).
+ * @param resource the resource part of the MUC JID
+ * @returns {JitsiRemoteTrack|null}
+ */
+RTC.prototype.removeRemoteTracks = function (resource) {
     if(this.remoteTracks[resource]) {
         delete this.remoteTracks[resource];
     }

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -341,6 +341,14 @@ RTC.isDesktopSharingEnabled = function () {
 RTC.prototype.dispose = function() {
 };
 
+/*
+ //FIXME Never used, but probably *should* be used for switching
+ //      between camera and screen, but has to be adjusted to work with tracks.
+ //      Current when switching to desktop we can see recv-only being advertised
+ //      because we do remove and add.
+ //
+ //      Leaving it commented out, in order to not forget about FF specific
+ //      thing
 RTC.prototype.switchVideoTracks = function (newStream) {
     this.localVideo.stream = newStream;
 
@@ -350,7 +358,7 @@ RTC.prototype.switchVideoTracks = function (newStream) {
     if (this.localAudio.getOriginalStream() != newStream)
         this.localTracks.push(this.localAudio);
     this.localTracks.push(this.localVideo);
-};
+};*/
 
 RTC.prototype.setAudioLevel = function (resource, audioLevel) {
     if(!resource)

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -73,9 +73,11 @@ function RTC(room, options) {
  * @param {Object} [options] optional parameters
  * @param {Array} options.devices the devices that will be requested
  * @param {string} options.resolution resolution constraints
- * @param {bool} options.dontCreateJitsiTrack if <tt>true</tt> objects with the following structure {stream: the Media Stream,
+ * @param {bool} options.dontCreateJitsiTrack if <tt>true</tt> objects with the
+ * following structure {stream: the Media Stream,
  * type: "audio" or "video", videoType: "camera" or "desktop"}
- * will be returned trough the Promise, otherwise JitsiTrack objects will be returned.
+ * will be returned trough the Promise, otherwise JitsiTrack objects will be
+ * returned.
  * @param {string} options.cameraDeviceId
  * @param {string} options.micDeviceId
  * @returns {*} Promise object that will receive the new JitsiTracks
@@ -85,7 +87,7 @@ RTC.obtainAudioAndVideoPermissions = function (options) {
     return RTCUtils.obtainAudioAndVideoPermissions(options).then(function (streams) {
         return createLocalTracks(streams, options);
     });
-}
+};
 
 RTC.prototype.onIncommingCall = function(event) {
     if(this.options.config.openSctp)
@@ -123,17 +125,17 @@ RTC.prototype.onIncommingCall = function(event) {
             this.room.addStream(this.localStreams[i].getOriginalStream(),
                 function () {}, ssrcInfo, true);
         }
-}
+};
 
 RTC.prototype.selectedEndpoint = function (id) {
     if(this.dataChannels)
         this.dataChannels.handleSelectedEndpointEvent(id);
-}
+};
 
 RTC.prototype.pinEndpoint = function (id) {
     if(this.dataChannels)
         this.dataChannels.handlePinnedEndpointEvent(id);
-}
+};
 
 RTC.prototype.addListener = function (type, listener) {
     this.eventEmitter.on(type, listener);
@@ -145,24 +147,24 @@ RTC.prototype.removeListener = function (eventType, listener) {
 
 RTC.addListener = function (eventType, listener) {
     RTCUtils.addListener(eventType, listener);
-}
+};
 
 RTC.removeListener = function (eventType, listener) {
     RTCUtils.removeListener(eventType, listener)
-}
+};
 
 RTC.isRTCReady = function () {
     return RTCUtils.isRTCReady();
-}
+};
 
 RTC.init = function (options) {
     this.options = options || {};
     return RTCUtils.init(this.options);
-}
+};
 
 RTC.getDeviceAvailability = function () {
     return RTCUtils.getDeviceAvailability();
-}
+};
 
 RTC.prototype.addLocalStream = function (stream) {
     this.localStreams.push(stream);
@@ -200,7 +202,7 @@ RTC.prototype.setAudioMute = function (value) {
     }
     // we return a Promise from all Promises so we can wait for their execution
     return Promise.all(mutePromises);
-}
+};
 
 RTC.prototype.removeLocalStream = function (stream) {
     var pos = this.localStreams.indexOf(stream);
@@ -265,7 +267,7 @@ RTC.isDeviceListAvailable = function () {
  */
 RTC.isDeviceChangeAvailable = function () {
     return RTCUtils.isDeviceChangeAvailable();
-}
+};
 /**
  * Allows to receive list of available cameras/microphones.
  * @param {function} callback would receive array of devices as an argument

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -1,13 +1,14 @@
-/* global APP */
+/* global APP, module */
 var EventEmitter = require("events");
 var RTCBrowserType = require("./RTCBrowserType");
+var RTCEvents = require("../../service/RTC/RTCEvents.js");
 var RTCUtils = require("./RTCUtils.js");
 var JitsiTrack = require("./JitsiTrack");
 var JitsiLocalTrack = require("./JitsiLocalTrack.js");
 var DataChannels = require("./DataChannels");
 var JitsiRemoteTrack = require("./JitsiRemoteTrack.js");
 var MediaType = require("../../service/RTC/MediaType");
-var RTCEvents = require("../../service/RTC/RTCEvents.js");
+var VideoType = require("../../service/RTC/VideoType");
 
 function createLocalTracks(streams, options) {
     var newStreams = []
@@ -15,7 +16,7 @@ function createLocalTracks(streams, options) {
     for (var i = 0; i < streams.length; i++) {
         if (streams[i].type === MediaType.AUDIO) {
           deviceId = options.micDeviceId;
-        } else if (streams[i].videoType === 'camera'){
+        } else if (streams[i].videoType === VideoType.CAMERA){
           deviceId = options.cameraDeviceId;
         }
         var localStream = new JitsiLocalTrack(streams[i].stream,
@@ -43,7 +44,7 @@ function RTC(room, options) {
             if(!self.remoteStreams[from][MediaType.VIDEO]) {
                 var track = self.createRemoteStream(
                     {peerjid:room.roomjid + "/" + from,
-                     videoType:"camera",
+                     videoType: VideoType.CAMERA,
                      jitsiTrackType: MediaType.VIDEO},
                     null, null);
                 self.eventEmitter

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -404,12 +404,13 @@ RTC.prototype.getResourceBySSRC = function (ssrc) {
 
     var self = this;
     var resultResource = null;
-    Object.keys(this.remoteTracks).forEach(function (resource) {
+    Object.keys(this.remoteTracks).some(function (resource) {
         var audioTrack = self.getRemoteAudioTrack(resource);
         var videoTrack = self.getRemoteVideoTrack(resource);
         if((audioTrack && audioTrack.getSSRC() == ssrc) ||
             (videoTrack && videoTrack.getSSRC() == ssrc)) {
             resultResource = resource;
+            return true;
         }
     });
 

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -21,8 +21,6 @@ function createLocalTracks(streams, options) {
         var localStream = new JitsiLocalTrack(streams[i].stream,
             streams[i].videoType, streams[i].resolution, deviceId);
         newStreams.push(localStream);
-        if (streams[i].isMuted === true)
-            localStream.setMute(true);
     }
     return newStreams;
 }

--- a/modules/RTC/RTCUIHelper.js
+++ b/modules/RTC/RTCUIHelper.js
@@ -1,4 +1,5 @@
-/* global $ */
+/* global $, __filename */
+var logger = require("jitsi-meet-logger").getLogger(__filename);
 var RTCBrowserType = require("./RTCBrowserType");
 var RTC = require('./RTC');
 
@@ -27,21 +28,13 @@ var RTCUIHelper = {
         } else {
             var matching = $(containerElement).find(
                 ' ' + videoElemName + '>param[value="video"]');
-            if (matching.length < 2) {
-                return matching.parent()[0];
-            } else {
-                // there are 2 video objects from FF
-                // object with id which ends with '_default'
-                // (like 'remoteVideo_default')
-                // doesn't contain video, so we ignore it
-                for (var i = 0; i < matching.length; i += 1) {
-                    var el = matching[i].parentNode;
-
-                    // check id suffix
-                    if (el.id.substr(-8) !== '_default') {
-                        return el;
-                    }
+            if (matching.length) {
+                if (matching.length > 1) {
+                    logger.warn(
+                        "Container with more than one video elements: ",
+                        containerElement);
                 }
+                return matching.parent()[0];
             }
         }
         return undefined;

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -14,6 +14,7 @@ var SDPUtil = require("../xmpp/SDPUtil");
 var EventEmitter = require("events");
 var screenObtainer = require("./ScreenObtainer");
 var JitsiTrackErrors = require("../../JitsiTrackErrors");
+var MediaType = require("../../service/RTC/MediaType");
 
 var eventEmitter = new EventEmitter();
 
@@ -407,13 +408,13 @@ function handleLocalStream(streams, resolution) {
 
     if (desktopStream)
         res.push({stream: desktopStream,
-            type: "video", videoType: "desktop"});
+            type: MediaType.VIDEO, videoType: "desktop"});
 
     if(audioStream)
-        res.push({stream: audioStream, type: "audio", videoType: null});
+        res.push({stream: audioStream, type: MediaType.AUDIO, videoType: null});
 
     if(videoStream)
-        res.push({stream: videoStream, type: "video", videoType: "camera",
+        res.push({stream: videoStream, type: MediaType.VIDEO, videoType: "camera",
             resolution: resolution});
 
     return res;

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -410,21 +410,24 @@ function handleLocalStream(streams, resolution) {
     if (desktopStream)
         res.push({
             stream: desktopStream,
-            type: MediaType.VIDEO,
+            track: desktopStream.getVideoTracks()[0],
+            mediaType: MediaType.VIDEO,
             videoType: VideoType.DESKTOP
         });
 
     if(audioStream)
         res.push({
             stream: audioStream,
-            type: MediaType.AUDIO,
+            track: audioStream.getAudioTracks()[0],
+            mediaType: MediaType.AUDIO,
             videoType: null
         });
 
     if(videoStream)
         res.push({
             stream: videoStream,
-            type: MediaType.VIDEO,
+            track: videoStream.getVideoTracks()[0],
+            mediaType: MediaType.VIDEO,
             videoType: VideoType.CAMERA,
             resolution: resolution
         });

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -15,6 +15,7 @@ var EventEmitter = require("events");
 var screenObtainer = require("./ScreenObtainer");
 var JitsiTrackErrors = require("../../JitsiTrackErrors");
 var MediaType = require("../../service/RTC/MediaType");
+var VideoType = require("../../service/RTC/VideoType");
 
 var eventEmitter = new EventEmitter();
 
@@ -407,15 +408,26 @@ function handleLocalStream(streams, resolution) {
     }
 
     if (desktopStream)
-        res.push({stream: desktopStream,
-            type: MediaType.VIDEO, videoType: "desktop"});
+        res.push({
+            stream: desktopStream,
+            type: MediaType.VIDEO,
+            videoType: VideoType.DESKTOP
+        });
 
     if(audioStream)
-        res.push({stream: audioStream, type: MediaType.AUDIO, videoType: null});
+        res.push({
+            stream: audioStream,
+            type: MediaType.AUDIO,
+            videoType: null
+        });
 
     if(videoStream)
-        res.push({stream: videoStream, type: MediaType.VIDEO, videoType: "camera",
-            resolution: resolution});
+        res.push({
+            stream: videoStream,
+            type: MediaType.VIDEO,
+            videoType: VideoType.CAMERA,
+            resolution: resolution
+        });
 
     return res;
 }

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -705,7 +705,7 @@ ChatRoom.prototype.remoteStreamAdded = function(data, sid, thessrc) {
             && audiomuted[0]["value"] === "true")? true : false);
     }
 
-    this.eventEmitter.emit(XMPPEvents.REMOTE_STREAM_RECEIVED, data, sid, thessrc);
+    this.eventEmitter.emit(XMPPEvents.REMOTE_TRACK_ADDED, data, sid, thessrc);
 };
 
 /**

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -706,12 +706,13 @@ ChatRoom.prototype.remoteTrackAdded = function(data) {
             mutedNode = filterNodeFromPresenceJSON(pres, "videomuted");
         } else {
             logger.warn("Unsupported media type: " + mediaType);
-            data.muted= null;
+            data.muted = null;
         }
 
         if (mutedNode) {
-            data.muted = !!(mutedNode.length > 0 &&
-                            mutedNode[0] && mutedNode[0]["value"] === "true");
+            data.muted = mutedNode.length > 0 &&
+                         mutedNode[0] &&
+                         mutedNode[0]["value"] === "true";
         }
     }
 

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -96,7 +96,9 @@ ChatRoom.prototype.initPresenceMap = function () {
         "value": navigator.userAgent,
         "attributes": {xmlns: 'http://jitsi.org/jitmeet/user-agent'}
     });
-
+    // We need to broadcast 'videomuted' status from the beginning, cause Jicofo
+    // makes decisions based on that. Initialize it with 'false' here.
+    this.addVideoInfoToPresence(false);
 };
 
 ChatRoom.prototype.updateDeviceAvailability = function (devices) {

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -641,7 +641,6 @@ ChatRoom.prototype.generateNewStreamSSRCInfo = function () {
 };
 
 ChatRoom.prototype.setVideoMute = function (mute, callback, options) {
-    var self = this;
     this.sendVideoInfoPresence(mute);
     if(callback)
         callback(mute);
@@ -726,7 +725,7 @@ ChatRoom.prototype.getRecordingState = function () {
     if(this.recording)
         return this.recording.getState();
     return "off";
-}
+};
 
 /**
  * Returns the url of the recorded video.
@@ -735,7 +734,7 @@ ChatRoom.prototype.getRecordingURL = function () {
     if(this.recording)
         return this.recording.getURL();
     return null;
-}
+};
 
 /**
  * Starts/stops the recording
@@ -748,7 +747,7 @@ ChatRoom.prototype.toggleRecording = function (options, statusChangeHandler) {
 
     return statusChangeHandler("error",
         new Error("The conference is not created yet!"));
-}
+};
 
 /**
  * Returns true if the SIP calls are supported and false otherwise
@@ -757,7 +756,7 @@ ChatRoom.prototype.isSIPCallingSupported = function () {
     if(this.moderator)
         return this.moderator.isSipGatewayEnabled();
     return false;
-}
+};
 
 /**
  * Dials a number.
@@ -767,28 +766,28 @@ ChatRoom.prototype.dial = function (number) {
     return this.connection.rayo.dial(number, "fromnumber",
         Strophe.getNodeFromJid(this.myroomjid), this.password,
         this.focusMucJid);
-}
+};
 
 /**
  * Hangup an existing call
  */
 ChatRoom.prototype.hangup = function () {
     return this.connection.rayo.hangup();
-}
+};
 
 /**
  * Returns the phone number for joining the conference.
  */
 ChatRoom.prototype.getPhoneNumber = function () {
     return this.phoneNumber;
-}
+};
 
 /**
  * Returns the pin for joining the conference with phone.
  */
 ChatRoom.prototype.getPhonePin = function () {
     return this.phonePin;
-}
+};
 
 /**
  * Returns the connection state for the current session.
@@ -797,7 +796,7 @@ ChatRoom.prototype.getConnectionState = function () {
     if(!this.session)
         return null;
     return this.session.getIceConnectionState();
-}
+};
 
 /**
  * Mutes remote participant.
@@ -823,7 +822,7 @@ ChatRoom.prototype.muteParticipant = function (jid, mute) {
         function (error) {
             logger.log('set mute error', error);
         });
-}
+};
 
 ChatRoom.prototype.onMute = function (iq) {
     var from = iq.getAttribute('from');
@@ -837,7 +836,7 @@ ChatRoom.prototype.onMute = function (iq) {
         this.eventEmitter.emit(XMPPEvents.AUDIO_MUTED_BY_FOCUS, doMuteAudio);
     }
     return true;
-}
+};
 
 /**
  * Leaves the room. Closes the jingle session.

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1253,7 +1253,7 @@ JingleSessionPC.prototype.getIceConnectionState = function () {
 JingleSessionPC.prototype.close = function () {
     this.closed = true;
     this.peerconnection && this.peerconnection.close();
-}
+};
 
 
 /**

--- a/modules/xmpp/SDP.js
+++ b/modules/xmpp/SDP.js
@@ -248,6 +248,7 @@ SDP.prototype.toJingle = function (elem, thecreator) {
                     elem.up();
                     var msid = null;
                     if(mline.media == "audio") {
+                        // FIXME what is this ? global APP.RTC in SDP ?
                         msid = APP.RTC.localAudio._getId();
                     } else {
                         msid = APP.RTC.localVideo._getId();

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -32,6 +32,12 @@ module.exports = function(XMPP, eventEmitter) {
                 this.connection.disco.addFeature('urn:xmpp:jingle:apps:rtp:audio');
                 this.connection.disco.addFeature('urn:xmpp:jingle:apps:rtp:video');
 
+                // Lipsync
+                if (RTCBrowserType.isChrome()) {
+                    this.connection.disco.addFeature(
+                        'http://jitsi.org/meet/lipsync');
+                }
+
                 if (RTCBrowserType.isChrome() || RTCBrowserType.isOpera()
                     || RTCBrowserType.isTemasysPluginUsed()) {
                     this.connection.disco.addFeature('urn:ietf:rfc:4588');

--- a/service/RTC/MediaStreamTypes.js
+++ b/service/RTC/MediaStreamTypes.js
@@ -1,6 +1,0 @@
-var MediaStreamType = {
-    VIDEO_TYPE: "Video",
-
-    AUDIO_TYPE: "Audio"
-};
-module.exports = MediaStreamType;

--- a/service/RTC/MediaType.js
+++ b/service/RTC/MediaType.js
@@ -1,0 +1,15 @@
+/**
+ * Enumeration of RTC media stream types
+ * @type {{AUDIO: string, VIDEO: string}}
+ */
+var MediaType = {
+    /**
+     * The audio type.
+     */
+    AUDIO: "audio",
+    /**
+     * The video type.
+     */
+    VIDEO: "video"
+};
+module.exports = MediaType;

--- a/service/RTC/VideoType.js
+++ b/service/RTC/VideoType.js
@@ -1,0 +1,16 @@
+/* global module */
+/**
+ * Enumeration of the video types
+ * @type {{CAMERA: string, DESKTOP: string}}
+ */
+var VideoType = {
+    /**
+     * The camera video type.
+     */
+    CAMERA: "camera",
+    /**
+     * The desktop video type.
+     */
+    DESKTOP: "desktop"
+};
+module.exports = VideoType;

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -99,11 +99,11 @@ var XMPPEvents = {
     // Designates an event indicating that we received statistics from a
     // participant in the MUC.
     REMOTE_STATS: "xmpp.remote_stats",
-    REMOTE_STREAM_RECEIVED: "xmpp.remote_stream_received",
+    REMOTE_TRACK_ADDED: "xmpp.remote_track_added",
     /**
-     * Indicates that remote stream has been removed from the conference.
+     * Indicates that the remote track has been removed from the conference.
      */
-    REMOTE_STREAM_REMOVED: "xmpp.remote_stream_removed",
+    REMOTE_TRACK_REMOVED: "xmpp.remote_track_removed",
     RESERVATION_ERROR: "xmpp.room_reservation_error",
     ROOM_CONNECT_ERROR: 'xmpp.room_connect_error',
     ROOM_JOIN_ERROR: 'xmpp.room_join_error',

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -99,9 +99,23 @@ var XMPPEvents = {
     // Designates an event indicating that we received statistics from a
     // participant in the MUC.
     REMOTE_STATS: "xmpp.remote_stats",
+    /**
+     * Event fired when we remote track is added to the conference.
+     * The following structure is passed as an argument:
+     * {
+     *   stream: the WebRTC MediaStream instance 
+     *   track: the WebRTC MediaStreamTrack
+     *   mediaType: the MediaType instance
+     *   owner: the MUC JID of the stream owner
+     *   muted: a boolean indicating initial 'muted' status of the track or
+      *         'null' if unknown
+     **/
     REMOTE_TRACK_ADDED: "xmpp.remote_track_added",
     /**
      * Indicates that the remote track has been removed from the conference.
+     * 1st event argument is the ID of the parent WebRTC stream to which 
+     * the track being removed belongs to.
+     * 2nd event argument is the ID of the removed track.
      */
     REMOTE_TRACK_REMOVED: "xmpp.remote_track_removed",
     RESERVATION_ERROR: "xmpp.room_reservation_error",


### PR DESCRIPTION
Required to enable lipsync hack in Jicofo from [PR 77]. The goal of the changes here is to handle WebRTC media on MediaStreamTrack level instead of MediaStream. We were kind of doing that anyway because we were creating separate streams for audio and video. Now with lipsync we need to handle multiple tracks in one media stream which requires "track added"/"track removed" events handling. We found these events working as expected with Chrome only, so the lipsync is enabled only for Chrome clients. Other clients will still receive each audio and video tracks in separate streams.

[PR 77]: https://github.com/jitsi/jicofo/pull/77