### PR TITLE
Moves caching of selected endpoint out of data channel.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -597,6 +597,7 @@ JitsiConference.prototype.unlock = function () {
 /**
  * Elects the participant with the given id to be the selected participant in
  * order to receive higher video quality (if simulcast is enabled).
+ * Or cache it if channel is not created and send it once channel is available.
  * @param participantId the identifier of the participant
  * @throws NetworkError or InvalidStateError or Error if the operation fails.
  */

--- a/modules/RTC/DataChannels.js
+++ b/modules/RTC/DataChannels.js
@@ -51,7 +51,6 @@ function DataChannels(peerConnection, emitter) {
 DataChannels.prototype.onDataChannel = function (event) {
     var dataChannel = event.channel;
     var self = this;
-    var selectedEndpoint = null;
 
     dataChannel.onopen = function () {
         logger.info("Data channel opened by the Videobridge!", dataChannel);
@@ -63,19 +62,6 @@ DataChannels.prototype.onDataChannel = function (event) {
         //dataChannel.send(new ArrayBuffer(12));
 
         self.eventEmitter.emit(RTCEvents.DATA_CHANNEL_OPEN);
-
-        // when the data channel becomes available, tell the bridge about video
-        // selections so that it can do adaptive simulcast,
-        // we want the notification to trigger even if userJid is undefined,
-        // or null.
-        // XXX why do we not do the same for pinned endpoints?
-        try {
-            self.sendSelectedEndpointMessage(self.selectedEndpoint);
-        } catch (error) {
-            GlobalOnErrorHandler.callErrorHandler(error);
-            logger.error("Cannot sendSelectedEndpointMessage ",
-                self.selectedEndpoint, ". Error: ", error);
-        }
     };
 
     dataChannel.onerror = function (error) {
@@ -195,7 +181,6 @@ DataChannels.prototype.closeAllChannels = function () {
  * or Error with "No opened data channels found!" message.
  */
 DataChannels.prototype.sendSelectedEndpointMessage = function (endpointId) {
-    this.selectedEndpoint = endpointId;
     this._onXXXEndpointChanged("selected", endpointId);
 };
 


### PR DESCRIPTION
This currently fixes problem for participants joining in a room with other participants and trying to send initial value of selected local participant will throw an error. And fixes a potential problem if the UI can select participants before their video is available, before session initiated, can make local state with jvb inconsistent. Also if we want to have multiple selected endpoints or pinned participants and this is done before session-initiate caching should be done before creating data channel (currently selecting multiple is not possible).