### PR TITLE
Fix JitsiConference.leave

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -406,11 +406,6 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function () {
     });
 
     if(conference.statistics) {
-        chatRoom.addListener(XMPPEvents.DISPOSE_CONFERENCE,
-            function () {
-                conference.statistics.dispose();
-            });
-
         chatRoom.addListener(XMPPEvents.CONNECTION_ICE_FAILED,
             function (pc) {
                 conference.statistics.sendIceConnectionFailedEvent(pc);

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -216,6 +216,7 @@ Statistics.prototype.removeByteSentStatsListener = function (listener) {
 };
 
 Statistics.prototype.dispose = function () {
+    this.stopCallStats();
     this.stopRemoteStats();
     if(this.eventEmitter)
         this.eventEmitter.removeAllListeners();

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -43,7 +43,6 @@ var XMPPEvents = {
     // Designates an event indicating that the display name of a participant
     // has changed.
     DISPLAY_NAME_CHANGED: "xmpp.display_name_changed",
-    DISPOSE_CONFERENCE: "xmpp.dispose_conference",
     ETHERPAD: "xmpp.etherpad",
     FOCUS_DISCONNECTED: 'xmpp.focus_disconnected',
     FOCUS_LEFT: "xmpp.focus_left",


### PR DESCRIPTION
Fixes when the promise is resoved and rejected.
Removes unnecessary removal of local streams and participants.
