### PR TITLE
Fix JitsiMeetJS option disableAudioLevels

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -57,7 +57,7 @@ var LibJitsiMeet = {
      */
     _gumFailedHandler: [],
     init: function (options) {
-        Statistics.audioLevelsEnabled = !options.disableAudioLevels || true;
+        Statistics.audioLevelsEnabled = !options.disableAudioLevels;
 
         if (options.enableWindowOnErrorHandler) {
             // if an old handler exists also fire its events


### PR DESCRIPTION
JitsiMeetJS#init accepts an options object in which the property
disableAudioLevels may optionally be defined and is meant to disable RTC
statistics related to audio levels. Unfortunately, the option was used
in a boolean expression which ignored the value of the option and thus
effectively rendered it unused.