### PR TITLE
Introduced JitsiLocalTrack#getCameraFacingMode() method and CameraFacingMode enum

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -7,7 +7,9 @@ var JitsiTrackErrors = require("../../JitsiTrackErrors");
 var JitsiTrackError = require("../../JitsiTrackError");
 var RTCEvents = require("../../service/RTC/RTCEvents");
 var RTCUtils = require("./RTCUtils");
+var MediaType = require('../../service/RTC/MediaType');
 var VideoType = require('../../service/RTC/VideoType');
+var CameraFacingMode = require('../../service/RTC/CameraFacingMode');
 
 /**
  * Represents a single media track(either audio or video).
@@ -18,10 +20,11 @@ var VideoType = require('../../service/RTC/VideoType');
  * @param videoType the VideoType of the JitsiRemoteTrack
  * @param resolution the video resoultion if it's a video track
  * @param deviceId the ID of the local device for this track
+ * @param facingMode the camera facing mode used in getUserMedia call
  * @constructor
  */
 function JitsiLocalTrack(stream, track, mediaType, videoType, resolution,
-                         deviceId) {
+                         deviceId, facingMode) {
     var self = this;
 
     JitsiTrack.call(this,
@@ -39,6 +42,9 @@ function JitsiLocalTrack(stream, track, mediaType, videoType, resolution,
     this.startMuted = false;
     this.initialMSID = this.getMSID();
     this.inMuteOrUnmuteProgress = false;
+
+    // Store camera facing mode used during getUserMedia call.
+    this.facingMode = facingMode;
 
     // Currently there is no way to know the MediaStreamTrack ended due to to
     // device disconnect in Firefox through e.g. "readyState" property. Instead
@@ -395,5 +401,42 @@ JitsiLocalTrack.prototype.isLocal = function () {
 JitsiLocalTrack.prototype.getDeviceId = function () {
     return this._realDeviceId || this.deviceId;
 };
+
+/**
+ * Returns facing mode for video track from camera. For other cases (e.g. audio
+ * track or 'desktop' video track) returns undefined.
+ *
+ * @returns {CameraFacingMode|undefined}
+ */
+JitsiLocalTrack.prototype.getCameraFacingMode = function () {
+    if (this.isVideoTrack() && this.videoType === VideoType.CAMERA) {
+        // MediaStreamTrack#getSettings() is not implemented in many browsers,
+        // so we do a feature checking here. Progress on implementation can be
+        // tracked at https://bugs.chromium.org/p/webrtc/issues/detail?id=2481
+        // for Chromium and https://bugzilla.mozilla.org/show_bug.cgi?id=1213517
+        // for Firefox. Even if a browser already implements getSettings()
+        // it might still not return anything for 'facingMode' so we need to
+        // take into account this.
+        var trackSettings;
+
+        if (this.track &&
+            typeof this.track.getSettings === 'function' &&
+            (trackSettings = this.track.getSettings()) &&
+            'facingMode' in trackSettings) {
+            return trackSettings.facingMode;
+        } else if (typeof this.facingMode !== 'undefined') {
+            return this.facingMode;
+        } else {
+            // In most cases we are showing a webcam. So if we failed to satisfy
+            // any of the above conditions and got here, that means that we're
+            // probably showing the user facing camera.
+            return CameraFacingMode.USER;
+        }
+
+    }
+
+    return undefined;
+};
+
 
 module.exports = JitsiLocalTrack;

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -234,6 +234,7 @@ JitsiLocalTrack.prototype._setMute = function (mute, resolve, reject) {
                 streamOptions['micDeviceId'] = self.getDeviceId();
             } else if(self.videoType === VideoType.CAMERA) {
                 streamOptions['cameraDeviceId'] = self.getDeviceId();
+                streamOptions['facingMode'] = self.getCameraFacingMode();
             }
             RTCUtils.obtainAudioAndVideoPermissions(streamOptions)
                 .then(function (streamsInfo) {

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -17,16 +17,19 @@ function createLocalTracks(tracksInfo, options) {
     var deviceId = null;
     tracksInfo.forEach(function(trackInfo){
         if (trackInfo.mediaType === MediaType.AUDIO) {
-          deviceId = options.micDeviceId;
+            deviceId = options.micDeviceId;
         } else if (trackInfo.videoType === VideoType.CAMERA){
-          deviceId = options.cameraDeviceId;
+            deviceId = options.cameraDeviceId;
         }
         var localTrack
             = new JitsiLocalTrack(
-                trackInfo.stream,
-                trackInfo.track,
-                trackInfo.mediaType,
-                trackInfo.videoType, trackInfo.resolution, deviceId);
+            trackInfo.stream,
+            trackInfo.track,
+            trackInfo.mediaType,
+            trackInfo.videoType,
+            trackInfo.resolution,
+            deviceId,
+            options.facingMode);
         newTracks.push(localTrack);
     });
     return newTracks;

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -17,6 +17,7 @@ var JitsiTrackErrors = require("../../JitsiTrackErrors");
 var JitsiTrackError = require("../../JitsiTrackError");
 var MediaType = require("../../service/RTC/MediaType");
 var VideoType = require("../../service/RTC/VideoType");
+var CameraFacingMode = require("../../service/RTC/CameraFacingMode");
 var GlobalOnErrorHandler = require("../util/GlobalOnErrorHandler");
 
 var eventEmitter = new EventEmitter();
@@ -103,7 +104,7 @@ function setResolutionConstraints(constraints, resolution) {
  * @param {string} options.desktopStream
  * @param {string} options.cameraDeviceId
  * @param {string} options.micDeviceId
- * @param {'user'|'environment'} options.facingMode
+ * @param {CameraFacingMode} options.facingMode
  * @param {bool} firefox_fake_device
  */
 function getConstraints(um, options) {
@@ -141,11 +142,12 @@ function getConstraints(um, options) {
             // but this probably needs to be decided when updating other
             // constraints, as we currently don't use "exact" syntax anywhere.
             if (isNewStyleConstraintsSupported) {
-                constraints.video.facingMode = options.facingMode || 'user';
+                constraints.video.facingMode =
+                    options.facingMode || CameraFacingMode.USER;
             }
 
             constraints.video.optional.push({
-                facingMode: options.facingMode || 'user'
+                facingMode: options.facingMode || CameraFacingMode.USER
             });
         }
 

--- a/service/RTC/CameraFacingMode.js
+++ b/service/RTC/CameraFacingMode.js
@@ -1,0 +1,21 @@
+/* global module */
+/**
+ * Possible camera facing modes. For now support only 'user' and 'environment'
+ * modes as 'left' and 'right' and not used anywhere right at the moment.
+ * For more info see
+ * https://w3c.github.io/mediacapture-main/getusermedia.html#def-constraint-facingMode
+ *
+ * @enum {string}
+ */
+var CameraFacingMode = {
+    /**
+     * The user facing camera mode.
+     */
+    USER: "user",
+    /**
+     * The environment facing camera mode.
+     */
+    ENVIRONMENT: "environment"
+};
+
+module.exports = CameraFacingMode;


### PR DESCRIPTION
In some cases it's important to know if we are showing 'user' or 'environment' from camera (e.g. if we need to mirror it). This method will help us to determine facingMode of the video track if any.