### PR TITLE
Be forgiving towards API clients

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -308,17 +308,27 @@ JitsiConference.prototype.setSubject = function (subject) {
  * Adds JitsiLocalTrack object to the conference.
  * @param track the JitsiLocalTrack object.
  * @returns {Promise<JitsiLocalTrack>}
- * @throws will throw and error if track is video track
- * and there is already another video track in the conference.
+ * @throws {Error} if the specified track is a video track and there is already
+ * another video track in the conference.
  */
 JitsiConference.prototype.addTrack = function (track) {
-    if(track.disposed)
-    {
+    if (track.disposed) {
         throw new JitsiTrackError(JitsiTrackErrors.TRACK_IS_DISPOSED);
     }
 
-    if (track.isVideoTrack() && this.rtc.getLocalVideoTrack()) {
-        throw new Error("cannot add second video track to the conference");
+    if (track.isVideoTrack()) {
+        // Ensure there's exactly 1 local video track in the conference.
+        var localVideoTrack = this.rtc.getLocalVideoTrack();
+        if (localVideoTrack) {
+            // Don't be excessively harsh and severe if the API client happens
+            // to attempt to add the same local video track twice.
+            if (track === localVideoTrack) {
+                return Promise.resolve(track);
+            } else {
+                throw new Error(
+                        "cannot add second video track to the conference");
+            }
+        }
     }
 
     track.ssrcHandler = function (conference, ssrcMap) {


### PR DESCRIPTION
If the API client happened to try to add one and the same local video
track twice, the library would throw an error. I find that draconian
because:

1. The error message states that a second local video stream cannot be
added but that is incorrect because the API client is not trying to add
a second local video stream but add one and the same local video stream
multiple times.

2. The jsdoc says that a throw will happen if another local video stream
is added but that is misleading because the API client is not trying to
add another local video stream but add the same local video stream.

3. Adding one and the same local video stream multiple times can be
handled gracefully by the lib-jitsi-meet library. Thus, the library
appears more friendly.

Hence, gracefully handle the case of adding the same local video track
multiple times without throwing an error.