### PR TITLE
Don't rely on JitsiMeetJS being global

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -48,6 +48,7 @@ function JitsiConference(options) {
         disableThirdPartyRequests: this.options.config.disableThirdPartyRequests
     });
     setupListeners(this);
+    var JitsiMeetJS = this.connection.JitsiMeetJS;
     JitsiMeetJS._gumFailedHandler.push(function(error) {
         this.statistics.sendGetUserMediaFailed(error);
     }.bind(this));

--- a/JitsiConnection.js
+++ b/JitsiConnection.js
@@ -4,12 +4,20 @@ var XMPP = require("./modules/xmpp/xmpp");
 /**
  * Creates new connection object for the Jitsi Meet server side video conferencing service. Provides access to the
  * JitsiConference interface.
+ * @param JitsiMeetJS the JitsiMeetJS instance which is initializing the new
+ * JitsiConnection instance
  * @param appID identification for the provider of Jitsi Meet video conferencing services.
  * @param token the JWT token used to authenticate with the server(optional)
  * @param options Object with properties / settings related to connection with the server.
  * @constructor
  */
-function JitsiConnection(appID, token, options) {
+function JitsiConnection(JitsiMeetJS, appID, token, options) {
+    /**
+     * The {JitsiMeetJS} instance which has initialized this {JitsiConnection}
+     * instance.
+     * @public
+     */
+    this.JitsiMeetJS = JitsiMeetJS;
     this.appID = appID;
     this.token = token;
     this.options = options;
@@ -70,9 +78,10 @@ JitsiConnection.prototype.setToken = function (token) {
  * @returns {JitsiConference} returns the new conference object.
  */
 JitsiConnection.prototype.initJitsiConference = function (name, options) {
-    this.conferences[name] = new JitsiConference({name: name, config: options,
-        connection: this});
-    return this.conferences[name];
+    var conference
+        = new JitsiConference({name: name, config: options, connection: this});
+    this.conferences[name] = conference;
+    return conference;
 }
 
 /**

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -37,7 +37,6 @@ var LibJitsiMeet = {
 
     version: '{#COMMIT_HASH#}',
 
-    JitsiConnection: JitsiConnection,
     events: {
         conference: JitsiConferenceEvents,
         connection: JitsiConnectionEvents,
@@ -61,10 +60,10 @@ var LibJitsiMeet = {
             var oldOnErrorHandler = window.onerror;
             window.onerror = function (message, source, lineno, colno, error) {
 
-                JitsiMeetJS.getGlobalOnErrorHandler(
+                this.getGlobalOnErrorHandler(
                     message, source, lineno, colno, error);
 
-                if(oldOnErrorHandler)
+                if (oldOnErrorHandler)
                     oldOnErrorHandler(message, source, lineno, colno, error);
             }
         }
@@ -168,11 +167,12 @@ var LibJitsiMeet = {
             'Line: ' + lineno,
             'Column: ' + colno,
             'StackTrace: ', error);
-
-        JitsiMeetJS._globalOnErrorHandler.forEach(function (handler) {
-            handler(error);
-        });
-        if(!JitsiMeetJS._globalOnErrorHandler.length){
+        var globalOnErrorHandler = this._globalOnErrorHandler;
+        if (globalOnErrorHandler.length) {
+          globalOnErrorHandler.forEach(function (handler) {
+              handler(error);
+          });
+        } else {
             Statistics.sendUnhandledError(error);
         }
     },
@@ -186,6 +186,15 @@ var LibJitsiMeet = {
         RTCUIHelper: RTCUIHelper
     }
 };
+
+// XXX JitsiConnection or the instances it initializes and is associated with
+// (e.g. JitsiConference) may need a reference to LibJitsiMeet (aka
+// JitsiMeetJS). An approach could be to declare LibJitsiMeet global (which is
+// what we do in Jitsi Meet) but that could be seen as not such a cool decision
+// certainly looks even worse within the lib-jitsi-meet library itself. That's
+// why the decision is to provide LibJitsiMeet as a parameter of
+// JitsiConnection.
+LibJitsiMeet.JitsiConnection = JitsiConnection.bind(null, LibJitsiMeet);
 
 //Setups the promise object.
 window.Promise = window.Promise || require("es6-promise").Promise;


### PR DESCRIPTION
While we have JitsiMeetJS defined as a global variable in Jitsi Meet, it
doesn't sound like an absolutely necessary and beautiful requirement
inside the library itself.