### PR TITLE
Fix Uncaught TypeError: Cannot read property 'getTracks' of undefined

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -481,9 +481,16 @@ JitsiConferenceEventManager.prototype.setupRTCListeners = function () {
 
     conference.rtc.addListener(RTCEvents.ENDPOINT_MESSAGE_RECEIVED,
         function (from, payload) {
-            conference.eventEmitter.emit(
-                JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED,
-                conference.getParticipantById(from), payload);
+            const participant = conference.getParticipantById(from);
+            if (participant) {
+                conference.eventEmitter.emit(
+                    JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED,
+                    participant, payload);
+            } else {
+                logger.warn(
+                    "Ignored ENDPOINT_MESSAGE_RECEIVED " +
+                    "for not existing participant: " + from, payload);
+            }
         });
 };
 


### PR DESCRIPTION
This PR fixes:

Logger.js:89 [modules/xmpp/moderator.js] <i.onMucMemberLeft>:  Someone left is it focus ? hxxxxp@conference.beta.meet.jit.si/7e49f474
Logger.js:89 [JitsiMeetJS.js] <Object.getGlobalOnErrorHandler>:  UnhandledError: Uncaught TypeError: Cannot read property 'getTracks' of undefined Script: https://beta.meet.jit.si/libs/app.bundle.min.js?v=1429 Line: 37 Column: 21914 StackTrace:  TypeError: Cannot read property 'getTracks' of undefined
    at n.<anonymous> (https://beta.meet.jit.si/libs/app.bundle.min.js?v=1429:37:21914)
    at n.emit (https://beta.meet.jit.si/libs/lib-jitsi-meet.min.js?v=1429:1:17598)
    at n.<anonymous> (https://beta.meet.jit.si/libs/lib-jitsi-meet.min.js?v=1429:23:10144)
    at n.emit (https://beta.meet.jit.si/libs/lib-jitsi-meet.min.js?v=1429:1:17598)
    at RTCDataChannel.t.onmessage (https://beta.meet.jit.si/libs/lib-jitsi-meet.min.js?v=1429:23:18728)r @ Logger.js:89
conference.js:1348 Uncaught TypeError: Cannot read property 'getTracks' of undefined