### PR TITLE
Add setter for callstats username

### DIFF
--- a/modules/settings/Settings.js
+++ b/modules/settings/Settings.js
@@ -85,8 +85,17 @@ class Settings {
     }
 
     /**
-     * Returns fake username for callstats
-     * @returns {string} fake username for callstats
+     * Sets the callstats username
+     * @param {string} userName user name for callstats
+     */
+    setCallStatsUserName (userName) {
+        this.callStatsUserName = userName;
+        this.save();
+    }
+
+    /**
+     * Returns username for callstats
+     * @returns {string} username for callstats
      */
     getCallStatsUserName () {
         return this.callStatsUserName;


### PR DESCRIPTION
Adds a setter for the callstats username to allow for other usernames besides the randomly generated names. 