### PR TITLE
Clean up event listeners attached inside JitsiConference and related classes

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -53,7 +53,7 @@ function JitsiConference(options) {
             this.options.config.disableThirdPartyRequests,
         roomName: this.options.name
     });
-    setupListeners(this);
+    this._setupListeners();
     this.participants = {};
     this.lastDominantSpeaker = null;
     this.dtmfManager = null;
@@ -101,9 +101,8 @@ JitsiConference.prototype._leaveRoomAndRemoveParticipants = function () {
     this.getParticipants().forEach(function (participant) {
         this.onMemberLeft(participant.getJid());
     }.bind(this));
+};
 
-    this.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_LEFT);
-}
 /**
  * Leaves the conference.
  * @returns {Promise}
@@ -114,17 +113,24 @@ JitsiConference.prototype.leave = function () {
     return Promise.all(
         conference.getLocalTracks().map(function (track) {
             return conference.removeTrack(track);
-        })
-    ).then(this._leaveRoomAndRemoveParticipants.bind(this))
-    .catch(function (error) {
-        logger.error(error);
-        GlobalOnErrorHandler.callUnhandledRejectionHandler(
-            {promise: this, reason: error});
-        // We are proceeding with leaving the conference because room.leave may
-        // succeed.
-        this._leaveRoomAndRemoveParticipants();
-        return Promise.resolve();
-    }.bind(this));
+        }))
+        .then(this._leaveRoomAndRemoveParticipants.bind(this))
+        .catch(function (error) {
+            logger.error(error);
+            GlobalOnErrorHandler.callUnhandledRejectionHandler(
+                {promise: this, reason: error});
+            // We are proceeding with leaving the conference because room.leave
+            // may succeed.
+            this._leaveRoomAndRemoveParticipants();
+            return Promise.resolve();
+        }.bind(this))
+        .then(function() {
+            conference.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_LEFT);
+
+            conference._dispose();
+
+            return Promise.resolve();
+        });
 };
 
 /**
@@ -1012,46 +1018,42 @@ JitsiConference.prototype.sendApplicationLog = function(message) {
 };
 
 /**
- * Setups the listeners needed for the conference.
- * @param conference the conference
+ * Cleans all attached event listeners.
+ *
+ * @private
  */
