### PR TITLE
Better JitsiTrack#dispose() method to prevent memory leaks

### DIFF
--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -84,6 +84,4 @@ JitsiRemoteTrack.prototype._setVideoType = function (type) {
     this.eventEmitter.emit(JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED, type);
 };
 
-delete JitsiRemoteTrack.prototype.dispose;
-
 module.exports = JitsiRemoteTrack;

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -71,6 +71,8 @@ function JitsiTrack(conference, stream, track, streamInactiveHandler, trackMedia
     this.track = track;
     this.videoType = videoType;
 
+    this.disposed = false;
+
     if(stream) {
         if (RTCBrowserType.isFirefox()) {
             implementOnEndedHandling(this);
@@ -208,10 +210,16 @@ JitsiTrack.prototype.detach = function (container) {
 };
 
 /**
- * Dispose sending the media track. And removes it from the HTML.
- * NOTE: Works for local tracks only.
+ * Removes attached event listeners.
+ *
+ * @returns {Promise}
  */
 JitsiTrack.prototype.dispose = function () {
+    this.eventEmitter.removeAllListeners();
+
+    this.disposed = true;
+
+    return Promise.resolve();
 };
 
 /**

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1101,6 +1101,13 @@ var RTCUtils = {
             mediaStream.stop();
         }
 
+        // MediaStream in react-native-webrtc implementation has special
+        // "release" method to do the clean up of memory. We use it to prevent
+        // memory leaks.
+        if (mediaStream.release) {
+            mediaStream.release();
+        }
+
         // if we have done createObjectURL, lets clean it
         var url = mediaStream.jitsiObjectURL;
         if (url) {


### PR DESCRIPTION
Now there is base ```dispose()``` implementation for ```JitsiTrack``` which cleans all attached events.
Also we call ```MediaStream#release()``` for MediaStreams in React-Native environment (https://github.com/jitsi/react-native-webrtc/blob/master/MediaStream.js#L75)