### PR TITLE
Remove audio problem detection

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -59,7 +59,6 @@ function JitsiConference(options) {
         video: undefined
     };
     this.isMutedByFocus = false;
-    this.reportedAudioSSRCs = {};
     // Flag indicates if the 'onCallEnded' method was ever called on this
     // instance. Used to log extra analytics event for debugging purpose.
     // We need to know if the potential issue happened before or after
@@ -1197,104 +1196,6 @@ JitsiConference.prototype._onTrackAttach = function(track, container) {
     }
     this.statistics.associateStreamWithVideoTag(
         ssrc, track.isLocal(), track.getUsageLabel(), container.id);
-};
-
-/**
- * Reports detected audio problem with the media stream related to the passed
- * ssrc.
- * @param ssrc {string} the ssrc
- * NOTE: all logger.log calls are there only to be able to see the info in
- * torture
- */
-JitsiConference.prototype._reportAudioProblem = function (ssrc) {
-    if(this.reportedAudioSSRCs[ssrc])
-        return;
-    var track = this.rtc.getRemoteTrackBySSRC(ssrc);
-    if(!track || !track.isAudioTrack())
-        return;
-
-    var id = track.getParticipantId();
-    var displayName = null;
-    if(id) {
-        var participant = this.getParticipantById(id);
-        if(participant) {
-            displayName = participant.getDisplayName();
-        }
-    }
-    this.reportedAudioSSRCs[ssrc] = true;
-    var errorContent = {
-        errMsg: "The audio is received but not played",
-        ssrc: ssrc,
-        jid: id,
-        displayName: displayName
-    };
-
-    logger.log("=================The audio is received but not played" +
-        "======================");
-    logger.log("ssrc: ", ssrc);
-    logger.log("jid: ", id);
-    logger.log("displayName: ", displayName);
-
-    var mstream = track.stream, mtrack = track.track;
-    if(mstream) {
-        logger.log("MediaStream:");
-        errorContent.MediaStream = {
-            active: mstream.active,
-            id: mstream.id
-        };
-        logger.log("active: ", mstream.active);
-        logger.log("id: ", mstream.id);
-    }
-
-    if(mtrack) {
-        logger.log("MediaStreamTrack:");
-        errorContent.MediaStreamTrack = {
-            enabled: mtrack.enabled,
-            id: mtrack.id,
-            label: mtrack.label,
-            muted: mtrack.muted
-        };
-        logger.log("enabled: ", mtrack.enabled);
-        logger.log("id: ", mtrack.id);
-        logger.log("label: ", mtrack.label);
-        logger.log("muted: ", mtrack.muted);
-    }
-
-    if(track.containers) {
-        errorContent.containers = [];
-        logger.log("Containers:");
-        track.containers.forEach(function (container) {
-            logger.log("Container:");
-            errorContent.containers.push({
-                autoplay: container.autoplay,
-                muted: container.muted,
-                src: container.src,
-                volume: container.volume,
-                id: container.id,
-                ended: container.ended,
-                paused: container.paused,
-                readyState: container.readyState
-            });
-            logger.log("autoplay: ", container.autoplay);
-            logger.log("muted: ", container.muted);
-            logger.log("src: ", container.src);
-            logger.log("volume: ", container.volume);
-            logger.log("id: ", container.id);
-            logger.log("ended: ", container.ended);
-            logger.log("paused: ", container.paused);
-            logger.log("readyState: ", container.readyState);
-        });
-    }
-
-    // Prints JSON.stringify(errorContent) to be able to see all properties of
-    // errorContent from torture
-    logger.error("Audio problem detected. The audio is received but not played",
-        errorContent);
-
-    delete errorContent.displayName;
-
-    this.statistics.sendDetectedAudioProblem(
-        new Error(JSON.stringify(errorContent)));
 };
 
 /**

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -572,10 +572,6 @@ JitsiConferenceEventManager.prototype.setupStatisticsListeners = function () {
             JitsiConferenceEvents.CONNECTION_STATS, stats);
     });
 
-    conference.statistics.addAudioProblemListener(function (ssrc) {
-        conference._reportAudioProblem(ssrc);
-    });
-
     conference.statistics.addByteSentStatsListener(function (stats) {
         conference.getLocalTracks().forEach(function (track) {
             var ssrc = track.getSSRC();

--- a/JitsiTrackEvents.js
+++ b/JitsiTrackEvents.js
@@ -6,10 +6,7 @@ export const LOCAL_TRACK_STOPPED = "track.stopped";
  * Audio levels of a this track was changed.
  */
 export const TRACK_AUDIO_LEVEL_CHANGED = "track.audioLevelsChanged";
