### PR TITLE
False callstats failures

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -160,23 +160,21 @@ var LibJitsiMeet = {
             }).catch(function (error) {
                 promiseFulfilled = true;
 
-                Statistics.sendGetUserMediaFailed(error);
-
                 if(error.name === JitsiTrackErrors.UNSUPPORTED_RESOLUTION) {
                     var oldResolution = options.resolution || '360',
                         newResolution = getLowerResolution(oldResolution);
 
-                    if (newResolution === null) {
-                        return Promise.reject(error);
+                    if (newResolution !== null) {
+                        options.resolution = newResolution;
+
+                        logger.debug("Retry createLocalTracks with resolution",
+                            newResolution);
+
+                        return LibJitsiMeet.createLocalTracks(options);
                     }
-
-                    options.resolution = newResolution;
-
-                    logger.debug("Retry createLocalTracks with resolution",
-                                newResolution);
-
-                    return LibJitsiMeet.createLocalTracks(options);
                 }
+
+                Statistics.sendGetUserMediaFailed(error);
 
                 return Promise.reject(error);
             }.bind(this));

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -174,7 +174,16 @@ var LibJitsiMeet = {
                     }
                 }
 
-                Statistics.sendGetUserMediaFailed(error);
+                if (JitsiTrackErrors.CHROME_EXTENSION_USER_CANCELED ===
+                        error.name) {
+                    // User cancelled action is not really an error, so only
+                    // log it as an event to avoid having conference classified
+                    // as partially failed
+                    Statistics.sendLog(error.message);
+                } else {
+                    // Report gUM failed to the stats
+                    Statistics.sendGetUserMediaFailed(error);
+                }
 
                 return Promise.reject(error);
             }.bind(this));

--- a/modules/xmpp/strophe.ping.js
+++ b/modules/xmpp/strophe.ping.js
@@ -116,10 +116,13 @@ module.exports = function (XMPP, eventEmitter) {
                 function (error) {
                     self.failedPings += 1;
                     var errmsg = "Ping " + (error ? "error" : "timeout");
-                    GlobalOnErrorHandler.callErrorHandler(new Error(errmsg));
-                    logger.error(errmsg, error);
                     if (self.failedPings >= PING_THRESHOLD) {
+                        GlobalOnErrorHandler.callErrorHandler(
+                            new Error(errmsg));
+                        logger.error(errmsg, error);
                         self.connection.disconnect();
+                    } else {
+                        logger.warn(errmsg, error);
                     }
                 }, PING_TIMEOUT);
             }, interval);

--- a/modules/xmpp/strophe.ping.js
+++ b/modules/xmpp/strophe.ping.js
@@ -120,7 +120,12 @@ module.exports = function (XMPP, eventEmitter) {
                         GlobalOnErrorHandler.callErrorHandler(
                             new Error(errmsg));
                         logger.error(errmsg, error);
-                        self.connection.disconnect();
+                        // FIXME it doesn't help to disconnect when 3rd PING
+                        // times out, it only stops Strophe from retrying.
+                        // Not really sure what's the right thing to do in that
+                        // situation, but just closing the connection makes no
+                        // sense.
+                        //self.connection.disconnect();
                     } else {
                         logger.warn(errmsg, error);
                     }

--- a/modules/xmpp/strophe.util.js
+++ b/modules/xmpp/strophe.util.js
@@ -8,6 +8,16 @@ var GlobalOnErrorHandler = require("../util/GlobalOnErrorHandler");
 module.exports = function () {
 
     Strophe.log = function (level, msg) {
+        // Our global handler reports uncaught errors to the stats which may
+        // interpret those as partial call failure.
+        // Strophe log entry about secondary request timeout does not mean that
+        // it's a final failure(the request will be restarted), so we lower it's
+        // level here to a warning.
+        if (typeof msg === 'string' &&
+                msg.indexOf("Request ") !== -1 &&
+                msg.indexOf("timed out (secondary), restarting") !== -1) {
+            level = Strophe.LogLevel.WARN;
+        }
         switch (level) {
             case Strophe.LogLevel.WARN:
                 logger.warn("Strophe: " + msg);


### PR DESCRIPTION
This series of commits prevent Callstats.io from classifying conference as partially failed when that's not really the case.