### PR TITLE
Added ability to change output audio device for browsers that support it

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -147,6 +147,31 @@ var LibJitsiMeet = {
     isDeviceChangeAvailable: function () {
         return RTC.isDeviceChangeAvailable();
     },
+    /**
+     * Returns true if changing the audio output of media elements is supported
+     * and false if not.
+     */
+    isAudioOutputDeviceChangeAvailable: function () {
+        return RTC.isAudioOutputDeviceChangeAvailable();
+    },
+    /**
+     * Returns currently used audio output device id, '' stands for default
+     * device
+     * @returns {string}
+     */
+    getAudioOutputDevice: function () {
+        return RTC.getAudioOutputDevice();
+    },
+    /**
+     * Sets current audio output device.
+     * @param {string} deviceId - id of 'audiooutput' device from
+     *      navigator.mediaDevices.enumerateDevices()
+     * @returns {Promise} - resolves when audio output is changed, is rejected
+     *      otherwise
+     */
+    setAudioOutputDevice: function (deviceId) {
+        return RTC.setAudioOutputDevice(deviceId);
+    },
     enumerateDevices: function (callback) {
         RTC.enumerateDevices(callback);
     },

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -140,19 +140,14 @@ var LibJitsiMeet = {
         return RTC.isDeviceListAvailable();
     },
     /**
-     * Returns true if changing the camera / microphone device is supported and
-     * false if not.
+     * Returns true if changing the input (camera / microphone) or output
+     * (audio) device is supported and false if not.
+     * @params {string} [deviceType] - type of device to change. Default is
+     *      undefined or 'input', 'output' - for audio output device change.
      * @returns {boolean} true if available, false otherwise.
      */
-    isDeviceChangeAvailable: function () {
-        return RTC.isDeviceChangeAvailable();
-    },
-    /**
-     * Returns true if changing the audio output of media elements is supported
-     * and false if not.
-     */
-    isAudioOutputDeviceChangeAvailable: function () {
-        return RTC.isAudioOutputDeviceChangeAvailable();
+    isDeviceChangeAvailable: function (deviceType) {
+        return RTC.isDeviceChangeAvailable(deviceType);
     },
     /**
      * Returns currently used audio output device id, '' stands for default
@@ -165,7 +160,7 @@ var LibJitsiMeet = {
     /**
      * Sets current audio output device.
      * @param {string} deviceId - id of 'audiooutput' device from
-     *      navigator.mediaDevices.enumerateDevices()
+     *      navigator.mediaDevices.enumerateDevices(), '' is for default device
      * @returns {Promise} - resolves when audio output is changed, is rejected
      *      otherwise
      */

--- a/JitsiTrackEvents.js
+++ b/JitsiTrackEvents.js
@@ -14,7 +14,11 @@ var JitsiTrackEvents = {
     /**
      * The video type("camera" or "desktop") of the track was changed.
      */
-     TRACK_VIDEOTYPE_CHANGED: "track.videoTypeChanged"
+    TRACK_VIDEOTYPE_CHANGED: "track.videoTypeChanged",
+    /**
+     * The audio output of the track was changed.
+     */
+    TRACK_AUDIO_OUTPUT_CHANGED: "track.audioOutputChanged"
 };
 
 module.exports = JitsiTrackEvents;

--- a/doc/API.md
+++ b/doc/API.md
@@ -70,10 +70,14 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
     - kind - "audioinput" or "videoinput"
     - deviceId - the id of the device.
 
-* ```JitsiMeetJS.isDeviceListAvailable()```- returns true if retrieving the device list is support and false - otherwise.
-
+* ```JitsiMeetJS.isDeviceListAvailable()``` - returns true if retrieving the device list is support and false - otherwise.
+* ```JitsiMeetJS.isDeviceChangeAvailable(deviceType)``` - returns true if changing the input (camera / microphone) or output (audio) device is supported and false if not. ```deviceType``` is a type of device to change. Undefined or 'input' stands for input devices, 'output' - for audio output devices.
+* ```JitsiMeetJS.setAudioOutputDevice(deviceId)``` - sets current audio output device. ```deviceId``` - id of 'audiooutput' device from ```JitsiMeetJS.enumerateDevices()```, '' is for default device.
+* ```JitsiMeetJS.getAudioOutputDevice()``` - returns currently used audio output device id, '' stands for default device.
 * ```JitsiMeetJS.isDesktopSharingEnabled()``` - returns true if desktop sharing is supported and false otherwise. NOTE: that method can be used after ```JitsiMeetJS.init(options)``` is completed otherwise the result will be always null.
 * ```JitsiMeetJS.getGlobalOnErrorHandler()``` - returns function that can be used to be attached to window.onerror and if options.enableWindowOnErrorHandler is enabled returns the function used by the lib. (function(message, source, lineno, colno, error)).
+
+
 
 * ```JitsiMeetJS.events``` - JS object that contains all events used by the API. You will need that JS object when you try to subscribe for connection or conference events.
     We have two event types - connection and conference. You can access the events with the following code ```JitsiMeetJS.events.<event_type>.<event_name>```.
@@ -114,6 +118,8 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
     3. tracks
         - LOCAL_TRACK_STOPPED - indicates that a local track was stopped. This
         event can be fired when ```dispose()``` method is called or for other reasons.
+        - TRACK_AUDIO_OUTPUT_CHANGED - indicates that audio output device for track was changed (parameters - deviceId (string) - new audio output device ID).
+        
 
 * ```JitsiMeetJS.errors``` - JS object that contains all errors used by the API. You can use that object to check the reported errors from the API
     We have two error types - connection and conference. You can access the events with the following code ```JitsiMeetJS.errors.<error_type>.<error_name>```.

--- a/doc/API.md
+++ b/doc/API.md
@@ -343,6 +343,8 @@ We have the following methods for controling the tracks:
 9. getParticipantId() - returns id(string) of the track owner
 
    Note: This method is implemented only for the remote tracks.
+   
+10. setAudioOutput(audioOutputDeviceId) - sets new audio output device for track's DOM elements. Video tracks are ignored.
 
 
 Getting Started

--- a/doc/example/example.js
+++ b/doc/example/example.js
@@ -241,7 +241,7 @@ JitsiMeetJS.init(initOptions).then(function(){
 });
 
 
-if (JitsiMeetJS.isAudioOutputDeviceChangeAvailable()) {
+if (JitsiMeetJS.isDeviceChangeAvailable('output')) {
     JitsiMeetJS.enumerateDevices(function(devices) {
         var audioOutputDevices = devices.filter(function(d) { return d.kind === 'audiooutput'; });
 

--- a/doc/example/example.js
+++ b/doc/example/example.js
@@ -36,6 +36,10 @@ function onLocalTracks(tracks)
             function () {
                 console.log("local track stoped");
             });
+        localTracks[i].addEventListener(JitsiMeetJS.events.track.TRACK_AUDIO_OUTPUT_CHANGED,
+            function (deviceId) {
+                console.log("track audio output device was changed to " + deviceId);
+            });
         if(localTracks[i].getType() == "video") {
             $("body").append("<video autoplay='1' id='localVideo" + i + "' />");
             localTracks[i].attach($("#localVideo" + i)[0]);
@@ -70,6 +74,10 @@ function onRemoteTrack(track) {
     track.addEventListener(JitsiMeetJS.events.track.LOCAL_TRACK_STOPPED,
         function () {
             console.log("remote track stoped");
+        });
+    track.addEventListener(JitsiMeetJS.events.track.TRACK_AUDIO_OUTPUT_CHANGED,
+        function (deviceId) {
+            console.log("track audio output device was changed to " + deviceId);
         });
     var id = participant + track.getType() + idx;
     if(track.getType() == "video") {
@@ -180,6 +188,10 @@ function switchVideo() {
         });
 }
 
+function changeAudioOutput(selected) {
+    JitsiMeetJS.setAudioOutputDevice(selected.value);
+}
+
 $(window).bind('beforeunload', unload);
 $(window).bind('unload', unload);
 
@@ -227,6 +239,23 @@ JitsiMeetJS.init(initOptions).then(function(){
 }).catch(function (error) {
     console.log(error);
 });
+
+
+if (JitsiMeetJS.isAudioOutputDeviceChangeAvailable()) {
+    JitsiMeetJS.enumerateDevices(function(devices) {
+        var audioOutputDevices = devices.filter(function(d) { return d.kind === 'audiooutput'; });
+
+        if (audioOutputDevices.length > 1) {
+            $('#audioOutputSelect').html(
+                audioOutputDevices.map(function (d) {
+                    return '<option value="' + d.deviceId + '">' + d.label + '</option>';
+                }).join('\n')
+            );
+
+            $('#audioOutputSelectWrapper').show();
+        }
+    })
+}
 
 var connection = null;
 var room = null;

--- a/doc/example/index.html
+++ b/doc/example/index.html
@@ -13,6 +13,10 @@
 <body>
     <a href="#" onclick="unload()">Unload</a>
     <a href="#" onclick="switchVideo()">switchVideo</a>
+    <div id="audioOutputSelectWrapper" style="display: none;">
+        Change audio output device
+        <select id="audioOutputSelect" onchange="changeAudioOutput(this)"></select>
+    </div>
     <!-- <video id="localVideo" autoplay="true"></video> -->
     <!--<audio id="localAudio" autoplay="true" muted="true"></audio>-->
 </body>

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -190,6 +190,36 @@ JitsiTrack.prototype.attach = function (container) {
     return container;
 };
 
+JitsiTrack.prototype.changeAudioOutput = function (audioOutputDeviceId) {
+    return Promise.all(this.containers.map(function(element) {
+        if (typeof element.setSinkId !== 'undefined') {
+            try {
+                return element.setSinkId(audioOutputDeviceId)
+                    .then(function () {
+                        console.log('Audio output device changed on element ' + element);
+                    })
+                    .catch(function (error) {
+                        var errorMessage = error;
+
+                        if (error.name === 'SecurityError') {
+                            errorMessage = 'You need to use HTTPS for selecting audio output device: ' + error;
+                        }
+
+                        console.error('Failed to change audio output device on element ' + element + ': ' + errorMessage);
+
+                        return Promise.resolve();
+                    });
+            } catch(ex) {
+                console.error(ex);
+                return Promise.resolve();
+            }
+        } else {
+            console.warn('Browser does not support output device selection.');
+            return Promise.resolve();
+        }
+    }));
+};
+
 /**
  * Removes the track from the passed HTML container.
  * @param container the HTML container. If <tt>null</tt> all containers are removed.

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -307,19 +307,14 @@ RTC.isDeviceListAvailable = function () {
 };
 
 /**
- * Returns true if changing the camera / microphone device is supported and
- * false if not.
+ * Returns true if changing the input (camera / microphone) or output
+ * (audio) device is supported and false if not.
+ * @params {string} [deviceType] - type of device to change. Default is
+ *      undefined or 'input', 'output' - for audio output device change.
+ * @returns {boolean} true if available, false otherwise.
  */
-RTC.isDeviceChangeAvailable = function () {
-    return RTCUtils.isDeviceChangeAvailable();
-};
-
-/**
- * Returns true if changing the audio output of media elements is supported
- * and false if not.
- */
-RTC.isAudioOutputDeviceChangeAvailable = function () {
-    return RTCUtils.isAudioOutputDeviceChangeAvailable();
+RTC.isDeviceChangeAvailable = function (deviceType) {
+    return RTCUtils.isDeviceChangeAvailable(deviceType);
 };
 
 /**
@@ -346,11 +341,11 @@ RTC.setAudioOutputDevice = function (deviceId) {
  * Returns <tt>true<tt/> if given WebRTC MediaStream is considered a valid
  * "user" stream which means that it's not a "receive only" stream nor a "mixed"
  * JVB stream.
- * 
+ *
  * Clients that implement Unified Plan, such as Firefox use recvonly
  * "streams/channels/tracks" for receiving remote stream/tracks, as opposed to
  * Plan B where there are only 3 channels: audio, video and data.
- * 
+ *
  * @param stream WebRTC MediaStream instance
  * @returns {boolean}
  */

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -315,6 +315,34 @@ RTC.isDeviceChangeAvailable = function () {
 };
 
 /**
+ * Returns true if changing the audio output of media elements is supported
+ * and false if not.
+ */
+RTC.isAudioOutputDeviceChangeAvailable = function () {
+    return RTCUtils.isAudioOutputDeviceChangeAvailable();
+};
+
+/**
+ * Returns currently used audio output device id, '' stands for default
+ * device
+ * @returns {string}
+ */
+RTC.getAudioOutputDevice = function () {
+    return RTCUtils.getAudioOutputDevice();
+};
+
+/**
+ * Sets current audio output device.
+ * @param {string} deviceId - id of 'audiooutput' device from
+ *      navigator.mediaDevices.enumerateDevices()
+ * @returns {Promise} - resolves when audio output is changed, is rejected
+ *      otherwise
+ */
+RTC.setAudioOutputDevice = function (deviceId) {
+    return RTCUtils.setAudioOutputDevice(deviceId);
+};
+
+/**
  * Returns <tt>true<tt/> if given WebRTC MediaStream is considered a valid
  * "user" stream which means that it's not a "receive only" stream nor a "mixed"
  * JVB stream.

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -330,7 +330,9 @@ function enumerateDevicesThroughMediaStreamTrack (callback) {
             return {
                 facing: source.facing || null,
                 label: source.label,
-                kind: kind ? kind + 'input': null,
+                // theoretically deprecated MediaStreamTrack.getSources should not return 'audiooutput' devices but
+                // let's handle it in any case
+                kind: kind ? (kind === 'audiooutput' ? kind : kind + 'input') : null,
                 deviceId: source.id,
                 groupId: source.groupId || null
             };

--- a/service/RTC/RTCEvents.js
+++ b/service/RTC/RTCEvents.js
@@ -6,7 +6,8 @@ var RTCEvents = {
     LASTN_ENDPOINT_CHANGED: "rtc.lastn_endpoint_changed",
     AVAILABLE_DEVICES_CHANGED: "rtc.available_devices_changed",
     FAKE_VIDEO_TRACK_CREATED: "rtc.fake_video_track_created",
-    TRACK_ATTACHED: "rtc.track_attached"
+    TRACK_ATTACHED: "rtc.track_attached",
+    AUDIO_OUTPUT_DEVICE_CHANGED: "rtc.audio_output_device_changed"
 };
 
 module.exports = RTCEvents;


### PR DESCRIPTION
1. Added new methods to JitsiMeetJS (and RTC and RTCUtils respectively)
 - isAudioOutputDeviceChangeAvailable
 - getAudioOutputDevice
 - setAudioOutputDevice

2. Added new events:
 - JitsiTrackEvents.TRACK_AUDIO_OUTPUT_CHANGED
 - RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED

3. Update sample from docs to give ability to select output devices
