### PR TITLE
Don't mix old and new-style for gUM constraints for Chrome, as it fails with TypeError in new Chrome versions

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -114,10 +114,10 @@ function getConstraints(um, options) {
         constraints.video = { mandatory: {}, optional: [] };
 
         if (options.cameraDeviceId) {
-            // Don't mix new and old style settings for Chrome as this leads to
-            // TypeError in new Chrome versions. @see
+            // Don't mix new and old style settings for Chromium as this leads
+            // to TypeError in new Chromium versions. @see
             // https://bugs.chromium.org/p/chromium/issues/detail?id=614716
-            if (!RTCBrowserType.isChrome()) {
+            if (!RTCBrowserType.isChrome() && !RTCBrowserType.isOpera()) {
                 // New style of setting device id.
                 constraints.video.deviceId = options.cameraDeviceId;
             }
@@ -132,10 +132,10 @@ function getConstraints(um, options) {
             // but this probably needs to be decided when updating other
             // constraints, as we currently don't use "exact" syntax anywhere.
 
-            // Don't mix new and old style settings for Chrome as this leads to
-            // TypeError in new Chrome versions. @see
+            // Don't mix new and old style settings for Chromium as this leads
+            // to TypeError in new Chromium versions. @see
             // https://bugs.chromium.org/p/chromium/issues/detail?id=614716
-            if (!RTCBrowserType.isChrome()) {
+            if (!RTCBrowserType.isChrome() && !RTCBrowserType.isOpera()) {
                 constraints.video.facingMode = options.facingMode || 'user';
             }
 
@@ -157,10 +157,10 @@ function getConstraints(um, options) {
             // same behaviour as true
             constraints.audio = { mandatory: {}, optional: []};
             if (options.micDeviceId) {
-                // Don't mix new and old style settings for Chrome as this leads to
-                // TypeError in new Chrome versions. @see
+                // Don't mix new and old style settings for Chromium as this
+                // leads to TypeError in new Chromium versions. @see
                 // https://bugs.chromium.org/p/chromium/issues/detail?id=614716
-                if (!RTCBrowserType.isChrome()) {
+                if (!RTCBrowserType.isChrome() && !RTCBrowserType.isOpera()) {
                     // New style of setting device id.
                     constraints.audio.deviceId = options.micDeviceId;
                 }

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -109,15 +109,24 @@ function setResolutionConstraints(constraints, resolution) {
 function getConstraints(um, options) {
     var constraints = {audio: false, video: false};
 
+    // Don't mix new and old style settings for Chromium as this leads
+    // to TypeError in new Chromium versions. @see
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=614716
+    // This is a temporary solution, in future we will fully split old and
+    // new style constraints when new versions of Chromium and Firefox will
+    // have stable support of new constraints format. For more information
+    // @see https://github.com/jitsi/lib-jitsi-meet/pull/136
+    var isNewStyleConstraintsSupported =
+        RTCBrowserType.isFirefox() ||
+        RTCBrowserType.isReactNative() ||
+        RTCBrowserType.isTemasysPluginUsed();
+
     if (um.indexOf('video') >= 0) {
         // same behaviour as true
         constraints.video = { mandatory: {}, optional: [] };
 
         if (options.cameraDeviceId) {
-            // Don't mix new and old style settings for Chromium as this leads
-            // to TypeError in new Chromium versions. @see
-            // https://bugs.chromium.org/p/chromium/issues/detail?id=614716
-            if (!RTCBrowserType.isChrome() && !RTCBrowserType.isOpera()) {
+            if (isNewStyleConstraintsSupported) {
                 // New style of setting device id.
                 constraints.video.deviceId = options.cameraDeviceId;
             }
@@ -131,11 +140,7 @@ function getConstraints(um, options) {
             // TODO: Maybe use "exact" syntax if options.facingMode is defined,
             // but this probably needs to be decided when updating other
             // constraints, as we currently don't use "exact" syntax anywhere.
-
-            // Don't mix new and old style settings for Chromium as this leads
-            // to TypeError in new Chromium versions. @see
-            // https://bugs.chromium.org/p/chromium/issues/detail?id=614716
-            if (!RTCBrowserType.isChrome() && !RTCBrowserType.isOpera()) {
+            if (isNewStyleConstraintsSupported) {
                 constraints.video.facingMode = options.facingMode || 'user';
             }
 
@@ -157,10 +162,7 @@ function getConstraints(um, options) {
             // same behaviour as true
             constraints.audio = { mandatory: {}, optional: []};
             if (options.micDeviceId) {
-                // Don't mix new and old style settings for Chromium as this
-                // leads to TypeError in new Chromium versions. @see
-                // https://bugs.chromium.org/p/chromium/issues/detail?id=614716
-                if (!RTCBrowserType.isChrome() && !RTCBrowserType.isOpera()) {
+                if (isNewStyleConstraintsSupported) {
                     // New style of setting device id.
                     constraints.audio.deviceId = options.micDeviceId;
                 }

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -114,9 +114,14 @@ function getConstraints(um, options) {
         constraints.video = { mandatory: {}, optional: [] };
 
         if (options.cameraDeviceId) {
-            // new style of settings device id (FF only)
-            constraints.video.deviceId = options.cameraDeviceId;
-            // old style
+            // Don't mix new and old style settings for Chrome as this leads to
+            // TypeError in new Chrome versions. @see
+            // https://bugs.chromium.org/p/chromium/issues/detail?id=614716
+            if (!RTCBrowserType.isChrome()) {
+                // New style of setting device id.
+                constraints.video.deviceId = options.cameraDeviceId;
+            }
+            // Old style.
             constraints.video.optional.push({
                 sourceId: options.cameraDeviceId
             });
@@ -126,7 +131,17 @@ function getConstraints(um, options) {
             // TODO: Maybe use "exact" syntax if options.facingMode is defined,
             // but this probably needs to be decided when updating other
             // constraints, as we currently don't use "exact" syntax anywhere.
-            constraints.video.facingMode = options.facingMode || 'user';
+
+            // Don't mix new and old style settings for Chrome as this leads to
+            // TypeError in new Chrome versions. @see
+            // https://bugs.chromium.org/p/chromium/issues/detail?id=614716
+            if (!RTCBrowserType.isChrome()) {
+                constraints.video.facingMode = options.facingMode || 'user';
+            }
+
+            constraints.video.optional.push({
+                facingMode: options.facingMode || 'user'
+            });
         }
 
         constraints.video.optional.push({ googLeakyBucket: true });
@@ -142,9 +157,14 @@ function getConstraints(um, options) {
             // same behaviour as true
             constraints.audio = { mandatory: {}, optional: []};
             if (options.micDeviceId) {
-                // new style of settings device id (FF only)
-                constraints.audio.deviceId = options.micDeviceId;
-                // old style
+                // Don't mix new and old style settings for Chrome as this leads to
+                // TypeError in new Chrome versions. @see
+                // https://bugs.chromium.org/p/chromium/issues/detail?id=614716
+                if (!RTCBrowserType.isChrome()) {
+                    // New style of setting device id.
+                    constraints.audio.deviceId = options.micDeviceId;
+                }
+                // Old style.
                 constraints.audio.optional.push({
                     sourceId: options.micDeviceId
                 });


### PR DESCRIPTION
For more details see https://bugs.chromium.org/p/chromium/issues/detail?id=614716.
In Chrome 51 this error happens when "enable-experimental-web-platform-feature" flag is enabled, while in Chrome Canary 53 it fails always.

This is extracted code from https://github.com/jitsi/lib-jitsi-meet/pull/136 as it seems that currently we're not able to fully switch to new style constraints for new browsers due to bugs.