### PR TITLE
Fix createConnection broken in 9781a0d

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -40,7 +40,7 @@ export default class XMPP {
         this.token = token;
         this._initStrophePlugins(this);
 
-        this.connection = createConnection(options.bosh, token);
+        this.connection = createConnection(token, options.bosh);
 
         if(!this.connection.disco || !this.connection.caps)
             throw new Error(


### PR DESCRIPTION
The places of the two arguments of the function createConnection were
switched in the function definition but the call to the function
remained unchanged.