### PR TITLE
Refactor callstats removing improve static calls to Statistics.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -55,12 +55,6 @@ function JitsiConference(options) {
         roomName: this.options.name
     });
     setupListeners(this);
-    var JitsiMeetJS = this.connection.JitsiMeetJS;
-    JitsiMeetJS._gumFailedHandler.push(function(error) {
-        this.statistics.sendGetUserMediaFailed(error);
-    }.bind(this));
-    JitsiMeetJS._globalOnErrorHandler.push(
-        Statistics.reportGlobalError.bind(this.statistics));
     this.participants = {};
     this.lastDominantSpeaker = null;
     this.dtmfManager = null;
@@ -75,17 +69,6 @@ function JitsiConference(options) {
         video: undefined
     };
     this.isMutedByFocus = false;
-
-    // Lets send some general stats useful for debugging problems
-    if (window.jitsiRegionInfo
-            && Object.keys(window.jitsiRegionInfo).length > 0) {
-        // remove quotes to make it prettier
-        Statistics.sendLog(
-            JSON.stringify(window.jitsiRegionInfo).replace(/\"/g, ""));
-    }
-
-    if(JitsiMeetJS.version)
-        Statistics.sendLog("LibJitsiMeet:" + JitsiMeetJS.version);
 }
 
 /**

--- a/JitsiConnection.js
+++ b/JitsiConnection.js
@@ -4,20 +4,12 @@ var XMPP = require("./modules/xmpp/xmpp");
 /**
  * Creates new connection object for the Jitsi Meet server side video conferencing service. Provides access to the
  * JitsiConference interface.
- * @param JitsiMeetJS the JitsiMeetJS instance which is initializing the new
- * JitsiConnection instance
  * @param appID identification for the provider of Jitsi Meet video conferencing services.
  * @param token the JWT token used to authenticate with the server(optional)
  * @param options Object with properties / settings related to connection with the server.
  * @constructor
  */
-function JitsiConnection(JitsiMeetJS, appID, token, options) {
-    /**
-     * The {JitsiMeetJS} instance which has initialized this {JitsiConnection}
-     * instance.
-     * @public
-     */
-    this.JitsiMeetJS = JitsiMeetJS;
+function JitsiConnection(appID, token, options) {
     this.appID = appID;
     this.token = token;
     this.options = options;

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -84,6 +84,12 @@ function Statistics(xmpp, options) {
 }
 Statistics.audioLevelsEnabled = false;
 
+/**
+ * Array of callstats instances. Used to call Statistics static methods and
+ * send stats to all cs instances.
+ */
+Statistics.callsStatsInstances = [];
+
 Statistics.prototype.startRemoteStats = function (peerconnection) {
     if(!Statistics.audioLevelsEnabled)
         return;
@@ -194,6 +200,7 @@ Statistics.prototype.stopRemoteStats = function () {
 Statistics.prototype.startCallStats = function (session, settings) {
     if(this.callStatsIntegrationEnabled && !this.callstats) {
         this.callstats = new CallStats(session, settings, this.options);
+        Statistics.callsStatsInstances.push(this.callstats);
     }
 };
 
@@ -270,27 +277,23 @@ function (ssrc, isLocal, usageLabel, containerId) {
  *
  * @param {Error} e error to send
  */
-Statistics.prototype.sendGetUserMediaFailed = function (e) {
-    if(this.callstats) {
+Statistics.sendGetUserMediaFailed = function (e) {
+
+    if (Statistics.callsStatsInstances.length) {
+        Statistics.callsStatsInstances.forEach(function (cs) {
+            CallStats.sendGetUserMediaFailed(
+                e instanceof JitsiTrackError
+                    ? formatJitsiTrackErrorForCallStats(e)
+                    : e,
+                cs);
+        });
+    } else {
         CallStats.sendGetUserMediaFailed(
             e instanceof JitsiTrackError
                 ? formatJitsiTrackErrorForCallStats(e)
                 : e,
-            this.callstats);
+            null);
     }
-};
-
-/**
- * Notifies CallStats that getUserMedia failed.
- *
- * @param {Error} e error to send
- */
-Statistics.sendGetUserMediaFailed = function (e) {
-    CallStats.sendGetUserMediaFailed(
-        e instanceof JitsiTrackError
-            ? formatJitsiTrackErrorForCallStats(e)
-            : e,
-        null);
 };
 
 /**
@@ -349,23 +352,18 @@ Statistics.prototype.sendAddIceCandidateFailed = function (e, pc) {
 };
 
 /**
- * Notifies CallStats that there is an unhandled error on the page.
- *
- * @param {Error} e error to send
- * @param {RTCPeerConnection} pc connection on which failure occured.
- */
-Statistics.prototype.sendUnhandledError = function (e) {
-    if(this.callstats)
-        CallStats.sendUnhandledError(e, this.callstats);
-};
-
-/**
  * Notifies CallStats that there is unhandled exception.
  *
  * @param {Error} e error to send
  */
 Statistics.sendUnhandledError = function (e) {
-    CallStats.sendUnhandledError(e, null);
+    if (Statistics.callsStatsInstances.length) {
+        Statistics.callsStatsInstances.forEach(function (cs) {
+            CallStats.sendUnhandledError(e, cs);
+        });
+    } else {
+        CallStats.sendUnhandledError(e, null);
+    }
 };
 
 /**
@@ -375,7 +373,7 @@ Statistics.sendUnhandledError = function (e) {
  */
 Statistics.sendLog = function (m) {
     // uses  the same field for cs stat as unhandled error
-    CallStats.sendUnhandledError(m, null);
+    Statistics.sendUnhandledError(m);
 };
 
 /**
@@ -398,9 +396,9 @@ Statistics.LOCAL_JID = require("../../service/statistics/constants").LOCAL_JID;
  */
 Statistics.reportGlobalError = function (error) {
     if (error instanceof JitsiTrackError && error.gum) {
-        this.sendGetUserMediaFailed(error);
+        Statistics.sendGetUserMediaFailed(error);
     } else {
-        this.sendUnhandledError(error);
+        Statistics.sendUnhandledError(error);
     }
 };
 


### PR DESCRIPTION
You can call static Statistics methods which will internally handle callstats instances to send stats. Drops handlers and JitsiMeetJS references.