### PR TITLE
Suspend LocalStatsCollector#AudioContext if not used.

### DIFF
--- a/modules/statistics/LocalStatsCollector.js
+++ b/modules/statistics/LocalStatsCollector.js
@@ -22,6 +22,7 @@ var context = null;
 
 if(window.AudioContext) {
     context = new AudioContext();
+    context.suspend();
 }
 
 /**
@@ -89,7 +90,7 @@ LocalStatsCollector.prototype.start = function () {
     if (!context ||
         RTCBrowserType.isTemasysPluginUsed())
         return;
-
+    context.resume();
     var analyser = context.createAnalyser();
     analyser.smoothingTimeConstant = WEBAUDIO_ANALYZER_SMOOTING_TIME;
     analyser.fftSize = WEBAUDIO_ANALYZER_FFT_SIZE;


### PR DESCRIPTION
LocalStatsCollector uses a global AudioContext for implementing metrics on webrtc audio streams. If there is an audio stream the stream gets attached to the global AudioContext and metrics for this stream are collected.
When using lib-jitsi-meet with no audio streams (for example only screen sharing) the orphan AudioContext does have a default audio level. In other words even if no audio stream is attached to it the element plays some default sound using cpu/battery and most crucial in clients with virtualized harware causing network traffic to send audio output to local hardware which clients are operating.
The solution provided suspends the global AudioContext right after its creation. Therefore, there is no default audio signal emitted by it.
