### PR TITLE
Support pinning multiple users

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -642,6 +642,18 @@ JitsiConference.prototype.pinParticipant = function(participantId) {
 };
 
 /**
+ * Elects the participan(s) to be the pinned participants in
+ * order to always receive video for this participant (even when last n is
+ * enabled).
+ * @param participantIdList (Array) a list of the participant ids
+ * @throws NetworkError or InvalidStateError or Error if the operation fails.
+ */
+JitsiConference.prototype.pinParticipants = function(participantIdList) {
+    this.rtc.pinEndpoints(participantIdList);
+};
+
+/**
+ * Returns the list of participants for this conference.
  * @return Array<JitsiParticipant> an array of all participants in this
  * conference.
  */

--- a/doc/API.md
+++ b/doc/API.md
@@ -378,6 +378,11 @@ Throws NetworkError or InvalidStateError or Error if the operation fails.
 
 Throws NetworkError or InvalidStateError or Error if the operation fails.
 
+35. pinParticipants(participantIdList) - Elects the participants with the given ids to be pinned in order to always receive video for this participants (even when last n is enabled).
+    - participantIdList - an array of participant identifiers
+
+Throws NetworkError or InvalidStateError or Error if the operation fails.
+
 JitsiTrack
 ======
 The object represents single track - video or audio. They can be remote tracks ( from the other participants in the call) or local tracks (from the devices of the local participant).

--- a/modules/RTC/DataChannels.js
+++ b/modules/RTC/DataChannels.js
@@ -201,6 +201,27 @@ DataChannels.prototype.sendPinnedEndpointMessage = function (endpointId) {
 };
 
 /**
+ * Sends a "pinned endpoints changed" message via the data channel.
+ * @param endpointIdList {array} an array the ids of the pinned endpoints
+ * @throws NetworkError or InvalidStateError from RTCDataChannel#send (@see
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/send})
+ * or Error with "No opened data channels found!" message.
+ */
+DataChannels.prototype.sendPinnedEndpointsMessage = function (endpointIdList) {
+    logger.log(
+        'sending pinned endpoints changed notification to the bridge: ',
+        endpointIdList);
+
+    var jsonObject = {};
+
+    jsonObject.colibriClass = 'PinnedEndpointsChangedEvent';
+    jsonObject["pinnedEndpoints"]
+        = (endpointIdList ? endpointIdList : []);
+
+    this.send(jsonObject);
+};
+
+/**
  * Notifies Videobridge about a change in the value of a specific
  * endpoint-related property such as selected endpoint and pinned endpoint.
  *

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -172,6 +172,23 @@ export default class RTC extends Listenable {
         }
     }
 
+    /**
+     * Elects the participant(s) to be the pinned participants in
+     * order to always receive video for this participant (even when last n is
+     * enabled).
+     * @param idList {Array} the user id
+     * @throws NetworkError or InvalidStateError or Error if the operation fails.
+     */
+    pinEndpoints (idList) {
+        if(this.dataChannels) {
+            this.dataChannels.sendPinnedEndpointsMessage(idList);
+        } else {
+            // FIXME: cache value while there is no data channel created
+            // and send the cached state once channel is created
+            throw new Error("Data channels support is disabled!");
+        }
+    }
+
     static addListener (eventType, listener) {
         RTCUtils.addListener(eventType, listener);
     }


### PR DESCRIPTION
This adds support for sending the PinnedEndpointsChangedEvent over the data channel to pin multiple users when last-n is enabled.