### PR TITLE
Report DOMException when audio output device change fails as gUM error to callstats

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -60,7 +60,11 @@ function JitsiConference(options) {
         this.statistics.sendGetUserMediaFailed(error);
     }.bind(this));
     JitsiMeetJS._globalOnErrorHandler.push(function(error) {
-        this.statistics.sendUnhandledError(error);
+        if (error instanceof JitsiTrackError && error.gum) {
+            this.statistics.sendGetUserMediaFailed(error);
+        } else {
+            this.statistics.sendUnhandledError(error);
+        }
     }.bind(this));
     this.participants = {};
     this.lastDominantSpeaker = null;
@@ -1310,7 +1314,7 @@ function setupListeners(conference) {
                 conference.statistics.sendIceConnectionFailedEvent(pc);
                 conference.room.eventEmitter.emit(
                     XMPPEvents.CONFERENCE_SETUP_FAILED,
-                    new Error("ICE fail")); 
+                    new Error("ICE fail"));
             });
 
         conference.rtc.addListener(RTCEvents.TRACK_ATTACHED,

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -59,13 +59,8 @@ function JitsiConference(options) {
     JitsiMeetJS._gumFailedHandler.push(function(error) {
         this.statistics.sendGetUserMediaFailed(error);
     }.bind(this));
-    JitsiMeetJS._globalOnErrorHandler.push(function(error) {
-        if (error instanceof JitsiTrackError && error.gum) {
-            this.statistics.sendGetUserMediaFailed(error);
-        } else {
-            this.statistics.sendUnhandledError(error);
-        }
-    }.bind(this));
+    JitsiMeetJS._globalOnErrorHandler.push(
+        Statistics.reportGlobalError.bind(this.statistics));
     this.participants = {};
     this.lastDominantSpeaker = null;
     this.dtmfManager = null;

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -197,7 +197,7 @@ var LibJitsiMeet = {
               handler(error);
           });
         } else {
-            Statistics.reportGlobalError.call(Statistics, error);
+            Statistics.reportGlobalError(error);
         }
     },
 

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -197,11 +197,7 @@ var LibJitsiMeet = {
               handler(error);
           });
         } else {
-            if (error instanceof JitsiTrackError && error.gum) {
-                Statistics.sendGetUserMediaFailed(error);
-            } else {
-                Statistics.sendUnhandledError(error);
-            }
+            Statistics.reportGlobalError.call(Statistics, error);
         }
     },
 

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -197,7 +197,11 @@ var LibJitsiMeet = {
               handler(error);
           });
         } else {
-            Statistics.sendUnhandledError(error);
+            if (error instanceof JitsiTrackError && error.gum) {
+                Statistics.sendGetUserMediaFailed(error);
+            } else {
+                Statistics.sendUnhandledError(error);
+            }
         }
     },
 

--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -33,8 +33,8 @@ TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.TRACK_MUTE_UNMUTE_IN_PROGRESS]
  * @param {Object|string} error - error object or error name
  * @param {Object|string} (options) - getUserMedia constraints object or error
  *      message
- * @param {('audio'|'video'|'desktop'|'screen')[]} (devices) - list of
- *      getUserMedia requested devices
+ * @param {('audio'|'video'|'desktop'|'screen'|'audiooutput')[]} (devices) -
+ *      list of getUserMedia requested devices
  */
 function JitsiTrackError(error, options, devices) {
     if (typeof error === "object" && typeof error.name !== "undefined") {

--- a/doc/API.md
+++ b/doc/API.md
@@ -381,7 +381,7 @@ so ```"name"```, ```"message"``` and ```"stack"``` properties are available. For
 exposes additional ```"gum"``` property, which is an object with following properties:
  - error - original GUM error
  - constraints - GUM constraints object used for the call
- - devices - array of devices requested in GUM call (possible values - "audio", "video", "screen", "desktop")
+ - devices - array of devices requested in GUM call (possible values - "audio", "video", "screen", "desktop", "audiooutput")
 
 Getting Started
 ==============

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -578,12 +578,15 @@ function wrapAttachMediaStream(origAttachMediaStream) {
             stream.getAudioTracks && stream.getAudioTracks().length) {
             element.setSinkId(RTCUtils.getAudioOutputDevice())
                 .catch(function (ex) {
+                    var err = new JitsiTrackError(ex, null, ['audiooutput']);
+
                     GlobalOnErrorHandler.callUnhandledRejectionHandler(
-                        {promise: this, reason: ex});
+                        {promise: this, reason: err});
+
                     logger.warn('Failed to set audio output device for the ' +
                         'element. Default audio output device will be used ' +
                         'instead',
-                        element, ex);
+                        element, err);
                 });
         }
 
@@ -603,7 +606,7 @@ var RTCUtils = {
             disableNS = options.disableNS;
             logger.info("Disable NS: " + disableNS);
         }
-        
+
         return new Promise(function(resolve, reject) {
             if (RTCBrowserType.isFirefox()) {
                 var FFversion = RTCBrowserType.getFirefoxVersion();

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -381,4 +381,17 @@ Statistics.prototype.sendFeedback = function(overall, detailed) {
 
 Statistics.LOCAL_JID = require("../../service/statistics/constants").LOCAL_JID;
 
+/**
+ * Reports global error to CallStats.
+ *
+ * @param {Error} error
+ */
+Statistics.reportGlobalError = function (error) {
+    if (error instanceof JitsiTrackError && error.gum) {
+        this.sendGetUserMediaFailed(error);
+    } else {
+        this.sendUnhandledError(error);
+    }
+};
+
 module.exports = Statistics;


### PR DESCRIPTION
Currently if browser fails to set audiooutput device on tracks, this error was logged as SignalingError to callstats. This is actually not very obvious, so instead log it as gUM error.