### PR TITLE
Fix logging audio output device to callstats

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -340,7 +340,7 @@ JitsiConference.prototype.addTrack = function (track) {
                 && d.label === track.getTrack().label;
         });
         if(device)
-            Statistics.sendАctiveDeviceListEvent(
+            Statistics.sendActiveDeviceListEvent(
                 RTC.getEventDataForActiveDevice(device));
     }
     return new Promise(function (resolve, reject) {

--- a/JitsiMediaDevices.js
+++ b/JitsiMediaDevices.js
@@ -30,8 +30,10 @@ function logOutputDevice (deviceID, devices) {
         return d.kind === 'audiooutput' && d.deviceId === deviceID;
     });
 
-    Statistics.sendАctiveDeviceListEvent(
-        RTC.getEventDataForActiveDevice(device));
+    if (device) {
+        Statistics.sendActiveDeviceListEvent(
+            RTC.getEventDataForActiveDevice(device));
+    }
 }
 
 var JitsiMediaDevices = {

--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -293,7 +293,7 @@ CallStats.sendDominantSpeakerEvent = _try_catch(function (cs) {
  * @param {{deviceList: {String:String}}} list of devices with their data
  * @param {CallStats} cs callstats instance related to the event
  */
-CallStats.sendАctiveDeviceListEvent = _try_catch(function (devicesData, cs) {
+CallStats.sendActiveDeviceListEvent = _try_catch(function (devicesData, cs) {
 
     CallStats._reportEvent.call(cs, fabricEvent.activeDeviceList, devicesData);
 });

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -253,15 +253,16 @@ Statistics.prototype.sendDominantSpeakerEvent = function () {
 
 /**
  * Notifies about active device.
- * @param {{deviceList: {String:String}}} list of devices with their data
+ * @param {{deviceList: {String:String}}} devicesData - list of devices with
+ *      their data
  */
-Statistics.sendАctiveDeviceListEvent = function (devicesData) {
+Statistics.sendActiveDeviceListEvent = function (devicesData) {
     if (Statistics.callsStatsInstances.length) {
         Statistics.callsStatsInstances.forEach(function (cs) {
-            CallStats.sendАctiveDeviceListEvent(devicesData, cs);
+            CallStats.sendActiveDeviceListEvent(devicesData, cs);
         });
     } else {
-        CallStats.sendАctiveDeviceListEvent(devicesData, null);
+        CallStats.sendActiveDeviceListEvent(devicesData, null);
     }
 };
 


### PR DESCRIPTION
Do not send event to callstats when no audiooutput devices are available.
Fix non-ASCII letter in Statistics.sendActiveDeviceListEvent() method