### PR TITLE
Fixes sip calling.

### DIFF
--- a/modules/xmpp/strophe.rayo.js
+++ b/modules/xmpp/strophe.rayo.js
@@ -42,7 +42,7 @@ class RayoConnectionPlugin extends ConnectionPlugin {
                 value: roomName
             }).up();
 
-            if (roomPass !== null && roomPass.length) {
+            if (roomPass && roomPass.length) {
                 req.c('header', {
                     name: 'JvbRoomPassword',
                     value: roomPass


### PR DESCRIPTION
In case of roomPass is undefined, an error occurs: Cannot read property 'length' of undefined.