### PR TITLE
Added ability to notify about available media device list changes

### DIFF
--- a/JitsiMediaDevices.js
+++ b/JitsiMediaDevices.js
@@ -1,0 +1,74 @@
+var EventEmitter = require("events");
+var RTCEvents = require('./service/RTC/RTCEvents');
+var RTC = require("./modules/RTC/RTC");
+var JitsiMediaDevicesEvents = require('./JitsiMediaDevicesEvents');
+
+var eventEmitter = new EventEmitter();
+
+RTC.addListener(RTCEvents.DEVICE_LIST_CHANGED,
+    function (devices) {
+        eventEmitter.emit(JitsiMediaDevicesEvents.DEVICE_LIST_CHANGED, devices);
+    });
+
+var JitsiMediaDevices = {
+    /**
+     * Executes callback with list of media devices connected.
+     * @param {function} callback
+     */
+    enumerateDevices: function (callback) {
+        RTC.enumerateDevices(callback);
+    },
+    /**
+     * Checks if its possible to enumerate available cameras/micropones.
+     * @returns {boolean} true if available, false otherwise.
+     */
+    isDeviceListAvailable: function () {
+        return RTC.isDeviceListAvailable();
+    },
+    /**
+     * Returns true if changing the input (camera / microphone) or output
+     * (audio) device is supported and false if not.
+     * @params {string} [deviceType] - type of device to change. Default is
+     *      undefined or 'input', 'output' - for audio output device change.
+     * @returns {boolean} true if available, false otherwise.
+     */
+    isDeviceChangeAvailable: function (deviceType) {
+        return RTC.isDeviceChangeAvailable(deviceType);
+    },
+    /**
+     * Returns currently used audio output device id, '' stands for default
+     * device
+     * @returns {string}
+     */
+    getAudioOutputDevice: function () {
+        return RTC.getAudioOutputDevice();
+    },
+    /**
+     * Sets current audio output device.
+     * @param {string} deviceId - id of 'audiooutput' device from
+     *      navigator.mediaDevices.enumerateDevices(), '' is for default device
+     * @returns {Promise} - resolves when audio output is changed, is rejected
+     *      otherwise
+     */
+    setAudioOutputDevice: function (deviceId) {
+        return RTC.setAudioOutputDevice(deviceId);
+    },
+    /**
+     * Adds an event handler.
+     * @param {string} event - event name
+     * @param {function} handler - event handler
+     */
+    addEventListener: function (event, handler) {
+        eventEmitter.addListener(event, handler);
+    },
+    /**
+     * Removes event handler.
+     * @param {string} event - event name
+     * @param {function} handler - event handler
+     */
+    removeEventListener: function (event, handler) {
+        eventEmitter.removeListener(event, handler);
+    }
+};
+
+module.exports = JitsiMediaDevices;

--- a/JitsiMediaDevicesEvents.js
+++ b/JitsiMediaDevicesEvents.js
@@ -1,0 +1,17 @@
+/**
+ * Enumeration with the events for the media devices.
+ * @type {{string: string}}
+ */
+var JitsiMediaDevicesEvents = {
+    /**
+     * Indicates that the list of available media devices has been changed. The
+     * event provides the following parameters to its listeners:
+     *
+     * @param {MediaDeviceInfo[]} devices - array of MediaDeviceInfo or
+     *  MediaDeviceInfo-like objects that are currently connected.
+     *  @see https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo
+     */
+    DEVICE_LIST_CHANGED: "mediaDevices.devicechange"
+};
+
+module.exports = JitsiMediaDevicesEvents;

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -1,7 +1,9 @@
 var logger = require("jitsi-meet-logger").getLogger(__filename);
 var JitsiConnection = require("./JitsiConnection");
+var JitsiMediaDevices = require("./JitsiMediaDevices");
 var JitsiConferenceEvents = require("./JitsiConferenceEvents");
 var JitsiConnectionEvents = require("./JitsiConnectionEvents");