-function setupListeners(conference) {
-    conference.xmpp.addListener(
-        XMPPEvents.CALL_INCOMING, function (jingleSession, jingleOffer, now) {
+JitsiConference.prototype._dispose = function () {
+    // ChatRoom's listeners cleared inside its leave() method, so there is no
+    // need to clean them separately here.
 
-        if (conference.room.isFocus(jingleSession.peerjid)) {
-            // Accept incoming call
-            conference.room.setJingleSession(jingleSession);
-            conference.room.connectionTimes["session.initiate"] = now;
-            try{
-                jingleSession.initialize(false /* initiator */,
-                    conference.room);
-            } catch (error) {
-                GlobalOnErrorHandler.callErrorHandler(error);
-            };
-            conference.rtc.onIncommingCall(jingleSession);
-            jingleSession.acceptOffer(jingleOffer, null,
-                function (error) {
-                    GlobalOnErrorHandler.callErrorHandler(error);
-                    logger.error(
-                        "Failed to accept incoming Jingle session", error);
-                }
-            );
-            // Start callstats as soon as peerconnection is initialized,
-            // do not wait for XMPPEvents.PEERCONNECTION_READY, as it may never
-            // happen in case if user doesn't have or denied permission to
-            // both camera and microphone.
-            conference.statistics.startCallStats(jingleSession, conference.settings);
-            conference.statistics.startRemoteStats(jingleSession.peerconnection);
-        } else {
-            // Error cause this should never happen unless something is wrong!
-            var errmsg
-                = "Rejecting session-initiate from non-focus user: "
-                    + jingleSession.peerjid;
-            GlobalOnErrorHandler.callErrorHandler(new Error(errmsg));
-            logger.error(errmsg);
-        }
-    });
+    this.statistics.dispose();
+    this.rtc.dispose();
+
+    // Remove specific XMPP listeners attached in _setupListeners() method.
+    this.xmpp.removeListener(
+        XMPPEvents.CALL_INCOMING, this._onCallIncoming);
+    this.xmpp.removeListener(
+        XMPPEvents.START_MUTED_FROM_FOCUS, this._onStartMutedFromFocus);
+
+    this.eventEmitter.removeAllListeners();
+};
+
+/**
+ * Setups the listeners needed for the conference.
+ *
+ * @private
+ */
+JitsiConference.prototype._setupListeners = function() {
+    var conference = this;
+
+    this._onCallIncoming = this._onCallIncoming.bind(this);
+    this._onStartMutedFromFocus = this._onStartMutedFromFocus.bind(this);
+
+    this.xmpp.addListener(
+        XMPPEvents.CALL_INCOMING, this._onCallIncoming);
+
+    this.xmpp.addListener(
+        XMPPEvents.START_MUTED_FROM_FOCUS, this._onStartMutedFromFocus);
 
     conference.room.addListener(XMPPEvents.ICE_RESTARTING, function () {
         // All data channels have to be closed, before ICE restart
@@ -1265,25 +1267,6 @@ function setupListeners(conference) {
                 lastNEndpoints, endpointsEnteringLastN);
         });
 
-    conference.xmpp.addListener(XMPPEvents.START_MUTED_FROM_FOCUS,
-        function (audioMuted, videoMuted) {
-            conference.startAudioMuted = audioMuted;
-            conference.startVideoMuted = videoMuted;
-
-            // mute existing local tracks because this is initial mute from
-            // Jicofo
-            conference.getLocalTracks().forEach(function (track) {
-                if (conference.startAudioMuted && track.isAudioTrack()) {
-                    track.mute();
-                }
-                if (conference.startVideoMuted && track.isVideoTrack()) {
-                    track.mute();
-                }
-            });
-
-            conference.eventEmitter.emit(JitsiConferenceEvents.STARTED_MUTED);
-        });
-
     conference.room.addPresenceListener("startmuted", function (data, from) {
         var isModerator = false;
         if (conference.myUserId() === from && conference.isModerator()) {
@@ -1416,10 +1399,6 @@ function setupListeners(conference) {
             conference.eventEmitter.emit(
                 JitsiConferenceEvents.CONNECTION_STATS, stats);
         });
-        conference.room.addListener(XMPPEvents.DISPOSE_CONFERENCE,
-            function () {
-                conference.statistics.dispose();
-            });
 
         conference.room.addListener(XMPPEvents.CONNECTION_ICE_FAILED,
             function (pc) {
@@ -1474,7 +1453,77 @@ function setupListeners(conference) {
             }
         );
     }
-}
+};
 
+/**
+ * Event handler for XMPPEvents.START_MUTED_FROM_FOCUS event.
+ *
+ * @private
+ * @param {boolean} audioMuted - If audio is muted.
+ * @param {boolean} videoMuted - If video is muted.
+ */
+JitsiConference.prototype._onStartMutedFromFocus = function(
+    audioMuted, videoMuted) {
+    var self = this;
+
+    this.startAudioMuted = audioMuted;
+    this.startVideoMuted = videoMuted;
+
+    // mute existing local tracks because this is initial mute from
+    // Jicofo
+    this.getLocalTracks().forEach(function (track) {
+        if (self.startAudioMuted && track.isAudioTrack()) {
+            track.mute();
+        }
+        if (self.startVideoMuted && track.isVideoTrack()) {
+            track.mute();
+        }
+    });
+
+    this.eventEmitter.emit(JitsiConferenceEvents.STARTED_MUTED);
+};
+
+/**
+ * Event handler for XMPPEvents.CALL_INCOMING event.
+ *
+ * @private
+ * @param jingleSession
+ * @param jingleOffer
+ * @param now
+ */
+JitsiConference.prototype._onCallIncoming = function(
+    jingleSession, jingleOffer, now) {
+    if (this.room.isFocus(jingleSession.peerjid)) {
+        // Accept incoming call
+        this.room.setJingleSession(jingleSession);
+        this.room.connectionTimes["session.initiate"] = now;
+        try {
+            jingleSession.initialize(false /* initiator */, this.room);
+        } catch (error) {
+            GlobalOnErrorHandler.callErrorHandler(error);
+        }
+        this.rtc.onIncommingCall(jingleSession);
+        jingleSession.acceptOffer(jingleOffer, null,
+            function (error) {
+                GlobalOnErrorHandler.callErrorHandler(error);
+                logger.error(
+                    "Failed to accept incoming Jingle session", error);
+            }
+        );
+        // Start callstats as soon as peerconnection is initialized,
+        // do not wait for XMPPEvents.PEERCONNECTION_READY, as it may never
+        // happen in case if user doesn't have or denied permission to
+        // both camera and microphone.
+        this.statistics.startCallStats(jingleSession, this.settings);
+        this.statistics.startRemoteStats(jingleSession.peerconnection);
+    } else {
+        // Error cause this should never happen unless something is wrong!
+        var errmsg
+            = "Rejecting session-initiate from non-focus user: "
+            + jingleSession.peerjid;
+        GlobalOnErrorHandler.callErrorHandler(new Error(errmsg));
+        logger.error(errmsg);
+    }
+};
 
 module.exports = JitsiConference;

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -37,7 +37,6 @@ function JitsiLocalTrack(stream, track, mediaType, videoType, resolution,
     this.resolution = resolution;
     this.deviceId = deviceId;
     this.startMuted = false;
-    this.disposed = false;
     //FIXME: This dependacy is not necessary.
     this.conference = null;
     this.initialMSID = this.getMSID();
@@ -287,9 +286,12 @@ JitsiLocalTrack.prototype._setMute = function (mute, resolve, reject) {
 /**
  * Stops sending the media track. And removes it from the HTML.
  * NOTE: Works for local tracks only.
+ *
+ * @extends JitsiTrack#dispose
  * @returns {Promise}
  */
 JitsiLocalTrack.prototype.dispose = function () {
+    var self = this;
     var promise = Promise.resolve();
 
     if (this.conference){
@@ -301,8 +303,6 @@ JitsiLocalTrack.prototype.dispose = function () {
         this.detach();
     }
 
-    this.disposed = true;
-
     RTCUtils.removeListener(RTCEvents.DEVICE_LIST_CHANGED,
         this._onDeviceListChanged);
 
@@ -311,7 +311,10 @@ JitsiLocalTrack.prototype.dispose = function () {
             this._onAudioOutputDeviceChanged);
     }
 
-    return promise;
+    return promise
+        .then(function() {
+            return JitsiTrack.prototype.dispose.call(self);
+        });
 };
 
 /**

--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -84,6 +84,4 @@ JitsiRemoteTrack.prototype._setVideoType = function (type) {
     this.eventEmitter.emit(JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED, type);
 };
 
-delete JitsiRemoteTrack.prototype.dispose;
-
 module.exports = JitsiRemoteTrack;

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -71,6 +71,8 @@ function JitsiTrack(rtc, stream, track, streamInactiveHandler, trackMediaType,
     this.track = track;
     this.videoType = videoType;
 
+    this.disposed = false;
+
     if(stream) {
         if (RTCBrowserType.isFirefox()) {
             implementOnEndedHandling(this);
@@ -208,10 +210,16 @@ JitsiTrack.prototype.detach = function (container) {
 };
 
 /**
- * Dispose sending the media track. And removes it from the HTML.
- * NOTE: Works for local tracks only.
+ * Removes attached event listeners.
+ *
+ * @returns {Promise}
  */
 JitsiTrack.prototype.dispose = function () {
+    this.eventEmitter.removeAllListeners();
+
+    this.disposed = true;
+
+    return Promise.resolve();
 };
 
 /**

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -888,6 +888,18 @@ ChatRoom.prototype.leave = function () {
     this.eventEmitter.emit(XMPPEvents.DISPOSE_CONFERENCE);
     this.doLeave();
     this.connection.emuc.doLeave(this.roomjid);
+    this._dispose();
+};
+
+/**
+ * Cleans up instance from attached event listeners.
+ *
+ * @private
+ */
+ChatRoom.prototype._dispose = function () {
+    this.moderator.dispose();
+    this.eventEmitter.removeAllListeners();
+    this.presHandlers = {};
 };
 
 module.exports = ChatRoom;

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -43,7 +43,7 @@ function Moderator(roomName, xmpp, emitter, settings, options) {
     this.focusUserJid;
     //FIXME:
     // Message listener that talks to POPUP window
-    function listener(event) {
+    this._listener = function listener(event) {
         if (event.data && event.data.sessionId) {
             if (event.origin !== window.location.origin) {
                 logger.warn("Ignoring sessionId from different origin: " +
@@ -53,12 +53,12 @@ function Moderator(roomName, xmpp, emitter, settings, options) {
             settings.setSessionId(event.data.sessionId);
             // After popup is closed we will authenticate
         }
-    }
+    };
     // Register
     if (window.addEventListener) {
-        window.addEventListener("message", listener, false);
-    } else {
-        window.attachEvent("onmessage", listener);
+        window.addEventListener("message", this._listener, false);
+    } else if (window.attachEvent) {
+        window.attachEvent("onmessage", this._listener);
     }
 }
 
@@ -525,6 +525,17 @@ Moderator.prototype.logout =  function (callback) {
             logger.error(errmsg, error);
         }
     );
+};
+
+/**
+ * Disposes instance.
+ */
+Moderator.prototype.dispose = function () {
+    if (window.removeEventListener) {
+        window.removeEventListener("message", this._listener, false);
+    } else if (window.detachEvent) {
+        window.detachEvent("onmessage", this._listener);
+    }
 };
 
 module.exports = Moderator;


### PR DESCRIPTION
Since we are moving to single page web app and native app in scope of jitsi-meet-react project, it's important for us to work better with memory and do not allow possible memory leaks.

This PR is the first step towards better memory management. Here we clean up all event listeners attached to JitsiConference and some other related classes like ChatRoom, RTC, Moderator, JitsiTrack etc.
Also we clean up events attached to window.

Future PRs will address JitsiConference and XMPP classes and also some static classes like JitsiMeetJS, RTC, RTCUtils.