### PR TITLE
Tsareg handle create local tracks errors better

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -13,6 +13,7 @@ var Statistics = require("./modules/statistics/statistics");
 var JitsiDTMFManager = require('./modules/DTMF/JitsiDTMFManager');
 var JitsiTrackEvents = require("./JitsiTrackEvents");
 var JitsiTrackErrors = require("./JitsiTrackErrors");
+var JitsiTrackError = require("./JitsiTrackError");
 var Settings = require("./modules/settings/Settings");
 var ComponentsVersions = require("./modules/version/ComponentsVersions");
 var GlobalOnErrorHandler = require("./modules/util/GlobalOnErrorHandler");
@@ -320,7 +321,7 @@ JitsiConference.prototype.setSubject = function (subject) {
 JitsiConference.prototype.addTrack = function (track) {
     if(track.disposed)
     {
-        throw new Error(JitsiTrackErrors.TRACK_IS_DISPOSED);
+        throw new JitsiTrackError(JitsiTrackErrors.TRACK_IS_DISPOSED);
     }
 
     if (track.isVideoTrack() && this.rtc.getLocalVideoTrack()) {

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -944,8 +944,12 @@ function setupListeners(conference) {
                         "Failed to accept incoming Jingle session", error);
                 }
             );
-            conference.statistics.startRemoteStats(
-                    jingleSession.peerconnection);
+            // Start callstats as soon as peerconnection is initialized,
+            // do not wait for XMPPEvents.PEERCONNECTION_READY, as it may never
+            // happen in case if user doesn't have or denied permission to
+            // both camera and microphone.
+            conference.statistics.startCallStats(jingleSession, conference.settings);
+            conference.statistics.startRemoteStats(jingleSession.peerconnection);
         } else {
             // Error cause this should never happen unless something is wrong!
             var errmsg
@@ -1294,12 +1298,6 @@ function setupListeners(conference) {
         conference.room.addListener(XMPPEvents.DISPOSE_CONFERENCE,
             function () {
                 conference.statistics.dispose();
-            });
-
-        conference.room.addListener(XMPPEvents.PEERCONNECTION_READY,
-            function (session) {
-                conference.statistics.startCallStats(
-                    session, conference.settings);
             });
 
         conference.room.addListener(XMPPEvents.CONNECTION_ICE_FAILED,

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -8,6 +8,7 @@ var JitsiConnectionErrors = require("./JitsiConnectionErrors");
 var JitsiConferenceErrors = require("./JitsiConferenceErrors");
 var JitsiTrackEvents = require("./JitsiTrackEvents");
 var JitsiTrackErrors = require("./JitsiTrackErrors");
+var JitsiTrackError = require("./JitsiTrackError");
 var JitsiRecorderErrors = require("./JitsiRecorderErrors");
 var Logger = require("jitsi-meet-logger");
 var MediaType = require("./service/RTC/MediaType");
@@ -218,6 +219,10 @@ var LibJitsiMeet = {
 // why the decision is to provide LibJitsiMeet as a parameter of
 // JitsiConnection.
 LibJitsiMeet.JitsiConnection = JitsiConnection.bind(null, LibJitsiMeet);
+
+// expose JitsiTrackError this way to give library consumers to do checks like
+// if (error instanceof JitsiMeetJS.JitsiTrackError) { }
+LibJitsiMeet.JitsiTrackError = JitsiTrackError;
 
 //Setups the promise object.
 window.Promise = window.Promise || require("es6-promise").Promise;

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -116,18 +116,27 @@ var LibJitsiMeet = {
                 this._gumFailedHandler.forEach(function (handler) {
                     handler(error);
                 });
-                if(!this._gumFailedHandler.length)
+
+                if(!this._gumFailedHandler.length) {
                     Statistics.sendGetUserMediaFailed(error);
-                if(error === JitsiTrackErrors.UNSUPPORTED_RESOLUTION) {
-                    var oldResolution = options.resolution || '360';
-                    var newResolution = getLowerResolution(oldResolution);
-                    if(newResolution === null)
+                }
+
+                if(error.name === JitsiTrackErrors.UNSUPPORTED_RESOLUTION) {
+                    var oldResolution = options.resolution || '360',
+                        newResolution = getLowerResolution(oldResolution);
+
+                    if (newResolution === null) {
                         return Promise.reject(error);
+                    }
+
                     options.resolution = newResolution;
+
                     logger.debug("Retry createLocalTracks with resolution",
                                 newResolution);
+
                     return LibJitsiMeet.createLocalTracks(options);
                 }
+
                 return Promise.reject(error);
             }.bind(this));
     },

--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -33,17 +33,26 @@ TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.TRACK_MUTE_UNMUTE_IN_PROGRESS]
  * @param {Object|string} error - error object or error name
  * @param {Object|string} (options) - getUserMedia constraints object or error
  *      message
+ * @param {('audio'|'video'|'desktop'|'screen')[]} (devices) - list of
+ *      getUserMedia requested devices
  */
-function JitsiTrackError(error, options) {
+function JitsiTrackError(error, options, devices) {
     if (typeof error === "object" && typeof error.name !== "undefined") {
         /**
          * Additional information about original getUserMedia error
          * and constraints.
-         * @type {{error: Object, constraints: Object }}
+         * @type {{
+         *          error: Object,
+         *          constraints: Object,
+         *          devices: Array.<'audio'|'video'|'desktop'|'screen'>
+         *      }}
          */
         this.gum = {
             error: error,
-            constraints: options
+            constraints: options,
+            devices: devices && Array.isArray(devices)
+                ? devices.slice(0)
+                : undefined
         };
 
         switch (error.name) {
@@ -70,6 +79,7 @@ function JitsiTrackError(error, options) {
                 var constraintName = error.constraintName;
 
                 if (options && options.video
+                    && (devices || []).indexOf('video') > -1
                     &&
                     (constraintName === "minWidth" ||
                         constraintName === "maxWidth" ||

--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -62,17 +62,13 @@ function JitsiTrackError(error, options, devices) {
                 this.message = error.message
                     || TRACK_ERROR_TO_MESSAGE_MAP[
                         JitsiTrackErrors.PERMISSION_DENIED]
-                        + Object.keys(options || {}).filter(function (k) {
-                            return !!options[k];
-                        }).join(", ");
+                        + (this.gum.devices || []).join(", ");
                 break;
             case "NotFoundError":
                 this.name = JitsiTrackErrors.NOT_FOUND;
-                this.message = error.message
-                    || TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.NOT_FOUND]
-                        + Object.keys(options || {}).filter(function (k) {
-                            return !!options[k];
-                        }).join(", ");
+                this.message = TRACK_ERROR_TO_MESSAGE_MAP[
+                        JitsiTrackErrors.NOT_FOUND]
+                        + (this.gum.devices || []).join(", ");
                 break;
             case "ConstraintNotSatisfiedError":
             case "OverconstrainedError":

--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -1,0 +1,139 @@
+var JitsiTrackErrors = require("./JitsiTrackErrors");
+
+var TRACK_ERROR_TO_MESSAGE_MAP = {};
+
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.UNSUPPORTED_RESOLUTION]
+    = "Video resolution is not supported: ";
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.FIREFOX_EXTENSION_NEEDED]
+    = "Firefox extension is not installed";
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.CHROME_EXTENSION_INSTALLATION_ERROR]
+    = "Failed to install Chrome extension";
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.CHROME_EXTENSION_USER_CANCELED]
+    = "User canceled Chrome's screen sharing prompt";
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.CHROME_EXTENSION_GENERIC_ERROR]
+    = "Unknown error from Chrome extension";
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.GENERAL]
+    = "Generic getUserMedia error";
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.PERMISSION_DENIED]
+    = "User denied permission to use device(s): ";
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.NOT_FOUND]
+    = "Requested device(s) was/were not found: ";
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.CONSTRAINT_FAILED]
+    = "Constraint could not be satisfied: ";
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.TRACK_IS_DISPOSED]
+    = "Track has been already disposed";
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.TRACK_MUTE_UNMUTE_IN_PROGRESS]
+    = "Track mute/unmute process is currently in progress";
+
+/**
+ * Object representing error that happened to a JitsiTrack. Can represent
+ * various types of errors. For error descriptions (@see JitsiTrackErrors).
+ * @constructor
+ * @extends Error
+ * @param {Object|string} error - error object or error name
+ * @param {Object|string} (options) - getUserMedia constraints object or error
+ *      message
+ */
+function JitsiTrackError(error, options) {
+    if (typeof error === "object" && typeof error.name !== "undefined") {
+        /**
+         * Additional information about original getUserMedia error
+         * and constraints.
+         * @type {{error: Object, constraints: Object }}
+         */
+        this.gum = {
+            error: error,
+            constraints: options
+        };
+
+        switch (error.name) {
+            case "PermissionDeniedError":
+            case "SecurityError":
+                this.name = JitsiTrackErrors.PERMISSION_DENIED;
+                this.message = error.message
+                    || TRACK_ERROR_TO_MESSAGE_MAP[
+                        JitsiTrackErrors.PERMISSION_DENIED]
+                        + Object.keys(options || {}).filter(function (k) {
+                            return !!options[k];
+                        }).join(", ");
+                break;
+            case "NotFoundError":
+                this.name = JitsiTrackErrors.NOT_FOUND;
+                this.message = error.message
+                    || TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.NOT_FOUND]
+                        + Object.keys(options || {}).filter(function (k) {
+                            return !!options[k];
+                        }).join(", ");
+                break;
+            case "ConstraintNotSatisfiedError":
+            case "OverconstrainedError":
+                var constraintName = error.constraintName;
+
+                if (options && options.video
+                    &&
+                    (constraintName === "minWidth" ||
+                        constraintName === "maxWidth" ||
+                        constraintName === "minHeight" ||
+                        constraintName === "maxHeight" ||
+                        constraintName === "width" ||
+                        constraintName === "height")) {
+                    this.name = JitsiTrackErrors.UNSUPPORTED_RESOLUTION;
+                    this.message = error.message ||
+                        TRACK_ERROR_TO_MESSAGE_MAP[
+                            JitsiTrackErrors.UNSUPPORTED_RESOLUTION] +
+                        getResolutionFromFailedConstraint(constraintName,
+                            options);
+                } else {
+                    this.name = JitsiTrackErrors.CONSTRAINT_FAILED;
+                    this.message = error.message ||
+                        TRACK_ERROR_TO_MESSAGE_MAP[
+                            JitsiTrackErrors.CONSTRAINT_FAILED] +
+                        error.constraintName;
+                }
+                break;
+            default:
+                this.name = JitsiTrackErrors.GENERAL;
+                this.message = error.message ||
+                    TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.GENERAL];
+                break;
+        }
+    } else if (typeof error === "string") {
+        if (TRACK_ERROR_TO_MESSAGE_MAP[error]) {
+            this.name = error;
+            this.message = options || TRACK_ERROR_TO_MESSAGE_MAP[error];
+        } else {
+            // this is some generic error that do not fit any of our pre-defined
+            // errors, so don't give it any specific name, just store message
+            this.message = error;
+        }
+    } else {
+        throw new Error("Invalid arguments");
+    }
+
+    this.stack = error.stack || (new Error()).stack;
+}
+
+JitsiTrackError.prototype = Object.create(Error.prototype);
+JitsiTrackError.prototype.constructor = JitsiTrackError;
+
+/**
+ * Gets failed resolution constraint from corresponding object.
+ * @param {string} failedConstraintName
+ * @param {Object} constraints
+ * @returns {string|number}
+ */
+function getResolutionFromFailedConstraint(failedConstraintName, constraints) {
+    if (constraints && constraints.video && constraints.video.mandatory) {
+        if (failedConstraintName === "width") {
+            return constraints.video.mandatory.minWidth;
+        } else if (failedConstraintName === "height") {
+            return constraints.video.mandatory.minHeight;
+        } else {
+            return constraints.video.mandatory[failedConstraintName] || "";
+        }
+    }
+
+    return "";
+}
+
+module.exports = JitsiTrackError;

