### PR TITLE
Fix conference being broken after someone without any video device joins (ver 2)

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2,6 +2,7 @@
 
 var logger = require("jitsi-meet-logger").getLogger(__filename);
 import RTC from "./modules/RTC/RTC";
+import * as MediaType from "./service/RTC/MediaType";
 var XMPPEvents = require("./service/xmpp/XMPPEvents");
 var EventEmitter = require("events");
 import * as JitsiConferenceErrors from "./JitsiConferenceErrors";
@@ -246,7 +247,7 @@ JitsiConference.prototype.getExternalAuthUrl = function (urlForPopup) {
 /**
  * Returns the local tracks of the given media type, or all local tracks if no
  * specific type is given.
- * @param mediaType {MediaType} Optional media type (audio or video).
+ * @param {MediaType} [mediaType] Optional media type (audio or video).
  */
 JitsiConference.prototype.getLocalTracks = function (mediaType) {
     let tracks = [];
@@ -883,7 +884,7 @@ function (jingleSession, jingleOffer, now) {
     this.rtc.localTracks.forEach(function(localTrack) {
         var ssrcInfo = null;
         /**
-         * We don't do this for Firefox because, on Firefox, we keep the 
+         * We don't do this for Firefox because, on Firefox, we keep the
          *  stream in the peer connection and just set 'enabled' on the
          *  track to false (see JitsiLocalTrack::_setMute).  This means
          *  that if we generated an ssrc here and set it in the cache, it
@@ -926,6 +927,10 @@ function (jingleSession, jingleOffer, now) {
             logger.error(e);
         }
     }.bind(this));
+    // Generate the 'recvonly' SSRC in case there are no video tracks
+    if (!this.getLocalTracks(MediaType.VIDEO).length) {
+        this.room.generateRecvonlySsrc();
+    }
 
     jingleSession.acceptOffer(jingleOffer, null,
         function (error) {

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -425,6 +425,19 @@ export default class ChatRoom extends Listenable {
         this.participantPropertyListener = listener;
     }
 
+    /**
+     * Makes the underlying JingleSession generate new SSRC for the recvonly
+     * video stream.
+     * @deprecated
+     */
+    generateRecvonlySsrc() {
+        if (this.session) {
+            this.session.generateRecvonlySsrc();
+        } else {
+            logger.warn("Unable to generate recvonly SSRC - no session");
+        }
+    }
+
     processNode (node, from) {
         // make sure we catch all errors coming from any handler
         // otherwise we can remove the presence handler from strophe

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -288,6 +288,19 @@ JingleSessionPC.prototype.readSsrcInfo = function (contents) {
 };
 
 /**
+ * Makes the underlying TraceablePeerConnection generate new SSRC for
+ * the recvonly video stream.
+ * @deprecated
+ */
+JingleSessionPC.prototype.generateRecvonlySsrc = function() {
+    if (this.peerconnection) {
+        this.peerconnection.generateRecvonlySsrc();
+    } else {
+        logger.error("Unable to generate recvonly SSRC - no peerconnection");
+    }
+};
+
+/**
  * Does accept incoming Jingle 'session-initiate' and should send
  * 'session-accept' in result.
  * @param jingleOffer jQuery selector pointing to the jingle element of

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -115,7 +115,7 @@ export default class SdpConsistency {
      */
     makeVideoPrimarySsrcsConsistent (sdpStr) {
         let parsedSdp = transform.parse(sdpStr);
-        let videoMLine = 
+        let videoMLine =
             parsedSdp.media.find(mLine => mLine.type === "video");
         if (videoMLine.direction === "inactive") {
             console.log("Sdp-consistency doing nothing, " +
@@ -126,29 +126,33 @@ export default class SdpConsistency {
             // If the mline is recvonly, we'll add the primary
             //  ssrc as a recvonly ssrc
             videoMLine.ssrcs = videoMLine.ssrcs || [];
-            videoMLine.ssrcs.push({
-                id: this.cachedPrimarySsrc,
-                attribute: "cname",
-                value: "recvonly-" + this.cachedPrimarySsrc
-            });
+            if (this.cachedPrimarySsrc) {
+                videoMLine.ssrcs.push({
+                    id: this.cachedPrimarySsrc,
+                    attribute: "cname",
+                    value: "recvonly-" + this.cachedPrimarySsrc
+                });
+            } else {
+                console.error("No SSRC found for the recvonly video stream!");
+            }
         } else {
             let newPrimarySsrc = getPrimarySsrc(videoMLine);
             if (!newPrimarySsrc) {
                 console.log("Sdp-consistency couldn't parse new primary ssrc");
                 return sdpStr;
             }
-            let newPrimaryRtxSsrc = 
+            let newPrimaryRtxSsrc =
                 getRtxSsrc(videoMLine, newPrimarySsrc);
             if (!this.cachedPrimarySsrc) {
                 this.cachedPrimarySsrc = newPrimarySsrc;
                 this.cachedPrimaryRtxSsrc = newPrimaryRtxSsrc;
-                console.log("Sdp-consistency caching primary ssrc " + 
-                    this.cachedPrimarySsrc + " and rtx " + 
+                console.log("Sdp-consistency caching primary ssrc " +
+                    this.cachedPrimarySsrc + " and rtx " +
                     this.cachedPrimaryRtxSsrc);
             } else {
-                console.log("Sdp-consistency replacing new ssrc " + 
-                    newPrimarySsrc + " with cached " + this.cachedPrimarySsrc + 
-                    " and new rtx " + newPrimaryRtxSsrc + " with cached " + 
+                console.log("Sdp-consistency replacing new ssrc " +
+                    newPrimarySsrc + " with cached " + this.cachedPrimarySsrc +
+                    " and new rtx " + newPrimaryRtxSsrc + " with cached " +
                     this.cachedPrimaryRtxSsrc);
                 let self = this;
                 videoMLine.ssrcs.forEach(ssrcInfo => {
@@ -161,11 +165,11 @@ export default class SdpConsistency {
                 if (videoMLine.ssrcGroups) {
                     videoMLine.ssrcGroups.forEach(group => {
                         if (group.semantics === "FID") {
-                            let primarySsrc = 
+                            let primarySsrc =
                                 parseInt(group.ssrcs.split(" ")[0]);
                             if (primarySsrc == self.cachedPrimarySsrc) {
-                                group.ssrcs = 
-                                    self.cachedPrimarySsrc + " " + 
+                                group.ssrcs =
+                                    self.cachedPrimarySsrc + " " +
                                         self.cachedPrimaryRtxSsrc;
                             }
                         }

--- a/modules/xmpp/TraceablePeerConnection.js
+++ b/modules/xmpp/TraceablePeerConnection.js
@@ -396,6 +396,18 @@ TraceablePeerConnection.prototype.setRemoteDescription
      */
 };
 
+/**
+ * Makes the underlying TraceablePeerConnection generate new SSRC for
+ * the recvonly video stream.
+ * @deprecated
+ */
+TraceablePeerConnection.prototype.generateRecvonlySsrc = function() {
+    // FIXME replace with SDPUtil.generateSsrc (when it's added)
+    const newSSRC = this.generateNewStreamSSRCInfo().ssrcs[0];
+    logger.info("Generated new recvonly SSRC: " + newSSRC);
+    this.sdpConsistency.setPrimarySsrc(newSSRC);
+};
+
 TraceablePeerConnection.prototype.close = function () {
     this.trace('stop');
     if (this.statsinterval !== null) {


### PR DESCRIPTION
Video SSRC has to be generated for the recvonly stream if there are no video tracks in the PeerConnection.