### PR TITLE
Move JingleSessionPC from ChatRoom to JitsiConference

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -34,7 +34,7 @@ import ConnectionQuality from "./modules/connectivity/ConnectionQuality";
  * @constructor
  */
 function JitsiConference(options) {
-    if(!options.name || options.name.toLowerCase() !== options.name) {
+    if (!options.name || options.name.toLowerCase() !== options.name) {
         var errmsg
             = "Invalid conference name (no conference name passed or it "
                 + "contains invalid characters like capital letters)!";
@@ -92,12 +92,12 @@ function JitsiConference(options) {
  * @param connection {JitsiConnection} overrides this.connection
  */
 JitsiConference.prototype._init = function (options) {
-    if(!options)
+    if (!options)
         options = {};
 
     // Override connection and xmpp properties (Usefull if the connection
     // reloaded)
-    if(options.connection) {
+    if (options.connection) {
         this.connection = options.connection;
         this.xmpp = this.connection.xmpp;
         // Setup XMPP events only if we have new connection object.
@@ -108,7 +108,7 @@ JitsiConference.prototype._init = function (options) {
 
     this.room.updateDeviceAvailability(RTC.getDeviceAvailability());
 
-    if(!this.rtc) {
+    if (!this.rtc) {
         this.rtc = new RTC(this, options);
         this.eventManager.setupRTCListeners();
     }
@@ -119,7 +119,7 @@ JitsiConference.prototype._init = function (options) {
                 options.config.peerDisconnectedThroughRtcTimeout);
     this.participantConnectionStatus.init();
 
-    if(!this.statistics) {
+    if (!this.statistics) {
         this.statistics = new Statistics(this.xmpp, {
             callStatsID: this.options.config.callStatsID,
             callStatsSecret: this.options.config.callStatsSecret,
@@ -149,7 +149,7 @@ JitsiConference.prototype._init = function (options) {
  * @param password {string} the password
  */
 JitsiConference.prototype.join = function (password) {
-    if(this.room)
+    if (this.room)
         this.room.join(password);
 };
 
@@ -173,7 +173,7 @@ JitsiConference.prototype.leave = function () {
     this.getLocalTracks().forEach(track => this.onTrackRemoved(track));
 
     this.rtc.closeAllDataChannels();
-    if(this.statistics)
+    if (this.statistics)
         this.statistics.dispose();
 
     // leave the conference
@@ -282,7 +282,7 @@ JitsiConference.prototype.getLocalTracks = function (mediaType) {
  * Note: consider adding eventing functionality by extending an EventEmitter impl, instead of rolling ourselves
  */
 JitsiConference.prototype.on = function (eventId, handler) {
-    if(this.eventEmitter)
+    if (this.eventEmitter)
         this.eventEmitter.on(eventId, handler);
 };
 
@@ -294,7 +294,7 @@ JitsiConference.prototype.on = function (eventId, handler) {
  * Note: consider adding eventing functionality by extending an EventEmitter impl, instead of rolling ourselves
  */
 JitsiConference.prototype.off = function (eventId, handler) {
-    if(this.eventEmitter)
+    if (this.eventEmitter)
         this.eventEmitter.removeListener(eventId, handler);
 };
 
@@ -309,7 +309,7 @@ JitsiConference.prototype.removeEventListener = JitsiConference.prototype.off;
  * @param handler {Function} handler for the command
  */
  JitsiConference.prototype.addCommandListener = function (command, handler) {
-    if(this.room)
+    if (this.room)
         this.room.addPresenceListener(command, handler);
  };
 
@@ -318,7 +318,7 @@ JitsiConference.prototype.removeEventListener = JitsiConference.prototype.off;
   * @param command {String} the name of the command
   */
  JitsiConference.prototype.removeCommandListener = function (command) {
-    if(this.room)
+    if (this.room)
         this.room.removePresenceListener(command);
  };
 
@@ -327,7 +327,7 @@ JitsiConference.prototype.removeEventListener = JitsiConference.prototype.off;
  * @param message the text message.
  */
 JitsiConference.prototype.sendTextMessage = function (message) {
-    if(this.room)
+    if (this.room)
         this.room.sendMessage(message);
 };
 
@@ -337,7 +337,7 @@ JitsiConference.prototype.sendTextMessage = function (message) {
  * @param values {Object} with keys and values that will be sent.
  **/
 JitsiConference.prototype.sendCommand = function (name, values) {
-    if(this.room) {
+    if (this.room) {
         this.room.addToPresence(name, values);
         this.room.sendPresence();
     }
@@ -358,7 +358,7 @@ JitsiConference.prototype.sendCommandOnce = function (name, values) {
  * @param name {String} the name of the command.
  **/
 JitsiConference.prototype.removeCommand = function (name) {
-    if(this.room)
+    if (this.room)
         this.room.removeFromPresence(name);
 };
 
@@ -367,7 +367,7 @@ JitsiConference.prototype.removeCommand = function (name) {
  * @param name the display name to set
  */
 JitsiConference.prototype.setDisplayName = function(name) {
-    if(this.room){
+    if (this.room){
         // remove previously set nickname
         this.room.removeFromPresence("nick");
 
@@ -391,17 +391,17 @@ JitsiConference.prototype.setSubject = function (subject) {
  * @return {Transcriber} the transcriber object
  */
 JitsiConference.prototype.getTranscriber = function(){
-    if(this.transcriber === undefined){
+    if (this.transcriber === undefined){
         this.transcriber = new Transcriber();
         //add all existing local audio tracks to the transcriber
         this.rtc.localTracks.forEach(function (localTrack) {
-            if(localTrack.isAudioTrack()){
+            if (localTrack.isAudioTrack()){
                 this.transcriber.addTrack(localTrack);
             }
         }.bind(this));
         //and all remote audio tracks
         this.rtc.remoteTracks.forEach(function (remoteTrack){
-            if(remoteTrack.isAudioTrack()){
+            if (remoteTrack.isAudioTrack()){
                 this.transcriber.addTrack(remoteTrack);
             }
         }.bind(this));
@@ -632,7 +632,7 @@ JitsiConference.prototype._setupNewTrack = function (newTrack) {
  */
 JitsiConference.prototype._addLocalStream
     = function (stream, callback, errorCallback, ssrcInfo, dontModifySources) {
-    if(this.jingleSession) {
+    if (this.jingleSession) {
         this.jingleSession.addStream(
             stream, callback, errorCallback, ssrcInfo, dontModifySources);
     } else {
@@ -652,7 +652,7 @@ JitsiConference.prototype._addLocalStream
  */
 JitsiConference.prototype.removeLocalStream
     = function (stream, callback, errorCallback, ssrcInfo) {
-    if(this.jingleSession) {
+    if (this.jingleSession) {
         this.jingleSession.removeStream(
             stream, callback, errorCallback, ssrcInfo);
     } else {
@@ -668,7 +668,7 @@ JitsiConference.prototype.removeLocalStream
  * - groups - Array of the groups associated with the stream.
  */
 JitsiConference.prototype._generateNewStreamSSRCInfo = function () {
-    if(!this.jingleSession) {
+    if (!this.jingleSession) {
         logger.warn("The call haven't been started. " +
             "Cannot generate ssrc info at the moment!");
         return null;
@@ -911,7 +911,7 @@ JitsiConference.prototype.onTrackAdded = function (track) {
     // Add track to JitsiParticipant.
     participant._tracks.push(track);
 
-    if(this.transcriber){
+    if (this.transcriber){
         this.transcriber.addTrack(track);
     }
 
@@ -997,7 +997,7 @@ function (jingleSession, jingleOffer, now) {
          *  problems between sdp-interop and trying to keep the ssrcs
          *  consistent
          */
-        if(localTrack.isVideoTrack() && localTrack.isMuted() && !RTCBrowserType.isFirefox()) {
+        if (localTrack.isVideoTrack() && localTrack.isMuted() && !RTCBrowserType.isFirefox()) {
             /**
              * Handles issues when the stream is added before the peerconnection
              * is created. The peerconnection is created when second participant
@@ -1158,7 +1158,7 @@ JitsiConference.prototype.sendTones = function (tones, duration, pause) {
  * Returns true if recording is supported and false if not.
  */
 JitsiConference.prototype.isRecordingSupported = function () {
-    if(this.room)
+    if (this.room)
         return this.room.isRecordingSupported();
     return false;
 };
@@ -1182,7 +1182,7 @@ JitsiConference.prototype.getRecordingURL = function () {
  * Starts/stops the recording
  */
 JitsiConference.prototype.toggleRecording = function (options) {
-    if(this.room)
+    if (this.room)
         return this.room.toggleRecording(options, function (status, error) {
             this.eventEmitter.emit(
                 JitsiConferenceEvents.RECORDER_STATE_CHANGED, status, error);
@@ -1196,7 +1196,7 @@ JitsiConference.prototype.toggleRecording = function (options) {
  * Returns true if the SIP calls are supported and false otherwise
  */
 JitsiConference.prototype.isSIPCallingSupported = function () {
-    if(this.room)
+    if (this.room)
         return this.room.isSIPCallingSupported();
     return false;
 };
@@ -1206,7 +1206,7 @@ JitsiConference.prototype.isSIPCallingSupported = function () {
  * @param number the number
  */
 JitsiConference.prototype.dial = function (number) {
-    if(this.room)
+    if (this.room)
         return this.room.dial(number);
     return new Promise(function(resolve, reject){
         reject(new Error("The conference is not created yet!"));});
@@ -1216,7 +1216,7 @@ JitsiConference.prototype.dial = function (number) {
  * Hangup an existing call
  */
 JitsiConference.prototype.hangup = function () {
-    if(this.room)
+    if (this.room)
         return this.room.hangup();
     return new Promise(function(resolve, reject){
         reject(new Error("The conference is not created yet!"));});
@@ -1226,7 +1226,7 @@ JitsiConference.prototype.hangup = function () {
  * Returns the phone number for joining the conference.
  */
 JitsiConference.prototype.getPhoneNumber = function () {
-    if(this.room)
+    if (this.room)
         return this.room.getPhoneNumber();
     return null;
 };
@@ -1235,7 +1235,7 @@ JitsiConference.prototype.getPhoneNumber = function () {
  * Returns the pin for joining the conference with phone.
  */
 JitsiConference.prototype.getPhonePin = function () {
-    if(this.room)
+    if (this.room)
         return this.room.getPhonePin();
     return null;
 };
@@ -1245,7 +1245,7 @@ JitsiConference.prototype.getPhonePin = function () {
  * for its session.
  */
 JitsiConference.prototype.getConnectionState = function () {
-    if(this.jingleSession) {
+    if (this.jingleSession) {
         return this.jingleSession.getIceConnectionState();
     } else {
         return null;

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -626,10 +626,11 @@ JitsiConference.prototype._setupNewTrack = function (newTrack) {
  * @param {function(error)} errorCallback callback executed if stream addition fail.
  * @param {object} ssrcInfo object with information about the SSRCs associated with the
  * stream.
- * @param {boolean} [dontModifySources] if true _modifySources won't be called.
- * Used for streams added before the call start.
+ * @param {boolean} [dontModifySources] if <tt>true</tt> _modifySources won't be
+ * called. The option is used for adding stream, before the Jingle call is
+ * started. That is before the 'session-accept' is sent.
  */
-JitsiConference.prototype.addLocalStream
+JitsiConference.prototype._addLocalStream
     = function (stream, callback, errorCallback, ssrcInfo, dontModifySources) {
     if(this.jingleSession) {
         this.jingleSession.addStream(
@@ -1021,7 +1022,7 @@ function (jingleSession, jingleOffer, now) {
             };
         }
         try {
-            this.addLocalStream(
+            this._addLocalStream(
                 localTrack.getOriginalStream(), function () {}, function () {},
                 ssrcInfo, true /* don't modify SSRCs */);
         } catch(e) {

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -629,7 +629,7 @@ JitsiConference.prototype._setupNewTrack = function (newTrack) {
  * @param {boolean} [dontModifySources] if true _modifySources won't be called.
  * Used for streams added before the call start.
  */
-JitsiConference.prototype.addLocalWebRTCStream
+JitsiConference.prototype.addLocalStream
     = function (stream, callback, errorCallback, ssrcInfo, dontModifySources) {
     if(this.jingleSession) {
         this.jingleSession.addStream(
@@ -649,7 +649,7 @@ JitsiConference.prototype.addLocalWebRTCStream
  * @param {object} ssrcInfo object with information about the SSRCs associated
  * with the stream.
  */
-JitsiConference.prototype.removeLocalWebRTCStream
+JitsiConference.prototype.removeLocalStream
     = function (stream, callback, errorCallback, ssrcInfo) {
     if(this.jingleSession) {
         this.jingleSession.removeStream(
@@ -1021,7 +1021,7 @@ function (jingleSession, jingleOffer, now) {
             };
         }
         try {
-            this.addLocalWebRTCStream(
+            this.addLocalStream(
                 localTrack.getOriginalStream(), function () {}, function () {},
                 ssrcInfo, true /* don't modify SSRCs */);
         } catch(e) {

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -486,7 +486,7 @@ JitsiConference.prototype.onTrackRemoved = function (track) {
 /**
  * Removes JitsiLocalTrack from the conference and performs
  * a new offer/answer cycle.
- * @param track the JitsiLocalTrack object.
+ * @param {JitsiLocalTrack} track
  * @returns {Promise}
  */
 JitsiConference.prototype.removeTrack = function (track) {
@@ -548,14 +548,14 @@ JitsiConference.prototype.replaceTrack = function (oldTrack, newTrack) {
  * currently no JingleSession started.
  * @param {JitsiLocalTrack|null} oldTrack the track to be removed during
  * the process or <tt>null</t> if the method should act as "add track"
- * @param {JitsiLocalTrackn|null} newTrack the new track to be added or
+ * @param {JitsiLocalTrack|null} newTrack the new track to be added or
  * <tt>null</tt> if the method should act as "remove track"
  * @return {Promise}
  * @private
  */
 JitsiConference.prototype._doReplaceTrack = function (oldTrack, newTrack) {
     if (this.jingleSession) {
-        return this.jingleSession.replaceStream(oldTrack, newTrack);
+        return this.jingleSession.replaceTrack(oldTrack, newTrack);
     } else {
         return Promise.resolve();
     }

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1244,9 +1244,11 @@ JitsiConference.prototype.getPhonePin = function () {
  * for its session.
  */
 JitsiConference.prototype.getConnectionState = function () {
-    if(this.jingleSession)
+    if(this.jingleSession) {
         return this.jingleSession.getIceConnectionState();
-    return null;
+    } else {
+        return null;
+    }
 };
 
 /**

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -370,7 +370,7 @@ JitsiLocalTrack.prototype._addStreamToConferenceAsUnmute = function () {
     var self = this;
 
     return new Promise(function(resolve, reject) {
-        self.conference.addLocalStream(
+        self.conference._addLocalStream(
             self.stream,
             resolve,
             (error) => reject(new Error(error)),

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -370,7 +370,7 @@ JitsiLocalTrack.prototype._addStreamToConferenceAsUnmute = function () {
     var self = this;
 
     return new Promise(function(resolve, reject) {
-        self.conference.addLocalWebRTCStream(
+        self.conference.addLocalStream(
             self.stream,
             resolve,
             (error) => reject(new Error(error)),
@@ -396,7 +396,7 @@ function (successCallback, errorCallback) {
         return;
     }
 
-    this.conference.removeLocalWebRTCStream(
+    this.conference.removeLocalStream(
         this.stream,
         successCallback,
         (error) => errorCallback(new Error(error)),

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -363,14 +363,14 @@ JitsiLocalTrack.prototype._setMute = function (mute) {
  * @returns {Promise}
  */
 JitsiLocalTrack.prototype._addStreamToConferenceAsUnmute = function () {
-    if (!this.conference || !this.conference.room) {
+    if (!this.conference) {
         return Promise.resolve();
     }
 
     var self = this;
 
     return new Promise(function(resolve, reject) {
-        self.conference.room.addStream(
+        self.conference.addLocalWebRTCStream(
             self.stream,
             resolve,
             (error) => reject(new Error(error)),
@@ -391,12 +391,12 @@ JitsiLocalTrack.prototype._addStreamToConferenceAsUnmute = function () {
  */
 JitsiLocalTrack.prototype._removeStreamFromConferenceAsMute =
 function (successCallback, errorCallback) {
-    if (!this.conference || !this.conference.room) {
+    if (!this.conference) {
         successCallback();
         return;
     }
 
-    this.conference.room.removeStream(
+    this.conference.removeLocalWebRTCStream(
         this.stream,
         successCallback,
         (error) => errorCallback(new Error(error)),

--- a/modules/xmpp/JingleSession.js
+++ b/modules/xmpp/JingleSession.js
@@ -9,7 +9,7 @@ const logger = getLogger(__filename);
 import * as JingleSessionState from "./JingleSessionState";
 
 function JingleSession(me, sid, peerjid, connection,
-                       media_constraints, ice_config, service, eventEmitter) {
+                       media_constraints, ice_config, service) {
     /**
      * Our JID.
      */
@@ -34,11 +34,6 @@ function JingleSession(me, sid, peerjid, connection,
      * The XMPP service.
      */
     this.service = service;
-
-    /**
-     * The event emitter.
-     */
-    this.eventEmitter = eventEmitter;
 
     /**
      * Whether to use dripping or not. Dripping is sending trickle candidates

--- a/modules/xmpp/JingleSession.js
+++ b/modules/xmpp/JingleSession.js
@@ -9,7 +9,7 @@ const logger = getLogger(__filename);
 import * as JingleSessionState from "./JingleSessionState";
 
 function JingleSession(me, sid, peerjid, connection,
-                       media_constraints, ice_config, service) {
+                       media_constraints, ice_config) {
     /**
      * Our JID.
      */
@@ -29,11 +29,6 @@ function JingleSession(me, sid, peerjid, connection,
      * The XMPP connection.
      */
     this.connection = connection;
-
-    /**
-     * The XMPP service.
-     */
-    this.service = service;
 
     /**
      * Whether to use dripping or not. Dripping is sending trickle candidates

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -104,10 +104,19 @@ JingleSessionPC.prototype.doInitialize = function () {
     this.wasstable = false;
 
     this.peerconnection = new TraceablePeerConnection(
-            this.connection.jingle.ice_config,
-            RTC.getPCConstraints(),
-            this.room.options,
-            this.room.eventEmitter);
+        this.connection.jingle.ice_config,
+        RTC.getPCConstraints(),
+        /* Options */
+        {
+            disableSimulcast: this.room.options.disableSimulcast,
+            disableRtx: this.room.options.disableRtx,
+            preferH264: this.room.options.preferH264
+        },
+        // TPC is using room's eventEmitter, so that all XMPPEvents can be
+        // captured from ChatRoom. But at the same time it makes hard
+        // or impossible to deal with more than one TPC instance without
+        // further refactoring.
+        this.room.eventEmitter);
 
     this.peerconnection.onicecandidate = function (ev) {
         if (!ev) {

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -25,9 +25,9 @@ var IQ_TIMEOUT = 10000;
 
 // Jingle stuff
 function JingleSessionPC(me, sid, peerjid, connection,
-                         media_constraints, ice_config, service, eventEmitter) {
+                         media_constraints, ice_config, service) {
     JingleSession.call(this, me, sid, peerjid, connection,
-                       media_constraints, ice_config, service, eventEmitter);
+                       media_constraints, ice_config, service);
 
     this.lasticecandidate = false;
     this.closed = false;

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -866,24 +866,25 @@ JingleSessionPC.prototype._renegotiate = function(optionalRemoteSdp) {
  *  cycle after both operations are done.  Either oldStream or newStream
  *  can be null; replacing a valid 'oldStream' with a null 'newStream'
  *  effectively just removes 'oldStream'
- * @param oldStream the current stream in use to be replaced
- * @param newStream the new stream to use
+ * @param {JitsiLocalTrack|null} oldTrack the current track in use to be
+ * replaced
+ * @param {JitsiLocalTrack|null} newTrack the new track to use
  * @returns {Promise} which resolves once the replacement is complete
  *  with no arguments or rejects with an error {string}
  */
-JingleSessionPC.prototype.replaceStream = function (oldStream, newStream) {
+JingleSessionPC.prototype.replaceTrack = function (oldTrack, newTrack) {
     return new Promise((resolve, reject) => {
         let workFunction = (finishedCallback) => {
             let oldSdp = new SDP(this.peerconnection.localDescription.sdp);
-            this.removeStreamFromPeerConnection(oldStream);
-            this.addStreamToPeerConnection(newStream);
+            this.removeStreamFromPeerConnection(oldTrack);
+            this.addStreamToPeerConnection(newTrack);
             this._renegotiate()
                 .then(() => {
                     var newSdp = new SDP(this.peerconnection.localDescription.sdp);
                     this.notifyMySSRCUpdate(oldSdp, newSdp);
                     finishedCallback();
                 }, (error) => {
-                    logger.error("replaceStream renegotiation failed: " + error);
+                    logger.error("replaceTrack renegotiation failed: " + error);
                     finishedCallback(error);
                 });
         };
@@ -972,11 +973,11 @@ JingleSessionPC.prototype._parseSsrcInfoFromSourceRemove = function (sourceRemov
  * stream.
  * @param dontModifySources {boolean} if true _modifySources won't be called.
  * Used for streams added before the call start.
- * NOTE(brian): there is a decent amount of overlap here with replaceStream that
+ * NOTE(brian): there is a decent amount of overlap here with replaceTrack that
  *  could be re-used...however we can't leverage that currently because the
  *  extra work we do here must be in the work function context and if we
- *  then called replaceStream we'd be adding another task on the queue
- *  from within a task which would then deadlock.  The 'replaceStream' core
+ *  then called replaceTrack we'd be adding another task on the queue
+ *  from within a task which would then deadlock.  The 'replaceTrack' core
  *  logic should be moved into a helper function that could be called within
  *  the 'doReplaceStream' task or the 'doAddStream' task (for example)
  */

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -87,7 +87,8 @@ JingleSessionPC.prototype.doInitialize = function () {
     this.peerconnection = new TraceablePeerConnection(
             this.connection.jingle.ice_config,
             RTC.getPCConstraints(),
-            this);
+            this.room.options,
+            this.room.eventEmitter);
 
     this.peerconnection.onicecandidate = function (ev) {
         if (!ev) {

--- a/modules/xmpp/strophe.emuc.js
+++ b/modules/xmpp/strophe.emuc.js
@@ -106,14 +106,6 @@ class MucConnectionPlugin extends ConnectionPluginListenable {
         return true;
     }
 
-    setJingleSession (from, session) {
-        const room = this.rooms[Strophe.getBareJidFromJid(from)];
-        if(!room)
-            return;
-
-        room.setJingleSession(session);
-    }
-
     onMute(iq) {
         const from = iq.getAttribute('from');
         const room = this.rooms[Strophe.getBareJidFromJid(from)];

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -90,7 +90,7 @@ class JingleConnectionPlugin extends ConnectionPlugin {
                         fromJid,
                         this.connection,
                         this.media_constraints,
-                        this.ice_config, this.xmpp);
+                        this.ice_config, this.xmpp.options);
 
                 this.sessions[sess.sid] = sess;
 


### PR DESCRIPTION
This PR detaches components one from another to end up with JitsiConference managing the jingle session instance instead of the ChatRoom.