### PR TITLE
Safe ScriptUtil#loadScript() method

### DIFF
--- a/modules/util/ScriptUtil.js
+++ b/modules/util/ScriptUtil.js
@@ -41,10 +41,16 @@ var ScriptUtil = {
         }
 
         script.src = src;
-        if (prepend) {
-            referenceNode.parentNode.insertBefore(script, referenceNode);
-        } else {
-            referenceNode.parentNode.appendChild(script);
+
+        // Some environments (e.g. React-Native) do not have <script> tags and
+        // do load not JS files in this way, so we need add additional safe
+        // checks here.
+        if (referenceNode && referenceNode.parentNode) {
+            if (prepend) {
+                referenceNode.parentNode.insertBefore(script, referenceNode);
+            } else {
+                referenceNode.parentNode.appendChild(script);
+            }
         }
     }
 };


### PR DESCRIPTION
Some environments (e.g. React-Native) do not have ```<script>``` tags and do not load JS files in this way, so we need add additional safe checks in "loadScript" method.