### PR TITLE
Nukes the pre-configured bridge from the example config file.

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -175,7 +175,6 @@ This objects represents the server connection. You can create new ```JitsiConnec
         2. hosts - JS Object
             - domain
             - muc
-            - bridge
             - anonymousdomain
         3. useStunTurn -
 

--- a/doc/example/example.js
+++ b/doc/example/example.js
@@ -2,7 +2,6 @@ var options = {
     hosts: {
         domain: 'jitsi-meet.example.com',
         muc: 'conference.jitsi-meet.example.com', // FIXME: use XEP-0030
-        bridge: 'jitsi-videobridge.jitsi-meet.example.com', // FIXME: use XEP-0030
     },
     bosh: '//jitsi-meet.example.com/http-bind', // FIXME: use xep-0156 for that
     clientNode: 'http://jitsi.org/jitsimeet', // The name of client node advertised in XEP-0115 'c' stanza

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -124,14 +124,6 @@ Moderator.prototype.createConferenceIq =  function () {
     if (sessionId) {
         elem.attrs({ 'session-id': sessionId});
     }
-    if (this.options.connection.hosts !== undefined
-        && this.options.connection.hosts.bridge !== undefined) {
-        elem.c(
-            'property', {
-                name: 'bridge',
-                value: this.options.connection.hosts.bridge
-            }).up();
-    }
     if (this.options.connection.enforcedBridge !== undefined) {
         elem.c(
             'property', {


### PR DESCRIPTION
Jicofo is smart and can find any bridge with service discovery and/or
pubsub.