### PR TITLE
Define the main/primary entry point of the library

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,6 @@
   "pre-commit": [
     "lint"
   ],
+  "main": "./JitsiMeetJS.js",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
Enables the library to be used via require. Example usage is a React
Native (mobile) app which bundles its dependencies (in its release
build).