### PR TITLE
Uses the empty element with namespace for initial presence.

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -139,13 +139,20 @@ ChatRoom.prototype.sendPresence = function (fromJoin) {
     }
 
     var pres = $pres({to: to });
-    pres.c('x', {xmlns: this.presMap['xns']});
 
-    if (this.password) {
-        pres.c('password').t(this.password).up();
+    // xep-0045 defines: "including in the initial presence stanza an empty
+    // <x/> element qualified by the 'http://jabber.org/protocol/muc' namespace"
+    // and subsequent presences should not include that or it can be considered
+    // as joining, and server can send us the message history for the room on
+    // every presence
+    if (fromJoin) {
+        pres.c('x', {xmlns: this.presMap['xns']});
+
+        if (this.password) {
+            pres.c('password').t(this.password).up();
+        }
+        pres.up();
     }
-
-    pres.up();
 
     // Send XEP-0115 'c' stanza that contains our capabilities info
     var connection = this.connection;


### PR DESCRIPTION
Fixes a problem where, sending that namespace on every presence will make the server think we are joining every time and will return us the message history for the muc.