### PR TITLE
Fire an optional JitsiMediaDevices.PERMISSION_PROMPT_IS_SHOWN event when JitsiMeetJS.createLocalTracks()

### DIFF
--- a/JitsiMediaDevices.js
+++ b/JitsiMediaDevices.js
@@ -88,6 +88,13 @@ var JitsiMediaDevices = {
      */
     removeEventListener: function (event, handler) {
         eventEmitter.removeListener(event, handler);
+    },
+    /**
+     * Emits an event.
+     * @param {string} event - event name
+     */
+    emitEvent: function (event) {
+        eventEmitter.emit.apply(eventEmitter, arguments);
     }
 };
 

--- a/JitsiMediaDevicesEvents.js
+++ b/JitsiMediaDevicesEvents.js
@@ -11,7 +11,17 @@ var JitsiMediaDevicesEvents = {
      *  MediaDeviceInfo-like objects that are currently connected.
      *  @see https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo
      */
-    DEVICE_LIST_CHANGED: "mediaDevices.devicechange"
+    DEVICE_LIST_CHANGED: "mediaDevices.devicechange",
+    /**
+     * Indicates that the environment is currently showing permission prompt to
+     * access camera and/or microphone. The event provides the following
+     * parameters to its listeners:
+     *
+     * @param {'chrome'|'opera'|'firefox'|'iexplorer'|'safari'|'nwjs'
+     *      |'react-native'|'android'} environmentType - type of browser or
+     *      other execution environment.
+     */
+    PERMISSION_PROMPT_IS_SHOWN: "mediaDevices.permissionPromptIsShown"
 };
 
 module.exports = JitsiMediaDevicesEvents;

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -18,7 +18,6 @@ var Statistics = require("./modules/statistics/statistics");
 var Resolutions = require("./service/RTC/Resolutions");
 var ScriptUtil = require("./modules/util/ScriptUtil");
 var GlobalOnErrorHandler = require("./modules/util/GlobalOnErrorHandler");
