### PR TITLE
if enabled, prefer to use h264 (if it exists in the offer)

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -54,6 +54,8 @@ The ```options``` parameter is JS object with the following properties:
     14. enableAnalyticsLogging - boolean property (default false). Enables/disables analytics logging.
     15. callStatsCustomScriptUrl - (optional) custom url to access callstats client script
     16. callStatsConfIDNamespace - (optional) a namespace to prepend the callstats conference ID with. Defaults to the window.location.hostname
+    17. disableRtx - (optional) boolean property (default to false).  Enables/disable the use of RTX.
+    18. preferH264 - (optional) boolean property (default to false).  Enables/disable preferring the first instance of an h264 codec in an offer by moving it to the front of the codec list.
 
 * ```JitsiMeetJS.JitsiConnection``` - the ```JitsiConnection``` constructor. You can use that to create new server connection.
 

--- a/modules/xmpp/SDPUtil.js
+++ b/modules/xmpp/SDPUtil.js
@@ -466,11 +466,13 @@ var SDPUtil = {
      */
     preferVideoCodec: function(videoMLine, codecName) {
         let payloadType = null;
-        videoMLine.rtp.forEach(rtp => {
-            if (rtp.codec === codecName) {
-                payloadType = rtp.payload;
-            }
-        });
+        for (let i = 0; i < videoMLine.rtp.length; ++i) {
+          const rtp = videoMLine.rtp[i];
+          if (rtp.codec === codecName) {
+              payloadType = rtp.payload;
+              break;
+          }
+        }
         if (payloadType) {
             const payloadTypes = videoMLine.payloads.split(" ").map(p => parseInt(p));
             const payloadIndex = payloadTypes.indexOf(payloadType);

--- a/modules/xmpp/SDPUtil.js
+++ b/modules/xmpp/SDPUtil.js
@@ -456,7 +456,10 @@ var SDPUtil = {
     /**
      * Sets the given codecName as the preferred codec by
      *  moving it to the beginning of the payload types
-     *  list (modifies the given mline in place)
+     *  list (modifies the given mline in place).  If there
+     *  are multiple options within the same codec (multiple h264
+     *  profiles, for instance), this will prefer the first one
+     *  that is found.
      * @param {object} videoMLine the video mline object from
      *  an sdp as parsed by transform.parse
      * @param {string} the name of the preferred codec
@@ -469,7 +472,7 @@ var SDPUtil = {
             }
         });
         if (payloadType) {
-            let payloadTypes = videoMLine.payloads.split(" ").map(p => parseInt(p));
+            const payloadTypes = videoMLine.payloads.split(" ").map(p => parseInt(p));
             const payloadIndex = payloadTypes.indexOf(payloadType);
             payloadTypes.splice(payloadIndex, 1);
             payloadTypes.unshift(payloadType);

--- a/modules/xmpp/SDPUtil.js
+++ b/modules/xmpp/SDPUtil.js
@@ -453,6 +453,29 @@ var SDPUtil = {
     getMedia: function (sdp, type) {
         return sdp.media.find(m => m.type === type);
     },
+    /**
+     * Sets the given codecName as the preferred codec by
+     *  moving it to the beginning of the payload types
+     *  list (modifies the given mline in place)
+     * @param {object} videoMLine the video mline object from
+     *  an sdp as parsed by transform.parse
+     * @param {string} the name of the preferred codec
+     */
+    preferVideoCodec: function(videoMLine, codecName) {
+        let payloadType = null;
+        videoMLine.rtp.forEach(rtp => {
+            if (rtp.codec === codecName) {
+                payloadType = rtp.payload;
+            }
+        });
+        if (payloadType) {
+            let payloadTypes = videoMLine.payloads.split(" ").map(p => parseInt(p));
+            const payloadIndex = payloadTypes.indexOf(payloadType);
+            payloadTypes.splice(payloadIndex, 1);
+            payloadTypes.unshift(payloadType);
+            videoMLine.payloads = payloadTypes.join(" ");
+        }
+    },
 };
 
 module.exports = SDPUtil;

--- a/modules/xmpp/SDPUtil.spec.js
+++ b/modules/xmpp/SDPUtil.spec.js
@@ -14,7 +14,6 @@ describe("SDPUtil", function() {
         it("should move a preferred codec to the front", function() {
             const sdp = SampleSdpStrings.multiCodecVideoSdp;
             const videoMLine = sdp.media.find(m => m.type === "video");
-            debugger;
             SDPUtil.preferVideoCodec(videoMLine, "H264");
             const newPayloadTypesOrder = 
                 videoMLine.payloads.split(" ").map(ptStr => parseInt(ptStr));

--- a/modules/xmpp/SDPUtil.spec.js
+++ b/modules/xmpp/SDPUtil.spec.js
@@ -1,11 +1,24 @@
-var SDPUtil = require("./SDPUtil.js");
+import * as SDPUtil from "./SDPUtil";
+import * as SampleSdpStrings from "./SampleSdpStrings.js";
+import * as transform from 'sdp-transform';
 
 describe("SDPUtil", function() {
-
     it("should parse an ice ufrag correctly", function() {
-        let line = "a=ice-ufrag:3jlcc1b3j1rqt6";
-        let parsed = SDPUtil.parse_iceufrag(line);
+        const line = "a=ice-ufrag:3jlcc1b3j1rqt6";
+        const parsed = SDPUtil.parse_iceufrag(line);
 
         expect(parsed).toEqual("3jlcc1b3j1rqt6");
+    });
+
+    describe("preferVideoCodec", function() {
+        it("should move a preferred codec to the front", function() {
+            const sdp = SampleSdpStrings.multiCodecVideoSdp;
+            const videoMLine = sdp.media.find(m => m.type === "video");
+            debugger;
+            SDPUtil.preferVideoCodec(videoMLine, "H264");
+            const newPayloadTypesOrder = 
+                videoMLine.payloads.split(" ").map(ptStr => parseInt(ptStr));
+            expect(newPayloadTypesOrder[0]).toEqual(126);
+        });
     });
 });

--- a/modules/xmpp/SDPUtil.spec.js
+++ b/modules/xmpp/SDPUtil.spec.js
@@ -1,6 +1,5 @@
 import * as SDPUtil from "./SDPUtil";
 import * as SampleSdpStrings from "./SampleSdpStrings.js";
-import * as transform from 'sdp-transform';
 
 describe("SDPUtil", function() {
     it("should parse an ice ufrag correctly", function() {

--- a/modules/xmpp/SampleSdpStrings.js
+++ b/modules/xmpp/SampleSdpStrings.js
@@ -69,6 +69,31 @@ const plainVideoMLineSdp = "" +
 "a=ssrc:1757014965 cname:peDGrDD6WsxUOki/\r\n" +
 "a=rtcp-mux\r\n";
 
+// A basic sdp video mline with a single stream and multiple codecs
+const multiCodecVideoMLine = "" +
+"m=video 9 RTP/SAVPF 100 126 97\r\n" +
+"c=IN IP4 0.0.0.0\r\n" +
+"a=rtpmap:100 VP8/90000\r\n" +
+"a=rtpmap:126 H264/90000\r\n" +
+"a=rtpmap:97 H264/90000\r\n" +
+"a=rtcp:9 IN IP4 0.0.0.0\r\n" +
+"a=rtcp-fb:100 ccm fir\r\n" +
+"a=rtcp-fb:100 nack\r\n" +
+"a=rtcp-fb:100 nack pli\r\n" +
+"a=rtcp-fb:100 goog-remb\r\n" +
+"a=fmtp:126 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1\r\n" +
+"a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1\r\n" +
+"a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\n" +
+"a=setup:passive\r\n" +
+"a=mid:video\r\n" +
+"a=sendrecv\r\n" +
+"a=ice-ufrag:adPg\r\n" +
+"a=ice-pwd:Xsr05Mq8S7CR44DAnusZE26F\r\n" +
+"a=fingerprint:sha-256 6A:39:DE:11:24:AD:2E:4E:63:D6:69:D3:85:05:53:C7:3C:38:A4:B7:91:74:C0:91:44:FC:94:63:7F:01:AB:A9\r\n" +
+"a=ssrc:1757014965 msid:0836cc8e-a7bb-47e9-affb-0599414bc56d bdbd2c0a-7959-4578-8db5-9a6a1aec4ecf\r\n" +
+"a=ssrc:1757014965 cname:peDGrDD6WsxUOki/\r\n" +
+"a=rtcp-mux\r\n";
+
 // An sdp video mline with 3 simulcast streams
 const simulcastVideoMLineSdp = "" +
 "m=video 9 RTP/SAVPF 100\r\n" +
@@ -165,10 +190,13 @@ const simulcastRtxSdpStr = baseSessionSdp + baseAudioMLineSdp + simulcastRtxVide
 const plainVideoSdpStr = baseSessionSdp + baseAudioMLineSdp + plainVideoMLineSdp + baseDataMLineSdp;
 // A full sdp string representing a client doing a single video stream with rtx
 const rtxVideoSdpStr = baseSessionSdp + baseAudioMLineSdp + rtxVideoMLineSdp + baseDataMLineSdp;
+// A full sdp string representing a client doing a single video stream with multiple codec options
+const multiCodecVideoSdpStr = baseSessionSdp + baseAudioMLineSdp + multiCodecVideoMLine + baseDataMLineSdp;
 
 export const simulcastSdp = transform.parse(simulcastSdpStr);
 export const simulcastRtxSdp = transform.parse(simulcastRtxSdpStr);
 export const plainVideoSdp = transform.parse(plainVideoSdpStr);
 export const rtxVideoSdp = transform.parse(rtxVideoSdpStr);
+export const multiCodecVideoSdp = transform.parse(multiCodecVideoSdpStr);
 
 /*eslint-enable max-len*/

--- a/modules/xmpp/TraceablePeerConnection.js
+++ b/modules/xmpp/TraceablePeerConnection.js
@@ -389,6 +389,13 @@ TraceablePeerConnection.prototype.setRemoteDescription
     description = this.simulcast.mungeRemoteDescription(description);
     this.trace('setRemoteDescription::postTransform (simulcast)', dumpSDP(description));
 
+    if (this.session.room.options.preferH264) {
+        const parsedSdp = transform.parse(description.sdp);
+        const videoMLine = parsedSdp.media.find(m => m.type === "video");
+        SDPUtil.preferVideoCodec(videoMLine, "h264");
+        description.sdp = transform.write(parsedSdp);
+    }
+
     // if we're running on FF, transform to Plan A first.
     if (RTCBrowserType.usesUnifiedPlan()) {
         description.sdp = this.rtxModifier.stripRtx(description.sdp);


### PR DESCRIPTION
the idea here is to let clients configure a preference for h264 if it's in the offer.  the plan for now is that just ios would exercise this.