### PR TITLE
Second attempt on #292

### DIFF
--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -312,7 +312,14 @@ export default class ParticipantConnectionStatus {
 
         const isConnectionActive = participant.isConnectionActive();
         const hasAnyVideoRTCMuted = participant.hasAnyVideoTrackWebRTCMuted();
-        const isConnActiveByJvb = this.rtcConnStatusCache[endpointId];
+        let isConnActiveByJvb = this.rtcConnStatusCache[endpointId];
+
+        // If no status was received from the JVB it means that it's active
+        // (the bridge does not send notification unless there is a problem).
+        if (typeof isConnActiveByJvb !== 'boolean') {
+            logger.debug("Assuming connection active by JVB - no notification");
+            isConnActiveByJvb = true;
+        }
 
         logger.debug(
             "Remote track removed, is active: " + isConnectionActive


### PR DESCRIPTION
The PR fixes one case missing from https://github.com/jitsi/lib-jitsi-meet/pull/292

If there was no notification from the JVB about the connectivity status
it means it's connected. That's because the bridge does not send any
notification unless there is a problem.