### PR TITLE
Fix JitsiConferenceEvents.TRACK_REMOVED is fired inconsistently

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -60,6 +60,10 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function () {
                         && tracks[i].getStreamId() == streamId
                         && tracks[i].getTrackId() == trackId) {
                         var track = participant._tracks.splice(i, 1)[0];
+
+                        conference.rtc.removeRemoteTrack(
+                            participant.getId(), track.getType());
+
                         conference.eventEmitter.emit(
                             JitsiConferenceEvents.TRACK_REMOVED, track);
                         return;

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -287,17 +287,56 @@ RTC.prototype.createRemoteTrack = function (event) {
 
 /**
  * Removes all JitsiRemoteTracks associated with given MUC nickname (resource
- * part of the JID).
- * @param resource the resource part of the MUC JID
- * @returns {JitsiRemoteTrack|null}
+ * part of the JID). Returns array of removed tracks.
+ *
+ * @param {string} resource - The resource part of the MUC JID.
+ * @returns {JitsiRemoteTrack[]}
  */
 RTC.prototype.removeRemoteTracks = function (resource) {
-    var remoteTracks = this.remoteTracks[resource];
+    var remoteTracksForResource = this.remoteTracks[resource];
+    var removedTracks = [];
 
-    if(remoteTracks) {
-        remoteTracks['audio'] && remoteTracks['audio'].dispose();
-        remoteTracks['video'] && remoteTracks['video'].dispose();
+    if (remoteTracksForResource) {
+        for (var key in remoteTracksForResource) {
+            if (remoteTracksForResource.hasOwnProperty(key) &&
+                remoteTracksForResource[key]) {
+                var removedTrack = this.removeRemoteTrack(
+                    resource, remoteTracksForResource[key]);
+
+                if (removedTrack) {
+                    removedTracks.push(removedTrack);
+                }
+            }
+        }
+
         delete this.remoteTracks[resource];
+    }
+
+    return removedTracks;
+};
+
+/**
+ * Removes specified JitsiRemoteTrack associated with given MUC nickname
+ * (resource part of the JID). Returns removed track if any.
+ *
+ * @param {string} resource - The resource part of the MUC JID.
+ * @param {JitsiRemoteTrack} track - Track to remove.
+ * @returns {JitsiRemoteTrack|undefined}
+ */
+RTC.prototype.removeRemoteTrack = function (resource, track) {
+    var remoteTracksForResource = this.remoteTracks[resource];
+
+    if (remoteTracksForResource) {
+        for (var key in remoteTracksForResource) {
+            if (remoteTracksForResource.hasOwnProperty(key) &&
+                remoteTracksForResource[key] &&
+                remoteTracksForResource[key] === track) {
+                remoteTracksForResource[key].dispose();
+                delete remoteTracksForResource[key];
+                return track;
+            }
+
+        }
     }
 };
 

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -247,50 +247,34 @@ RTC.prototype.createRemoteTrack = function (event) {
  * @returns {JitsiRemoteTrack[]}
  */
 RTC.prototype.removeRemoteTracks = function (resource) {
-    var remoteTracksForResource = this.remoteTracks[resource];
     var removedTracks = [];
+    var removedAudioTrack = this.removeRemoteTrack(resource, MediaType.AUDIO);
+    var removedVideoTrack = this.removeRemoteTrack(resource, MediaType.VIDEO);
 
-    if (remoteTracksForResource) {
-        for (var key in remoteTracksForResource) {
-            if (remoteTracksForResource.hasOwnProperty(key) &&
-                remoteTracksForResource[key]) {
-                var removedTrack = this.removeRemoteTrack(
-                    resource, remoteTracksForResource[key]);
+    removedAudioTrack && removedTracks.push(removedAudioTrack);
+    removedVideoTrack && removedTracks.push(removedVideoTrack);
 
-                if (removedTrack) {
-                    removedTracks.push(removedTrack);
-                }
-            }
-        }
-
-        delete this.remoteTracks[resource];
-    }
+    delete this.remoteTracks[resource];
 
     return removedTracks;
 };
 
 /**
- * Removes specified JitsiRemoteTrack associated with given MUC nickname
+ * Removes specified track type associated with given MUC nickname
  * (resource part of the JID). Returns removed track if any.
  *
  * @param {string} resource - The resource part of the MUC JID.
- * @param {JitsiRemoteTrack} track - Track to remove.
+ * @param {string} mediaType - Type of track to remove.
  * @returns {JitsiRemoteTrack|undefined}
  */
-RTC.prototype.removeRemoteTrack = function (resource, track) {
+RTC.prototype.removeRemoteTrack = function (resource, mediaType) {
     var remoteTracksForResource = this.remoteTracks[resource];
 
-    if (remoteTracksForResource) {
-        for (var key in remoteTracksForResource) {
-            if (remoteTracksForResource.hasOwnProperty(key) &&
-                remoteTracksForResource[key] &&
-                remoteTracksForResource[key] === track) {
-                remoteTracksForResource[key].dispose();
-                delete remoteTracksForResource[key];
-                return track;
-            }
-
-        }
+    if (remoteTracksForResource && remoteTracksForResource[mediaType]) {
+        var track = remoteTracksForResource[mediaType];
+        track.dispose();
+        delete remoteTracksForResource[mediaType];
+        return track;
     }
 };
 


### PR DESCRIPTION
Currently ```JitsiConferenceEvents.TRACK_REMOVED``` is fired for remote tracks only on ```XMPPEvents.REMOTE_TRACK_REMOVED``` event (https://github.com/jitsi/lib-jitsi-meet/blob/master/JitsiConference.js#L1116-L1132). 

However in the case when participant leaves conference at all and we get into ```JitsiConference#onMemberLeft()``` method, we just silently remove remote tracks without firing any events except for ```JitsiConferenceEvents.USER_LEFT``` (https://github.com/jitsi/lib-jitsi-meet/blob/master/JitsiConference.js#L623-L634).

This fact causes inconsistencies for library users. So in this PR I propose to always fire  ```JitsiConferenceEvents.TRACK_REMOVED``` whenever track is removed. Also with this PR we are going to fix warnings "Overwriting remote track!" every time user changes his audio/video track (https://github.com/jitsi/lib-jitsi-meet/blob/master/modules/RTC/RTC.js#L282).