### PR TITLE
Remove repetitions

### DIFF
--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -503,29 +503,24 @@ StatsCollector.prototype.processStatsReport = function () {
 
         if(now.type == 'googCandidatePair')
         {
-            var ip, type, localIP, active;
+            var ip, type, localip, active;
             try {
                 ip = getStatValue(now, 'remoteAddress');
                 type = getStatValue(now, "transportType");
-                localIP = getStatValue(now, "localAddress");
+                localip = getStatValue(now, "localAddress");
                 active = getStatValue(now, "activeConnection");
             }
             catch(e){/*not supported*/}
-            if(!ip || !type || !localIP || active != "true")
+            if(!ip || !type || !localip || active != "true")
                 continue;
-            var addressSaved = false;
-            for(var i = 0; i < this.conferenceStats.transport.length; i++)
-            {
-                if(this.conferenceStats.transport[i].ip == ip &&
-                    this.conferenceStats.transport[i].type == type &&
-                    this.conferenceStats.transport[i].localip == localIP)
-                {
-                    addressSaved = true;
-                }
+            // Save the address unless it has been saved already.
+            var conferenceStatsTransport = this.conferenceStats.transport;
+            if(!conferenceStatsTransport.some(function (t) { return (
+                        t.ip == ip && t.type == type && t.localip == localip
+                    )})) {
+                conferenceStatsTransport.push(
+                    {ip: ip, type: type, localip: localip});
             }
-            if(addressSaved)
-                continue;
-            this.conferenceStats.transport.push({localip: localIP, ip: ip, type: type});
             continue;
         }
 
@@ -536,9 +531,9 @@ StatsCollector.prototype.processStatsReport = function () {
             var local = this.currentStatsReport[now.localCandidateId];
             var remote = this.currentStatsReport[now.remoteCandidateId];
             this.conferenceStats.transport.push({
-                localip: local.ipAddress + ":" + local.portNumber,
                 ip: remote.ipAddress + ":" + remote.portNumber,
-                type: local.transport
+                type: local.transport,
+                localip: local.ipAddress + ":" + local.portNumber
             });
         }
 

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -106,8 +106,7 @@ function acceptReport(id, type) {
  * Peer statistics data holder.
  * @constructor
  */
-function PeerStats()
-{
+function PeerStats() {
     this.ssrc2Loss = {};
     this.ssrc2AudioLevel = {};
     this.ssrc2bitrate = {
@@ -167,7 +166,6 @@ PeerStats.prototype.setSsrcAudioLevel = function (audioLevel) {
 
 function ConferenceStats() {
 
-
     /**
      * The bandwidth
      * @type {{}}
@@ -185,7 +183,6 @@ function ConferenceStats() {
      * @type {{}}
      */
     this.packetLoss = null;
-
 
     /**
      * Array with the transport information.
@@ -233,8 +230,7 @@ function StatsCollector(peerconnection, audioLevelsInterval, statsInterval, even
     /**
      * Stores the statistics which will be send to the focus to be logged.
      */
-    this.statsToBeLogged =
-    {
+    this.statsToBeLogged = {
         timestamps: [],
         stats: {}
     };
@@ -259,14 +255,12 @@ StatsCollector.prototype.stop = function () {
         this.audioLevelsIntervalId = null;
     }
 
-    if (this.statsIntervalId)
-    {
+    if (this.statsIntervalId) {
         clearInterval(this.statsIntervalId);
         this.statsIntervalId = null;
     }
 
-    if(this.gatherStatsIntervalId)
-    {
+    if (this.gatherStatsIntervalId) {
         clearInterval(this.gatherStatsIntervalId);
         this.gatherStatsIntervalId = null;
     }
@@ -276,8 +270,7 @@ StatsCollector.prototype.stop = function () {
  * Callback passed to <tt>getStats</tt> method.
  * @param error an error that occurred on <tt>getStats</tt> call.
  */
-StatsCollector.prototype.errorCallback = function (error)
-{
+StatsCollector.prototype.errorCallback = function (error) {
     logger.error("Get stats error", error);
     this.stop();
 };
@@ -285,8 +278,7 @@ StatsCollector.prototype.errorCallback = function (error)
 /**
  * Starts stats updates.
  */
-StatsCollector.prototype.start = function ()
-{
+StatsCollector.prototype.start = function () {
     var self = this;
     this.audioLevelsIntervalId = setInterval(
         function () {
@@ -458,16 +450,17 @@ StatsCollector.prototype.processStatsReport = function () {
             continue;
         }
 
-        if(now.type == "candidatepair")
-        {
+        if(now.type == "candidatepair") {
             if(now.state == "succeeded")
                 continue;
 
             var local = this.currentStatsReport[now.localCandidateId];
             var remote = this.currentStatsReport[now.remoteCandidateId];
-            this.conferenceStats.transport.push({localip: local.ipAddress + ":" + local.portNumber,
-                ip: remote.ipAddress + ":" + remote.portNumber, type: local.transport});
-
+            this.conferenceStats.transport.push({
+                localip: local.ipAddress + ":" + local.portNumber,
+                ip: remote.ipAddress + ":" + remote.portNumber,
+                type: local.transport
+            });
         }
 
         if (now.type != 'ssrc' && now.type != "outboundrtp" &&
@@ -619,7 +612,8 @@ StatsCollector.prototype.processStatsReport = function () {
         this
     );
 
-    this.conferenceStats.bitrate = {"upload": bitrateUpload, "download": bitrateDownload};
+    this.conferenceStats.bitrate
+      = {"upload": bitrateUpload, "download": bitrateDownload};
 
     this.conferenceStats.packetLoss = {
         total:
@@ -630,8 +624,7 @@ StatsCollector.prototype.processStatsReport = function () {
         upload:
             calculatePacketLoss(lostPackets.upload, totalPackets.upload)
     };
-    this.eventEmitter.emit(StatisticsEvents.CONNECTION_STATS,
-        {
+    this.eventEmitter.emit(StatisticsEvents.CONNECTION_STATS, {
             "bitrate": this.conferenceStats.bitrate,
             "packetLoss": this.conferenceStats.packetLoss,
             "bandwidth": this.conferenceStats.bandwidth,
@@ -639,7 +632,6 @@ StatsCollector.prototype.processStatsReport = function () {
             "transport": this.conferenceStats.transport
         });
     this.conferenceStats.transport = [];
-
 };
 
 /**
@@ -666,7 +658,7 @@ StatsCollector.prototype.processAudioLevelReport = function () {
 
         var ssrc = getStatValue(now, 'ssrc');
         if (!ssrc) {
-            if((Date.now() - now.timestamp) < 3000)
+            if ((Date.now() - now.timestamp) < 3000)
                 logger.warn("No ssrc: ");
             continue;
         }

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -69,10 +69,11 @@ function formatAudioLevel(audioLevel) {
  * Checks whether a certain record should be included in the logged statistics.
  */
 function acceptStat(reportId, reportType, statName) {
-    if (reportType == "googCandidatePair" && statName == "googChannelId")
-        return false;
+    if (reportType == "googCandidatePair") {
+        if (statName == "googChannelId")
+            return false;
 
-    if (reportType == "ssrc") {
+    } else if (reportType == "ssrc") {
         if (statName == "googTrackId" ||
             statName == "transportId" ||
             statName == "ssrc")
@@ -86,12 +87,12 @@ function acceptStat(reportId, reportType, statName) {
  * Checks whether a certain record should be included in the logged statistics.
  */
 function acceptReport(id, type) {
+    if (type == "googComponent")
+        return false;
+
     if (id.substring(0, 15) == "googCertificate" ||
         id.substring(0, 9) == "googTrack" ||
         id.substring(0, 20) == "googLibjingleSession")
-        return false;
-
-    if (type == "googComponent")
         return false;
 
     return true;

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -27,8 +27,6 @@ function loadCallStatsAPI() {
  */
 var LOG_INTERVAL = 60000;
 
-var eventEmitter = new EventEmitter();
-
 function Statistics(xmpp, options) {
     this.rtpStats = null;
     this.eventEmitter = new EventEmitter();
@@ -104,9 +102,6 @@ Statistics.prototype.dispose = function () {
         this.stopRemoteStats();
         if(this.eventEmitter)
             this.eventEmitter.removeAllListeners();
-
-        if(eventEmitter)
-            eventEmitter.removeAllListeners();
     }
 };
 

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -170,7 +170,7 @@ Statistics.prototype.isCallstatsEnabled = function () {
  * @param {RTCPeerConnection} pc connection on which failure occured.
  */
 Statistics.prototype.sendIceConnectionFailedEvent = function (pc) {
-    if(this.callStatsIntegrationEnabled && this.callstats)
+    if(this.callstats)
         this.callstats.sendIceConnectionFailedEvent(pc, this.callstats);
 };
 
@@ -180,7 +180,7 @@ Statistics.prototype.sendIceConnectionFailedEvent = function (pc) {
  * @param type {String} "audio"/"video"
  */
 Statistics.prototype.sendMuteEvent = function (muted, type) {
-    if(this.callStatsIntegrationEnabled)
+    if(this.callstats)
         CallStats.sendMuteEvent(muted, type, this.callstats);
 };
 
@@ -190,7 +190,7 @@ Statistics.prototype.sendMuteEvent = function (muted, type) {
  * false for not stopping
  */
 Statistics.prototype.sendScreenSharingEvent = function (start) {
-    if(this.callStatsIntegrationEnabled)
+    if(this.callstats)
         CallStats.sendScreenSharingEvent(start, this.callstats);
 };
 
@@ -199,7 +199,7 @@ Statistics.prototype.sendScreenSharingEvent = function (start) {
  * conference.
  */
 Statistics.prototype.sendDominantSpeakerEvent = function () {
-    if(this.callStatsIntegrationEnabled)
+    if(this.callstats)
         CallStats.sendDominantSpeakerEvent(this.callstats);
 };
 
@@ -216,7 +216,7 @@ Statistics.prototype.sendDominantSpeakerEvent = function () {
  */
 Statistics.prototype.associateStreamWithVideoTag =
 function (ssrc, isLocal, usageLabel, containerId) {
-    if(this.callStatsIntegrationEnabled && this.callstats) {
+    if(this.callstats) {
         this.callstats.associateStreamWithVideoTag(
             ssrc, isLocal, usageLabel, containerId);
     }
@@ -228,7 +228,7 @@ function (ssrc, isLocal, usageLabel, containerId) {
  * @param {Error} e error to send
  */
 Statistics.prototype.sendGetUserMediaFailed = function (e) {
-    if(this.callStatsIntegrationEnabled)
+    if(this.callstats)
         CallStats.sendGetUserMediaFailed(e, this.callstats);
 };
 
@@ -248,7 +248,7 @@ Statistics.sendGetUserMediaFailed = function (e) {
  * @param {RTCPeerConnection} pc connection on which failure occured.
  */
 Statistics.prototype.sendCreateOfferFailed = function (e, pc) {
-    if(this.callStatsIntegrationEnabled)
+    if(this.callstats)
         CallStats.sendCreateOfferFailed(e, pc, this.callstats);
 };
 
@@ -259,7 +259,7 @@ Statistics.prototype.sendCreateOfferFailed = function (e, pc) {
  * @param {RTCPeerConnection} pc connection on which failure occured.
  */
 Statistics.prototype.sendCreateAnswerFailed = function (e, pc) {
-    if(this.callStatsIntegrationEnabled)
+    if(this.callstats)
         CallStats.sendCreateAnswerFailed(e, pc, this.callstats);
 };
 
@@ -270,7 +270,7 @@ Statistics.prototype.sendCreateAnswerFailed = function (e, pc) {
  * @param {RTCPeerConnection} pc connection on which failure occured.
  */
 Statistics.prototype.sendSetLocalDescFailed = function (e, pc) {
-    if(this.callStatsIntegrationEnabled)
+    if(this.callstats)
         CallStats.sendSetLocalDescFailed(e, pc, this.callstats);
 };
 
@@ -281,7 +281,7 @@ Statistics.prototype.sendSetLocalDescFailed = function (e, pc) {
  * @param {RTCPeerConnection} pc connection on which failure occured.
  */
 Statistics.prototype.sendSetRemoteDescFailed = function (e, pc) {
-    if(this.callStatsIntegrationEnabled)
+    if(this.callstats)
         CallStats.sendSetRemoteDescFailed(e, pc, this.callstats);
 };
 
@@ -292,7 +292,7 @@ Statistics.prototype.sendSetRemoteDescFailed = function (e, pc) {
  * @param {RTCPeerConnection} pc connection on which failure occured.
  */
 Statistics.prototype.sendAddIceCandidateFailed = function (e, pc) {
-    if(this.callStatsIntegrationEnabled)
+    if(this.callstats)
         CallStats.sendAddIceCandidateFailed(e, pc, this.callstats);
 };
 
@@ -303,7 +303,7 @@ Statistics.prototype.sendAddIceCandidateFailed = function (e, pc) {
  * @param {RTCPeerConnection} pc connection on which failure occured.
  */
 Statistics.prototype.sendUnhandledError = function (e) {
-    if(this.callStatsIntegrationEnabled)
+    if(this.callstats)
         CallStats.sendUnhandledError(e, this.callstats);
 };
 
@@ -319,14 +319,12 @@ Statistics.sendUnhandledError = function (e) {
 /**
  * Sends the given feedback through CallStats.
  *
- * @param overallFeedback an integer between 1 and 5 indicating the
- * user feedback
- * @param detailedFeedback detailed feedback from the user. Not yet used
+ * @param overall an integer between 1 and 5 indicating the user feedback
+ * @param detailed detailed feedback from the user. Not yet used
  */
-Statistics.prototype.sendFeedback =
-function(overallFeedback, detailedFeedback){
-    if(this.callStatsIntegrationEnabled && this.callstats)
-        this.callstats.sendFeedback(overallFeedback, detailedFeedback);
+Statistics.prototype.sendFeedback = function(overall, detailed) {
+    if(this.callstats)
+        this.callstats.sendFeedback(overall, detailed);
 };
 
 Statistics.LOCAL_JID = require("../../service/statistics/constants").LOCAL_JID;

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -6,13 +6,13 @@ var StatisticsEvents = require("../../service/statistics/Events");
 var CallStats = require("./CallStats");
 var ScriptUtil = require('../util/ScriptUtil');
 
-// Since callstats.io is a third party, we cannot guarantee the quality of
-// their service. More specifically, their server may take noticeably long
-// time to respond. Consequently, it is in our best interest (in the sense
-// that the intergration of callstats.io is pretty important to us but not
-// enough to allow it to prevent people from joining a conference) to (1)
-// start downloading their API as soon as possible and (2) do the
-// downloading asynchronously.
+// Since callstats.io is a third party, we cannot guarantee the quality of their
+// service. More specifically, their server may take noticeably long time to
+// respond. Consequently, it is in our best interest (in the sense that the
+// intergration of callstats.io is pretty important to us but not enough to
+// allow it to prevent people from joining a conference) to (1) start
+// downloading their API as soon as possible and (2) do the downloading
+// asynchronously.
 function loadCallStatsAPI() {
     ScriptUtil.loadScript(
             'https://api.callstats.io/static/callstats.min.js',
@@ -21,7 +21,6 @@ function loadCallStatsAPI() {
     // FIXME At the time of this writing, we hope that the callstats.io API will
     // have loaded by the time we needed it (i.e. CallStats.init is invoked).
 }
-
 
 /**
  * Log stats via the focus once every this many milliseconds.
@@ -37,17 +36,16 @@ function Statistics(xmpp, options) {
     this.options = options || {};
     this.callStatsIntegrationEnabled
         = this.options.callStatsID && this.options.callStatsSecret
-        // Even though AppID and AppSecret may be specified, the integration of
-        // callstats.io may be disabled because of globally-disallowed requests
-        // to any third parties.
-        && (this.options.disableThirdPartyRequests !== true);
+            // Even though AppID and AppSecret may be specified, the integration
+            // of callstats.io may be disabled because of globally-disallowed
+            // requests to any third parties.
+            && (this.options.disableThirdPartyRequests !== true);
     if(this.callStatsIntegrationEnabled)
         loadCallStatsAPI();
     this.callStats = null;
 
     /**
-     * Send the stats already saved in rtpStats to be logged via
-     * the focus.
+     * Send the stats already saved in rtpStats to be logged via the focus.
      */
     this.logStatsIntervalId = null;
 }
@@ -80,15 +78,13 @@ Statistics.startLocalStats = function (stream, callback) {
     localStats.start();
 };
 
-Statistics.prototype.addAudioLevelListener = function(listener)
-{
+Statistics.prototype.addAudioLevelListener = function(listener) {
     if(!Statistics.audioLevelsEnabled)
         return;
     this.eventEmitter.on(StatisticsEvents.AUDIO_LEVEL, listener);
 };
 
-Statistics.prototype.removeAudioLevelListener = function(listener)
-{
+Statistics.prototype.removeAudioLevelListener = function(listener) {
     if(!Statistics.audioLevelsEnabled)
         return;
     this.eventEmitter.removeListener(StatisticsEvents.AUDIO_LEVEL, listener);
@@ -113,7 +109,6 @@ Statistics.prototype.dispose = function () {
             eventEmitter.removeAllListeners();
     }
 };
-
 
 Statistics.stopAllLocalStats = function () {
     if(!Statistics.audioLevelsEnabled)


### PR DESCRIPTION
There were at least 3 kinds of repetitions that caused inefficiency and
burdened debugging:

1. Complex if conditions in which the value of one expression was
practically dependent upon the other so it was enough to check 1 of the
2 exressions.

2. getStatValue was called multiple times within the same function to
retrieve the value with 1 and the same key. That was wasteful, harder to
read and hampered debugging (on React Native).

3. getStatValue which is called multiple times within 1 second was
checking the RTCBrowserType of the executing browser. Since the latter
is very unlikely to change during a session i.e. at runtime, I
refactored the source code to perform as many of the checks as possible
just once.

Additionally, getStatValue used to throw an error if the executing
browser is unsupported but that throw would happen in the callback of
RTCPeerConnection#getStats. Hence, (a) it would be repeated multiple
times within 1 second which was unnecessarily inefficient and
repetitive and (b) it would come much later after the startup of the
application. It makes sense to discover the lack of support for the
executing browser as soon as possible and log an error once.