### PR TITLE
Participant connection status tune up and extra logging

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -95,7 +95,9 @@ JitsiConference.prototype._init = function (options) {
     }
 
     this.participantConnectionStatus
-        = new ParticipantConnectionStatus(this.rtc, this);
+        = new ParticipantConnectionStatus(
+                this.rtc, this,
+                options.config.peerDisconnectedThroughRtcTimeout);
     this.participantConnectionStatus.init();
 
     if(!this.statistics) {

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -8,12 +8,12 @@ import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 import * as JitsiTrackEvents from '../../JitsiTrackEvents';
 
 /**
- * Default value of 1000 milliseconds for
+ * Default value of 2000 milliseconds for
  * {@link ParticipantConnectionStatus.rtcMuteTimeout}.
  *
  * @type {number}
  */
-const DEFAULT_RTC_MUTE_TIMEOUT = 1000;
+const DEFAULT_RTC_MUTE_TIMEOUT = 2000;
 
 /**
  * Class is responsible for emitting

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -21,8 +21,8 @@ const RTC_MUTE_TIMEOUT = 1000;
  * JitsiConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED events.
  *
  * @constructor
- * @param rtc {RTC} the RTC service instance
- * @param conference {JitsiConference} parent conference instance
+ * @param {RTC} rtc the RTC service instance
+ * @param {JitsiConference} conference parent conference instance
  */
 function ParticipantConnectionStatus(rtc, conference) {
     this.rtc = rtc;
@@ -232,7 +232,7 @@ ParticipantConnectionStatus.prototype.onRemoteTrackRemoved
 /**
  * Handles RTC 'onmute' event for the video track.
  *
- * @param track {JitsiRemoteTrack} the video track for which 'onmute' event will
+ * @param {JitsiRemoteTrack} track the video track for which 'onmute' event will
  * be processed.
  */
 ParticipantConnectionStatus.prototype.onTrackRtcMuted = function(track) {
@@ -261,7 +261,7 @@ ParticipantConnectionStatus.prototype.onTrackRtcMuted = function(track) {
 /**
  * Handles RTC 'onunmute' event for the video track.
  *
- * @param track {JitsiRemoteTrack} the video track for which 'onunmute' event
+ * @param {JitsiRemoteTrack} track the video track for which 'onunmute' event
  * will be processed.
  */
 ParticipantConnectionStatus.prototype.onTrackRtcUnmuted = function(track) {
@@ -281,7 +281,7 @@ ParticipantConnectionStatus.prototype.onTrackRtcUnmuted = function(track) {
 /**
  * Here the signalling "mute"/"unmute" events are processed.
  *
- * @param track {JitsiRemoteTrack} the remote video track for which
+ * @param {JitsiRemoteTrack} track the remote video track for which
  * the signalling mute/unmute event will be processed.
  */
 ParticipantConnectionStatus.prototype.onSignallingMuteChanged

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -8,13 +8,12 @@ import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 import * as JitsiTrackEvents from '../../JitsiTrackEvents';
 
 /**
- * How long we're going to wait after the RTC video track muted event for
- * the corresponding signalling mute event, before the connection interrupted
- * is fired.
+ * Default value of 1000 milliseconds for
+ * {@link ParticipantConnectionStatus.rtcMuteTimeout}.
  *
- * @type {number} amount of time in milliseconds
+ * @type {number}
  */
-const RTC_MUTE_TIMEOUT = 1000;
+const DEFAULT_RTC_MUTE_TIMEOUT = 1000;
 
 /**
  * Class is responsible for emitting
@@ -23,8 +22,10 @@ const RTC_MUTE_TIMEOUT = 1000;
  * @constructor
  * @param {RTC} rtc the RTC service instance
  * @param {JitsiConference} conference parent conference instance
+ * @param {number} rtcMuteTimeout (optional) custom value for
+ * {@link ParticipantConnectionStatus.rtcMuteTimeout}.
  */
-function ParticipantConnectionStatus(rtc, conference) {
+function ParticipantConnectionStatus(rtc, conference, rtcMuteTimeout) {
     this.rtc = rtc;
     this.conference = conference;
     /**
@@ -34,6 +35,18 @@ function ParticipantConnectionStatus(rtc, conference) {
      * @type {Object.<string, number>}
      */
     this.trackTimers = {};
+    /**
+     * How long we're going to wait after the RTC video track muted event for
+     * the corresponding signalling mute event, before the connection
+     * interrupted is fired. The default value is
+     * {@link DEFAULT_RTC_MUTE_TIMEOUT}.
+     *
+     * @type {number} amount of time in milliseconds
+     */
+    this.rtcMuteTimeout
+        = typeof rtcMuteTimeout === 'number'
+            ? rtcMuteTimeout : DEFAULT_RTC_MUTE_TIMEOUT;
+    logger.info("RtcMuteTimeout set to: " + this.rtcMuteTimeout);
 }
 
 /**
@@ -254,7 +267,7 @@ ParticipantConnectionStatus.prototype.onTrackRtcMuted = function(track) {
                 this._changeConnectionStatus(participantId, false);
             }
             this.clearTimeout(participantId);
-        }.bind(this), RTC_MUTE_TIMEOUT);
+        }.bind(this), this.rtcMuteTimeout);
     }
 };
 

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -6,6 +6,7 @@ var RTCEvents = require('../../service/RTC/RTCEvents');
 
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 import * as JitsiTrackEvents from '../../JitsiTrackEvents';
+import Statistics from '../statistics/statistics';
 
 /**
  * Default value of 2000 milliseconds for
@@ -178,10 +179,24 @@ ParticipantConnectionStatus.prototype._changeConnectionStatus
         return;
     }
     if (participant.isConnectionActive() !== newStatus) {
+
         participant._setIsConnectionActive(newStatus);
+
         logger.debug(
             'Emit endpoint conn status(' + Date.now() + '): ',
             endpointId, newStatus);
+
+        // Log the event on CallStats
+        Statistics.sendLog(
+            JSON.stringify({
+                id: 'peer.conn.status',
+                participant: endpointId,
+                status: newStatus
+            }));
+
+        // and analytics
+        Statistics.analytics.sendEvent('peer.conn.status', null, newStatus);
+
         this.conference.eventEmitter.emit(
             JitsiConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED,
             endpointId, newStatus);


### PR DESCRIPTION
This PR changes the amount of time we wait after RTC video track muted event before marking participant's connection as interrupted. It also makes the timeout value configurable, changes the default to 2 seconds and logs status updates on CallStats and analytics.