### PR TITLE
getUserMedia: prefer the "user" camera if we have not specified the exact device id for mobile devices

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -119,6 +119,12 @@ function getConstraints(um, options) {
             constraints.video.optional.push({
                 sourceId: options.cameraDeviceId
             });
+        } else {
+            // by default prefer the "user" camera if we have not specified the
+            // exact device id for mobile devices
+            if (RTCBrowserType.isReactNative() || RTCBrowserType.isAndroid()) {
+                constraints.video.facingMode = "user";
+            }
         }
 
         constraints.video.optional.push({ googLeakyBucket: true });
@@ -603,7 +609,7 @@ var RTCUtils = {
             disableNS = options.disableNS;
             logger.info("Disable NS: " + disableNS);
         }
-        
+
         return new Promise(function(resolve, reject) {
             if (RTCBrowserType.isFirefox()) {
                 var FFversion = RTCBrowserType.getFirefoxVersion();

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -120,11 +120,9 @@ function getConstraints(um, options) {
                 sourceId: options.cameraDeviceId
             });
         } else {
-            // by default prefer the "user" camera if we have not specified the
-            // exact device id for mobile devices
-            if (RTCBrowserType.isReactNative() || RTCBrowserType.isAndroid()) {
-                constraints.video.facingMode = "user";
-            }
+            // by default prefer the front ("user") camera if we have not
+            // specified the exact device id
+            constraints.video.facingMode = "user";
         }
 
         constraints.video.optional.push({ googLeakyBucket: true });


### PR DESCRIPTION
This should make us to select "front" camera for mobile apps by default. To really work with react-native, needs support for "facingMode" constraint in react-native-webrtc, which will be done by @paweldomas and @lyubomir 