### PR TITLE
Improve device errors

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -250,19 +250,27 @@ var LibJitsiMeet = {
                     Statistics.sendLog(JSON.stringify(logObject));
                     Statistics.analytics.sendEvent(
                         "getUserMedia.userCancel.extensionInstall");
+                } else if (JitsiTrackErrors.NOT_FOUND === error.name) {
+                    // logs not found devices with just application log to cs
+                    var logObject = {
+                        id: "usermedia_missing_device",
+                        status: error.gum.devices
+                    };
+                    Statistics.sendLog(JSON.stringify(logObject));
+                    Statistics.analytics.sendEvent(
+                        "getUserMedia.deviceNotFound."
+                            + error.gum.devices.join('.'));
                 } else {
                     // Report gUM failed to the stats
                     Statistics.sendGetUserMediaFailed(error);
+                    Statistics.analytics.sendEvent(
+                        addDeviceTypeToAnalyticsEvent(
+                            "getUserMedia.failed", options) + '.' + error.name,
+                        options);
                 }
 
                 window.connectionTimes["obtainPermissions.end"] =
                     window.performance.now();
-
-
-                Statistics.analytics.sendEvent(
-                    addDeviceTypeToAnalyticsEvent(
-                        "getUserMedia.failed", options) + '.' + error.name,
-                    options);
 
                 return Promise.reject(error);
             }.bind(this));

--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -65,6 +65,7 @@ function JitsiTrackError(error, options, devices) {
                         JitsiTrackErrors.PERMISSION_DENIED]
                         + (this.gum.devices || []).join(", ");
                 break;
+            case "DevicesNotFoundError":
             case "NotFoundError":
                 this.name = JitsiTrackErrors.NOT_FOUND;
                 this.message = TRACK_ERROR_TO_MESSAGE_MAP[

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -302,8 +302,8 @@ function getConstraints(um, options) {
  * @param stream the stream we received from calling getUserMedia.
  */
 function setAvailableDevices(um, stream) {
-    var audioTracksReceived = !!stream.getAudioTracks().length;
-    var videoTracksReceived = !!stream.getVideoTracks().length;
+    var audioTracksReceived = stream && !!stream.getAudioTracks().length;
+    var videoTracksReceived = stream && !!stream.getVideoTracks().length;
 
     if (um.indexOf("video") != -1) {
         devices.video = videoTracksReceived;
@@ -918,7 +918,7 @@ var RTCUtils = {
                     success_callback(stream);
                 },
                 function (error) {
-                    setAvailableDevices(um, stream);
+                    setAvailableDevices(um, undefined);
                     logger.warn('Failed to get access to local media. Error ',
                         error, constraints);
 


### PR DESCRIPTION
Retrieves real device error in the case where we request audio and video and one of them fails, but we receive successful callback from getUserMedia with one of the medias missing.