### PR TITLE
Connection problems indication stalled when video muted

### DIFF
--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -46,7 +46,7 @@ export default class ParticipantConnectionStatus {
          * Required for getting back in sync when remote video track is removed.
          * @type {Object.<string, boolean>}
          */
-        this.rtcConnStatusCache = { };
+        this.connStatusFromJvb = { };
         /**
          * How long we're going to wait after the RTC video track muted event
          * for the corresponding signalling mute event, before the connection
@@ -137,7 +137,7 @@ export default class ParticipantConnectionStatus {
         }.bind(this));
 
         // Clear RTC connection status cache
-        this.rtcConnStatusCache = {};
+        this.connStatusFromJvb = {};
     }
 
     /**
@@ -159,7 +159,7 @@ export default class ParticipantConnectionStatus {
             // Cache the status received received over the data channels, as
             // it will be needed to verify for out of sync when the remote video
             // track is being removed.
-            this.rtcConnStatusCache[endpointId] = isActive;
+            this.connStatusFromJvb[endpointId] = isActive;
 
             var participant = this.conference.getParticipantById(endpointId);
             // Delay the 'active' event until the video track gets
@@ -312,7 +312,7 @@ export default class ParticipantConnectionStatus {
 
         const isConnectionActive = participant.isConnectionActive();
         const hasAnyVideoRTCMuted = participant.hasAnyVideoTrackWebRTCMuted();
-        let isConnActiveByJvb = this.rtcConnStatusCache[endpointId];
+        let isConnActiveByJvb = this.connStatusFromJvb[endpointId];
 
         // If no status was received from the JVB it means that it's active
         // (the bridge does not send notification unless there is a problem).

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -304,7 +304,7 @@ export default class ParticipantConnectionStatus {
         }
 
         const hasAnyVideoRTCMuted = participant.hasAnyVideoTrackWebRTCMuted();
-        var rtcMutedTimestamp
+        const rtcMutedTimestamp
             = this.rtcMutedTimestamp[participant.getId()];
 
         return hasAnyVideoRTCMuted
@@ -320,7 +320,7 @@ export default class ParticipantConnectionStatus {
      * ID).
      */
     figureOutConnectionStatus(id) {
-        var participant = this.conference.getParticipantById(id);
+        const participant = this.conference.getParticipantById(id);
         if (!participant) {
             // Probably the participant is no longer in the conference
             // (at the time of writing this code, participant is
@@ -343,7 +343,7 @@ export default class ParticipantConnectionStatus {
             isConnActiveByJvb = true;
         }
 
-        var isConnectionActive = true;
+        let isConnectionActive = true;
         if (!isVideoMuted && (isVideoTrackFrozen || !isConnActiveByJvb)) {
             // Disconnected when not video muted and either got that status from
             // JVB or the video track is "RTC muted"
@@ -369,8 +369,8 @@ export default class ParticipantConnectionStatus {
      * will be processed.
      */
     onTrackRtcMuted(track) {
-        var participantId = track.getParticipantId();
-        var participant = this.conference.getParticipantById(participantId);
+        const participantId = track.getParticipantId();
+        const participant = this.conference.getParticipantById(participantId);
         logger.debug('Detector track RTC muted: ' + participantId);
         if (!participant) {
             logger.error('No participant for id: ' + participantId);
@@ -397,7 +397,7 @@ export default class ParticipantConnectionStatus {
      * event will be processed.
      */
     onTrackRtcUnmuted(track) {
-        var participantId = track.getParticipantId();
+        const participantId = track.getParticipantId();
 
         logger.debug('Detector track RTC unmuted: ' + participantId);
 

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -332,7 +332,8 @@ export default class ParticipantConnectionStatus {
             logger.info(
                 "Remote track removed for disconnected" +
                 " participant, when the status according to" +
-                " the JVB is connected. Adjusting to the JVB value.");
+                " the JVB is connected. Adjusting to the JVB value for: "
+                + endpointId);
             this._changeConnectionStatus(endpointId, isConnActiveByJvb);
         }
     }
@@ -374,8 +375,8 @@ export default class ParticipantConnectionStatus {
      * event will be processed.
      */
     onTrackRtcUnmuted(track) {
-        logger.debug('Detector track RTC unmuted: ', track);
         var participantId = track.getParticipantId();
+        logger.debug('Detector track RTC unmuted: ' + participantId);
         if (!track.isMuted() &&
             !this.conference.getParticipantById(participantId)
                 .isConnectionActive()) {
@@ -394,11 +395,13 @@ export default class ParticipantConnectionStatus {
      * the signalling mute/unmute event will be processed.
      */
     onSignallingMuteChanged (track) {
-        logger.debug(
-            'Detector on track signalling mute changed: ',
-            track, track.isMuted());
         var isMuted = track.isMuted();
         var participantId = track.getParticipantId();
+
+        logger.debug(
+            'Detector on track signalling mute changed: ',
+            participantId, track.isMuted());
+
         var participant = this.conference.getParticipantById(participantId);
         if (!participant) {
             logger.error('No participant for id: ' + participantId);

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -343,15 +343,8 @@ export default class ParticipantConnectionStatus {
             isConnActiveByJvb = true;
         }
 
-        let isConnectionActive = true;
-        if (!isVideoMuted && (isVideoTrackFrozen || !isConnActiveByJvb)) {
-            // Disconnected when not video muted and either got that status from
-            // JVB or the video track is "RTC muted"
-            isConnectionActive = false;
-        } else if (isVideoMuted && !isConnActiveByJvb){
-            // If is video muted, but JVB reports no data
-            isConnectionActive = false;
-        }
+        let isConnectionActive
+            = isConnActiveByJvb && (isVideoMuted || !isVideoTrackFrozen);
 
         logger.debug(
             'Figure out conn status, is video muted: ' + isVideoMuted

--- a/service/RTC/RTCEvents.js
+++ b/service/RTC/RTCEvents.js
@@ -7,7 +7,11 @@ var RTCEvents = {
     LASTN_ENDPOINT_CHANGED: "rtc.lastn_endpoint_changed",
     AVAILABLE_DEVICES_CHANGED: "rtc.available_devices_changed",
     TRACK_ATTACHED: "rtc.track_attached",
+    // FIXME get rid of this event in favour of NO_DATA_FROM_SOURCE event
+    // (currently implemented for local tracks only)
     REMOTE_TRACK_MUTE: "rtc.remote_track_mute",
+    // FIXME get rid of this event in favour of NO_DATA_FROM_SOURCE event
+    // (currently implemented for local tracks only)
     REMOTE_TRACK_UNMUTE: "rtc.remote_track_unmute",
     AUDIO_OUTPUT_DEVICE_CHANGED: "rtc.audio_output_device_changed",
     DEVICE_LIST_CHANGED: "rtc.device_list_changed",


### PR DESCRIPTION
This PR fixes issue when video muted signalling arrive after the timeout which adjusts user's status to disconnected. It also refactors the logic from event based like advised during https://github.com/jitsi/lib-jitsi-meet/pull/292 review.