### PR TITLE
Fixes callstats feedback

### DIFF
--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -411,12 +411,11 @@ function(overallFeedback, detailedFeedback) {
         return;
     }
 
-    var feedbackString =    '{"userID":"' + this.userID + '"' +
-                            ', "overall":' + overallFeedback +
-                            ', "comment": "' + detailedFeedback + '"}';
-    var feedbackJSON = JSON.parse(feedbackString);
-
-    callStats.sendUserFeedback(this.confID, feedbackJSON);
+    callStats.sendUserFeedback(this.confID, {
+        userID: this.userID,
+        overall: overallFeedback,
+        comment: detailedFeedback
+    });
 });
 
 /**


### PR DESCRIPTION
The issue was that we were setting  userID to [Object object] since the format of userID was changed from String to Object.

Now the code is simplified and the userID is correct.