### PR TITLE
Add events to notify ICE state changes and ICE candidates info

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -241,6 +241,15 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function () {
             this.conference.connectionIsInterrupted = false;
         });
 
+    this.chatRoomForwarder.forward(XMPPEvents.NO_TCP_ICE_CANDIDATES,
+        JitsiConferenceEvents.NO_TCP_ICE_CANDIDATES);
+
+    this.chatRoomForwarder.forward(XMPPEvents.TCP_ICE_CANDIDATE,
+        JitsiConferenceEvents.TCP_ICE_CANDIDATE);
+
+    this.chatRoomForwarder.forward(XMPPEvents.UDP_ICE_CANDIDATE,
+        JitsiConferenceEvents.UDP_ICE_CANDIDATE);
+
     this.chatRoomForwarder.forward(XMPPEvents.CONFERENCE_SETUP_FAILED,
         JitsiConferenceEvents.CONFERENCE_FAILED,
         JitsiConferenceErrors.SETUP_FAILED);

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -167,6 +167,26 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function () {
             chatRoom.eventEmitter.emit(
                 XMPPEvents.CONFERENCE_SETUP_FAILED,
                 new Error("ICE fail"));
+            conference.eventEmitter.emit(
+                JitsiConferenceEvents.ICE_STATE_CHANGED,
+                conference.myUserId(),
+                "failed");
+        });
+
+    chatRoom.addListener(XMPPEvents.CONNECTION_RESTORED,
+        () => {
+            conference.eventEmitter.emit(
+                JitsiConferenceEvents.ICE_STATE_CHANGED,
+                conference.myUserId(),
+                "restored");
+        });
+
+    chatRoom.addListener(XMPPEvents.CONNECTION_ESTABLISHED,
+        () => {
+            conference.eventEmitter.emit(
+                JitsiConferenceEvents.ICE_STATE_CHANGED,
+                conference.myUserId(),
+                "connected");
         });
 
     this.chatRoomForwarder.forward(XMPPEvents.MUC_DESTROYED,
@@ -201,6 +221,10 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function () {
         () => {
             Statistics.sendEventToAll('connection.interrupted');
             this.conference.connectionIsInterrupted = true;
+            conference.eventEmitter.emit(
+                JitsiConferenceEvents.ICE_STATE_CHANGED,
+                conference.myUserId(),
+                "interrupted");
         });
 
     this.chatRoomForwarder.forward(XMPPEvents.RECORDER_STATE_CHANGED,

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -105,6 +105,14 @@ export const MESSAGE_RECEIVED = "conference.messageReceived";
 export const PARTICIPANT_CONN_STATUS_CHANGED
     = "conference.participant_conn_status_changed";
 /**
+ * Indicates if no TCP ICE candidates were found when accepting an offer.
+ */
+export const NO_TCP_ICE_CANDIDATES = "conference.no_tcp_ice_candidates";
+/**
+ * Indicates if no UDP ICE candidates were found when accepting an offer.
+ */
+export const NO_UDP_ICE_CANDIDATES = "conference.no_udp_ice_candidates";
+/**
  * Indicates that a the value of a specific property of a specific participant
  * has changed.
  */
@@ -139,6 +147,15 @@ export const SUSPEND_DETECTED = "conference.suspendDetected";
  * Event indicates that local user is talking while he muted himself
  */
 export const TALK_WHILE_MUTED = "conference.talk_while_muted";
+/**
+ * Indicates that a TCP ICE candidate was found that if it was reachable via
+ * HTTPS
+ */
+export const TCP_ICE_CANDIDATE = "conference.tcpIceCandidate";
+/**
+ * Reports the ip and port of the UDP ICE candidate
+ */
+export const UDP_ICE_CANDIDATE = "conference.udpIceCandidate";
 /**
  * A new media track was added to the conference. The event provides the
  * following parameters to its listeners:

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -71,6 +71,10 @@ export const DTMF_SUPPORT_CHANGED = "conference.dtmfSupportChanged";
  */
 export const ENDPOINT_MESSAGE_RECEIVED = "conference.endpoint_message_received";
 /**
+ * Indicates that the state of the ICE process had changed.
+ */
+export const ICE_STATE_CHANGED = "conference.ice_state_changed";
+/**
  * You are included / excluded in somebody's last N set
  */
 export const IN_LAST_N_CHANGED = "conference.inLastNChanged";

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -162,6 +162,8 @@ JingleSessionPC.prototype.doInitialize = function () {
                 // Informs interested parties that the connection has been restored.
                 if (self.peerconnection.signalingState === 'stable' && self.isreconnect)
                     self.room.eventEmitter.emit(XMPPEvents.CONNECTION_RESTORED);
+                else if (self.peerconnection.signalingState === 'stable')
+                    self.room.eventEmitter.emit(XMPPEvents.CONNECTION_ESTABLISHED);
                 self.isreconnect = false;
 
                 break;

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -87,6 +87,12 @@ var XMPPEvents = {
     MUC_ROLE_CHANGED: "xmpp.muc_role_changed",
     // Designates an event indicating that the MUC has been locked or unlocked.
     MUC_LOCK_CHANGED: "xmpp.muc_lock_changed",
+    // Designates an event indicating that among the list of candidates there
+    // were no TCP candidates.
+    NO_TCP_ICE_CANDIDATES: "xmpp.no_tcp_ice_candidates",
+    // Designates an event indicating that among the list of candidates there
+    // were no UDP candidates.
+    NO_UDP_ICE_CANDIDATES: "xmpp.no_udp_ice_candidates",
     // Designates an event indicating that a participant in the XMPP MUC has
     // advertised that they have audio muted (or unmuted).
     PARTICIPANT_AUDIO_MUTED: "xmpp.audio_muted",
@@ -180,6 +186,10 @@ var XMPPEvents = {
     SUBJECT_CHANGED: "xmpp.subject_changed",
     // suspending detected
     SUSPEND_DETECTED: "xmpp.suspend_detected",
+    // Event fired when a TCP ICE candidate is found in the offer
+    TCP_ICE_CANDIDATE: "xmpp.tcp_ice_candidate",
+    // Reports each of the UDP ICE candidates received
+    UDP_ICE_CANDIDATE: "xmpp.udp_ice_candidate",
     // Designates an event indicating that the local ICE username fragment of
     // the jingle session has changed.
     LOCAL_UFRAG_CHANGED: "xmpp.local_ufrag_changed",


### PR DESCRIPTION
I've been working on a 'troubleshooting' tool and I added some new events related to ICE:
- notify state changes
- notify the list of candidates or its absence.

In my case I use the list of candidates to double check that what is being advertised matches our expectations and also to check if one of the REST endpoints in the JVBs is reachable for the TCP 443 candidates.