### PR TITLE
Page reloads on BOSH HTTP errors

### DIFF
--- a/JitsiConnectionEvents.js
+++ b/JitsiConnectionEvents.js
@@ -20,13 +20,13 @@ export const CONNECTION_DISCONNECTED = "connection.connectionDisconnected";
 export const CONNECTION_ESTABLISHED = "connection.connectionEstablished";
 /**
  * Indicates that the connection has been failed for some reason. The event
- * proivdes the following parameters to its listeners:
+ * provides the following parameters to its listeners:
  *
  * @param err {string} the error (message) associated with the failure
  */
 export const CONNECTION_FAILED = "connection.connectionFailed";
 /**
- * Indicates that the perfomed action cannot be executed because the
+ * Indicates that the performed action cannot be executed because the
  * connection is not in the correct state(connected, disconnected, etc.)
  */
 export const WRONG_STATE = "connection.wrongState";

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -146,6 +146,7 @@ export default class XMPP {
         } else if (status === Strophe.Status.DISCONNECTED) {
             // Stop ping interval
             this.connection.ping.stopInterval();
+            const wasIntentionalDisconnect = this.disconnectInProgress;
             const errMsg = msg ? msg : this.lastErrorMsg;
             this.disconnectInProgress = false;
             if (this.anonymousConnectionFailed) {
@@ -157,6 +158,17 @@ export default class XMPP {
                 this.eventEmitter.emit(
                     JitsiConnectionEvents.CONNECTION_FAILED,
                     JitsiConnectionErrors.OTHER_ERROR, errMsg);
+            } else if (!wasIntentionalDisconnect) {
+                // XXX if Strophe drops the connection while not being asked to,
+                // it means that most likely some serious error has occurred.
+                // One currently known case is when a BOSH request fails for
+                // more than 4 times. The connection is dropped without
+                // supplying a reason(error message/event) through the API.
+                logger.error("XMPP connection dropped!");
+                this.eventEmitter.emit(
+                    JitsiConnectionEvents.CONNECTION_FAILED,
+                    JitsiConnectionErrors.OTHER_ERROR,
+                    errMsg ? errMsg : 'connection-dropped-error');
             } else {
                 this.eventEmitter.emit(
                     JitsiConnectionEvents.CONNECTION_DISCONNECTED, errMsg);

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -146,19 +146,20 @@ export default class XMPP {
         } else if (status === Strophe.Status.DISCONNECTED) {
             // Stop ping interval
             this.connection.ping.stopInterval();
+            const errMsg = msg ? msg : this.lastErrorMsg;
             this.disconnectInProgress = false;
             if (this.anonymousConnectionFailed) {
                 // prompt user for username and password
-                this.eventEmitter.emit(JitsiConnectionEvents.CONNECTION_FAILED,
+                this.eventEmitter.emit(
+                    JitsiConnectionEvents.CONNECTION_FAILED,
                     JitsiConnectionErrors.PASSWORD_REQUIRED);
             } else if(this.connectionFailed) {
-                this.eventEmitter.emit(JitsiConnectionEvents.CONNECTION_FAILED,
-                    JitsiConnectionErrors.OTHER_ERROR,
-                    msg ? msg : this.lastErrorMsg);
+                this.eventEmitter.emit(
+                    JitsiConnectionEvents.CONNECTION_FAILED,
+                    JitsiConnectionErrors.OTHER_ERROR, errMsg);
             } else {
                 this.eventEmitter.emit(
-                        JitsiConnectionEvents.CONNECTION_DISCONNECTED,
-                        msg ? msg : this.lastErrorMsg);
+                    JitsiConnectionEvents.CONNECTION_DISCONNECTED, errMsg);
             }
         } else if (status === Strophe.Status.AUTHFAIL) {
             // wrong password or username, prompt user


### PR DESCRIPTION
The goal of this PR is to trigger the CONNECTION_FAILED event when the XMPP connection is dropped.