+var JitsiMediaDevicesEvents = require('./JitsiMediaDevicesEvents');
 var JitsiConnectionErrors = require("./JitsiConnectionErrors");
 var JitsiConferenceErrors = require("./JitsiConferenceErrors");
 var JitsiTrackEvents = require("./JitsiTrackEvents");
@@ -40,7 +42,8 @@ var LibJitsiMeet = {
     events: {
         conference: JitsiConferenceEvents,
         connection: JitsiConnectionEvents,
-        track: JitsiTrackEvents
+        track: JitsiTrackEvents,
+        mediaDevices: JitsiMediaDevicesEvents
     },
     errors: {
         conference: JitsiConferenceErrors,
@@ -48,6 +51,7 @@ var LibJitsiMeet = {
         track: JitsiTrackErrors
     },
     logLevels: Logger.levels,
+    mediaDevices: JitsiMediaDevices,
     /**
      * Array of functions that will receive the GUM error.
      */
@@ -146,9 +150,12 @@ var LibJitsiMeet = {
     /**
      * Checks if its possible to enumerate available cameras/micropones.
      * @returns {boolean} true if available, false otherwise.
+     * @deprecated use JitsiMeetJS.mediaDevices.isDeviceListAvailable instead
      */
     isDeviceListAvailable: function () {
-        return RTC.isDeviceListAvailable();
+        logger.warn('This method is deprecated, use ' +
+            'JitsiMeetJS.mediaDevices.isDeviceListAvailable instead');
+        return this.mediaDevices.isDeviceListAvailable();
     },
     /**
      * Returns true if changing the input (camera / microphone) or output
@@ -156,30 +163,22 @@ var LibJitsiMeet = {
      * @params {string} [deviceType] - type of device to change. Default is
      *      undefined or 'input', 'output' - for audio output device change.
      * @returns {boolean} true if available, false otherwise.
+     * @deprecated use JitsiMeetJS.mediaDevices.isDeviceChangeAvailable instead
      */
     isDeviceChangeAvailable: function (deviceType) {
-        return RTC.isDeviceChangeAvailable(deviceType);
+        logger.warn('This method is deprecated, use ' +
+            'JitsiMeetJS.mediaDevices.isDeviceChangeAvailable instead');
+        return this.mediaDevices.isDeviceChangeAvailable(deviceType);
     },
     /**
-     * Returns currently used audio output device id, '' stands for default
-     * device
-     * @returns {string}
+     * Executes callback with list of media devices connected.
+     * @param {function} callback
+     * @deprecated use JitsiMeetJS.mediaDevices.enumerateDevices instead
      */
-    getAudioOutputDevice: function () {
-        return RTC.getAudioOutputDevice();
-    },
-    /**
-     * Sets current audio output device.
-     * @param {string} deviceId - id of 'audiooutput' device from
-     *      navigator.mediaDevices.enumerateDevices(), '' is for default device
-     * @returns {Promise} - resolves when audio output is changed, is rejected
-     *      otherwise
-     */
-    setAudioOutputDevice: function (deviceId) {
-        return RTC.setAudioOutputDevice(deviceId);
-    },
     enumerateDevices: function (callback) {
-        RTC.enumerateDevices(callback);
+        logger.warn('This method is deprecated, use ' +
+            'JitsiMeetJS.mediaDevices.enumerateDevices instead');
+        this.mediaDevices.enumerateDevices(callback);
     },
     /**
      * Array of functions that will receive the unhandled errors.

--- a/doc/API.md
+++ b/doc/API.md
@@ -65,18 +65,24 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
         5. minFps - the minimum frame rate for the video stream (passed to GUM)
         6. maxFps - the maximum frame rate for the video stream (passed to GUM)
 
-* ```JitsiMeetJS.enumerateDevices(callback)``` - returns list of the available devices as a parameter to the callback function. Every device is a object with the following format:
-    - label - the name of the device
-    - kind - "audioinput" or "videoinput"
-    - deviceId - the id of the device.
-
-* ```JitsiMeetJS.isDeviceListAvailable()``` - returns true if retrieving the device list is support and false - otherwise.
-* ```JitsiMeetJS.isDeviceChangeAvailable(deviceType)``` - returns true if changing the input (camera / microphone) or output (audio) device is supported and false if not. ```deviceType``` is a type of device to change. Undefined or 'input' stands for input devices, 'output' - for audio output devices.
-* ```JitsiMeetJS.setAudioOutputDevice(deviceId)``` - sets current audio output device. ```deviceId``` - id of 'audiooutput' device from ```JitsiMeetJS.enumerateDevices()```, '' is for default device.
-* ```JitsiMeetJS.getAudioOutputDevice()``` - returns currently used audio output device id, '' stands for default device.
+* ```JitsiMeetJS.enumerateDevices(callback)``` - __DEPRECATED__. Use ```JitsiMeetJS.mediaDevices.enumerateDevices(callback)``` instead.
+* ```JitsiMeetJS.isDeviceListAvailable()``` - __DEPRECATED__. Use ```JitsiMeetJS.mediaDevices.isDeviceListAvailable()``` instead.
+* ```JitsiMeetJS.isDeviceChangeAvailable(deviceType)``` - __DEPRECATED__. Use ```JitsiMeetJS.mediaDevices.isDeviceChangeAvailable(deviceType)``` instead.
 * ```JitsiMeetJS.isDesktopSharingEnabled()``` - returns true if desktop sharing is supported and false otherwise. NOTE: that method can be used after ```JitsiMeetJS.init(options)``` is completed otherwise the result will be always null.
 * ```JitsiMeetJS.getGlobalOnErrorHandler()``` - returns function that can be used to be attached to window.onerror and if options.enableWindowOnErrorHandler is enabled returns the function used by the lib. (function(message, source, lineno, colno, error)).
 
+* ```JitsiMeetJS.mediaDevices``` - JS object that contains methods for interaction with media devices. Following methods are available:
+    - ```isDeviceListAvailable()``` - returns true if retrieving the device list is supported and false - otherwise
+    - ```isDeviceChangeAvailable(deviceType)``` - returns true if changing the input (camera / microphone) or output (audio) device is supported and false if not. ```deviceType``` is a type of device to change. Undefined or 'input' stands for input devices, 'output' - for audio output devices.
+    - ```enumerateDevices(callback)``` - returns list of the available devices as a parameter to the callback function. Every device is a MediaDeviceInfo object with the following properties:
+        - label - the name of the device
+        - kind - "audioinput", "videoinput" or "audiooutput"
+        - deviceId - the id of the device
+        - groupId - group identifier, two devices have the same group identifier if they belong to the same physical device; for example a monitor with both a built-in camera and microphone
+    - ```setAudioOutputDevice(deviceId)``` - sets current audio output device. ```deviceId``` - id of 'audiooutput' device from ```JitsiMeetJS.enumerateDevices()```, '' is for default device.
+    - ```getAudioOutputDevice()``` - returns currently used audio output device id, '' stands for default device.
+    - ```addEventListener(event, handler)``` - attaches an event handler.
+    - ```removeEventListener(event, handler)``` - removes an event handler.
 
 
 * ```JitsiMeetJS.events``` - JS object that contains all events used by the API. You will need that JS object when you try to subscribe for connection or conference events.
@@ -119,6 +125,9 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
         - LOCAL_TRACK_STOPPED - indicates that a local track was stopped. This
         event can be fired when ```dispose()``` method is called or for other reasons.
         - TRACK_AUDIO_OUTPUT_CHANGED - indicates that audio output device for track was changed (parameters - deviceId (string) - new audio output device ID).
+        
+    4. mediaDevices
+        - DEVICE_LIST_CHANGED - indicates that list of currently connected devices has changed (parameters - devices(MediaDeviceInfo[])).
         
 
 * ```JitsiMeetJS.errors``` - JS object that contains all errors used by the API. You can use that object to check the reported errors from the API

--- a/doc/example/example.js
+++ b/doc/example/example.js
@@ -148,6 +148,13 @@ function onConnectionSuccess(){
 function onConnectionFailed(){console.error("Connection Failed!")};
 
 /**
+ * This function is called when the connection fail.
+ */
+function onDeviceListChanged(devices) {
+    console.info('current devices', devices);
+}
+
+/**
  * This function is called when we disconnect.
  */
 function disconnect(){
@@ -189,7 +196,7 @@ function switchVideo() {
 }
 
 function changeAudioOutput(selected) {
-    JitsiMeetJS.setAudioOutputDevice(selected.value);
+    JitsiMeetJS.mediaDevices.setAudioOutputDevice(selected.value);
 }
 
 $(window).bind('beforeunload', unload);
@@ -231,6 +238,8 @@ JitsiMeetJS.init(initOptions).then(function(){
     connection.addEventListener(JitsiMeetJS.events.connection.CONNECTION_FAILED, onConnectionFailed);
     connection.addEventListener(JitsiMeetJS.events.connection.CONNECTION_DISCONNECTED, disconnect);
 
+    JitsiMeetJS.mediaDevices.addEventListener(JitsiMeetJS.events.mediaDevices.DEVICE_LIST_CHANGED, onDeviceListChanged);
+
     connection.connect();
     JitsiMeetJS.createLocalTracks({devices: ["audio", "video"]}).
         then(onLocalTracks).catch(function (error) {
@@ -241,8 +250,8 @@ JitsiMeetJS.init(initOptions).then(function(){
 });
 
 
-if (JitsiMeetJS.isDeviceChangeAvailable('output')) {
-    JitsiMeetJS.enumerateDevices(function(devices) {
+if (JitsiMeetJS.mediaDevices.isDeviceChangeAvailable('output')) {
+    JitsiMeetJS.mediaDevices.enumerateDevices(function(devices) {
         var audioOutputDevices = devices.filter(function(d) { return d.kind === 'audiooutput'; });
 
         if (audioOutputDevices.length > 1) {

--- a/service/RTC/RTCEvents.js
+++ b/service/RTC/RTCEvents.js
@@ -7,7 +7,8 @@ var RTCEvents = {
     AVAILABLE_DEVICES_CHANGED: "rtc.available_devices_changed",
     FAKE_VIDEO_TRACK_CREATED: "rtc.fake_video_track_created",
     TRACK_ATTACHED: "rtc.track_attached",
-    AUDIO_OUTPUT_DEVICE_CHANGED: "rtc.audio_output_device_changed"
+    AUDIO_OUTPUT_DEVICE_CHANGED: "rtc.audio_output_device_changed",
+    DEVICE_LIST_CHANGED: "rtc.device_list_changed"
 };
 
 module.exports = RTCEvents;


### PR DESCRIPTION
1. Added ability to discover device list changes by polling ```enumerateDevices()``` each 3 seconds.

2. Extracted all methods related to interaction with media devices from JitsiMeetJS into separate object JitsiMeetJS.mediaDevices:
 - enumerateDevices (deprecation note added to ```JitsiMeetJS.enumerateDevices```)
 - isDeviceListAvailable (deprecation note added to ```JitsiMeetJS.isDeviceListAvailable```)
 - isDeviceChangeAvailable (deprecation note added to ```JitsiMeetJS.isDeviceChangeAvailable```)
 - getAudioOutputDevice
 - setAudioOutputDevice

3. Added ability to subscribe/unsubscribe to media devices events via ```JitsiMeetJS.mediaDevices.addEventListener```/```JitsiMeetJS.mediaDevices.removeEventListener```

4. New event group ```JitsiMeetJS.events.mediaDevices```

5. Added new events:
 - JitsiMediaDevicesEvents.DEVICE_LIST_CHANGED
 - RTCEvents.DEVICE_LIST_CHANGED

6. Updated sample from docs and API document