### PR TITLE
Disable Temasys on React Native

### DIFF
--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -6,7 +6,6 @@ var logger = require("jitsi-meet-logger").getLogger(__filename);
 var RTCBrowserType = require("./RTCBrowserType");
 var RTCEvents = require("../../service/RTC/RTCEvents");
 var Statistics = require("../statistics/statistics");
-var AdapterJS = require("./adapter.screenshare");
 
 var ttfmTrackerAudioAttached = false;
 var ttfmTrackerVideoAttached = false;
@@ -170,6 +169,10 @@ JitsiRemoteTrack.prototype._attachTTFMTracker = function (container) {
         ttfmTrackerVideoAttached = true;
 
     if (RTCBrowserType.isTemasysPluginUsed()) {
+        // XXX Don't require Temasys unless it's to be used because it doesn't
+        // run on React Native, for example.
+        const AdapterJS = require("./adapter.screenshare");
+
         // FIXME: this is not working for IE11
         AdapterJS.addEvent(container, 'play', this._playCallback.bind(this));
     }

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -16,7 +16,6 @@ var logger = require("jitsi-meet-logger").getLogger(__filename);
 var RTCBrowserType = require("./RTCBrowserType");
 var Resolutions = require("../../service/RTC/Resolutions");
 var RTCEvents = require("../../service/RTC/RTCEvents");
-var AdapterJS = require("./adapter.screenshare");
 var SDPUtil = require("../xmpp/SDPUtil");
 var EventEmitter = require("events");
 var screenObtainer = require("./ScreenObtainer");
@@ -25,6 +24,13 @@ var MediaType = require("../../service/RTC/MediaType");
 var VideoType = require("../../service/RTC/VideoType");
 var CameraFacingMode = require("../../service/RTC/CameraFacingMode");
 var GlobalOnErrorHandler = require("../util/GlobalOnErrorHandler");
+
+// XXX Don't require Temasys unless it's to be used because it doesn't run on
+// React Native, for example.
+const AdapterJS
+    = RTCBrowserType.isTemasysPluginUsed()
+        ? require("./adapter.screenshare")
+        : undefined;
 
 var eventEmitter = new EventEmitter();
 

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -1,6 +1,5 @@
 /* global chrome, $, alert */
 
-var AdapterJS = require("./adapter.screenshare");
 var GlobalOnErrorHandler = require("../util/GlobalOnErrorHandler");
 var logger = require("jitsi-meet-logger").getLogger(__filename);
 var RTCBrowserType = require("./RTCBrowserType");
@@ -115,6 +114,10 @@ var ScreenObtainer = {
                     });
             };
         } else if (RTCBrowserType.isTemasysPluginUsed()) {
+            // XXX Don't require Temasys unless it's to be used because it
+            // doesn't run on React Native, for example.
+            const AdapterJS = require("./adapter.screenshare");
+
             if (!AdapterJS.WebRTCPlugin.plugin.HasScreensharingFeature) {
                 logger.info("Screensharing not supported by this plugin " +
                     "version");


### PR DESCRIPTION
Lib-jitsi-meet uses Temasys on Internet Explorer and Safari so it does
not make sense to require its adapter.screenshare.js on React Native,
for example, where it fails anyway.