### PR TITLE
Delete latedef repetition

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,19 +1,18 @@
 {
     // Refer to http://jshint.com/docs/options/ for an exhaustive list of options
     "asi": false, // true: Tolerate Automatic Semicolon Insertion (no semicolons)
-    "expr": true, // true: Tolerate `ExpressionStatement` as Programs
-    "loopfunc": true, // true: Tolerate functions being defined in loops
+    "browser": true, // Web Browser (window, document, etc)
     "curly": false, // true: Require {} for every new block or scope
     "evil": true, // true: Tolerate use of `eval` and `new Function()`
-    "white": true,
-    "undef": true, // true: Require all non-global variables to be declared (prevents global leaks)
-    "browser": true, // Web Browser (window, document, etc)
+    "expr": true, // true: Tolerate `ExpressionStatement` as Programs
+    "indent": 4, // {int} Number of spaces to use for indentation
+    "latedef": false, //This option prohibits the use of a variable before it was defined
+    "laxbreak": true, //Ignore line breaks around "=", "==", "&&", etc.
+    "loopfunc": true, // true: Tolerate functions being defined in loops
+    "maxlen": 80, // {int} Max number of characters per line
+    "newcap": true, // true: Require capitalization of all constructor functions e.g. `new F()`
     "node": true, // Node.js
     "trailing": true,
-    "indent": 4, // {int} Number of spaces to use for indentation
-    "latedef": true, // true: Require variables/functions to be defined before being used
-    "newcap": true, // true: Require capitalization of all constructor functions e.g. `new F()`
-    "maxlen": 80, // {int} Max number of characters per line
-    "latedef": false, //This option prohibits the use of a variable before it was defined
-    "laxbreak": true //Ignore line breaks around "=", "==", "&&", etc.
+    "undef": true, // true: Require all non-global variables to be declared (prevents global leaks)
+    "white": true
 }


### PR DESCRIPTION
Sorts the jshint configuration keys in alphabetical order (which
revealed that latedef was used twice with conflicting values). Removes
the early value of latedef because the late was in effect anyway.