--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -59,8 +59,7 @@ function JitsiTrackError(error, options, devices) {
             case "PermissionDeniedError":
             case "SecurityError":
                 this.name = JitsiTrackErrors.PERMISSION_DENIED;
-                this.message = error.message
-                    || TRACK_ERROR_TO_MESSAGE_MAP[
+                this.message = TRACK_ERROR_TO_MESSAGE_MAP[
                         JitsiTrackErrors.PERMISSION_DENIED]
                         + (this.gum.devices || []).join(", ");
                 break;
@@ -84,15 +83,13 @@ function JitsiTrackError(error, options, devices) {
                         constraintName === "width" ||
                         constraintName === "height")) {
                     this.name = JitsiTrackErrors.UNSUPPORTED_RESOLUTION;
-                    this.message = error.message ||
-                        TRACK_ERROR_TO_MESSAGE_MAP[
+                    this.message = TRACK_ERROR_TO_MESSAGE_MAP[
                             JitsiTrackErrors.UNSUPPORTED_RESOLUTION] +
                         getResolutionFromFailedConstraint(constraintName,
                             options);
                 } else {
                     this.name = JitsiTrackErrors.CONSTRAINT_FAILED;
-                    this.message = error.message ||
-                        TRACK_ERROR_TO_MESSAGE_MAP[
+                    this.message = TRACK_ERROR_TO_MESSAGE_MAP[
                             JitsiTrackErrors.CONSTRAINT_FAILED] +
                         error.constraintName;
                 }

--- a/JitsiTrackErrors.js
+++ b/JitsiTrackErrors.js
@@ -1,49 +1,61 @@
-var logger = require("jitsi-meet-logger").getLogger(__filename);
-
+/**
+ * Enumeration with the errors for the JitsiTrack objects.
+ * @type {{string: string}}
+ */
 module.exports = {
     /**
-     * Returns JitsiTrackErrors based on the error object passed by GUM
-     * @param error the error
-     * @param {Array} devices Array with the requested devices
+     * An error which indicates that requested video resolution is not supported
+     * by a webcam.
      */
-    parseError: function (error, devices) {
-        if (typeof error === "object") {
-          var constraintName = error.constraintName;
-          var name;
-          if (constraintName
-                  && (name = error.name)
-                  && (name == "ConstraintNotSatisfiedError"
-                      || name == "OverconstrainedError")
-                  && (constraintName == "minWidth"
-                      || constraintName == "maxWidth"
-                      || constraintName == "minHeight"
-                      || constraintName == "maxHeight"
-                      || constraintName == "width"
-                      || constraintName == "height")
-                  && (devices || []).indexOf("video") !== -1) {
-              return this.UNSUPPORTED_RESOLUTION;
-          }
-          if (error.type === "jitsiError") {
-              return error.errorObject;
-          }
-        }
-        // XXX We're about to lose the details represented by error and devices
-        // (because we're about to generalize them to GENERAL). At the very
-        // least log the details.
-        logger.error('Parsing error into ' + this.GENERAL + ': ' + error);
-        return this.GENERAL;
-    },
     UNSUPPORTED_RESOLUTION: "gum.unsupported_resolution",
     /**
-     * An event which indicates that the jidesha extension for Firefox is
+     * An error which indicates that the jidesha extension for Firefox is
      * needed to proceed with screen sharing, and that it is not installed.
      */
     FIREFOX_EXTENSION_NEEDED: "gum.firefox_extension_needed",
+    /**
+     * An error which indicates that the jidesha extension for Chrome is
+     * failed to install.
+     */
     CHROME_EXTENSION_INSTALLATION_ERROR:
         "gum.chrome_extension_installation_error",
+    /**
+     * An error which indicates that user canceled screen sharing window
+     * selection dialog in jidesha extension for Chrome.
+     */
     CHROME_EXTENSION_USER_CANCELED:
         "gum.chrome_extension_user_canceled",
+    /**
+     * Generic error for jidesha extension for Chrome.
+     */
+    CHROME_EXTENSION_GENERIC_ERROR:
+        "gum.chrome_extension_generic_error",
+    /**
+     * Generic getUserMedia error.
+     */
     GENERAL: "gum.general",
+    /**
+     * An error which indicates that user denied permission to share requested
+     * device.
+     */
+    PERMISSION_DENIED: "gum.permission_denied",
+    /**
+     * An error which indicates that requested device was not found.
+     */
+    NOT_FOUND: "gum.not_found",
+    /**
+     * An error which indicates that some of requested constraints in
+     * getUserMedia call were not satisfied.
+     */
+    CONSTRAINT_FAILED: "gum.constraint_failed",
+    /**
+     * An error which indicates that track has been already disposed and cannot
+     * be longer used.
+     */
     TRACK_IS_DISPOSED: "track.track_is_disposed",
+    /**
+     * An error which indicates that track is currently in progress of muting or
+     * unmuting itself.
+     */
     TRACK_MUTE_UNMUTE_IN_PROGRESS: "track.mute_unmute_inprogress"
 };

--- a/doc/API.md
+++ b/doc/API.md
@@ -27,6 +27,8 @@ Jitsi Meet API has the following components:
 
 * JitsiTrack
 
+* JitsiTrackError
+
 Usage
 ======
 JitsiMeetJS
@@ -56,7 +58,7 @@ The ```options``` parameter is JS object with the following properties:
 JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
 ```
 
-* ```JitsiMeetJS.createLocalTracks(options)``` - Creates the media tracks and returns them trough ```Promise``` object.
+* ```JitsiMeetJS.createLocalTracks(options)``` - Creates the media tracks and returns them trough ```Promise``` object. If rejected, passes ```JitsiTrackError``` instance to catch block.
     - options - JS object with configuration options for the local media tracks. You can change the following properties there:
         1. devices - array with the devices - "desktop", "video" and "audio" that will be passed to GUM. If that property is not set GUM will try to get all available devices.
         2. resolution - the prefered resolution for the local video.
@@ -132,7 +134,7 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
 
 
 * ```JitsiMeetJS.errors``` - JS object that contains all errors used by the API. You can use that object to check the reported errors from the API
-    We have two error types - connection and conference. You can access the events with the following code ```JitsiMeetJS.errors.<error_type>.<error_name>```.
+    We have three error types - connection, conference and track. You can access the events with the following code ```JitsiMeetJS.errors.<error_type>.<error_name>```.
     For example if you want to use the conference event that is fired when somebody leave conference you can use the following code - ```JitsiMeetJS.errors.conference.PASSWORD_REQUIRED```.
     We support the following errors:
     1. conference
@@ -154,6 +156,19 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
         - PASSWORD_REQUIRED - passed when the connection to the server failed. You should try to authenticate with password.
         - CONNECTION_ERROR - indicates connection failures.
         - OTHER_ERROR - all other errors
+    3. track
+        - GENERAL - generic getUserMedia-related error.
+        - UNSUPPORTED_RESOLUTION - getUserMedia-related error, indicates that requested video resolution is not supported by camera.
+        - PERMISSION_DENIED - getUserMedia-related error, indicates that user denied permission to share requested device.
+        - NOT_FOUND - getUserMedia-related error, indicates that requested device was not found.
+        - CONSTRAINT_FAILED - getUserMedia-related error, indicates that some of requested constraints in getUserMedia call were not satisfied.
+        - TRACK_IS_DISPOSED - an error which indicates that track has been already disposed and cannot be longer used.
+        - TRACK_MUTE_UNMUTE_IN_PROGRESS - an error which indicates that track is currently in progress of muting or unmuting itself.
+        - CHROME_EXTENSION_GENERIC_ERROR - generic error for jidesha extension for Chrome.
+        - CHROME_EXTENSION_USER_CANCELED - an error which indicates that user canceled screen sharing window selection dialog in jidesha extension for Chrome.
+        - CHROME_EXTENSION_INSTALLATION_ERROR - an error which indicates that the jidesha extension for Chrome is failed to install.
+        - FIREFOX_EXTENSION_NEEDED - An error which indicates that the jidesha extension for Firefox is needed to proceed with screen sharing, and that it is not installed.
+        
 * ```JitsiMeetJS.logLevels``` - object with the log levels:
     1. TRACE
     2. DEBUG
@@ -359,6 +374,14 @@ We have the following methods for controling the tracks:
 
 12. isEnded() - returns true if track is ended
 
+JitsiTrackError
+======
+The object represents error that happened to a JitsiTrack. Is inherited from JavaScript base ```Error``` object, 
+so ```"name"```, ```"message"``` and ```"stack"``` properties are available. For GUM-related errors,
+exposes additional ```"gum"``` property, which is an object with following properties:
+ - error - original GUM error
+ - constraints - GUM constraints object used for the call
+ - devices - array of devices requested in GUM call (possible values - "audio", "video", "screen", "desktop")
 
 Getting Started
 ==============

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -4,6 +4,7 @@ var JitsiTrack = require("./JitsiTrack");
 var RTCBrowserType = require("./RTCBrowserType");
 var JitsiTrackEvents = require('../../JitsiTrackEvents');
 var JitsiTrackErrors = require("../../JitsiTrackErrors");
+var JitsiTrackError = require("../../JitsiTrackError");
 var RTCEvents = require("../../service/RTC/RTCEvents");
 var RTCUtils = require("./RTCUtils");
 var VideoType = require('../../service/RTC/VideoType');
@@ -141,7 +142,8 @@ function createMuteUnmutePromise(track, mute)
     return new Promise(function (resolve, reject) {
 
         if(this.inMuteOrUnmuteProgress) {
-            reject(new Error(JitsiTrackErrors.TRACK_MUTE_UNMUTE_IN_PROGRESS));
+            reject(new JitsiTrackError(
+                JitsiTrackErrors.TRACK_MUTE_UNMUTE_IN_PROGRESS));
             return;
         }
         this.inMuteOrUnmuteProgress = true;

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -812,8 +812,9 @@ var RTCUtils = {
                 });
         } catch (e) {
             logger.error('GUM failed: ', e);
+
             if (failure_callback) {
-                failure_callback(e);
+                failure_callback(new JitsiTrackError(e, constraints, um));
             }
         }
     },

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -885,10 +885,13 @@ var RTCUtils = {
                     this.getUserMediaWithConstraints(
                         options.devices,
                         function (stream) {
-                            if((options.devices.indexOf("audio") !== -1 &&
-                                !stream.getAudioTracks().length) ||
-                                (options.devices.indexOf("video") !== -1 &&
-                                !stream.getVideoTracks().length))
+                            var audioDeviceRequested = options.devices.indexOf("audio") !== -1;
+                            var videoDeviceRequested = options.devices.indexOf("video") !== -1;
+                            var audioTracksReceived = !!stream.getAudioTracks().length;
+                            var videoTracksReceived = !!stream.getVideoTracks().length;
+
+                            if((audioDeviceRequested && !audioTracksReceived) ||
+                                (videoDeviceRequested && !videoTracksReceived))
                             {
                                 self.stopMediaStream(stream);
 
@@ -899,13 +902,11 @@ var RTCUtils = {
                                 // this happened, so reject with general error.
                                 var devices = [];
 
-                                if (options.devices.indexOf("audio") !== -1 &&
-                                    !stream.getAudioTracks().length) {
+                                if (audioDeviceRequested && !audioTracksReceived) {
                                     devices.push("audio");
                                 }
 
-                                if (options.devices.indexOf("video") !== -1 &&
-                                    !stream.getVideoTracks().length) {
+                                if (videoDeviceRequested && !videoTracksReceived) {
                                     devices.push("video");
                                 }
 

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -4,6 +4,7 @@ var logger = require("jitsi-meet-logger").getLogger(__filename);
 var RTCBrowserType = require("./RTCBrowserType");
 var AdapterJS = require("./adapter.screenshare");
 var JitsiTrackErrors = require("../../JitsiTrackErrors");
+var JitsiTrackError = require("../../JitsiTrackError");
 var GlobalOnErrorHandler = require("../util/GlobalOnErrorHandler");
 
 /**
@@ -66,7 +67,11 @@ var ScreenObtainer = {
 
         if (RTCBrowserType.isNWJS()) {
             obtainDesktopStream = function (onSuccess, onFailure) {
-                window.JitsiMeetNW.obtainDesktopStream (onSuccess, onFailure);
+                window.JitsiMeetNW.obtainDesktopStream (
+                    onSuccess, function (error, constraints) {
+                        onFailure && onFailure(
+                            new JitsiTrackError(error, constraints));
+                    });
             };
         } else if (RTCBrowserType.isTemasysPluginUsed()) {
             if (!AdapterJS.WebRTCPlugin.plugin.HasScreensharingFeature) {
@@ -174,10 +179,8 @@ var ScreenObtainer = {
 
         // Make sure desktopsharing knows that we failed, so that it doesn't get
         // stuck in 'switching' mode.
-        errorCallback({
-            type: "jitsiError",
-            errorObject: JitsiTrackErrors.FIREFOX_EXTENSION_NEEDED
-        });
+        errorCallback(
+            new JitsiTrackError(JitsiTrackErrors.FIREFOX_EXTENSION_NEEDED));
     },
     /**
      * Asks Chrome extension to call chooseDesktopMedia and gets chrome
@@ -209,23 +212,28 @@ var ScreenObtainer = {
                         }, 500);
                     },
                     function (arg) {
-                        logger.log("Failed to install the extension from:"
-                            + getWebStoreInstallUrl(self.options), arg);
-                        failCallback({
-                            type: "jitsiError",
-                            errorObject: JitsiTrackErrors
-                                .CHROME_EXTENSION_INSTALLATION_ERROR
-                        });
+                        var msg = "Failed to install the extension from "
+                            + getWebStoreInstallUrl(self.options);
+
+                        logger.log(msg, arg);
+
+                        failCallback(new JitsiTrackError(
+                            JitsiTrackErrors
+                                .CHROME_EXTENSION_INSTALLATION_ERROR,
+                            msg
+                        ));
                     }
                 );
             } catch(e) {
-                logger.log("Failed to install the extension from:"
-                    + self.getWebStoreInstallUrl(this.options), e);
-                failCallback({
-                    type: "jitsiError",
-                    errorObject:
-                        JitsiTrackErrors.CHROME_EXTENSION_INSTALLATION_ERROR
-                });
+                var msg = "Failed to install the extension from "
+                    + getWebStoreInstallUrl(self.options);
+
+                logger.log(msg, e);
+
+                failCallback(new JitsiTrackError(
+                    JitsiTrackErrors.CHROME_EXTENSION_INSTALLATION_ERROR,
+                    msg
+                ));
             }
         }
     }
@@ -348,7 +356,13 @@ function doGetStreamFromExtension(options, streamCallback, failCallback) {
         },
         function (response) {
             if (!response) {
-                failCallback(chrome.runtime.lastError);
+                // possibly re-wraping error message to make code consistent
+                var lastError = chrome.runtime.lastError;
+                failCallback(lastError instanceof Error
+                    ? lastError
+                    : new JitsiTrackError(
+                        JitsiTrackErrors.CHROME_EXTENSION_GENERIC_ERROR,
+                        lastError));
                 return;
             }
             logger.log("Response from extension: ", response);
@@ -366,15 +380,14 @@ function doGetStreamFromExtension(options, streamCallback, failCallback) {
                 // then the callback is called with an empty streamId.
                 if(response.streamId === "")
                 {
-                    failCallback({
-                        type: "jitsiError",
-                        errorObject:
-                            JitsiTrackErrors.CHROME_EXTENSION_USER_CANCELED
-                    });
+                    failCallback(new JitsiTrackError(
+                        JitsiTrackErrors.CHROME_EXTENSION_USER_CANCELED));
                     return;
                 }
 
-                failCallback("Extension failed to get the stream");
+                failCallback(new JitsiTrackError(
+                    JitsiTrackErrors.CHROME_EXTENSION_GENERIC_ERROR,
+                    response.error));
             }
         }
     );

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -211,30 +211,23 @@ var ScreenObtainer = {
                                 streamCallback, failCallback);
                         }, 500);
                     },
-                    function (arg) {
-                        var msg = "Failed to install the extension from "
-                            + getWebStoreInstallUrl(self.options);
-
-                        logger.log(msg, arg);
-
-                        failCallback(new JitsiTrackError(
-                            JitsiTrackErrors
-                                .CHROME_EXTENSION_INSTALLATION_ERROR,
-                            msg
-                        ));
-                    }
+                    handleExtensionInstallationError
                 );
             } catch(e) {
-                var msg = "Failed to install the extension from "
-                    + getWebStoreInstallUrl(self.options);
-
-                logger.log(msg, e);
-
-                failCallback(new JitsiTrackError(
-                    JitsiTrackErrors.CHROME_EXTENSION_INSTALLATION_ERROR,
-                    msg
-                ));
+                handleExtensionInstallationError(e);
             }
+        }
+
+        function handleExtensionInstallationError(e) {
+            var msg = "Failed to install the extension from "
+                + getWebStoreInstallUrl(self.options);
+
+            logger.log(msg, e);
+
+            failCallback(new JitsiTrackError(
+                JitsiTrackErrors.CHROME_EXTENSION_INSTALLATION_ERROR,
+                msg
+            ));
         }
     }
 };

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -69,8 +69,8 @@ var ScreenObtainer = {
             obtainDesktopStream = function (onSuccess, onFailure) {
                 window.JitsiMeetNW.obtainDesktopStream (
                     onSuccess, function (error, constraints) {
-                        onFailure && onFailure(
-                            new JitsiTrackError(error, constraints));
+                        onFailure && onFailure(new JitsiTrackError(
+                            error, constraints, ["desktop"]));
                     });
             };
         } else if (RTCBrowserType.isTemasysPluginUsed()) {

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -6,6 +6,7 @@ var EventEmitter = require("events");
 var StatisticsEvents = require("../../service/statistics/Events");
 var CallStats = require("./CallStats");
 var ScriptUtil = require('../util/ScriptUtil');
+var JitsiTrackError = require("../../JitsiTrackError");
 
 // Since callstats.io is a third party, we cannot guarantee the quality of their
 // service. More specifically, their server may take noticeably long time to
@@ -265,8 +266,13 @@ function (ssrc, isLocal, usageLabel, containerId) {
  * @param {Error} e error to send
  */
 Statistics.prototype.sendGetUserMediaFailed = function (e) {
-    if(this.callstats)
-        CallStats.sendGetUserMediaFailed(e, this.callstats);
+    if(this.callstats) {
+        CallStats.sendGetUserMediaFailed(
+            e instanceof JitsiTrackError
+                ? formatJitsiTrackErrorForCallStats(e)
+                : e,
+            this.callstats);
+    }
 };
 
 /**
@@ -275,7 +281,11 @@ Statistics.prototype.sendGetUserMediaFailed = function (e) {
  * @param {Error} e error to send
  */
 Statistics.sendGetUserMediaFailed = function (e) {
-    CallStats.sendGetUserMediaFailed(e, null);
+    CallStats.sendGetUserMediaFailed(
+        e instanceof JitsiTrackError
+            ? formatJitsiTrackErrorForCallStats(e)
+            : e,
+        null);
 };
 
 /**


### PR DESCRIPTION
This PR is a 'clone' of https://github.com/jitsi/lib-jitsi-meet/pull/119 into the jitsi organization repository where I have (1) push access and (2) automatic PR testing.

@tsareg wrote:
Following changes are introduced:

- JitsiMeetJS.createLocalTracks is now rejected with JitsiTrackError instance, not a string
- Introduced JitsiTrackError class that is inherited from base JavaScript Error class, so ```"name"```, ```"message"``` and ```"stack"``` properties are available. For GUM-related errors, exposes additional ```"gum"``` property, which is an object with following properties:
  - error - original GUM error
  - constraints - GUM constraints object used for the call
  - devices - array of devices requested in GUM call (possible values - "audio", "video", "screen", "desktop")
- Changed the format of how JitsiTrackError instances are logged to callstats
- JitsiTrackError is exposed to global scope as ```JitsiMeetJS.JitsiTrackError```
- callstats are now initialized as soon as we have JingleSessionPC instance, do not wait for XMPPEvents.PEERCONNECTION_READY, as it may never happen in case if user doesn't have or denied permission to both camera and microphone.
-  new JitsiTrackErrors types introduced:
  - JitsiTrackErrors.CHROME_EXTENSION_GENERIC_ERROR
  - JitsiTrackErrors.PERMISSION_DENIED
  - JitsiTrackErrors.NOT_FOUND
  - JitsiTrackErrors.CONSTRAINT_FAILED
- API.md document updated with changes