### PR TITLE
cleanup: Make desktop sharing options consistent and drop deprecated …

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -39,21 +39,21 @@ You can access the following methods and objects trough ```JitsiMeetJS``` object
 *  ```JitsiMeetJS.init(options)``` - this method initialized Jitsi Meet API.
 The ```options``` parameter is JS object with the following properties:
     1. useIPv6 - boolean property
-    2. desktopSharingChromeMethod - Desktop sharing method. Can be set to 'ext', 'webrtc' or false to disable.
-    3. desktopSharingChromeExtId - The ID of the jidesha extension for Chrome or Firefox. Example: 'mbocklcggfhnbahlnepmldehdhpjfcjp'
-    desktopSharingChromeSources - Array of strings with the media sources to use when using screen sharing with the Chrome extension. Example: ['screen', 'window']
-    4. desktopSharingChromeMinExtVersion - Required version of Chrome extension. Example: '0.1'
-    5. desktopSharingFirefoxExtId - The ID of the jidesha extension for Firefox. If null, we assume that no extension is required.
-    6. desktopSharingFirefoxDisabled - Boolean. Whether desktop sharing should be disabled on Firefox. Example: false.
-    7. desktopSharingFirefoxMaxVersionExtRequired - The maximum version of Firefox which requires a jidesha extension. Example: if set to 41, we will require the extension for Firefox versions up to and including 41. On Firefox 42 and higher, we will run without the extension. If set to -1, an extension will be required for all versions of Firefox.
-    8. desktopSharingFirefoxExtensionURL - The URL to the Firefox extension for desktop sharing. "null" if no extension is required.
-    9. disableAudioLevels - boolean property. Enables/disables audio levels.
-    10. disableSimulcast - boolean property. Enables/disables simulcast.
-    11. enableWindowOnErrorHandler - boolean property (default false). Enables/disables attaching global onerror handler (window.onerror).
-    12. disableThirdPartyRequests - if true - callstats will be disabled and the callstats API won't be included.
-    13. enableAnalyticsLogging - boolean property (default false). Enables/disables analytics logging.
-    14. callStatsCustomScriptUrl - (optional) custom url to access callstats client script
-    15. callStatsConfIDNamespace - (optional) a namespace to prepend the callstats conference ID with. Defaults to the window.location.hostname
+    2. desktopSharingChromeExtId - The ID of the jidesha extension for Chrome. Example: 'mbocklcggfhnbahlnepmldehdhpjfcjp'
+    3. desktopSharingChromeDisabled - Boolean. Whether desktop sharing should be disabled on Chrome. Example: false.
+    4. desktopSharingChromeSources - Array of strings with the media sources to use when using screen sharing with the Chrome extension. Example: ['screen', 'window']
+    5. desktopSharingChromeMinExtVersion - Required version of Chrome extension. Example: '0.1'
+    6. desktopSharingFirefoxExtId - The ID of the jidesha extension for Firefox. If null, we assume that no extension is required.
+    7. desktopSharingFirefoxDisabled - Boolean. Whether desktop sharing should be disabled on Firefox. Example: false.
+    8. desktopSharingFirefoxMaxVersionExtRequired - The maximum version of Firefox which requires a jidesha extension. Example: if set to 41, we will require the extension for Firefox versions up to and including 41. On Firefox 42 and higher, we will run without the extension. If set to -1, an extension will be required for all versions of Firefox.
+    9. desktopSharingFirefoxExtensionURL - The URL to the Firefox extension for desktop sharing. "null" if no extension is required.
+    10. disableAudioLevels - boolean property. Enables/disables audio levels.
+    11. disableSimulcast - boolean property. Enables/disables simulcast.
+    12. enableWindowOnErrorHandler - boolean property (default false). Enables/disables attaching global onerror handler (window.onerror).
+    13. disableThirdPartyRequests - if true - callstats will be disabled and the callstats API won't be included.
+    14. enableAnalyticsLogging - boolean property (default false). Enables/disables analytics logging.
+    15. callStatsCustomScriptUrl - (optional) custom url to access callstats client script
+    16. callStatsConfIDNamespace - (optional) a namespace to prepend the callstats conference ID with. Defaults to the window.location.hostname
 
 * ```JitsiMeetJS.JitsiConnection``` - the ```JitsiConnection``` constructor. You can use that to create new server connection.
 

--- a/doc/example/example.js
+++ b/doc/example/example.js
@@ -208,10 +208,10 @@ $(window).bind('unload', unload);
 // JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
 var initOptions = {
     disableAudioLevels: true,
-    // Desktop sharing method. Can be set to 'ext', 'webrtc' or false to disable.
-    desktopSharingChromeMethod: 'ext',
     // The ID of the jidesha extension for Chrome.
     desktopSharingChromeExtId: 'mbocklcggfhnbahlnepmldehdhpjfcjp',
+    // Whether desktop sharing should be disabled on Chrome.
+    desktopSharingChromeDisabled: false,
     // The media sources to use when using screen sharing with the Chrome
     // extension.
     desktopSharingChromeSources: ['screen', 'window'],


### PR DESCRIPTION
…ones

Make sure there are options to set the extension ID and an enabled flag for
both Chrome and Firefox.

Removed checking for deprecated configuration options: desktopSharing and
chromeExtensionId.