### PR TITLE
Fix participant connection status stuck after device switch

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -18,8 +18,8 @@ var GlobalOnErrorHandler = require("./modules/util/GlobalOnErrorHandler");
 var JitsiConferenceEventManager = require("./JitsiConferenceEventManager");
 var VideoType = require('./service/RTC/VideoType');
 var Transcriber = require("./modules/transcription/transcriber");
-var ParticipantConnectionStatus
-    = require("./modules/connectivity/ParticipantConnectionStatus");
+import ParticipantConnectionStatus
+    from "./modules/connectivity/ParticipantConnectionStatus";
 import TalkMutedDetection from "./modules/TalkMutedDetection";
 
 /**

--- a/JitsiParticipant.js
+++ b/JitsiParticipant.js
@@ -50,6 +50,21 @@ export default class JitsiParticipant {
     }
 
     /**
+     * Checks whether this <tt>JitsiParticipant</tt> has any video tracks which
+     * are muted according to their underlying WebRTC <tt>MediaStreamTrack</tt>
+     * muted status.
+     * @return {boolean} <tt>true</tt> if this <tt>participant</tt> contains any
+     * video <tt>JitsiTrack</tt>s which are muted as defined in
+     * {@link JitsiTrack.isWebRTCTrackMuted}.
+     */
+    hasAnyVideoTrackWebRTCMuted() {
+        return this.getTracks().some(function(jitsiTrack) {
+            return jitsiTrack.getType() === MediaType.VIDEO
+                && jitsiTrack.isWebRTCTrackMuted();
+        });
+    }
+
+    /**
      * Updates participant's connection status.
      * @param {boolean} isActive true if the user's connection is fine or false
      * when the user is having connectivity issues.

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -142,6 +142,16 @@ JitsiTrack.prototype.isAudioTrack = function () {
 };
 
 /**
+ * Checks whether the underlying WebRTC <tt>MediaStreamTrack</tt> is muted
+ * according to it's 'muted' field status.
+ * @return {boolean} <tt>true</tt> if the underlying <tt>MediaStreamTrack</tt>
+ * is muted or <tt>false</tt> otherwise.
+ */
+JitsiTrack.prototype.isWebRTCTrackMuted = function () {
+    return this.track && this.track.muted;
+};
+
+/**
  * Check if this is videotrack.
  */
 JitsiTrack.prototype.isVideoTrack = function () {

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -19,6 +19,11 @@ const DEFAULT_RTC_MUTE_TIMEOUT = 2000;
 /**
  * Class is responsible for emitting
  * JitsiConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED events.
+ */
+export default class ParticipantConnectionStatus {
+
+/**
+ * Creates new instance of <tt>ParticipantConnectionStatus</tt>.
  *
  * @constructor
  * @param {RTC} rtc the RTC service instance
@@ -26,7 +31,7 @@ const DEFAULT_RTC_MUTE_TIMEOUT = 2000;
  * @param {number} rtcMuteTimeout (optional) custom value for
  * {@link ParticipantConnectionStatus.rtcMuteTimeout}.
  */
-function ParticipantConnectionStatus(rtc, conference, rtcMuteTimeout) {
+constructor(rtc, conference, rtcMuteTimeout) {
     this.rtc = rtc;
     this.conference = conference;
     /**
@@ -54,7 +59,7 @@ function ParticipantConnectionStatus(rtc, conference, rtcMuteTimeout) {
  * Initializes <tt>ParticipantConnectionStatus</tt> and bind required event
  * listeners.
  */
-ParticipantConnectionStatus.prototype.init = function() {
+init() {
 
     this._onEndpointConnStatusChanged
         = this.onEndpointConnStatusChanged.bind(this);
@@ -89,13 +94,13 @@ ParticipantConnectionStatus.prototype.init = function() {
         // signalling mute/unmute events.
         this._onSignallingMuteChanged = this.onSignallingMuteChanged.bind(this);
     }
-};
+}
 
 /**
  * Removes all event listeners and disposes of all resources held by this
  * instance.
  */
-ParticipantConnectionStatus.prototype.dispose = function () {
+dispose() {
 
     this.rtc.removeListener(
         RTCEvents.ENDPOINT_CONN_STATUS_CHANGED,
@@ -115,7 +120,7 @@ ParticipantConnectionStatus.prototype.dispose = function () {
     Object.keys(this.trackTimers).forEach(function (participantId) {
         this.clearTimeout(participantId);
     }.bind(this));
-};
+}
 
 /**
  * Handles RTCEvents.ENDPOINT_CONN_STATUS_CHANGED triggered when we receive
@@ -124,8 +129,7 @@ ParticipantConnectionStatus.prototype.dispose = function () {
  * @param endpointId {string} the endpoint ID(MUC nickname/resource JID)
  * @param isActive {boolean} true if the connection is OK or false otherwise
  */
-ParticipantConnectionStatus.prototype.onEndpointConnStatusChanged
-= function(endpointId, isActive) {
+onEndpointConnStatusChanged(endpointId, isActive) {
 
     logger.debug(
         'Detector RTCEvents.ENDPOINT_CONN_STATUS_CHANGED('
@@ -147,10 +151,9 @@ ParticipantConnectionStatus.prototype.onEndpointConnStatusChanged
             this._changeConnectionStatus(endpointId, isActive);
         }
     }
-};
+}
 
-ParticipantConnectionStatus.prototype._changeConnectionStatus
-= function (endpointId, newStatus) {
+_changeConnectionStatus(endpointId, newStatus) {
     var participant = this.conference.getParticipantById(endpointId);
     if (!participant) {
         // This will happen when participant exits the conference with broken
@@ -185,7 +188,7 @@ ParticipantConnectionStatus.prototype._changeConnectionStatus
             JitsiConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED,
             endpointId, newStatus);
     }
-};
+}
 
 /**
  * Reset the postponed "connection interrupted" event which was previously
@@ -194,12 +197,12 @@ ParticipantConnectionStatus.prototype._changeConnectionStatus
  * @param participantId the participant for which the "connection interrupted"
  * timeout was scheduled
  */
-ParticipantConnectionStatus.prototype.clearTimeout = function (participantId) {
+clearTimeout(participantId) {
     if (this.trackTimers[participantId]) {
         window.clearTimeout(this.trackTimers[participantId]);
         this.trackTimers[participantId] = null;
     }
-};
+}
 
 /**
  * Bind signalling mute event listeners for video {JitsiRemoteTrack} when
@@ -208,8 +211,7 @@ ParticipantConnectionStatus.prototype.clearTimeout = function (participantId) {
  * @param {JitsiTrack} remoteTrack the {JitsiTrack} which is being added to
  * the conference.
  */
-ParticipantConnectionStatus.prototype.onRemoteTrackAdded
-= function(remoteTrack) {
+onRemoteTrackAdded(remoteTrack) {
     if (!remoteTrack.isLocal() && remoteTrack.getType() === MediaType.VIDEO) {
 
         logger.debug(
@@ -219,7 +221,7 @@ ParticipantConnectionStatus.prototype.onRemoteTrackAdded
             JitsiTrackEvents.TRACK_MUTE_CHANGED,
             this._onSignallingMuteChanged);
     }
-};
+}
 
 /**
  * Removes all event listeners bound to the remote video track and clears any
@@ -228,8 +230,7 @@ ParticipantConnectionStatus.prototype.onRemoteTrackAdded
  * @param {JitsiRemoteTrack} remoteTrack the remote track which is being removed
  * from the conference.
  */
-ParticipantConnectionStatus.prototype.onRemoteTrackRemoved
-= function(remoteTrack) {
+onRemoteTrackRemoved(remoteTrack) {
     if (!remoteTrack.isLocal() && remoteTrack.getType() === MediaType.VIDEO) {
         logger.debug(
             'Detector on remote track removed: ',
@@ -239,7 +240,7 @@ ParticipantConnectionStatus.prototype.onRemoteTrackRemoved
             this._onSignallingMuteChanged);
         this.clearTimeout(remoteTrack.getParticipantId());
     }
-};
+}
 
 /**
  * Handles RTC 'onmute' event for the video track.
@@ -247,7 +248,7 @@ ParticipantConnectionStatus.prototype.onRemoteTrackRemoved
  * @param {JitsiRemoteTrack} track the video track for which 'onmute' event will
  * be processed.
  */
-ParticipantConnectionStatus.prototype.onTrackRtcMuted = function(track) {
+onTrackRtcMuted(track) {
     var participantId = track.getParticipantId();
     var participant = this.conference.getParticipantById(participantId);
     logger.debug('Detector track RTC muted: ', participantId);
@@ -268,7 +269,7 @@ ParticipantConnectionStatus.prototype.onTrackRtcMuted = function(track) {
             this.clearTimeout(participantId);
         }.bind(this), this.rtcMuteTimeout);
     }
-};
+}
 
 /**
  * Handles RTC 'onunmute' event for the video track.
@@ -276,7 +277,7 @@ ParticipantConnectionStatus.prototype.onTrackRtcMuted = function(track) {
  * @param {JitsiRemoteTrack} track the video track for which 'onunmute' event
  * will be processed.
  */
-ParticipantConnectionStatus.prototype.onTrackRtcUnmuted = function(track) {
+onTrackRtcUnmuted(track) {
     logger.debug('Detector track RTC unmuted: ', track);
     var participantId = track.getParticipantId();
     if (!track.isMuted() &&
@@ -288,7 +289,7 @@ ParticipantConnectionStatus.prototype.onTrackRtcUnmuted = function(track) {
         this._changeConnectionStatus(participantId, true);
     }
     this.clearTimeout(participantId);
-};
+}
 
 /**
  * Here the signalling "mute"/"unmute" events are processed.
@@ -296,8 +297,7 @@ ParticipantConnectionStatus.prototype.onTrackRtcUnmuted = function(track) {
  * @param {JitsiRemoteTrack} track the remote video track for which
  * the signalling mute/unmute event will be processed.
  */
-ParticipantConnectionStatus.prototype.onSignallingMuteChanged
-= function (track) {
+onSignallingMuteChanged (track) {
     logger.debug(
         'Detector on track signalling mute changed: ', track, track.isMuted());
     var isMuted = track.isMuted();
@@ -313,6 +313,6 @@ ParticipantConnectionStatus.prototype.onSignallingMuteChanged
             'Signalling got in sync - cancelling task for: ' + participantId);
         this.clearTimeout(participantId);
     }
-};
+}
 
-module.exports = ParticipantConnectionStatus;
+}

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -118,23 +118,6 @@ ParticipantConnectionStatus.prototype.dispose = function () {
 };
 
 /**
- * Checks whether given <tt>JitsiParticipant</tt> has any muted video
- * <tt>MediaStreamTrack</tt>s.
- *
- * @param {JitsiParticipant} participant to be checked for muted video tracks
- *
- * @return {boolean} <tt>true</tt> if given <tt>participant</tt> contains any
- * video <tt>MediaStreamTrack</tt>s muted according to their 'muted' field.
- */
-var hasRtcMutedVideoTrack = function (participant) {
-    return participant.getTracks().some(function(jitsiTrack) {
-        var rtcTrack = jitsiTrack.getTrack();
-        return jitsiTrack.getType() === MediaType.VIDEO
-            && rtcTrack && rtcTrack.muted === true;
-    });
-};
-
-/**
  * Handles RTCEvents.ENDPOINT_CONN_STATUS_CHANGED triggered when we receive
  * notification over the data channel from the bridge about endpoint's
  * connection status update.
@@ -155,7 +138,7 @@ ParticipantConnectionStatus.prototype.onEndpointConnStatusChanged
         if (isActive
                 && RTCBrowserType.isVideoMuteOnConnInterruptedSupported()
                 && participant
-                && hasRtcMutedVideoTrack(participant)
+                && participant.hasAnyVideoTrackWebRTCMuted()
                 && !participant.isVideoMuted()) {
             logger.debug(
                 'Ignoring RTCEvents.ENDPOINT_CONN_STATUS_CHANGED -'

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -178,8 +178,8 @@ export default class ParticipantConnectionStatus {
             participant._setIsConnectionActive(newStatus);
 
             logger.debug(
-                'Emit endpoint conn status(' + Date.now() + '): ',
-                endpointId, newStatus);
+                'Emit endpoint conn status(' + Date.now() + ') '
+                    + endpointId + ": " + newStatus);
 
             // Log the event on CallStats
             Statistics.sendLog(
@@ -225,8 +225,8 @@ export default class ParticipantConnectionStatus {
                 && remoteTrack.getType() === MediaType.VIDEO) {
 
             logger.debug(
-                'Detector on remote track added: ',
-                remoteTrack.getParticipantId());
+                'Detector on remote track added for: '
+                    + remoteTrack.getParticipantId());
 
             remoteTrack.on(
                 JitsiTrackEvents.TRACK_MUTE_CHANGED,
@@ -244,9 +244,12 @@ export default class ParticipantConnectionStatus {
     onRemoteTrackRemoved(remoteTrack) {
         if (!remoteTrack.isLocal()
                 && remoteTrack.getType() === MediaType.VIDEO) {
+
+            const endpointId = remoteTrack.getParticipantId();
+
             logger.debug(
-                'Detector on remote track removed: ',
-                remoteTrack.getParticipantId());
+                'Detector on remote track removed: ' + endpointId);
+
             remoteTrack.off(
                 JitsiTrackEvents.TRACK_MUTE_CHANGED,
                 this._onSignallingMuteChanged);
@@ -263,7 +266,7 @@ export default class ParticipantConnectionStatus {
     onTrackRtcMuted(track) {
         var participantId = track.getParticipantId();
         var participant = this.conference.getParticipantById(participantId);
-        logger.debug('Detector track RTC muted: ', participantId);
+        logger.debug('Detector track RTC muted: ' + participantId);
         if (!participant) {
             logger.error('No participant for id: ' + participantId);
             return;

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -21,298 +21,313 @@ const DEFAULT_RTC_MUTE_TIMEOUT = 2000;
  * JitsiConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED events.
  */
 export default class ParticipantConnectionStatus {
-
-/**
- * Creates new instance of <tt>ParticipantConnectionStatus</tt>.
- *
- * @constructor
- * @param {RTC} rtc the RTC service instance
- * @param {JitsiConference} conference parent conference instance
- * @param {number} rtcMuteTimeout (optional) custom value for
- * {@link ParticipantConnectionStatus.rtcMuteTimeout}.
- */
-constructor(rtc, conference, rtcMuteTimeout) {
-    this.rtc = rtc;
-    this.conference = conference;
     /**
-     * A map of the "endpoint ID"(which corresponds to the resource part of MUC
-     * JID(nickname)) to the timeout callback IDs scheduled using
-     * window.setTimeout.
-     * @type {Object.<string, number>}
-     */
-    this.trackTimers = {};
-    /**
-     * How long we're going to wait after the RTC video track muted event for
-     * the corresponding signalling mute event, before the connection
-     * interrupted is fired. The default value is
-     * {@link DEFAULT_RTC_MUTE_TIMEOUT}.
+     * Creates new instance of <tt>ParticipantConnectionStatus</tt>.
      *
-     * @type {number} amount of time in milliseconds
+     * @constructor
+     * @param {RTC} rtc the RTC service instance
+     * @param {JitsiConference} conference parent conference instance
+     * @param {number} rtcMuteTimeout (optional) custom value for
+     * {@link ParticipantConnectionStatus.rtcMuteTimeout}.
      */
-    this.rtcMuteTimeout
-        = typeof rtcMuteTimeout === 'number'
-            ? rtcMuteTimeout : DEFAULT_RTC_MUTE_TIMEOUT;
-    logger.info("RtcMuteTimeout set to: " + this.rtcMuteTimeout);
-}
-
-/**
- * Initializes <tt>ParticipantConnectionStatus</tt> and bind required event
- * listeners.
- */
-init() {
-
-    this._onEndpointConnStatusChanged
-        = this.onEndpointConnStatusChanged.bind(this);
-
-    this.rtc.addListener(
-        RTCEvents.ENDPOINT_CONN_STATUS_CHANGED,
-        this._onEndpointConnStatusChanged);
-
-    // On some browsers MediaStreamTrack trigger "onmute"/"onunmute"
-    // events for video type tracks when they stop receiving data which is
-    // often a sign that remote user is having connectivity issues
-    if (RTCBrowserType.isVideoMuteOnConnInterruptedSupported()) {
-
-        this._onTrackRtcMuted = this.onTrackRtcMuted.bind(this);
-        this.rtc.addListener(
-            RTCEvents.REMOTE_TRACK_MUTE, this._onTrackRtcMuted);
-
-        this._onTrackRtcUnmuted = this.onTrackRtcUnmuted.bind(this);
-        this.rtc.addListener(
-            RTCEvents.REMOTE_TRACK_UNMUTE, this._onTrackRtcUnmuted);
-
-        // Track added/removed listeners are used to bind "mute"/"unmute"
-        // event handlers
-        this._onRemoteTrackAdded = this.onRemoteTrackAdded.bind(this);
-        this.conference.on(
-            JitsiConferenceEvents.TRACK_ADDED, this._onRemoteTrackAdded);
-        this._onRemoteTrackRemoved = this.onRemoteTrackRemoved.bind(this);
-        this.conference.on(
-            JitsiConferenceEvents.TRACK_REMOVED, this._onRemoteTrackRemoved);
-
-        // Listened which will be bound to JitsiRemoteTrack to listen for
-        // signalling mute/unmute events.
-        this._onSignallingMuteChanged = this.onSignallingMuteChanged.bind(this);
-    }
-}
-
-/**
- * Removes all event listeners and disposes of all resources held by this
- * instance.
- */
-dispose() {
-
-    this.rtc.removeListener(
-        RTCEvents.ENDPOINT_CONN_STATUS_CHANGED,
-        this._onEndpointConnStatusChanged);
-
-    if (RTCBrowserType.isVideoMuteOnConnInterruptedSupported()) {
-        this.rtc.removeListener(
-            RTCEvents.REMOTE_TRACK_MUTE, this._onTrackRtcMuted);
-        this.rtc.removeListener(
-            RTCEvents.REMOTE_TRACK_UNMUTE, this._onTrackRtcUnmuted);
-        this.conference.off(
-            JitsiConferenceEvents.TRACK_ADDED, this._onRemoteTrackAdded);
-        this.conference.off(
-            JitsiConferenceEvents.TRACK_REMOVED, this._onRemoteTrackRemoved);
+    constructor(rtc, conference, rtcMuteTimeout) {
+        this.rtc = rtc;
+        this.conference = conference;
+        /**
+         * A map of the "endpoint ID"(which corresponds to the resource part
+         * of MUC JID(nickname)) to the timeout callback IDs scheduled using
+         * window.setTimeout.
+         * @type {Object.<string, number>}
+         */
+        this.trackTimers = {};
+        /**
+         * How long we're going to wait after the RTC video track muted event
+         * for the corresponding signalling mute event, before the connection
+         * interrupted is fired. The default value is
+         * {@link DEFAULT_RTC_MUTE_TIMEOUT}.
+         *
+         * @type {number} amount of time in milliseconds
+         */
+        this.rtcMuteTimeout
+            = typeof rtcMuteTimeout === 'number'
+                ? rtcMuteTimeout : DEFAULT_RTC_MUTE_TIMEOUT;
+        logger.info("RtcMuteTimeout set to: " + this.rtcMuteTimeout);
     }
 
-    Object.keys(this.trackTimers).forEach(function (participantId) {
-        this.clearTimeout(participantId);
-    }.bind(this));
-}
+    /**
+     * Initializes <tt>ParticipantConnectionStatus</tt> and bind required event
+     * listeners.
+     */
+    init() {
 
-/**
- * Handles RTCEvents.ENDPOINT_CONN_STATUS_CHANGED triggered when we receive
- * notification over the data channel from the bridge about endpoint's
- * connection status update.
- * @param endpointId {string} the endpoint ID(MUC nickname/resource JID)
- * @param isActive {boolean} true if the connection is OK or false otherwise
- */
-onEndpointConnStatusChanged(endpointId, isActive) {
+        this._onEndpointConnStatusChanged
+            = this.onEndpointConnStatusChanged.bind(this);
 
-    logger.debug(
-        'Detector RTCEvents.ENDPOINT_CONN_STATUS_CHANGED('
-            + Date.now() +'): ' + endpointId + ': ' + isActive);
+        this.rtc.addListener(
+            RTCEvents.ENDPOINT_CONN_STATUS_CHANGED,
+            this._onEndpointConnStatusChanged);
 
-    // Filter out events for the local JID for now
-    if (endpointId !== this.conference.myUserId()) {
-        var participant = this.conference.getParticipantById(endpointId);
-        // Delay the 'active' event until the video track gets RTC unmuted event
-        if (isActive
-                && RTCBrowserType.isVideoMuteOnConnInterruptedSupported()
-                && participant
-                && participant.hasAnyVideoTrackWebRTCMuted()
-                && !participant.isVideoMuted()) {
-            logger.debug(
-                'Ignoring RTCEvents.ENDPOINT_CONN_STATUS_CHANGED -'
-                    + ' will wait for unmute event');
-        } else {
-            this._changeConnectionStatus(endpointId, isActive);
+        // On some browsers MediaStreamTrack trigger "onmute"/"onunmute"
+        // events for video type tracks when they stop receiving data which is
+        // often a sign that remote user is having connectivity issues
+        if (RTCBrowserType.isVideoMuteOnConnInterruptedSupported()) {
+
+            this._onTrackRtcMuted = this.onTrackRtcMuted.bind(this);
+            this.rtc.addListener(
+                RTCEvents.REMOTE_TRACK_MUTE, this._onTrackRtcMuted);
+
+            this._onTrackRtcUnmuted = this.onTrackRtcUnmuted.bind(this);
+            this.rtc.addListener(
+                RTCEvents.REMOTE_TRACK_UNMUTE, this._onTrackRtcUnmuted);
+
+            // Track added/removed listeners are used to bind "mute"/"unmute"
+            // event handlers
+            this._onRemoteTrackAdded = this.onRemoteTrackAdded.bind(this);
+            this.conference.on(
+                JitsiConferenceEvents.TRACK_ADDED,
+                this._onRemoteTrackAdded);
+
+            this._onRemoteTrackRemoved = this.onRemoteTrackRemoved.bind(this);
+            this.conference.on(
+                JitsiConferenceEvents.TRACK_REMOVED,
+                this._onRemoteTrackRemoved);
+
+            // Listened which will be bound to JitsiRemoteTrack to listen for
+            // signalling mute/unmute events.
+            this._onSignallingMuteChanged
+                = this.onSignallingMuteChanged.bind(this);
         }
     }
-}
 
-_changeConnectionStatus(endpointId, newStatus) {
-    var participant = this.conference.getParticipantById(endpointId);
-    if (!participant) {
-        // This will happen when participant exits the conference with broken
-        // ICE connection and we join after that. The bridge keeps sending
-        // that notification until the conference does not expire.
-        logger.warn(
-            'Missed participant connection status update - ' +
-                'no participant for endpoint: ' + endpointId);
-        return;
-    }
-    if (participant.isConnectionActive() !== newStatus) {
+    /**
+     * Removes all event listeners and disposes of all resources held by this
+     * instance.
+     */
+    dispose() {
 
-        participant._setIsConnectionActive(newStatus);
+        this.rtc.removeListener(
+            RTCEvents.ENDPOINT_CONN_STATUS_CHANGED,
+            this._onEndpointConnStatusChanged);
 
-        logger.debug(
-            'Emit endpoint conn status(' + Date.now() + '): ',
-            endpointId, newStatus);
+        if (RTCBrowserType.isVideoMuteOnConnInterruptedSupported()) {
+            this.rtc.removeListener(
+                RTCEvents.REMOTE_TRACK_MUTE,
+                this._onTrackRtcMuted);
+            this.rtc.removeListener(
+                RTCEvents.REMOTE_TRACK_UNMUTE,
+                this._onTrackRtcUnmuted);
 
-        // Log the event on CallStats
-        Statistics.sendLog(
-            JSON.stringify({
-                id: 'peer.conn.status',
-                participant: endpointId,
-                status: newStatus
-            }));
+            this.conference.off(
+                JitsiConferenceEvents.TRACK_ADDED,
+                this._onRemoteTrackAdded);
+            this.conference.off(
+                JitsiConferenceEvents.TRACK_REMOVED,
+                this._onRemoteTrackRemoved);
+        }
 
-        // and analytics
-        Statistics.analytics.sendEvent('peer.conn.status',
-            {label: newStatus});
-
-        this.conference.eventEmitter.emit(
-            JitsiConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED,
-            endpointId, newStatus);
-    }
-}
-
-/**
- * Reset the postponed "connection interrupted" event which was previously
- * scheduled as a timeout on RTC 'onmute' event.
- *
- * @param participantId the participant for which the "connection interrupted"
- * timeout was scheduled
- */
-clearTimeout(participantId) {
-    if (this.trackTimers[participantId]) {
-        window.clearTimeout(this.trackTimers[participantId]);
-        this.trackTimers[participantId] = null;
-    }
-}
-
-/**
- * Bind signalling mute event listeners for video {JitsiRemoteTrack} when
- * a new one is added to the conference.
- *
- * @param {JitsiTrack} remoteTrack the {JitsiTrack} which is being added to
- * the conference.
- */
-onRemoteTrackAdded(remoteTrack) {
-    if (!remoteTrack.isLocal() && remoteTrack.getType() === MediaType.VIDEO) {
-
-        logger.debug(
-            'Detector on remote track added: ', remoteTrack.getParticipantId());
-
-        remoteTrack.on(
-            JitsiTrackEvents.TRACK_MUTE_CHANGED,
-            this._onSignallingMuteChanged);
-    }
-}
-
-/**
- * Removes all event listeners bound to the remote video track and clears any
- * related timeouts.
- *
- * @param {JitsiRemoteTrack} remoteTrack the remote track which is being removed
- * from the conference.
- */
-onRemoteTrackRemoved(remoteTrack) {
-    if (!remoteTrack.isLocal() && remoteTrack.getType() === MediaType.VIDEO) {
-        logger.debug(
-            'Detector on remote track removed: ',
-            remoteTrack.getParticipantId());
-        remoteTrack.off(
-            JitsiTrackEvents.TRACK_MUTE_CHANGED,
-            this._onSignallingMuteChanged);
-        this.clearTimeout(remoteTrack.getParticipantId());
-    }
-}
-
-/**
- * Handles RTC 'onmute' event for the video track.
- *
- * @param {JitsiRemoteTrack} track the video track for which 'onmute' event will
- * be processed.
- */
-onTrackRtcMuted(track) {
-    var participantId = track.getParticipantId();
-    var participant = this.conference.getParticipantById(participantId);
-    logger.debug('Detector track RTC muted: ', participantId);
-    if (!participant) {
-        logger.error('No participant for id: ' + participantId);
-        return;
-    }
-    if (!participant.isVideoMuted()) {
-        // If the user is not muted according to the signalling we'll give it
-        // some time, before the connection interrupted event is triggered.
-        this.trackTimers[participantId] = window.setTimeout(function () {
-            if (!track.isMuted() && participant.isConnectionActive()) {
-                logger.info(
-                    'Connection interrupted through the RTC mute: '
-                        + participantId, Date.now());
-                this._changeConnectionStatus(participantId, false);
-            }
+        Object.keys(this.trackTimers).forEach(function (participantId) {
             this.clearTimeout(participantId);
-        }.bind(this), this.rtcMuteTimeout);
+        }.bind(this));
     }
-}
 
-/**
- * Handles RTC 'onunmute' event for the video track.
- *
- * @param {JitsiRemoteTrack} track the video track for which 'onunmute' event
- * will be processed.
- */
-onTrackRtcUnmuted(track) {
-    logger.debug('Detector track RTC unmuted: ', track);
-    var participantId = track.getParticipantId();
-    if (!track.isMuted() &&
-        !this.conference.getParticipantById(participantId)
-            .isConnectionActive()) {
-        logger.info(
-            'Detector connection restored through the RTC unmute: '
-                + participantId, Date.now());
-        this._changeConnectionStatus(participantId, true);
-    }
-    this.clearTimeout(participantId);
-}
+    /**
+     * Handles RTCEvents.ENDPOINT_CONN_STATUS_CHANGED triggered when we receive
+     * notification over the data channel from the bridge about endpoint's
+     * connection status update.
+     * @param endpointId {string} the endpoint ID(MUC nickname/resource JID)
+     * @param isActive {boolean} true if the connection is OK or false otherwise
+     */
+    onEndpointConnStatusChanged(endpointId, isActive) {
 
-/**
- * Here the signalling "mute"/"unmute" events are processed.
- *
- * @param {JitsiRemoteTrack} track the remote video track for which
- * the signalling mute/unmute event will be processed.
- */
-onSignallingMuteChanged (track) {
-    logger.debug(
-        'Detector on track signalling mute changed: ', track, track.isMuted());
-    var isMuted = track.isMuted();
-    var participantId = track.getParticipantId();
-    var participant = this.conference.getParticipantById(participantId);
-    if (!participant) {
-        logger.error('No participant for id: ' + participantId);
-        return;
-    }
-    var isConnectionActive = participant.isConnectionActive();
-    if (isMuted && isConnectionActive && this.trackTimers[participantId]) {
         logger.debug(
-            'Signalling got in sync - cancelling task for: ' + participantId);
+            'Detector RTCEvents.ENDPOINT_CONN_STATUS_CHANGED('
+                + Date.now() +'): ' + endpointId + ': ' + isActive);
+
+        // Filter out events for the local JID for now
+        if (endpointId !== this.conference.myUserId()) {
+            var participant = this.conference.getParticipantById(endpointId);
+            // Delay the 'active' event until the video track gets
+            // the RTC unmuted event
+            if (isActive
+                    && RTCBrowserType.isVideoMuteOnConnInterruptedSupported()
+                    && participant
+                    && participant.hasAnyVideoTrackWebRTCMuted()
+                    && !participant.isVideoMuted()) {
+                logger.debug(
+                    'Ignoring RTCEvents.ENDPOINT_CONN_STATUS_CHANGED -'
+                        + ' will wait for unmute event');
+            } else {
+                this._changeConnectionStatus(endpointId, isActive);
+            }
+        }
+    }
+
+    _changeConnectionStatus(endpointId, newStatus) {
+        var participant = this.conference.getParticipantById(endpointId);
+        if (!participant) {
+            // This will happen when participant exits the conference with
+            // broken ICE connection and we join after that. The bridge keeps
+            // sending that notification until the conference does not expire.
+            logger.warn(
+                'Missed participant connection status update - ' +
+                    'no participant for endpoint: ' + endpointId);
+            return;
+        }
+        if (participant.isConnectionActive() !== newStatus) {
+
+            participant._setIsConnectionActive(newStatus);
+
+            logger.debug(
+                'Emit endpoint conn status(' + Date.now() + '): ',
+                endpointId, newStatus);
+
+            // Log the event on CallStats
+            Statistics.sendLog(
+                JSON.stringify({
+                    id: 'peer.conn.status',
+                    participant: endpointId,
+                    status: newStatus
+                }));
+
+            // and analytics
+            Statistics.analytics.sendEvent('peer.conn.status',
+                {label: newStatus});
+
+            this.conference.eventEmitter.emit(
+                JitsiConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED,
+                endpointId, newStatus);
+        }
+    }
+
+    /**
+     * Reset the postponed "connection interrupted" event which was previously
+     * scheduled as a timeout on RTC 'onmute' event.
+     *
+     * @param participantId the participant for which the "connection
+     * interrupted" timeout was scheduled
+     */
+    clearTimeout(participantId) {
+        if (this.trackTimers[participantId]) {
+            window.clearTimeout(this.trackTimers[participantId]);
+            this.trackTimers[participantId] = null;
+        }
+    }
+
+    /**
+     * Bind signalling mute event listeners for video {JitsiRemoteTrack} when
+     * a new one is added to the conference.
+     *
+     * @param {JitsiTrack} remoteTrack the {JitsiTrack} which is being added to
+     * the conference.
+     */
+    onRemoteTrackAdded(remoteTrack) {
+        if (!remoteTrack.isLocal()
+                && remoteTrack.getType() === MediaType.VIDEO) {
+
+            logger.debug(
+                'Detector on remote track added: ',
+                remoteTrack.getParticipantId());
+
+            remoteTrack.on(
+                JitsiTrackEvents.TRACK_MUTE_CHANGED,
+                this._onSignallingMuteChanged);
+        }
+    }
+
+    /**
+     * Removes all event listeners bound to the remote video track and clears
+     * any related timeouts.
+     *
+     * @param {JitsiRemoteTrack} remoteTrack the remote track which is being
+     * removed from the conference.
+     */
+    onRemoteTrackRemoved(remoteTrack) {
+        if (!remoteTrack.isLocal()
+                && remoteTrack.getType() === MediaType.VIDEO) {
+            logger.debug(
+                'Detector on remote track removed: ',
+                remoteTrack.getParticipantId());
+            remoteTrack.off(
+                JitsiTrackEvents.TRACK_MUTE_CHANGED,
+                this._onSignallingMuteChanged);
+            this.clearTimeout(remoteTrack.getParticipantId());
+        }
+    }
+
+    /**
+     * Handles RTC 'onmute' event for the video track.
+     *
+     * @param {JitsiRemoteTrack} track the video track for which 'onmute' event
+     * will be processed.
+     */
+    onTrackRtcMuted(track) {
+        var participantId = track.getParticipantId();
+        var participant = this.conference.getParticipantById(participantId);
+        logger.debug('Detector track RTC muted: ', participantId);
+        if (!participant) {
+            logger.error('No participant for id: ' + participantId);
+            return;
+        }
+        if (!participant.isVideoMuted()) {
+            // If the user is not muted according to the signalling we'll give
+            // it some time, before the connection interrupted event is
+            // triggered.
+            this.trackTimers[participantId] = window.setTimeout(function () {
+                if (!track.isMuted() && participant.isConnectionActive()) {
+                    logger.info(
+                        'Connection interrupted through the RTC mute: '
+                            + participantId, Date.now());
+                    this._changeConnectionStatus(participantId, false);
+                }
+                this.clearTimeout(participantId);
+            }.bind(this), this.rtcMuteTimeout);
+        }
+    }
+
+    /**
+     * Handles RTC 'onunmute' event for the video track.
+     *
+     * @param {JitsiRemoteTrack} track the video track for which 'onunmute'
+     * event will be processed.
+     */
+    onTrackRtcUnmuted(track) {
+        logger.debug('Detector track RTC unmuted: ', track);
+        var participantId = track.getParticipantId();
+        if (!track.isMuted() &&
+            !this.conference.getParticipantById(participantId)
+                .isConnectionActive()) {
+            logger.info(
+                'Detector connection restored through the RTC unmute: '
+                    + participantId, Date.now());
+            this._changeConnectionStatus(participantId, true);
+        }
         this.clearTimeout(participantId);
     }
-}
+
+    /**
+     * Here the signalling "mute"/"unmute" events are processed.
+     *
+     * @param {JitsiRemoteTrack} track the remote video track for which
+     * the signalling mute/unmute event will be processed.
+     */
+    onSignallingMuteChanged (track) {
+        logger.debug(
+            'Detector on track signalling mute changed: ',
+            track, track.isMuted());
+        var isMuted = track.isMuted();
+        var participantId = track.getParticipantId();
+        var participant = this.conference.getParticipantById(participantId);
+        if (!participant) {
+            logger.error('No participant for id: ' + participantId);
+            return;
+        }
+        var isConnectionActive = participant.isConnectionActive();
+        if (isMuted && isConnectionActive && this.trackTimers[participantId]) {
+            logger.debug(
+                'Signalling got in sync - cancelling task for: '
+                    + participantId);
+            this.clearTimeout(participantId);
+        }
+    }
 
 }


### PR DESCRIPTION
First part of the PR applies some of the comments for the original PR:
https://github.com/jitsi/lib-jitsi-meet/pull/259
The second part addresses an issue where participant's connection status would end up stuck in "disconnected" on device switch/screen sharing(sometimes).