### PR TITLE
Switch local audio and video tracks when list of available devices changes

### DIFF
--- a/JitsiMediaDevices.js
+++ b/JitsiMediaDevices.js
@@ -1,6 +1,7 @@
 var EventEmitter = require("events");
 var RTCEvents = require('./service/RTC/RTCEvents');
 var RTC = require("./modules/RTC/RTC");
+var MediaType = require('./service/RTC/MediaType');
 var JitsiMediaDevicesEvents = require('./JitsiMediaDevicesEvents');
 
 var eventEmitter = new EventEmitter();
@@ -28,7 +29,7 @@ var JitsiMediaDevices = {
     /**
      * Returns true if changing the input (camera / microphone) or output
      * (audio) device is supported and false if not.
-     * @params {string} [deviceType] - type of device to change. Default is
+     * @param {string} [deviceType] - type of device to change. Default is
      *      undefined or 'input', 'output' - for audio output device change.
      * @returns {boolean} true if available, false otherwise.
      */
@@ -36,8 +37,26 @@ var JitsiMediaDevices = {
         return RTC.isDeviceChangeAvailable(deviceType);
     },
     /**
-     * Returns currently used audio output device id, '' stands for default
-     * device
+     * Returns true if user granted permission to media devices.
+     * @param {'audio'|'video'} [type] - type of devices to check,
+     *      undefined stands for both 'audio' and 'video' together
+     * @returns {boolean}
+     */
+    isDevicePermissionGranted: function (type) {
+        var permissions = RTC.getDeviceAvailability();
+
+        switch(type) {
+            case MediaType.VIDEO:
+                return permissions.video === true;
+            case MediaType.AUDIO:
+                return permissions.audio === true;
+            default:
+                return permissions.video === true && permissions.audio === true;
+        }
+    },
+    /**
+     * Returns currently used audio output device id, 'default' stands
+     * for default device
      * @returns {string}
      */
     getAudioOutputDevice: function () {
@@ -46,7 +65,8 @@ var JitsiMediaDevices = {
     /**
      * Sets current audio output device.
      * @param {string} deviceId - id of 'audiooutput' device from
-     *      navigator.mediaDevices.enumerateDevices(), '' is for default device
+     *      navigator.mediaDevices.enumerateDevices(), 'default' is for
+     *      default device
      * @returns {Promise} - resolves when audio output is changed, is rejected
      *      otherwise
      */

--- a/doc/API.md
+++ b/doc/API.md
@@ -81,6 +81,7 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
         - groupId - group identifier, two devices have the same group identifier if they belong to the same physical device; for example a monitor with both a built-in camera and microphone
     - ```setAudioOutputDevice(deviceId)``` - sets current audio output device. ```deviceId``` - id of 'audiooutput' device from ```JitsiMeetJS.enumerateDevices()```, '' is for default device.
     - ```getAudioOutputDevice()``` - returns currently used audio output device id, '' stands for default device.
+    - ```isDevicePermissionGranted(type)``` - returns true if user granted permission to media devices. ```type``` - 'audio', 'video' or ```undefined```. In case of ```undefined``` will check if both audio and video permissions were granted.
     - ```addEventListener(event, handler)``` - attaches an event handler.
     - ```removeEventListener(event, handler)``` - removes an event handler.
 
@@ -354,6 +355,10 @@ We have the following methods for controling the tracks:
    Note: This method is implemented only for the remote tracks.
    
 10. setAudioOutput(audioOutputDeviceId) - sets new audio output device for track's DOM elements. Video tracks are ignored.
+
+11. getDeviceId() - returns device ID associated with track (for local tracks only)
+
+12. isEnded() - returns true if track is ended
 
 
 Getting Started

--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -14,7 +14,7 @@ var JitsiTrackEvents = require("../../JitsiTrackEvents");
  * @constructor
  */
 function JitsiRemoteTrack(RTC, ownerJid, stream, track, mediaType, videoType,
-                          ssrc, muted) {    
+                          ssrc, muted) {
     JitsiTrack.call(
         this, RTC, stream, track, function () {}, mediaType, videoType, ssrc);
     this.rtc = RTC;
@@ -83,7 +83,5 @@ JitsiRemoteTrack.prototype._setVideoType = function (type) {
     this.videoType = type;
     this.eventEmitter.emit(JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED, type);
 };
-
-delete JitsiRemoteTrack.prototype.dispose;
 
 module.exports = JitsiRemoteTrack;

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -70,6 +70,8 @@ function JitsiTrack(rtc, stream, track, streamInactiveHandler, trackMediaType,
     this.type = trackMediaType;
     this.track = track;
     this.videoType = videoType;
+    this.disposed = false;
+
     if(stream) {
         if (RTCBrowserType.isFirefox()) {
             implementOnEndedHandling(this);
@@ -77,7 +79,12 @@ function JitsiTrack(rtc, stream, track, streamInactiveHandler, trackMediaType,
         addMediaStreamInactiveHandler(stream, streamInactiveHandler);
     }
 
-    RTCUtils.addListener(RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED, this.setAudioOutput.bind(this));
+    this._onAudioOutputDeviceChanged = this.setAudioOutput.bind(this);
+
+    if (this.isAudioTrack()) {
+        RTCUtils.addListener(RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED,
+            this._onAudioOutputDeviceChanged);
+    }
 }
 
 /**
@@ -218,9 +225,12 @@ JitsiTrack.prototype.detach = function (container) {
 
 /**
  * Dispose sending the media track. And removes it from the HTML.
- * NOTE: Works for local tracks only.
  */
 JitsiTrack.prototype.dispose = function () {
+    RTCUtils.removeListener(RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED,
+        this._onAudioOutputDeviceChanged);
+
+    this.disposed = true;
 };
 
 /**

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -277,7 +277,11 @@ RTC.prototype.createRemoteTrack = function (event) {
  * @returns {JitsiRemoteTrack|null}
  */
 RTC.prototype.removeRemoteTracks = function (resource) {
-    if(this.remoteTracks[resource]) {
+    var remoteTracks = this.remoteTracks[resource];
+
+    if(remoteTracks) {
+        remoteTracks['audio'] && remoteTracks['audio'].dispose();
+        remoteTracks['video'] && remoteTracks['video'].dispose();
         delete this.remoteTracks[resource];
     }
 };


### PR DESCRIPTION
1. New methods added
 - JitsiMediaDevices.prototype.isDevicePermissionGranted(type)
 - JitsiLocalTrack.prototype.isEnded()
 - JitsiLocalTrack.prototype.getDeviceId()

2. Fixed potential memory leaks with not clearing event handlers

3. Updated API document