### PR TITLE
Remove FIXME for CallStats not reporting restarted calls

### DIFF
--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -259,11 +259,6 @@ Statistics.prototype.startCallStats = function (session, settings) {
     if(this.callStatsIntegrationEnabled && !this.callStatsStarted) {
         // Here we overwrite the previous instance, but it must be bound to
         // the new PeerConnection
-        // FIXME CallStats does not show the participant after
-        // stopCallStats/startCallStats, the issue is being investigated on both
-        // our and CallStats side, but given how rare this situation should
-        // be, we need to have this change merged. Without it "invalid pcHash"
-        // error is reported(lib calls are made for the old PeerConnection).
         this.callstats = new CallStats(session, settings, this.options);
         Statistics.callsStatsInstances.push(this.callstats);
         this.callStatsStarted = true;


### PR DESCRIPTION
The problem described by the FIXME has been fixed by CallStats. The call restarted after it has been "session-terminated" are now reported correctly on CallStats dashboard.