### PR TITLE
Cleaning resources after leaving (kick)

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -83,8 +83,6 @@ JitsiConference.prototype._init = function (options) {
     this.room = this.xmpp.createRoom(this.options.name, this.options.config,
         this.settings, (this.retries < 4 ? 3 : null));
 
-    this.eventManager.setupChatRoomListeners();
-
     //restore previous presence options
     if(options.roomState) {
         this.room.loadState(options.roomState);
@@ -96,7 +94,6 @@ JitsiConference.prototype._init = function (options) {
         this.eventManager.setupRTCListeners();
     }
 
-
     if(!this.statistics) {
         this.statistics = new Statistics(this.xmpp, {
             callStatsID: this.options.config.callStatsID,
@@ -106,6 +103,9 @@ JitsiConference.prototype._init = function (options) {
             roomName: this.options.name
         });
     }
+
+    this.eventManager.setupChatRoomListeners();
+
     // Always add listeners because on reload we are executing leave and the
     // listeners are removed from statistics module.
     this.eventManager.setupStatisticsListeners();

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -193,6 +193,11 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function () {
 
     this.chatRoomForwarder.forward(XMPPEvents.KICKED,
         JitsiConferenceEvents.KICKED);
+    chatRoom.addListener(XMPPEvents.KICKED,
+        function () {
+            conference.room = null;
+            conference.leave.bind(conference);
+        });
 
     chatRoom.addListener(XMPPEvents.MUC_MEMBER_JOINED,
         conference.onMemberJoined.bind(conference));

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -495,7 +495,7 @@ ChatRoom.prototype.onPresenceUnavailable = function (pres, from) {
     }
     if ($(pres).find('>x[xmlns="http://jabber.org/protocol/muc#user"]>status[code="307"]').length) {
         if (this.myroomjid === from) {
-            this.leave();
+            this.leave(true);
             this.eventEmitter.emit(XMPPEvents.KICKED);
         }
     }
@@ -943,13 +943,15 @@ ChatRoom.prototype.onMute = function (iq) {
 
 /**
  * Leaves the room. Closes the jingle session.
+ * @parama voidSendingPresence avoids sending the presence when leaving
  */
-ChatRoom.prototype.leave = function () {
+ChatRoom.prototype.leave = function (avoidSendingPresence) {
     if (this.session) {
         this.session.close();
     }
     this.eventEmitter.emit(XMPPEvents.DISPOSE_CONFERENCE);
-    this.doLeave();
+    if(!avoidSendingPresence)
+        this.doLeave();
     this.connection.emuc.doLeave(this.roomjid);
 };
 


### PR DESCRIPTION
Fixes attaching chat room listeners for statistics.
Cleans statistics after the participant was kicked.