### PR TITLE
fix: remove unneeded test when muting a local stream

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -286,8 +286,7 @@ JitsiLocalTrack.prototype._setMute = function (mute) {
     this.dontFireRemoveEvent = false;
 
     // FIXME FF does not support 'removeStream' method used to mute
-    if (window.location.protocol !== "https:" ||
-        this.isAudioTrack() ||
+    if (this.isAudioTrack() ||
         this.videoType === VideoType.DESKTOP ||
         RTCBrowserType.isFirefox()) {
         if(this.track)


### PR DESCRIPTION
Some runtimes such as React Native don't have a window.location.protocol
property, so don't check for it, assume removeStream is available.


I tried to do some "git archeology" in order to find why the check was introduced, but I couldn't find anything, it was introduced in https://github.com/jitsi/lib-jitsi-meet/commit/2328443ecb5d4aff8d284a2f92b097d5936c2f7e#diff-922e8edf325ba2a951da3fe2c72eaad4 as part of a larger refactor (the check wasn't present prior to the refactor).