### PR TITLE
fix: Adds NWJS and electron to the list of browsers which support

### DIFF
--- a/modules/RTC/RTCBrowserType.js
+++ b/modules/RTC/RTCBrowserType.js
@@ -161,10 +161,15 @@ var RTCBrowserType = {
 
     /**
      * Whether jitsi-meet supports simulcast on the current browser.
+     * TODO this is currently NOT used to make a decision of whether to
+     * enable simulcast or not (where we rely on sdp-simulcast instead). We
+     * should use either one or the other.
      * @returns {boolean}
      */
     supportsSimulcast: function() {
-        return RTCBrowserType.isChrome();
+        return RTCBrowserType.isChrome()
+            || RTCBrowserType.isNWJS()
+            || RTCBrowserType.isElectron();
     }
 
     // Add version getters for other browsers when needed

--- a/modules/connectivity/ConnectionQuality.js
+++ b/modules/connectivity/ConnectionQuality.js
@@ -121,8 +121,10 @@ export default class ConnectionQuality {
 
         /**
          * Whether simulcast is supported. Note that even if supported, it is
-         * currently not used for screensharing, which is why we have an
-         * additional check.
+         * currently not used for screensharing.
+         *
+         * TODO: use a more reliable check for whether simulcast is actually in
+         * use.
          */
         this._simulcast
             = !options.disableSimulcast && RTCBrowserType.supportsSimulcast();


### PR DESCRIPTION
simulcast. Adds TODOs for using a single place to determine simulcast
support.