### PR TITLE
Expose JitsiTrackError through JitsiMeetJS.errorTypes.JitsiTrackError

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -60,6 +60,9 @@ var LibJitsiMeet = {
         recorder: JitsiRecorderErrors,
         track: JitsiTrackErrors
     },
+    errorTypes: {
+        JitsiTrackError: JitsiTrackError
+    },
     logLevels: Logger.levels,
     mediaDevices: JitsiMediaDevices,
     init: function (options) {
@@ -236,10 +239,6 @@ var LibJitsiMeet = {
         RTCUIHelper: RTCUIHelper
     }
 };
-
-// expose JitsiTrackError this way to give library consumers to do checks like
-// if (error instanceof JitsiMeetJS.JitsiTrackError) { }
-LibJitsiMeet.JitsiTrackError = JitsiTrackError;
 
 //Setups the promise object.
 window.Promise = window.Promise || require("es6-promise").Promise;

--- a/doc/API.md
+++ b/doc/API.md
@@ -171,6 +171,9 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
         - CHROME_EXTENSION_INSTALLATION_ERROR - an error which indicates that the jidesha extension for Chrome is failed to install.
         - FIREFOX_EXTENSION_NEEDED - An error which indicates that the jidesha extension for Firefox is needed to proceed with screen sharing, and that it is not installed.
         
+* ```JitsiMeetJS.errorTypes``` - constructors for Error instances that can be produced by library. Are useful for checks like ```error instanceof JitsiMeetJS.errorTypes.JitsiTrackError```. Following Errors are available:
+    1. ```JitsiTrackError``` - Error that happened to a JitsiTrack.
+        
 * ```JitsiMeetJS.logLevels``` - object with the log levels:
     1. TRACE
     2. DEBUG


### PR DESCRIPTION
Exposes JitsiTrackError through JitsiMeetJS.errorTypes.JitsiTrackError.

This is a part of bigger PR (#149), which can be merged now.