### PR TITLE
Handle session-terminate

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -868,6 +868,8 @@ JitsiConference.prototype.onCallEnded
     // Send analytics event
     Statistics.analytics.sendEvent(
         "session.terminate", window.performance.now());
+    // Sends "session.terminate" through the stats as well
+    this.sendApplicationLog(JSON.stringify({ "id" : "session_terminate" }));
     // Stop the stats
     if (this.statistics) {
         this.statistics.stopRemoteStats();

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -865,6 +865,9 @@ function (jingleSession, jingleOffer, now) {
 JitsiConference.prototype.onCallEnded
 = function (JingleSession, reasonCondition, reasonText) {
     logger.info("Call ended: " + reasonCondition + " - " + reasonText);
+    // Send analytics event
+    Statistics.analytics.sendEvent(
+        "session.terminate", window.performance.now());
     // Stop the stats
     if (this.statistics) {
         this.statistics.stopRemoteStats();

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -865,6 +865,10 @@ function (jingleSession, jingleOffer, now) {
 JitsiConference.prototype.onCallEnded
 = function (JingleSession, reasonCondition, reasonText) {
     logger.info("Call ended: " + reasonCondition + " - " + reasonText);
+    // Stop the stats
+    if (this.statistics) {
+        this.statistics.stopRemoteStats();
+    }
 };
 
 

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -852,7 +852,21 @@ function (jingleSession, jingleOffer, now) {
     // both camera and microphone.
     this.statistics.startCallStats(jingleSession, this.settings);
     this.statistics.startRemoteStats(jingleSession.peerconnection);
-}
+};
+
+/**
+ * Handles the call ended event.
+ * @param {JingleSessionPC} JingleSession the jingle session which has been
+ * terminated.
+ * @param {String} reasonCondition the Jingle reason condition.
+ * @param {String|null} reasonText human readable reason text which may provide
+ * more details about why the call has been terminated.
+ */
+JitsiConference.prototype.onCallEnded
+= function (JingleSession, reasonCondition, reasonText) {
+    logger.info("Call ended: " + reasonCondition + " - " + reasonText);
+};
+
 
 JitsiConference.prototype.updateDTMFSupport = function () {
     var somebodySupportsDTMF = false;

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -868,6 +868,7 @@ JitsiConference.prototype.onCallEnded
     // Stop the stats
     if (this.statistics) {
         this.statistics.stopRemoteStats();
+        this.statistics.stopCallStats();
     }
     // Current JingleSession is invalid so set it to null on the room
     this.room.setJingleSession(null);

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -793,8 +793,7 @@ function (jingleSession, jingleOffer, now) {
     this.room.connectionTimes["session.initiate"] = now;
     // Log "session.restart"
     if (this.wasStopped) {
-        Statistics.analytics.sendEvent("session.restart", now);
-        this.sendApplicationLog(JSON.stringify({ "id" : "session_restart"}));
+        Statistics.sendEventToAll("session.restart");
     }
     // add info whether call is cross-region
     var crossRegion = null;
@@ -876,11 +875,8 @@ JitsiConference.prototype.onCallEnded
 = function (JingleSession, reasonCondition, reasonText) {
     logger.info("Call ended: " + reasonCondition + " - " + reasonText);
     this.wasStopped = true;
-    // Send analytics event
-    Statistics.analytics.sendEvent(
-        "session.terminate", window.performance.now());
-    // Sends "session.terminate" through the stats as well
-    this.sendApplicationLog(JSON.stringify({ "id" : "session_terminate" }));
+    // Send session.terminate event
+    Statistics.sendEventToAll("session.terminate");
     // Stop the stats
     if (this.statistics) {
         this.statistics.stopRemoteStats();

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -869,6 +869,8 @@ JitsiConference.prototype.onCallEnded
     if (this.statistics) {
         this.statistics.stopRemoteStats();
     }
+    // Current JingleSession is invalid so set it to null on the room
+    this.room.setJingleSession(null);
     // Let the RTC service do any cleanups
     this.rtc.onCallEnded();
     // PeerConnection has been closed which means that SSRCs stored in

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -869,6 +869,8 @@ JitsiConference.prototype.onCallEnded
     if (this.statistics) {
         this.statistics.stopRemoteStats();
     }
+    // Let the RTC service do any cleanups
+    this.rtc.onCallEnded();
     // PeerConnection has been closed which means that SSRCs stored in
     // JitsiLocalTrack will not match those assigned by the old PeerConnection
     // and SSRC replacement logic will not work as expected.

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -487,6 +487,8 @@ JitsiConferenceEventManager.prototype.setupXMPPListeners = function () {
     var conference = this.conference;
     conference.xmpp.addListener(
         XMPPEvents.CALL_INCOMING, conference.onIncomingCall.bind(conference));
+    conference.xmpp.addListener(
+        XMPPEvents.CALL_ENDED, conference.onCallEnded.bind(conference));
 
     conference.xmpp.addListener(XMPPEvents.START_MUTED_FROM_FOCUS,
         function (audioMuted, videoMuted) {

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -90,6 +90,20 @@ RTC.prototype.onIncommingCall = function(event) {
 };
 
 /**
+ * Should be called when current media session ends and after the PeerConnection
+ * has been closed using PeerConnection.close() method.
+ */
+RTC.prototype.onCallEnded = function() {
+    if (this.dataChannels) {
+        // DataChannels are not explicitly closed as the PeerConnection
+        // is closed on call ended which triggers data channel onclose events.
+        // The reference is cleared to disable any logic related to the data
+        // channels.
+        this.dataChannels = null;
+    }
+};
+
+/**
  * Elects the participant with the given id to be the pinned participant in
  * order to always receive video for this participant (even when last n is
  * enabled).

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -114,6 +114,8 @@ module.exports = function(XMPP, eventEmitter) {
                         reasonText = $(iq).find('>jingle>reason>text').text();
                     }
                     this.terminate(sess.sid, reasonCondition, reasonText);
+                    eventEmitter.emit(XMPPEvents.CALL_ENDED,
+                        sess, reasonCondition, reasonText);
                     break;
                 case 'transport-replace':
                     var now = window.performance.now();

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -11,6 +11,11 @@ var XMPPEvents = {
     // Designates an event indicating that an offer (e.g. Jingle
     // session-initiate) was received.
     CALL_INCOMING: "xmpp.callincoming.jingle",
+    // Triggered when Jicofo kills our media session, this can happen while
+    // we're still in the MUC, when it decides to terminate the media session.
+    // For example when the session is idle for too long, because we're the only
+    // person in the conference room.
+    CALL_ENDED: "xmpp.callended.jingle",
     CHAT_ERROR_RECEIVED: "xmpp.chat_error_received",
     CONFERENCE_SETUP_FAILED: "xmpp.conference_setup_failed",
     // Designates an event indicating that the connection to the XMPP server


### PR DESCRIPTION
The PR does necessary cleanup required after receiving 'session-terminate' to be able to start the conference again when new participant joins the room.

Required for https://github.com/jitsi/jicofo/pull/120