### PR TITLE
rtx: set disableRtx default to true

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -894,7 +894,7 @@ TraceablePeerConnection.prototype.generateNewStreamSSRCInfo = function () {
     } else {
         ssrcInfo = {ssrcs: [SDPUtil.generateSsrc()], groups: []};
     }
-    if (!this.options.disableRtx) {
+    if (!this.options.disableRtx && !RTCBrowserType.isFirefox()) {
         // Specifically use a for loop here because we'll
         //  be adding to the list we're iterating over, so we
         //  only want to iterate through the items originally

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -147,13 +147,11 @@ Moderator.prototype.createConferenceIq =  function () {
                 value: this.options.conference.channelLastN
             }).up();
     }
-    if (this.options.conference.disableRtx !== undefined) {
-        elem.c(
-            'property', {
-                name: 'disableRtx',
-                value: this.options.conference.disableRtx
-            }).up();
-    }
+    elem.c(
+        'property', {
+            name: 'disableRtx',
+            value: !!this.options.conference.disableRtx
+        }).up();
     elem.c(
         'property', {
             name: 'enableLipSync',

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -66,8 +66,7 @@ export default class XMPP extends Listenable {
         this.caps.addFeature('urn:xmpp:jingle:apps:rtp:audio');
         this.caps.addFeature('urn:xmpp:jingle:apps:rtp:video');
 
-        if (RTCBrowserType.isChrome() || RTCBrowserType.isOpera()
-            || RTCBrowserType.isTemasysPluginUsed()) {
+        if (!this.options.disableRtx && !RTCBrowserType.isFirefox()) {
             this.caps.addFeature('urn:ietf:rfc:4588');
         }
 


### PR DESCRIPTION
It used to be true by default, enforced by the library, without any
configuration option. This is the case for tag 1631, for example.

Later on, the default was changed to false and the configuration option is now
honored.

This creates a problem in the current situation:

* user A (using a new lib-jitsi-meet) creates the room and passes disableRtx as
  false (the new default)
* user B (using the old lib-jitsi-meet) joins the room
* RTX will be used because user B advertised RTX support and the conference has
  it enabled
* user B will fail to join because its lib-jitsi-meet is not RTX ready