### PR TITLE
chore: Only uses jslint 3+

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-loader": "*",
     "babel-polyfill": "*",
     "babel-preset-es2015": "*",
-    "eslint": "*",
+    "eslint": "~3",
     "jshint": "^2.8.0",
     "precommit-hook": "^3.0.0",
     "string-replace-loader": "*",


### PR DESCRIPTION
because older versions don't work with our .jslintrc file