### PR TITLE
Fixes issue with callstats confID

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -45,7 +45,9 @@ function JitsiConference(options) {
     this.statistics = new Statistics(this.xmpp, {
         callStatsID: this.options.config.callStatsID,
         callStatsSecret: this.options.config.callStatsSecret,
-        disableThirdPartyRequests: this.options.config.disableThirdPartyRequests
+        disableThirdPartyRequests:
+            this.options.config.disableThirdPartyRequests,
+        roomName: this.options.name
     });
     setupListeners(this);
     var JitsiMeetJS = this.connection.JitsiMeetJS;
@@ -315,7 +317,7 @@ JitsiConference.prototype.addTrack = function (track) {
     {
         throw new Error(JitsiTrackErrors.TRACK_IS_DISPOSED);
     }
-    
+
     if (track.isVideoTrack() && this.rtc.getLocalVideoTrack()) {
         throw new Error("cannot add second video track to the conference");
     }

--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -106,9 +106,9 @@ var CallStats = _try_catch(function(jingleSession, Settings, options) {
 
         this.userID = Settings.getCallStatsUserName();
 
-    //FIXME:  change it to something else (maybe roomName)
         var location = window.location;
-        this.confID = location.hostname + location.pathname;
+        // The confID is case sensitive!!!
+        this.confID = location.hostname + "/" + options.roomName;
 
         //userID is generated or given by the origin server
         callStats.initialize(options.callStatsID,


### PR DESCRIPTION
Changes the implementation to use  the roomName for generating the confID. This change will solve the issue with creating entries for 2 different calls in callstats for the same urls written with lower and upper case. For the roomName we are not accepting capital letters.