-var RTCBrowserType = require("./modules/RTC/RTCBrowserType");
 
 function getLowerResolution(resolution) {
     if(!Resolutions[resolution])
@@ -43,9 +42,6 @@ var LibJitsiMeet = {
 
     version: '{#COMMIT_HASH#}',
 
-    // expose JitsiTrackError this way to give library consumers to do checks
-    // like if (error instanceof JitsiMeetJS.JitsiTrackError) { }
-    JitsiTrackError: JitsiTrackError,
     JitsiConnection: JitsiConnection,
     events: {
         conference: JitsiConferenceEvents,
@@ -61,7 +57,6 @@ var LibJitsiMeet = {
     },
     logLevels: Logger.levels,
     mediaDevices: JitsiMediaDevices,
-    environment: RTCBrowserType,
     init: function (options) {
         Statistics.audioLevelsEnabled = !options.disableAudioLevels;
 
@@ -206,6 +201,10 @@ var LibJitsiMeet = {
         RTCUIHelper: RTCUIHelper
     }
 };
+
+// expose JitsiTrackError this way to give library consumers to do checks like
+// if (error instanceof JitsiMeetJS.JitsiTrackError) { }
+LibJitsiMeet.JitsiTrackError = JitsiTrackError;
 
 //Setups the promise object.
 window.Promise = window.Promise || require("es6-promise").Promise;

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -18,6 +18,11 @@ var Statistics = require("./modules/statistics/statistics");
 var Resolutions = require("./service/RTC/Resolutions");
 var ScriptUtil = require("./modules/util/ScriptUtil");
 var GlobalOnErrorHandler = require("./modules/util/GlobalOnErrorHandler");
+var RTCBrowserType = require("./modules/RTC/RTCBrowserType");
+
+// The amount of time to wait until firing
+// JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN event
+var USER_MEDIA_PERMISSION_PROMPT_TIMEOUT = 500;
 
 function getLowerResolution(resolution) {
     if(!Resolutions[resolution])
@@ -99,13 +104,36 @@ var LibJitsiMeet = {
      * will be returned trough the Promise, otherwise JitsiTrack objects will be returned.
      * @param {string} options.cameraDeviceId
      * @param {string} options.micDeviceId
+     * @param {boolean} (firePermissionPromptIsShownEvent) - if event
+     *      JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN should be fired
      * @returns {Promise.<{Array.<JitsiTrack>}, JitsiConferenceError>}
      *     A promise that returns an array of created JitsiTracks if resolved,
      *     or a JitsiConferenceError if rejected.
      */
-    createLocalTracks: function (options) {
-        return RTC.obtainAudioAndVideoPermissions(options || {}).then(
-            function(tracks) {
+    createLocalTracks: function (options, firePermissionPromptIsShownEvent) {
+        var promiseFulfilled = false;
+
+        if (firePermissionPromptIsShownEvent === true) {
+            window.setTimeout(function () {
+                if (!promiseFulfilled) {
+                    var browser = RTCBrowserType.getBrowserType()
+                        .split('rtc_browser.')[1];
+
+                    if (RTCBrowserType.isAndroid()) {
+                        browser = 'android';
+                    }
+
+                    JitsiMediaDevices.emitEvent(
+                        JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN,
+                        browser);
+                }
+            }, USER_MEDIA_PERMISSION_PROMPT_TIMEOUT);
+        }
+
+        return RTC.obtainAudioAndVideoPermissions(options || {})
+            .then(function(tracks) {
+                promiseFulfilled = true;
+
                 if(!RTC.options.disableAudioLevels)
                     for(var i = 0; i < tracks.length; i++) {
                         var track = tracks[i];
@@ -120,8 +148,11 @@ var LibJitsiMeet = {
                                 });
                         }
                     }
+
                 return tracks;
             }).catch(function (error) {
+                promiseFulfilled = true;
+
                 Statistics.sendGetUserMediaFailed(error);
 
                 if(error.name === JitsiTrackErrors.UNSUPPORTED_RESOLUTION) {

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -18,6 +18,7 @@ var Statistics = require("./modules/statistics/statistics");
 var Resolutions = require("./service/RTC/Resolutions");
 var ScriptUtil = require("./modules/util/ScriptUtil");
 var GlobalOnErrorHandler = require("./modules/util/GlobalOnErrorHandler");
+var RTCBrowserType = require("./modules/RTC/RTCBrowserType");
 
 function getLowerResolution(resolution) {
     if(!Resolutions[resolution])
@@ -42,6 +43,9 @@ var LibJitsiMeet = {
 
     version: '{#COMMIT_HASH#}',
 
+    // expose JitsiTrackError this way to give library consumers to do checks
+    // like if (error instanceof JitsiMeetJS.JitsiTrackError) { }
+    JitsiTrackError: JitsiTrackError,
     JitsiConnection: JitsiConnection,
     events: {
         conference: JitsiConferenceEvents,
@@ -57,6 +61,7 @@ var LibJitsiMeet = {
     },
     logLevels: Logger.levels,
     mediaDevices: JitsiMediaDevices,
+    environment: RTCBrowserType,
     init: function (options) {
         Statistics.audioLevelsEnabled = !options.disableAudioLevels;
 
@@ -201,10 +206,6 @@ var LibJitsiMeet = {
         RTCUIHelper: RTCUIHelper
     }
 };
-
-// expose JitsiTrackError this way to give library consumers to do checks like
-// if (error instanceof JitsiMeetJS.JitsiTrackError) { }
-LibJitsiMeet.JitsiTrackError = JitsiTrackError;
 
 //Setups the promise object.
 window.Promise = window.Promise || require("es6-promise").Promise;

--- a/doc/API.md
+++ b/doc/API.md
@@ -60,7 +60,7 @@ The ```options``` parameter is JS object with the following properties:
 JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
 ```
 
-* ```JitsiMeetJS.createLocalTracks(options)``` - Creates the media tracks and returns them trough ```Promise``` object. If rejected, passes ```JitsiTrackError``` instance to catch block.
+* ```JitsiMeetJS.createLocalTracks(options, firePermissionPromptIsShownEvent)``` - Creates the media tracks and returns them trough ```Promise``` object. If rejected, passes ```JitsiTrackError``` instance to catch block.
     - options - JS object with configuration options for the local media tracks. You can change the following properties there:
         1. devices - array with the devices - "desktop", "video" and "audio" that will be passed to GUM. If that property is not set GUM will try to get all available devices.
         2. resolution - the prefered resolution for the local video.
@@ -69,6 +69,7 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
         5. minFps - the minimum frame rate for the video stream (passed to GUM)
         6. maxFps - the maximum frame rate for the video stream (passed to GUM)
         7. facingMode - facing mode for a camera (possible values - 'user', 'environment')
+    - firePermissionPromptIsShownEvent - optional boolean parameter. If set to ```true```, ```JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN``` will be fired when browser shows gUM permission prompt.
 
 * ```JitsiMeetJS.enumerateDevices(callback)``` - __DEPRECATED__. Use ```JitsiMeetJS.mediaDevices.enumerateDevices(callback)``` instead.
 * ```JitsiMeetJS.isDeviceListAvailable()``` - __DEPRECATED__. Use ```JitsiMeetJS.mediaDevices.isDeviceListAvailable()``` instead.
@@ -89,27 +90,6 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
     - ```isDevicePermissionGranted(type)``` - returns true if user granted permission to media devices. ```type``` - 'audio', 'video' or ```undefined```. In case of ```undefined``` will check if both audio and video permissions were granted.
     - ```addEventListener(event, handler)``` - attaches an event handler.
     - ```removeEventListener(event, handler)``` - removes an event handler.
-
-* ```JitsiMeetJS.environment``` - environment detection helper. Provides following methods and properties:
-    - ```RTC_BROWSER_CHROME```
-    - ```RTC_BROWSER_OPERA```
-    - ```RTC_BROWSER_FIREFOX```
-    - ```RTC_BROWSER_IEXPLORER```
-    - ```RTC_BROWSER_SAFARI```
-    - ```RTC_BROWSER_NWJS```
-    - ```RTC_BROWSER_REACT_NATIVE```
-    - ```getBrowserType()``` - gets current browser type.
-    - ```isChrome()``` - checks if current browser is Chrome.
-    - ```isOpera()``` - checks if current browser is Opera.
-    - ```isFirefox()``` - checks if current browser is Firefox.
-    - ```isIExplorer()``` - checks if current browser is Internet Explorer.
-    - ```isSafari()``` - checks if current browser is Safari.
-    - ```isNWJS()``` - checks if current environment is NWJS.
-    - ```isReactNative()``` - checks if current environment is React Native.
-    - ```isTemasysPluginUsed()``` - checks if Temasys RTC plugin is used.
-    - ```getFirefoxVersion()``` - returns Firefox version.
-    - ```getChromeVersion()``` - returns Chrome version.
-    - ```isAndroid()``` - checks whether the browser is running on an android device.
 
 * ```JitsiMeetJS.events``` - JS object that contains all events used by the API. You will need that JS object when you try to subscribe for connection or conference events.
     We have two event types - connection and conference. You can access the events with the following code ```JitsiMeetJS.events.<event_type>.<event_name>```.
@@ -154,6 +134,7 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
 
     4. mediaDevices
         - DEVICE_LIST_CHANGED - indicates that list of currently connected devices has changed (parameters - devices(MediaDeviceInfo[])).
+        - PERMISSION_PROMPT_IS_SHOWN - Indicates that the environment is currently showing permission prompt to access camera and/or microphone (parameters - environmentType ('chrome'|'opera'|'firefox'|'iexplorer'|'safari'|'nwjs'|'react-native'|'android').
 
 
 * ```JitsiMeetJS.errors``` - JS object that contains all errors used by the API. You can use that object to check the reported errors from the API

--- a/doc/API.md
+++ b/doc/API.md
@@ -53,8 +53,6 @@ The ```options``` parameter is JS object with the following properties:
 
 * ```JitsiMeetJS.JitsiConnection``` - the ```JitsiConnection``` constructor. You can use that to create new server connection.
 
-* ```JitsiMeetJS.JitsiTrackError``` - the ```JitsiTrackError``` constructor. You can use that to check ```instanceof``` errors you get from ```JitsiMeetJS.createLocalTracks()``` method.
-
 * ```JitsiMeetJS.setLogLevel``` - changes the log level for the library. For example to have only error messages you should do:
 ```
 JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);

--- a/doc/API.md
+++ b/doc/API.md
@@ -53,6 +53,8 @@ The ```options``` parameter is JS object with the following properties:
 
 * ```JitsiMeetJS.JitsiConnection``` - the ```JitsiConnection``` constructor. You can use that to create new server connection.
 
+* ```JitsiMeetJS.JitsiTrackError``` - the ```JitsiTrackError``` constructor. You can use that to check ```instanceof``` errors you get from ```JitsiMeetJS.createLocalTracks()``` method.
+
 * ```JitsiMeetJS.setLogLevel``` - changes the log level for the library. For example to have only error messages you should do:
 ```
 JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
@@ -88,6 +90,26 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
     - ```addEventListener(event, handler)``` - attaches an event handler.
     - ```removeEventListener(event, handler)``` - removes an event handler.
 
+* ```JitsiMeetJS.environment``` - environment detection helper. Provides following methods and properties:
+    - ```RTC_BROWSER_CHROME```
+    - ```RTC_BROWSER_OPERA```
+    - ```RTC_BROWSER_FIREFOX```
+    - ```RTC_BROWSER_IEXPLORER```
+    - ```RTC_BROWSER_SAFARI```
+    - ```RTC_BROWSER_NWJS```
+    - ```RTC_BROWSER_REACT_NATIVE```
+    - ```getBrowserType()``` - gets current browser type.
+    - ```isChrome()``` - checks if current browser is Chrome.
+    - ```isOpera()``` - checks if current browser is Opera.
+    - ```isFirefox()``` - checks if current browser is Firefox.
+    - ```isIExplorer()``` - checks if current browser is Internet Explorer.
+    - ```isSafari()``` - checks if current browser is Safari.
+    - ```isNWJS()``` - checks if current environment is NWJS.
+    - ```isReactNative()``` - checks if current environment is React Native.
+    - ```isTemasysPluginUsed()``` - checks if Temasys RTC plugin is used.
+    - ```getFirefoxVersion()``` - returns Firefox version.
+    - ```getChromeVersion()``` - returns Chrome version.
+    - ```isAndroid()``` - checks whether the browser is running on an android device.
 
 * ```JitsiMeetJS.events``` - JS object that contains all events used by the API. You will need that JS object when you try to subscribe for connection or conference events.
     We have two event types - connection and conference. You can access the events with the following code ```JitsiMeetJS.events.<event_type>.<event_name>```.

--- a/modules/RTC/RTCBrowserType.js
+++ b/modules/RTC/RTCBrowserType.js
@@ -22,41 +22,90 @@ var RTCBrowserType = {
 
     RTC_BROWSER_REACT_NATIVE: "rtc_browser.react-native",
 
+    /**
+     * Gets current browser type.
+     * @returns {string}
+     */
     getBrowserType: function () {
         return currentBrowser;
     },
 
+    /**
+     * Checks if current browser is Chrome.
+     * @returns {boolean}
+     */
     isChrome: function () {
         return currentBrowser === RTCBrowserType.RTC_BROWSER_CHROME;
     },
 
+    /**
+     * Checks if current browser is Opera.
+     * @returns {boolean}
+     */
     isOpera: function () {
         return currentBrowser === RTCBrowserType.RTC_BROWSER_OPERA;
     },
+
+    /**
+     * Checks if current browser is Firefox.
+     * @returns {boolean}
+     */
     isFirefox: function () {
         return currentBrowser === RTCBrowserType.RTC_BROWSER_FIREFOX;
     },
 
+    /**
+     * Checks if current browser is Internet Explorer.
+     * @returns {boolean}
+     */
     isIExplorer: function () {
         return currentBrowser === RTCBrowserType.RTC_BROWSER_IEXPLORER;
     },
 
+    /**
+     * Checks if current browser is Safari.
+     * @returns {boolean}
+     */
     isSafari: function () {
         return currentBrowser === RTCBrowserType.RTC_BROWSER_SAFARI;
     },
+
+    /**
+     * Checks if current environment is NWJS.
+     * @returns {boolean}
+     */
     isNWJS: function () {
         return currentBrowser === RTCBrowserType.RTC_BROWSER_NWJS;
     },
+
+    /**
+     * Checks if current environment is React Native.
+     * @returns {boolean}
+     */
     isReactNative: function () {
         return currentBrowser === RTCBrowserType.RTC_BROWSER_REACT_NATIVE;
     },
+
+    /**
+     * Checks if Temasys RTC plugin is used.
+     * @returns {boolean}
+     */
     isTemasysPluginUsed: function () {
         return RTCBrowserType.isIExplorer() || RTCBrowserType.isSafari();
     },
+
+    /**
+     * Returns Firefox version.
+     * @returns {number|null}
+     */
     getFirefoxVersion: function () {
         return RTCBrowserType.isFirefox() ? browserVersion : null;
     },
 
+    /**
+     * Returns Chrome version.
+     * @returns {number|null}
+     */
     getChromeVersion: function () {
         return RTCBrowserType.isChrome() ? browserVersion : null;
     },
@@ -72,6 +121,7 @@ var RTCBrowserType = {
 
     /**
      * Whether the browser is running on an android device.
+     * @returns {boolean}
      */
     isAndroid: function() {
         return isAndroid;


### PR DESCRIPTION
Sometimes we need to do some browser/environment detection in code that uses lib-jitsi-meet, so we can re-use this info from lib.

This is required for https://github.com/jitsi/jitsi-meet/pull/701