-/**
- * Detects that no audio have been sent.
- */
-export const TRACK_AUDIO_NOT_WORKING = "track.audioNotWorking";
+
 /**
  * The audio output of the track was changed.
  */

--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -379,18 +379,6 @@ CallStats.prototype.sendTerminateEvent = _try_catch(function () {
 });
 
 /**
- * Notifies CallStats that audio problems are detected.
- *
- * @param {Error} e error to send
- * @param {CallStats} cs callstats instance related to the error (optional)
- */
-CallStats.prototype.sendDetectedAudioProblem = _try_catch(function (e) {
-    CallStats._reportError.call(this, wrtcFuncNames.applicationLog, e,
-        this.peerconnection);
-});
-
-
-/**
  * Notifies CallStats for ice connection failed
  * @param {RTCPeerConnection} pc connection on which failure occured.
  * @param {CallStats} cs callstats instance related to the error (optional)

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -648,11 +648,6 @@ StatsCollector.prototype.processStatsReport = function () {
             bytesSent = Math.round(((bytesSent * 8) / time) / 1000);
         }
 
-        //detect audio issues (receiving data but audioLevel == 0)
-        if(bytesReceived > 10 && ssrcStats.ssrc2AudioLevel === 0) {
-            this.eventEmitter.emit(StatisticsEvents.AUDIO_NOT_WORKING, ssrc);
-        }
-
         ssrcStats.setSsrcBitrate({
             "download": bytesReceived,
             "upload": bytesSent

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -190,14 +190,6 @@ Statistics.prototype.removeAudioLevelListener = function(listener) {
     this.eventEmitter.removeListener(StatisticsEvents.AUDIO_LEVEL, listener);
 };
 
-/**
- * Adds listener for detected audio problems.
- * @param listener the listener.
- */
-Statistics.prototype.addAudioProblemListener = function (listener) {
-    this.eventEmitter.on(StatisticsEvents.AUDIO_NOT_WORKING, listener);
-};
-
 Statistics.prototype.addConnectionStatsListener = function (listener) {
     this.eventEmitter.on(StatisticsEvents.CONNECTION_STATS, listener);
 };
@@ -442,16 +434,6 @@ Statistics.prototype.sendSetRemoteDescFailed = function (e, pc) {
 Statistics.prototype.sendAddIceCandidateFailed = function (e, pc) {
     if(this.callstats)
         CallStats.sendAddIceCandidateFailed(e, pc, this.callstats);
-};
-
-/**
- * Notifies CallStats that audio problems are detected.
- *
- * @param {Error} e error to send
- */
-Statistics.prototype.sendDetectedAudioProblem = function (e) {
-    if(this.callstats)
-        this.callstats.sendDetectedAudioProblem(e);
 };
 
 /**

--- a/service/statistics/Events.js
+++ b/service/statistics/Events.js
@@ -11,14 +11,6 @@
 export const AUDIO_LEVEL = "statistics.audioLevel";
 
 /**
- * Notifies about audio problem with remote participant.
- *
- * @param ssrc - The synchronization source identifier (SSRC) of the remote
- * participant whose audio exhibits problems.
- */
-export const AUDIO_NOT_WORKING = "statistics.audio_not_working";
-
-/**
  * An event carrying all statistics by ssrc.
  */
 export const BYTE_SENT_STATS = "statistics.byte_sent_stats";


### PR DESCRIPTION
Removing the audio problem detection that was checking for  remote streams with audioOutputLevel = 0 and  bytesReceived > 10. Detected problems were logged in the console and sent to callstats. Since the detection wasn’t reliable we don’t need it.
