### PR TITLE
Remove browser type check

### DIFF
--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -4,11 +4,17 @@
  */
 var JitsiConferenceEvents = {
     /**
-     * A new media track was added to the conference.
+     * A new media track was added to the conference. The event provides the
+     * following parameters to its listeners:
+     *
+     * @param {JitsiTrack} track the added JitsiTrack
      */
     TRACK_ADDED: "conference.trackAdded",
     /**
-     * The media track was removed from the conference.
+     * The media track was removed from the conference. The event provides the
+     * following parameters to its listeners:
+     *
+     * @param {JitsiTrack} track the removed JitsiTrack
      */
     TRACK_REMOVED: "conference.trackRemoved",
     /**

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -296,7 +296,8 @@ JitsiLocalTrack.prototype.getSSRC = function () {
 };
 
 /**
- * Return true;
+ * Returns <tt>true</tt>.
+ * @returns {boolean} <tt>true</tt>
  */
 JitsiLocalTrack.prototype.isLocal = function () {
     return true;

--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -30,7 +30,6 @@ JitsiRemoteTrack.prototype.constructor = JitsiRemoteTrack;
  * @param value the muted status.
  */
 JitsiRemoteTrack.prototype.setMute = function (value) {
-
     if(this.muted === value)
         return;
 

--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -67,7 +67,8 @@ JitsiRemoteTrack.prototype.isLocal = function () {
 };
 
 /**
- * Return false;
+ * Returns the synchronization source identifier (SSRC) of this remote track.
+ * @returns {string} the SSRC of this remote track
  */
 JitsiRemoteTrack.prototype.getSSRC = function () {
     return this.ssrc;

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -227,8 +227,7 @@ JitsiTrack.prototype.dispose = function () {
  * Returns true if this is a video track and the source of the video is a
  * screen capture as opposed to a camera.
  */
-JitsiTrack.prototype.isScreenSharing = function(){
-
+JitsiTrack.prototype.isScreenSharing = function() {
 };
 
 /**
@@ -258,7 +257,7 @@ JitsiTrack.prototype.getId = function () {
  * @returns {boolean} whether MediaStream is active.
  */
 JitsiTrack.prototype.isActive = function () {
-    if((typeof this.stream.active !== "undefined"))
+    if(typeof this.stream.active !== "undefined")
         return this.stream.active;
     else
         return true;
@@ -288,7 +287,6 @@ JitsiTrack.prototype.off = function (eventId, handler) {
 // Common aliases for event emitter
 JitsiTrack.prototype.addEventListener = JitsiTrack.prototype.on;
 JitsiTrack.prototype.removeEventListener = JitsiTrack.prototype.off;
-
 
 /**
  * Sets the audio level for the stream

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -642,16 +642,11 @@ var RTCUtils = {
                     return SDPUtil.filter_special_chars(stream.id);
                 };
                 this.getVideoSrc = function (element) {
-                    if (!element)
-                        return null;
-                    return element.getAttribute("src");
+                    return element ? element.getAttribute("src") : null;
                 };
                 this.setVideoSrc = function (element, src) {
-                    if (!src) {
-                        src = '';
-                    }
                     if (element)
-                        element.setAttribute("src", src);
+                        element.setAttribute("src", src || '');
                 };
                 // DTLS should now be enabled by default but..
                 this.pc_constraints = {'optional': [

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -637,7 +637,7 @@ var RTCUtils = {
                     return element;
                 });
                 this.getStreamID = function (stream) {
-                    // streams from FF endpoints have the characters '{' and '}'
+                    // Streams from FF endpoints have the characters '{' and '}'
                     // that make jQuery choke.
                     return SDPUtil.filter_special_chars(stream.id);
                 };

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -704,8 +704,8 @@ ChatRoom.prototype.removeListener = function (type, listener) {
 ChatRoom.prototype.remoteTrackAdded = function(data) {
     // Will figure out current muted status by looking up owner's presence
     var pres = this.lastPresences[data.owner];
-    var mediaType = data.mediaType;
     if(pres) {
+        var mediaType = data.mediaType;
         var mutedNode = null;
         if (mediaType === MediaType.AUDIO) {
             mutedNode = filterNodeFromPresenceJSON(pres, "audiomuted");

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1257,7 +1257,7 @@ JingleSessionPC.prototype.remoteTrackAdded = function (stream, track) {
     }
 
     var remoteSDP = new SDP(this.peerconnection.remoteDescription.sdp);
-    var medialines = remoteSDP.media.filter(function (mediaLines){
+    var medialines = remoteSDP.media.filter(function (mediaLines) {
         return mediaLines.startsWith("m=" + mediaType);
     });
 
@@ -1268,11 +1268,8 @@ JingleSessionPC.prototype.remoteTrackAdded = function (stream, track) {
 
     var ssrclines = SDPUtil.find_lines(medialines[0], 'a=ssrc:');
     ssrclines = ssrclines.filter(function (line) {
-        if (RTCBrowserType.isTemasysPluginUsed()) {
-            return ((line.indexOf('mslabel:' + streamId) !== -1));
-        } else {
-            return ((line.indexOf('msid:' + streamId) !== -1));
-        }
+        var msid = RTCBrowserType.isTemasysPluginUsed() ? 'mslabel' : 'msid';
+        return line.indexOf(msid + ':' + streamId) !== -1;
     });
 
     var thessrc;


### PR DESCRIPTION
RTCUtils' handleLocalStream deals with the results of obtainAudioAndVideoPermissions. The latter checks the type of the browser and branches in different execution paths depending on that and, eventually, defines .audioAndVideo, .audio, .video, .desktopStream and/or .desktop on handleLocalStream's streams argument.

As part of the development effort to support lib-jitsi-meet on React Native, I've defined a RTCBrowserType.isReactNative() and I've used it in obtainAudioAndVideoPermissions. Unfortunately, I have to use it in handleLocalStream and repeat the logic/checks.

That's practically unnecessary because handleLocalStream may just examine the streams argument's properties and figure out what's available without repeating the browser checks done by obtainAudioAndVideoPermissions (which have led to the streams arguments' properties).