### PR TITLE
Revert "Make sure the minimum resolution is no less than 320 x 180"

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -100,20 +100,26 @@ var isDeviceChangeEventSupported = false;
 var rtcReady = false;
 
 function setResolutionConstraints(constraints, resolution) {
-    // XXX Google Chrome has been observed to fall down to 240x135 which is an
-    // odd resolution and odd resolutions may cause crashes in WebRTC on Android
-    // at least:
-    // - https://bugs.chromium.org/p/webrtc/issues/detail?id=6651
-    // - https://bugs.chromium.org/p/webrtc/issues/detail?id=7206
-    // As a mitigation, do not fall bellow the following minimal resolution.
-    // TODO Odd resolutions may still occur, for example, in desktop sharing.
-    constraints.video.mandatory.minHeight = 180;
-    constraints.video.mandatory.minWidth = 320;
+    var isAndroid = RTCBrowserType.isAndroid();
 
     if (Resolutions[resolution]) {
-        constraints.video.mandatory.maxHeight = Resolutions[resolution].height;
-        constraints.video.mandatory.maxWidth = Resolutions[resolution].width;
+        constraints.video.mandatory.minWidth = Resolutions[resolution].width;
+        constraints.video.mandatory.minHeight = Resolutions[resolution].height;
     }
+    else if (isAndroid) {
+        // FIXME can't remember if the purpose of this was to always request
+        //       low resolution on Android ? if yes it should be moved up front
+        constraints.video.mandatory.minWidth = 320;
+        constraints.video.mandatory.minHeight = 180;
+        constraints.video.mandatory.maxFrameRate = 15;
+    }
+
+    if (constraints.video.mandatory.minWidth)
+        constraints.video.mandatory.maxWidth =
+            constraints.video.mandatory.minWidth;
+    if (constraints.video.mandatory.minHeight)
+        constraints.video.mandatory.maxHeight =
+            constraints.video.mandatory.minHeight;
 }
 
 /**


### PR DESCRIPTION
This reverts commit 886bc1519de7830314819f9fded692956b1bbedf.

Turns out Chrome decides to not choose the maximum possible resolution when
given a range. Oh well!