### PR TITLE
Stores jitsiObjectURL when creating url.

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -668,6 +668,8 @@ function defaultGetVideoSrc(element) {
         if (URL) {
             url = URL.createObjectURL(srcObject);
             try {
+                // store the url to avoid creating different url for every call
+                srcObject.jitsiObjectURL = url;
                 return url.toString();
             } finally {
                 URL.revokeObjectURL(url);


### PR DESCRIPTION
Fixes test failing when using chrome-beta. Stores jitsiObjectURL otherwise on every call of getVideoSrc we create new different url.