### PR TITLE
Reopen data channels on ice restart

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -931,6 +931,13 @@ function setupListeners(conference) {
         }
     });
 
+    conference.room.addListener(XMPPEvents.ICE_RESTARTING, function () {
+        // All data channels have to be closed, before ICE restart
+        // otherwise Chrome will not trigger "opened" event for the channel
+        // established with the new bridge
+        conference.rtc.closeAllDataChannels();
+    });
+
     conference.room.addListener(XMPPEvents.REMOTE_TRACK_ADDED,
         function (data) {
             var track = conference.rtc.createRemoteTrack(data);

--- a/modules/RTC/DataChannels.js
+++ b/modules/RTC/DataChannels.js
@@ -158,14 +158,24 @@ DataChannels.prototype.onDataChannel = function (event) {
     this._dataChannels.push(dataChannel);
 };
 
+/**
+ * Closes all currently opened data channels.
+ */
+DataChannels.prototype.closeAllChannels = function () {
+    this._dataChannels.forEach(function (dc){
+        // the DC will be removed from the array on 'onclose' event
+        dc.close();
+    });
+};
+
 DataChannels.prototype.handleSelectedEndpointEvent = function (userResource) {
     this.lastSelectedEndpoint = userResource;
     this._onXXXEndpointChanged("selected", userResource);
-}
+};
 
 DataChannels.prototype.handlePinnedEndpointEvent = function (userResource) {
     this._onXXXEndpointChanged("pinnned", userResource);
-}
+};
 
 /**
  * Notifies Videobridge about a change in the value of a specific
@@ -210,7 +220,7 @@ DataChannels.prototype._onXXXEndpointChanged = function (xxx, userResource) {
             return true;
         }
     });
-}
+};
 
 DataChannels.prototype._some = function (callback, thisArg) {
     var dataChannels = this._dataChannels;
@@ -223,6 +233,6 @@ DataChannels.prototype._some = function (callback, thisArg) {
     } else {
         return false;
     }
-}
+};
 
 module.exports = DataChannels;

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -387,6 +387,13 @@ RTC.isDesktopSharingEnabled = function () {
     return RTCUtils.isDesktopSharingEnabled();
 };
 
+/**
+ * Closes all currently opened data channels.
+ */
+RTC.prototype.closeAllDataChannels = function () {
+    this.dataChannels.closeAllChannels();
+};
+
 RTC.prototype.dispose = function() {
 };
 

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -43,6 +43,11 @@ var XMPPEvents = {
     FOCUS_DISCONNECTED: 'xmpp.focus_disconnected',
     FOCUS_LEFT: "xmpp.focus_left",
     GRACEFUL_SHUTDOWN: "xmpp.graceful_shutdown",
+    /**
+     * Event fired when 'transport-replace' Jingle message has been received,
+     * before the new offer is set on the PeerConnection.
+     */
+    ICE_RESTARTING: "rtc.ice_restarting",
     /* Event fired when XMPP error is returned to any request, it is meant to be
      * used to report 'signaling' errors to CallStats
      *


### PR DESCRIPTION
With this PR merged data channels will be correctly re-established with the new bridge after ICE restart. In order to achieve that we close all currently opened data channels and set remote description without "data" section. This will clean up SCTP association with the old bridge and allow to connect to the new one.