### PR TITLE
Append random hex string to MUC nickname with XMPP login

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -3,6 +3,7 @@
 var logger = require("jitsi-meet-logger").getLogger(__filename);
 var EventEmitter = require("events");
 var Pako = require("pako");
+var RandomUtil = require("../util/RandomUtil");
 var RTCEvents = require("../../service/RTC/RTCEvents");
 var XMPPEvents = require("../../service/xmpp/XMPPEvents");
 var JitsiConnectionErrors = require("../../JitsiConnectionErrors");
@@ -245,6 +246,9 @@ XMPP.prototype.createRoom = function (roomName, options, settings) {
 
         if (!authenticatedUser)
             tmpJid = tmpJid.substr(0, 8);
+        else
+            tmpJid += "-" + RandomUtil.randomHexString(6);
+
         roomjid += '/' + tmpJid;
     }
 


### PR DESCRIPTION
When XMPP authenticated user joins the conference his login is used as MUC nickname. Now if his connection gets interrupted and he stays as a ghost until it times out, he will be unable to join from the new connection. That's because Prosody allows to join twice under the same nickname from the same bare JID. Jicofo will not distinguish between those two users and will not invite the second one to the conference.