### PR TITLE
Enable lipsync by default + fixes

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -203,6 +203,7 @@ This objects represents the server connection. You can create new ```JitsiConnec
             - muc
             - anonymousdomain
         3. useStunTurn -
+        4. enableLipSync - (optional) boolean property which enables the lipsync feature. Currently works only in Chrome and is enabled by default.
 
 2. connect(options) - establish server connection
     - options - JS Object with ```id``` and ```password``` properties.

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -174,13 +174,11 @@ Moderator.prototype.createConferenceIq =  function () {
                 value: true
             }).up();
     //}
-    if (this.options.connection.enableLipSync !== undefined) {
-        elem.c(
-            'property', {
-                name: 'enableLipSync',
-                value: this.options.connection.enableLipSync
-            }).up();
-    }
+    elem.c(
+        'property', {
+            name: 'enableLipSync',
+            value: false !== this.options.connection.enableLipSync
+        }).up();
     if (this.options.conference.audioPacketDelay !== undefined) {
         elem.c(
             'property', {

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -174,11 +174,11 @@ Moderator.prototype.createConferenceIq =  function () {
                 value: true
             }).up();
     //}
-    if (this.options.conference.enableLipSync !== undefined) {
+    if (this.options.connection.enableLipSync !== undefined) {
         elem.c(
             'property', {
                 name: 'enableLipSync',
-                value: this.options.conference.enableLipSync
+                value: this.options.connection.enableLipSync
             }).up();
     }
     if (this.options.conference.audioPacketDelay !== undefined) {

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -122,7 +122,7 @@ XMPP.prototype.initFeaturesList = function () {
         //disco.addFeature('urn:ietf:rfc:5576'); // a=ssrc
 
         // Enable Lipsync ?
-        if (this.options.enableLipSync && RTCBrowserType.isChrome()) {
+        if (RTCBrowserType.isChrome() && false !== this.options.enableLipSync) {
             logger.info("Lip-sync enabled !");
             this.connection.disco.addFeature('http://jitsi.org/meet/lipsync');
         }


### PR DESCRIPTION
This PR enables lipsync by default and removes the option from the conference options.