### PR TITLE
Fix broken 'transport-replace'

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -412,8 +412,9 @@ JingleSessionPC.prototype.replaceTransport = function (jingleOfferElem,
             this.setOfferCycle(
                 originalOffer,
                 () => {
-                    // Set local description OK, now localSDP up to date
-                    this.sendTransportAccept(this.localSDP, success, failure);
+                    const localSDP
+                        = new SDP(this.peerconnection.localDescription.sdp);
+                    this.sendTransportAccept(localSDP, success, failure);
                 },
                 failure);
         },


### PR DESCRIPTION
This PR fixes a crash when conference is being moved to new JVB.