### PR TITLE
Fix "no data from source" before ICE has connected

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -536,7 +536,12 @@ JitsiLocalTrack.prototype.getDeviceId = function () {
  */
 JitsiLocalTrack.prototype._setByteSent = function (bytesSent) {
     this._bytesSent = bytesSent;
-    if(this._testByteSent) {
+    // FIXME it's a shame that PeerConnection and ICE status does not belong
+    // to the RTC module and it has to be accessed through
+    // the conference(and through the XMPP chat room ???) instead
+    let iceConnectionState
+        = this.conference ? this.conference.getConnectionState() : null;
+    if(this._testByteSent && "connected" === iceConnectionState) {
         setTimeout(function () {
             if(this._bytesSent <= 0){
                 //we are not receiving anything from the microphone


### PR DESCRIPTION
We can not assume that the audio source is not sending any data based on the stat until the media connection has not been established.