### PR TITLE
Do not subscribe each JitsiTrack to RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED event

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -36,6 +36,7 @@ function JitsiLocalTrack(stream, track, mediaType, videoType, resolution,
     this.resolution = resolution;
     this.deviceId = deviceId;
     this.startMuted = false;
+    this.disposed = false;
     //FIXME: This dependacy is not necessary.
     this.conference = null;
     this.initialMSID = this.getMSID();
@@ -282,7 +283,7 @@ JitsiLocalTrack.prototype.dispose = function () {
         this.detach();
     }
 
-    JitsiTrack.prototype.dispose.call(this);
+    this.disposed = true;
 
     RTCUtils.removeListener(RTCEvents.DEVICE_LIST_CHANGED,
         this._onDeviceListChanged);

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -69,6 +69,16 @@ function JitsiLocalTrack(stream, track, mediaType, videoType, resolution,
         }
     };
 
+    // Subscribe each created local audio track to
+    // RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED event. This is different from
+    // handling this event for remote tracks (which are handled in RTC.js),
+    // because there might be local tracks not attached to a conference.
+    if (this.isAudioTrack() && RTCUtils.isDeviceChangeAvailable('output')) {
+        this._onAudioOutputDeviceChanged = this.setAudioOutput.bind(this);
+
+        RTCUtils.addListener(RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED,
+            this._onAudioOutputDeviceChanged);
+    }
 
     RTCUtils.addListener(RTCEvents.DEVICE_LIST_CHANGED,
         this._onDeviceListChanged);
@@ -287,6 +297,11 @@ JitsiLocalTrack.prototype.dispose = function () {
 
     RTCUtils.removeListener(RTCEvents.DEVICE_LIST_CHANGED,
         this._onDeviceListChanged);
+
+    if (this._onAudioOutputDeviceChanged) {
+        RTCUtils.removeListener(RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED,
+            this._onAudioOutputDeviceChanged);
+    }
 
     return promise;
 };

--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -84,4 +84,6 @@ JitsiRemoteTrack.prototype._setVideoType = function (type) {
     this.eventEmitter.emit(JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED, type);
 };
 
+delete JitsiRemoteTrack.prototype.dispose;
+
 module.exports = JitsiRemoteTrack;

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -70,20 +70,12 @@ function JitsiTrack(rtc, stream, track, streamInactiveHandler, trackMediaType,
     this.type = trackMediaType;
     this.track = track;
     this.videoType = videoType;
-    this.disposed = false;
 
     if(stream) {
         if (RTCBrowserType.isFirefox()) {
             implementOnEndedHandling(this);
         }
         addMediaStreamInactiveHandler(stream, streamInactiveHandler);
-    }
-
-    this._onAudioOutputDeviceChanged = this.setAudioOutput.bind(this);
-
-    if (this.isAudioTrack()) {
-        RTCUtils.addListener(RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED,
-            this._onAudioOutputDeviceChanged);
     }
 }
 
@@ -225,12 +217,9 @@ JitsiTrack.prototype.detach = function (container) {
 
 /**
  * Dispose sending the media track. And removes it from the HTML.
+ * NOTE: Works for local tracks only.
  */
 JitsiTrack.prototype.dispose = function () {
-    RTCUtils.removeListener(RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED,
-        this._onAudioOutputDeviceChanged);
-
-    this.disposed = true;
 };
 
 /**

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -59,6 +59,23 @@ function RTC(room, options) {
             videoTrack._setVideoType(data.value);
         }
     });
+
+    // switch audio output device on all local and remote audio tracks
+    RTCUtils.addListener(RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED,
+        function (deviceId) {
+            if (RTCUtils.isDeviceChangeAvailable('output')) {
+                if (self.localAudio) {
+                    self.localAudio.setAudioOutput(deviceId);
+                }
+
+                for (var key in self.remoteTracks) {
+                    if (self.remoteTracks.hasOwnProperty(key)
+                        && self.remoteTracks[key].audio) {
+                        self.remoteTracks[key].audio.setAudioOutput(deviceId);
+                    }
+                }
+            }
+        });
 }
 
 /**

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -61,22 +61,19 @@ function RTC(room, options) {
         }
     });
 
-    // switch audio output device on all local and remote audio tracks
-    RTCUtils.addListener(RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED,
-        function (deviceId) {
-            if (RTCUtils.isDeviceChangeAvailable('output')) {
-                if (self.localAudio) {
-                    self.localAudio.setAudioOutput(deviceId);
-                }
-
+    // Switch audio output device on all remote audio tracks. Local audio tracks
+    // handle this event by themselves.
+    if (RTCUtils.isDeviceChangeAvailable('output')) {
+        RTCUtils.addListener(RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED,
+            function (deviceId) {
                 for (var key in self.remoteTracks) {
                     if (self.remoteTracks.hasOwnProperty(key)
                         && self.remoteTracks[key].audio) {
                         self.remoteTracks[key].audio.setAudioOutput(deviceId);
                     }
                 }
-            }
-        });
+            });
+    }
 }
 
 /**


### PR DESCRIPTION
Instead we subscribe once for this event in RTC, and then go through all our local and remote audio tracks.

Also restored "dispose" functionality as it was before changes done in https://github.com/jitsi/lib-jitsi-meet/pull/103