### PR TITLE
Add SdpTransformUtil.js

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1039,7 +1039,7 @@ function (jingleSession, jingleOffer, now) {
     this.rtc.initializeDataChannels(jingleSession.peerconnection);
     // Add local Tracks to the ChatRoom
     this.getLocalTracks().forEach(function(localTrack) {
-        var ssrcInfo = null;
+        let ssrcInfo = null;
         /**
          * We don't do this for Firefox because, on Firefox, we keep the
          *  stream in the peer connection and just set 'enabled' on the
@@ -1070,7 +1070,8 @@ function (jingleSession, jingleOffer, now) {
             ssrcInfo = {
                 mtype: localTrack.getType(),
                 type: "addMuted",
-                ssrc: localTrack.ssrc,
+                ssrcs: localTrack.ssrc.ssrcs,
+                groups: localTrack.ssrc.groups,
                 msid: localTrack.initialMSID
             };
         }

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -527,8 +527,9 @@ JitsiConference.prototype.replaceTrack = function (oldTrack, newTrack) {
         }
         // Set up the ssrcHandler for the new track before we add it at the lower levels
         newTrack.ssrcHandler = function (conference, ssrcMap) {
-            if (ssrcMap[this.getMSID()]) {
-                this._setSSRC(ssrcMap[this.getMSID()]);
+            const trackSSRCInfo = ssrcMap.get(this.getMSID());
+            if (trackSSRCInfo) {
+                this._setSSRC(trackSSRCInfo);
                 conference.rtc.removeListener(
                     RTCEvents.SENDRECV_STREAMS_CHANGED,
                     this.ssrcHandler);

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -380,8 +380,8 @@ JitsiLocalTrack.prototype._addStreamToConferenceAsUnmute = function () {
             {
                 mtype: self.type,
                 type: "unmute",
-                ssrcs: self.ssrc ? self.ssrc.ssrcs : undefined,
-                groups: self.ssrc ? self.ssrc.groups: undefined,
+                ssrcs: self.ssrc && self.ssrc.ssrcs,
+                groups: self.ssrc && self.ssrc.groups,
                 msid: self.getMSID()
             });
     });

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -380,7 +380,8 @@ JitsiLocalTrack.prototype._addStreamToConferenceAsUnmute = function () {
             {
                 mtype: self.type,
                 type: "unmute",
-                ssrc: self.ssrc,
+                ssrcs: self.ssrc ? self.ssrc.ssrcs : undefined,
+                groups: self.ssrc ? self.ssrc.groups: undefined,
                 msid: self.getMSID()
             });
     });
@@ -406,7 +407,8 @@ function (successCallback, errorCallback) {
         {
             mtype: this.type,
             type: "mute",
-            ssrc: this.ssrc
+            ssrcs: this.ssrc ? this.ssrc.ssrcs : undefined,
+            groups: this.ssrc ? this.ssrc.groups : undefined
         });
 };
 
@@ -521,7 +523,7 @@ JitsiLocalTrack.prototype._setConference = function(conference) {
  */
 JitsiLocalTrack.prototype.getSSRC = function () {
     if(this.ssrc && this.ssrc.groups && this.ssrc.groups.length)
-        return this.ssrc.groups[0].primarySSRC;
+        return this.ssrc.groups[0].ssrcs[0];
     else if(this.ssrc && this.ssrc.ssrcs && this.ssrc.ssrcs.length)
         return this.ssrc.ssrcs[0];
     else

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -370,19 +370,17 @@ JitsiLocalTrack.prototype._addStreamToConferenceAsUnmute = function () {
         return Promise.resolve();
     }
 
-    var self = this;
-
-    return new Promise(function(resolve, reject) {
-        self.conference._addLocalStream(
-            self.stream,
+    return new Promise((resolve, reject) => {
+        this.conference._addLocalStream(
+            this.stream,
             resolve,
             (error) => reject(new Error(error)),
             {
-                mtype: self.type,
+                mtype: this.type,
                 type: "unmute",
-                ssrcs: self.ssrc && self.ssrc.ssrcs,
-                groups: self.ssrc && self.ssrc.groups,
-                msid: self.getMSID()
+                ssrcs: this.ssrc && this.ssrc.ssrcs,
+                groups: this.ssrc && this.ssrc.groups,
+                msid: this.getMSID()
             });
     });
 };
@@ -407,8 +405,8 @@ function (successCallback, errorCallback) {
         {
             mtype: this.type,
             type: "mute",
-            ssrcs: this.ssrc ? this.ssrc.ssrcs : undefined,
-            groups: this.ssrc ? this.ssrc.groups : undefined
+            ssrcs: this.ssrc && this.ssrc.ssrcs,
+            groups: this.ssrc && this.ssrc.groups
         });
 };
 
@@ -424,11 +422,9 @@ JitsiLocalTrack.prototype._sendMuteStatus = function(mute) {
         return Promise.resolve();
     }
 
-    var self = this;
-
-    return new Promise(function(resolve) {
-        self.conference.room[
-            self.isAudioTrack()
+    return new Promise((resolve) => {
+        this.conference.room[
+            this.isAudioTrack()
                 ? 'setAudioMute'
                 : 'setVideoMute'](mute, resolve);
     });

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -417,15 +417,15 @@ function extractSSRCMap(desc) {
         return;
     }
 
-    session.media.forEach(function (bLine) {
-        if (!Array.isArray(bLine.ssrcs))
+    session.media.forEach(function (mLine) {
+        if (!Array.isArray(mLine.ssrcs))
         {
             return;
         }
 
-        if (typeof bLine.ssrcGroups !== 'undefined' &&
-            Array.isArray(bLine.ssrcGroups)) {
-            bLine.ssrcGroups.forEach(function (group) {
+        if (typeof mLine.ssrcGroups !== 'undefined' &&
+            Array.isArray(mLine.ssrcGroups)) {
+            mLine.ssrcGroups.forEach(function (group) {
                 if (typeof group.semantics !== 'undefined' &&
                     typeof group.ssrcs !== 'undefined') {
                     // Parse SSRCs and store as numbers
@@ -439,7 +439,7 @@ function extractSSRCMap(desc) {
                 }
             });
         }
-        bLine.ssrcs.forEach(function (ssrc) {
+        mLine.ssrcs.forEach(function (ssrc) {
             if(ssrc.attribute !== 'msid')
                 return;
             ssrcList[ssrc.value]

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -421,9 +421,9 @@ function extractSSRCMap(desc) {
     const ssrcMap = new Map();
     /**
      * Groups mapped by primary SSRC number
-     * @type {Map<number,SSRCGroupInfo>}
+     * @type {Map<number,Array<SSRCGroupInfo>>}
      */
-    const ssrcGroups = new Map();
+    const groupsMap = new Map();
 
     if (typeof desc !== 'object' || desc === null ||
         typeof desc.sdp !== 'string') {
@@ -453,10 +453,10 @@ function extractSSRCMap(desc) {
                     const primarySSRC = groupSSRCs[0];
                     // Note that group.semantics is already present
                     group.ssrcs = groupSSRCs;
-                    if (!ssrcGroups.has(primarySSRC)) {
-                        ssrcGroups.set(primarySSRC, []);
+                    if (!groupsMap.has(primarySSRC)) {
+                        groupsMap.set(primarySSRC, []);
                     }
-                    ssrcGroups.get(primarySSRC).push(group);
+                    groupsMap.get(primarySSRC).push(group);
                 }
             }
         }
@@ -480,8 +480,10 @@ function extractSSRCMap(desc) {
 
             ssrcInfo.ssrcs.push(ssrcNumber);
 
-            if (ssrcGroups.has(ssrcNumber)) {
-                for (const group of ssrcGroups[ssrcNumber]) {
+            if (groupsMap.has(ssrcNumber)) {
+                const ssrcGroups = groupsMap.get(ssrcNumber);
+
+                for (const group of ssrcGroups) {
                     ssrcInfo.groups.push(group);
                 }
             }

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -882,10 +882,15 @@ TraceablePeerConnection.prototype.generateNewStreamSSRCInfo = function () {
         for (let i = 0; i < SIMULCAST_LAYERS; i++) {
             ssrcInfo.ssrcs.push(SDPUtil.generateSsrc());
         }
-        ssrcInfo.groups.push(
-            { ssrcs: ssrcInfo.ssrcs.slice(), semantics: "SIM" });
+        ssrcInfo.groups.push({
+            ssrcs: ssrcInfo.ssrcs.slice(),
+            semantics: "SIM"
+        });
     } else {
-        ssrcInfo = {ssrcs: [SDPUtil.generateSsrc()], groups: []};
+        ssrcInfo = {
+            ssrcs: [SDPUtil.generateSsrc()],
+            groups: []
+        };
     }
     if (!this.options.disableRtx) {
         // Specifically use a for loop here because we'll

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1412,16 +1412,15 @@ export default class JingleSessionPC extends JingleSession {
                     ssrcObj.mtype + "\"]>description");
                 if (!desc || !desc.length)
                     return;
-                ssrcObj.ssrc.ssrcs.forEach(function (ssrc) {
+                ssrcObj.ssrcs.forEach(function (ssrc) {
                     const sourceNode = desc.find(">source[ssrc=\"" +
                         ssrc + "\"]");
                     sourceNode.remove();
                 });
-                ssrcObj.ssrc.groups.forEach(function (group) {
+                ssrcObj.groups.forEach(function (group) {
                     const groupNode = desc.find(">ssrc-group[semantics=\"" +
-                        group.group.semantics + "\"]:has(source[ssrc=\"" +
-                        group.primarySSRC +
-                        "\"])");
+                        group.semantics + "\"]:has(source[ssrc=\"" +
+                        group.ssrcs[0] + "\"])");
                     groupNode.remove();
                 });
             });
@@ -1435,7 +1434,7 @@ export default class JingleSessionPC extends JingleSession {
                     = JingleSessionPC.createDescriptionNode(
                         jingle, ssrcObj.mtype);
                 const cname = Math.random().toString(36).substring(2);
-                ssrcObj.ssrc.ssrcs.forEach(function (ssrc) {
+                ssrcObj.ssrcs.forEach(function (ssrc) {
                     const sourceNode
                         = desc.find(">source[ssrc=\"" + ssrc + "\"]");
                     sourceNode.remove();
@@ -1449,18 +1448,18 @@ export default class JingleSessionPC extends JingleSession {
                         "</source>";
                     desc.append(sourceXML);
                 });
-                ssrcObj.ssrc.groups.forEach(function (group) {
+                ssrcObj.groups.forEach(function (group) {
                     const groupNode
                         = desc.find(">ssrc-group[semantics=\"" +
-                            group.group.semantics + "\"]:has(source[ssrc=\""
-                            + group.primarySSRC + "\"])");
+                            group.semantics + "\"]:has(source[ssrc=\""
+                            + group.ssrcs[0] + "\"])");
                     groupNode.remove();
                     desc.append(
-                        "<ssrc-group semantics=\"" + group.group.semantics +
+                        "<ssrc-group semantics=\"" + group.semantics +
                         "\" xmlns=\"urn:xmpp:jingle:apps:rtp:ssma:0\">" +
                         "<source ssrc=\"" +
-                            group.group.ssrcs.split(" ")
-                                .join("\"/>" + "<source ssrc=\"") + "\"/>" +
+                            group.ssrcs.join("\"/>" + "<source ssrc=\"") +
+                            "\"/>" +
                         "</ssrc-group>");
                 });
             });
@@ -1478,20 +1477,20 @@ export default class JingleSessionPC extends JingleSession {
         this.modifiedSSRCs["mute"] = [];
         if (ssrcs && ssrcs.length)
             ssrcs.forEach(function (ssrcObj) {
-                ssrcObj.ssrc.ssrcs.forEach(function (ssrc) {
+                ssrcObj.ssrcs.forEach(function (ssrc) {
                     const sourceNode
                         = $(jingle.tree()).find(">jingle>content[name=\"" +
                             ssrcObj.mtype + "\"]>description>source[ssrc=\"" +
                             ssrc + "\"]");
                     sourceNode.remove();
                 });
-                ssrcObj.ssrc.groups.forEach(function (group) {
+                ssrcObj.groups.forEach(function (group) {
                     const groupNode
                         = $(jingle.tree()).find(
                             ">jingle>content[name=\"" + ssrcObj.mtype +
                             "\"]>description>ssrc-group[semantics=\"" +
-                            group.group.semantics + "\"]:has(source[ssrc=\"" +
-                            group.primarySSRC + "\"])");
+                            group.semantics + "\"]:has(source[ssrc=\"" +
+                            group.ssrcs[0] + "\"])");
                     groupNode.remove();
                 });
             });
@@ -1503,7 +1502,7 @@ export default class JingleSessionPC extends JingleSession {
                 const desc
                     = JingleSessionPC.createDescriptionNode(
                         jingle, ssrcObj.mtype);
-                ssrcObj.ssrc.ssrcs.forEach(function (ssrc) {
+                ssrcObj.ssrcs.forEach(function (ssrc) {
                     const sourceNode
                         = desc.find(">source[ssrc=\"" + ssrc + "\"]");
                     if (!sourceNode || !sourceNode.length) {
@@ -1514,18 +1513,18 @@ export default class JingleSessionPC extends JingleSession {
                             "ssrc=\"" + ssrc + "\"></source>");
                     }
                 });
-                ssrcObj.ssrc.groups.forEach(function (group) {
+                ssrcObj.groups.forEach(function (group) {
                     const groupNode
                         = desc.find(">ssrc-group[semantics=\"" +
-                            group.group.semantics + "\"]:has(source[ssrc=\"" +
-                            group.primarySSRC + "\"])");
+                            group.semantics + "\"]:has(source[ssrc=\"" +
+                            group.ssrcs[0] + "\"])");
                     if (!groupNode || !groupNode.length) {
                         desc.append("<ssrc-group semantics=\"" +
-                            group.group.semantics +
+                            group.semantics +
                             "\" xmlns=\"urn:xmpp:jingle:apps:rtp:ssma:0\">" +
                             "<source ssrc=\"" +
-                                group.group.ssrcs.split(" ")
-                                    .join("\"/><source ssrc=\"") + "\"/>" +
+                                group.ssrcs.join("\"/><source ssrc=\"") +
+                                "\"/>" +
                             "</ssrc-group>");
                     }
                 });

--- a/modules/xmpp/RtxModifier.js
+++ b/modules/xmpp/RtxModifier.js
@@ -126,7 +126,7 @@ export default class RtxModifier {
         let primaryVideoSsrcs = sdpTransformer.getPrimaryVideoSSRCs();
         logger.debug("Parsed primary video ssrcs ", primaryVideoSsrcs, " " +
             "making sure all have rtx streams");
-        primaryVideoSsrcs.forEach(ssrc => {
+        for (const ssrc of primaryVideoSsrcs) {
             let msid = sdpTransformer.getSSRCAttrValue(ssrc, "msid");
             let cname = sdpTransformer.getSSRCAttrValue(ssrc, "cname");
             let correspondingRtxSsrc = this.correspondingRtxSsrcs.get(ssrc);
@@ -163,7 +163,7 @@ export default class RtxModifier {
                     msid: msid
                 },
                 correspondingRtxSsrc);
-        });
+        }
         return sdpTransformer.toRawSDP();
     }
 
@@ -197,10 +197,10 @@ export default class RtxModifier {
         // Remove the fid groups from the mline
         sdpTransformer.removeGroupsBySemantics("FID");
         // Get the rtx ssrcs and remove them from the mline
-        fidGroups.forEach(fidGroup => {
+        for (const fidGroup of fidGroups) {
             const rtxSsrc = parseSecondarySSRC(fidGroup);
             sdpTransformer.removeSSRC(rtxSsrc);
-        });
+        }
 
         return sdpTransformer.toRawSDP();
     }

--- a/modules/xmpp/RtxModifier.js
+++ b/modules/xmpp/RtxModifier.js
@@ -1,7 +1,10 @@
+/* global __filename */
+
 import { getLogger } from "jitsi-meet-logger";
-const logger = getLogger(__filename);
-import { SdpTransformWrap, parseSecondarySSRC } from './SdpTransformUtil';
+import { parseSecondarySSRC, SdpTransformWrap  } from './SdpTransformUtil';
 import * as SDPUtil from "./SDPUtil";
+
+const logger = getLogger(__filename);
 
 /**
  * Begin helper functions

--- a/modules/xmpp/RtxModifier.js
+++ b/modules/xmpp/RtxModifier.js
@@ -21,27 +21,27 @@ const logger = getLogger(__filename);
  */
 function updateAssociatedRtxStream (mLine, primarySsrcInfo, rtxSsrc) {
     logger.debug(
-        "Updating mline to associate " + rtxSsrc +
-        " rtx ssrc with primary stream ", primarySsrcInfo.id);
+        `Updating mline to associate ${rtxSsrc}` +
+        `rtx ssrc with primary stream, ${primarySsrcInfo.id}`);
     let primarySsrc = primarySsrcInfo.id;
     let primarySsrcMsid = primarySsrcInfo.msid;
     let primarySsrcCname = primarySsrcInfo.cname;
 
     let previousRtxSSRC = mLine.getRtxSSRC(primarySsrc);
     if (previousRtxSSRC === rtxSsrc) {
-        logger.debug(rtxSsrc + " was already associated with " + primarySsrc);
+        logger.debug(`${rtxSsrc} was already associated with ${primarySsrc}`);
         return;
     }
     if (previousRtxSSRC) {
         logger.debug(
-            primarySsrc + " was previously assocaited with rtx " +
-            previousRtxSSRC + ", removing all references to it");
+            `${primarySsrc} was previously associated with rtx` +
+            `${previousRtxSSRC}, removing all references to it`);
 
         // Stream already had an rtx ssrc that is different than the one given,
         //  remove all trace of the old one
         mLine.removeSSRC(previousRtxSSRC);
 
-        logger.debug("groups before filtering for " + previousRtxSSRC);
+        logger.debug(`groups before filtering for ${previousRtxSSRC}`);
         logger.debug(mLine.dumpSSRCGroups());
 
         mLine.removeGroupsWithSSRC(previousRtxSSRC);
@@ -112,7 +112,7 @@ export default class RtxModifier {
         const sdpTransformer = new SdpTransformWrap(sdpStr);
         const videoMLine = sdpTransformer.selectMedia("video");
         if (!videoMLine) {
-            logger.error("No 'video' media found in the sdp: " + sdpStr);
+            logger.error(`No 'video' media found in the sdp: ${sdpStr}`);
             return sdpStr;
         }
         if (videoMLine.direction === "inactive"
@@ -127,34 +127,35 @@ export default class RtxModifier {
         }
         logger.debug("Current ssrc mapping: ", this.correspondingRtxSsrcs);
         let primaryVideoSsrcs = videoMLine.getPrimaryVideoSSRCs();
-        logger.debug("Parsed primary video ssrcs ", primaryVideoSsrcs, " " +
-            "making sure all have rtx streams");
+        logger.debug("Parsed primary video ssrcs ", primaryVideoSsrcs,
+            " making sure all have rtx streams");
         for (const ssrc of primaryVideoSsrcs) {
             let msid = videoMLine.getSSRCAttrValue(ssrc, "msid");
             let cname = videoMLine.getSSRCAttrValue(ssrc, "cname");
             let correspondingRtxSsrc = this.correspondingRtxSsrcs.get(ssrc);
             if (correspondingRtxSsrc) {
-                logger.debug("Already have an associated rtx ssrc for " +
-                    " video ssrc " + ssrc + ": " +
-                    correspondingRtxSsrc);
+                logger.debug(
+                    `Already have an associated rtx ssrc for` +
+                    `video ssrc ${ssrc}: ${correspondingRtxSsrc}`);
             } else {
-                logger.debug("No previously associated rtx ssrc for " +
-                    " video ssrc " + ssrc);
+                logger.debug(
+                    `No previously associated rtx ssrc for video ssrc ${ssrc}`);
                 // If there's one in the sdp already for it, we'll just set
                 //  that as the corresponding one
                 let previousAssociatedRtxStream = videoMLine.getRtxSSRC(ssrc);
                 if (previousAssociatedRtxStream) {
-                    logger.debug("Rtx stream " + previousAssociatedRtxStream +
-                        " already existed in the sdp as an rtx stream for " +
-                        ssrc);
+                    logger.debug(
+                        `Rtx stream ${previousAssociatedRtxStream} ` +
+                        `already existed in the sdp as an rtx stream for ` +
+                        `${ssrc}`);
                     correspondingRtxSsrc = previousAssociatedRtxStream;
                 } else {
                     correspondingRtxSsrc = SDPUtil.generateSsrc();
-                    logger.debug("Generated rtx ssrc " + correspondingRtxSsrc +
-                        " for ssrc " + ssrc);
+                    logger.debug(`Generated rtx ssrc ${correspondingRtxSsrc} ` +
+                                 `for ssrc ${ssrc}`);
                 }
-                logger.debug("Caching rtx ssrc " + correspondingRtxSsrc +
-                    " for video ssrc " + ssrc);
+                logger.debug(`Caching rtx ssrc ${correspondingRtxSsrc} ` +
+                             `for video ssrc ${ssrc}`);
                 this.correspondingRtxSsrcs.set(ssrc, correspondingRtxSsrc);
             }
             updateAssociatedRtxStream(
@@ -178,7 +179,7 @@ export default class RtxModifier {
         const sdpTransformer = new SdpTransformWrap(sdpStr);
         const videoMLine = sdpTransformer.selectMedia("video");
         if (!videoMLine) {
-            logger.error("No 'video' media found in the sdp: " + sdpStr);
+            logger.error(`No 'video' media found in the sdp: ${sdpStr}`);
             return sdpStr;
         }
         if (videoMLine.direction === "inactive"

--- a/modules/xmpp/RtxModifier.js
+++ b/modules/xmpp/RtxModifier.js
@@ -23,11 +23,11 @@ function updateAssociatedRtxStream (mLine, primarySsrcInfo, rtxSsrc) {
     logger.debug(
         `Updating mline to associate ${rtxSsrc}` +
         `rtx ssrc with primary stream, ${primarySsrcInfo.id}`);
-    let primarySsrc = primarySsrcInfo.id;
-    let primarySsrcMsid = primarySsrcInfo.msid;
-    let primarySsrcCname = primarySsrcInfo.cname;
+    const primarySsrc = primarySsrcInfo.id;
+    const primarySsrcMsid = primarySsrcInfo.msid;
+    const primarySsrcCname = primarySsrcInfo.cname;
 
-    let previousRtxSSRC = mLine.getRtxSSRC(primarySsrc);
+    const previousRtxSSRC = mLine.getRtxSSRC(primarySsrc);
     if (previousRtxSSRC === rtxSsrc) {
         logger.debug(`${rtxSsrc} was already associated with ${primarySsrc}`);
         return;
@@ -126,7 +126,7 @@ export default class RtxModifier {
           return sdpStr;
         }
         logger.debug("Current ssrc mapping: ", this.correspondingRtxSsrcs);
-        let primaryVideoSsrcs = videoMLine.getPrimaryVideoSSRCs();
+        const primaryVideoSsrcs = videoMLine.getPrimaryVideoSSRCs();
         logger.debug("Parsed primary video ssrcs ", primaryVideoSsrcs,
             " making sure all have rtx streams");
         for (const ssrc of primaryVideoSsrcs) {

--- a/modules/xmpp/RtxModifier.js
+++ b/modules/xmpp/RtxModifier.js
@@ -18,29 +18,31 @@ import * as SDPUtil from "./SDPUtil";
  * @param {number} rtxSsrc the rtx ssrc to associate with the primary ssrc
  */
 function updateAssociatedRtxStream (sdpTransformer, primarySsrcInfo, rtxSsrc) {
-    logger.debug("Updating mline to associate " + rtxSsrc +
+    logger.debug(
+        "Updating mline to associate " + rtxSsrc +
         " rtx ssrc with primary stream ", primarySsrcInfo.id);
     let primarySsrc = primarySsrcInfo.id;
     let primarySsrcMsid = primarySsrcInfo.msid;
     let primarySsrcCname = primarySsrcInfo.cname;
 
-    let previousAssociatedRtxStream
-        = sdpTransformer.getRtxSSRC(primarySsrc);
-    if (previousAssociatedRtxStream === rtxSsrc) {
-        logger.debug(rtxSsrc + " was already associated with " +
-            primarySsrc);
+    let previousRtxSSRC = sdpTransformer.getRtxSSRC(primarySsrc);
+    if (previousRtxSSRC === rtxSsrc) {
+        logger.debug(rtxSsrc + " was already associated with " + primarySsrc);
         return;
     }
-    if (previousAssociatedRtxStream) {
-        logger.debug(primarySsrc + " was previously assocaited with rtx " +
-            previousAssociatedRtxStream + ", removing all references to it");
+    if (previousRtxSSRC) {
+        logger.debug(
+            primarySsrc + " was previously assocaited with rtx " +
+            previousRtxSSRC + ", removing all references to it");
+
         // Stream already had an rtx ssrc that is different than the one given,
         //  remove all trace of the old one
-        sdpTransformer.removeSSRC(previousAssociatedRtxStream);
-        logger.debug("groups before filtering for " +
-            previousAssociatedRtxStream);
+        sdpTransformer.removeSSRC(previousRtxSSRC);
+
+        logger.debug("groups before filtering for " + previousRtxSSRC);
         logger.debug(sdpTransformer.dumpSSRCGroups());
-        sdpTransformer.removeGroupsWithSSRC(previousAssociatedRtxStream);
+
+        sdpTransformer.removeGroupsWithSSRC(previousRtxSSRC);
     }
     sdpTransformer.addSSRCAttribute({
         id: rtxSsrc,

--- a/modules/xmpp/RtxModifier.js
+++ b/modules/xmpp/RtxModifier.js
@@ -1,82 +1,31 @@
 import { getLogger } from "jitsi-meet-logger";
 const logger = getLogger(__filename);
-import * as transform from 'sdp-transform';
+import { SdpTransformWrap, parseSecondarySSRC } from './SdpTransformUtil';
 import * as SDPUtil from "./SDPUtil";
 
 /**
  * Begin helper functions
  */
 /**
- * Given a videoMLine, returns a list of the video
- *  ssrcs (those used to actually send video, not
- *  any associated secondary streams)
- * @param {object} videoMLine media line object from transform.parse
- * @returns {list<string>} list of primary video ssrcs
- */
-function getPrimaryVideoSsrcs (videoMLine) {
-    let videoSsrcs = videoMLine.ssrcs
-        .map(ssrcInfo => ssrcInfo.id)
-        .filter((ssrc, index, array) => array.indexOf(ssrc) === index);
-
-    if (videoMLine.ssrcGroups) {
-        videoMLine.ssrcGroups.forEach((ssrcGroupInfo) => {
-            // Right now, FID groups are the only ones we parse to 
-            //  disqualify streams.  If/when others arise we'll
-            //  need to add support for them here
-            if (ssrcGroupInfo.semantics === "FID") {
-                // secondary FID streams should be filtered out
-                let secondarySsrc = ssrcGroupInfo.ssrcs.split(" ")[1];
-                videoSsrcs.splice(
-                  videoSsrcs.indexOf(parseInt(secondarySsrc)), 1);
-            }
-        });
-    }
-    return videoSsrcs;
-}
-
-/**
- * Given a video mline (as parsed from transform.parse),
- *  and a primary ssrc, return the corresponding rtx ssrc
- *  (if there is one) for that video ssrc
- * @param {object} videoMLine the video MLine from which to extract the
- *  rtx video ssrc
- * @param {number} primarySsrc the video ssrc for which to find the
- *  corresponding rtx ssrc
- * @returns {number} the rtx ssrc (or undefined if there isn't one)
- */
-function getRtxSsrc (videoMLine, primarySsrc) {
-    if (videoMLine.ssrcGroups) {
-        let fidGroup = videoMLine.ssrcGroups.find(group => {
-            if (group.semantics === "FID") {
-                let groupPrimarySsrc = SDPUtil.parseGroupSsrcs(group)[0];
-                return groupPrimarySsrc === primarySsrc;
-            }
-        });
-        if (fidGroup) {
-          return SDPUtil.parseGroupSsrcs(fidGroup)[1];
-        }
-    }
-}
-
-/**
  * Updates or inserts the appropriate rtx information for primarySsrc with
  *  the given rtxSsrc.  If no rtx ssrc for primarySsrc currently exists, it will
  *  add the appropriate ssrc and ssrc group lines.  If primarySsrc already has
  *  an rtx ssrc, the appropriate ssrc and group lines will be updated
- * @param {object} videoMLine video mline object that will be updated (in place)
- * @param {object} primarySsrcInfo the info (ssrc, msid & cname) for the 
+ * @param {SdpTransformWrap} sdpTransformer the transformer instance which will
+ * be used to modify video media description
+ * @param {object} primarySsrcInfo the info (ssrc, msid & cname) for the
  *  primary ssrc
  * @param {number} rtxSsrc the rtx ssrc to associate with the primary ssrc
  */
-function updateAssociatedRtxStream (videoMLine, primarySsrcInfo, rtxSsrc) {
-    logger.debug("Updating mline to associate " + rtxSsrc + 
+function updateAssociatedRtxStream (sdpTransformer, primarySsrcInfo, rtxSsrc) {
+    logger.debug("Updating mline to associate " + rtxSsrc +
         " rtx ssrc with primary stream ", primarySsrcInfo.id);
     let primarySsrc = primarySsrcInfo.id;
     let primarySsrcMsid = primarySsrcInfo.msid;
     let primarySsrcCname = primarySsrcInfo.cname;
 
-    let previousAssociatedRtxStream = 
-        getRtxSsrc (videoMLine, primarySsrc);
+    let previousAssociatedRtxStream
+        = sdpTransformer.getRtxSSRC(primarySsrc);
     if (previousAssociatedRtxStream === rtxSsrc) {
         logger.debug(rtxSsrc + " was already associated with " +
             primarySsrc);
@@ -87,30 +36,23 @@ function updateAssociatedRtxStream (videoMLine, primarySsrcInfo, rtxSsrc) {
             previousAssociatedRtxStream + ", removing all references to it");
         // Stream already had an rtx ssrc that is different than the one given,
         //  remove all trace of the old one
-        videoMLine.ssrcs = videoMLine.ssrcs
-            .filter(ssrcInfo => ssrcInfo.id !== previousAssociatedRtxStream);
-        logger.debug("groups before filtering for " + 
+        sdpTransformer.removeSSRC(previousAssociatedRtxStream);
+        logger.debug("groups before filtering for " +
             previousAssociatedRtxStream);
-        logger.debug(JSON.stringify(videoMLine.ssrcGroups));
-        videoMLine.ssrcGroups = videoMLine.ssrcGroups
-            .filter(groupInfo => {
-                return groupInfo
-                    .ssrcs
-                    .indexOf(previousAssociatedRtxStream + "") === -1;
-            });
+        logger.debug(sdpTransformer.dumpSSRCGroups());
+        sdpTransformer.removeGroupsWithSSRC(previousAssociatedRtxStream);
     }
-    videoMLine.ssrcs.push({
+    sdpTransformer.addSSRCAttribute({
         id: rtxSsrc,
         attribute: "cname",
         value: primarySsrcCname
     });
-    videoMLine.ssrcs.push({
+    sdpTransformer.addSSRCAttribute({
         id: rtxSsrc,
         attribute: "msid",
         value: primarySsrcMsid
     });
-    videoMLine.ssrcGroups = videoMLine.ssrcGroups || [];
-    videoMLine.ssrcGroups.push({
+    sdpTransformer.addSSRCGroup({
         semantics: "FID",
         ssrcs: primarySsrc + " " + rtxSsrc
     });
@@ -163,54 +105,56 @@ export default class RtxModifier {
      * @param {string} sdpStr sdp in raw string format
      */
     modifyRtxSsrcs (sdpStr) {
-        let parsedSdp = transform.parse(sdpStr);
-        let videoMLine = 
-            parsedSdp.media.find(mLine => mLine.type === "video");
-        if (videoMLine.direction === "inactive" ||
-                videoMLine.direction === "recvonly") {
+        const sdpTransformer = new SdpTransformWrap(sdpStr);
+        if (!sdpTransformer.selectMedia("video")) {
+            logger.error("No 'video' media found in the sdp: " + sdpStr);
+            return sdpStr;
+        }
+        const direction = sdpTransformer.mediaDirection;
+        if (direction === "inactive" || direction === "recvonly") {
             logger.debug("RtxModifier doing nothing, video " +
                 "m line is inactive or recvonly");
             return sdpStr;
         }
-        if (!videoMLine.ssrcs) {
+        if (sdpTransformer.getSSRCCount() < 1) {
           logger.debug("RtxModifier doing nothing, no video ssrcs present");
           return sdpStr;
         }
         logger.debug("Current ssrc mapping: ", this.correspondingRtxSsrcs);
-        let primaryVideoSsrcs = getPrimaryVideoSsrcs(videoMLine);
+        let primaryVideoSsrcs = sdpTransformer.getPrimaryVideoSSRCs();
         logger.debug("Parsed primary video ssrcs ", primaryVideoSsrcs, " " +
             "making sure all have rtx streams");
         primaryVideoSsrcs.forEach(ssrc => {
-            let msid = SDPUtil.getSsrcAttribute(videoMLine, ssrc, "msid");
-            let cname = SDPUtil.getSsrcAttribute(videoMLine, ssrc, "cname");
+            let msid = sdpTransformer.getSSRCAttrValue(ssrc, "msid");
+            let cname = sdpTransformer.getSSRCAttrValue(ssrc, "cname");
             let correspondingRtxSsrc = this.correspondingRtxSsrcs.get(ssrc);
             if (correspondingRtxSsrc) {
                 logger.debug("Already have an associated rtx ssrc for " +
-                    " video ssrc " + ssrc + ": " + 
+                    " video ssrc " + ssrc + ": " +
                     correspondingRtxSsrc);
             } else {
                 logger.debug("No previously associated rtx ssrc for " +
                     " video ssrc " + ssrc);
                 // If there's one in the sdp already for it, we'll just set
                 //  that as the corresponding one
-                let previousAssociatedRtxStream = 
-                    getRtxSsrc (videoMLine, ssrc);
+                let previousAssociatedRtxStream
+                    = sdpTransformer.getRtxSSRC(ssrc);
                 if (previousAssociatedRtxStream) {
-                    logger.debug("Rtx stream " + previousAssociatedRtxStream + 
+                    logger.debug("Rtx stream " + previousAssociatedRtxStream +
                         " already existed in the sdp as an rtx stream for " +
                         ssrc);
                     correspondingRtxSsrc = previousAssociatedRtxStream;
                 } else {
                     correspondingRtxSsrc = SDPUtil.generateSsrc();
-                    logger.debug("Generated rtx ssrc " + correspondingRtxSsrc + 
+                    logger.debug("Generated rtx ssrc " + correspondingRtxSsrc +
                         " for ssrc " + ssrc);
                 }
-                logger.debug("Caching rtx ssrc " + correspondingRtxSsrc + 
+                logger.debug("Caching rtx ssrc " + correspondingRtxSsrc +
                     " for video ssrc " + ssrc);
                 this.correspondingRtxSsrcs.set(ssrc, correspondingRtxSsrc);
             }
             updateAssociatedRtxStream(
-                videoMLine, 
+                sdpTransformer,
                 {
                     id: ssrc,
                     cname: cname,
@@ -218,7 +162,7 @@ export default class RtxModifier {
                 },
                 correspondingRtxSsrc);
         });
-        return transform.write(parsedSdp);
+        return sdpTransformer.toRawSDP();
     }
 
     /**
@@ -227,39 +171,35 @@ export default class RtxModifier {
      * @returns {string} sdp string with all rtx streams stripped
      */
     stripRtx (sdpStr) {
-        const parsedSdp = transform.parse(sdpStr);
-        const videoMLine = 
-            parsedSdp.media.find(mLine => mLine.type === "video");
-        if (videoMLine.direction === "inactive" ||
-                videoMLine.direction === "recvonly") {
+        const sdpTransformer = new SdpTransformWrap(sdpStr);
+        if (!sdpTransformer.selectMedia("video")) {
+            logger.error("No 'video' media found in the sdp: " + sdpStr);
+            return sdpStr;
+        }
+        const direction = sdpTransformer.mediaDirection;
+        if (direction === "inactive" || direction === "recvonly") {
             logger.debug("RtxModifier doing nothing, video " +
                 "m line is inactive or recvonly");
             return sdpStr;
         }
-        if (!videoMLine.ssrcs) {
+        if (sdpTransformer.getSSRCCount() < 1) {
           logger.debug("RtxModifier doing nothing, no video ssrcs present");
           return sdpStr;
         }
-        if (!videoMLine.ssrcGroups) {
-          logger.debug("RtxModifier doing nothing, " + 
+        if (!sdpTransformer.containsAnySSRCGroups()) {
+          logger.debug("RtxModifier doing nothing, " +
               "no video ssrcGroups present");
           return sdpStr;
         }
-        const fidGroups = videoMLine.ssrcGroups
-            .filter(group => group.semantics === "FID");
+        const fidGroups = sdpTransformer.findGroups("FID");
         // Remove the fid groups from the mline
-        videoMLine.ssrcGroups = videoMLine.ssrcGroups
-            .filter(group => group.semantics !== "FID");
+        sdpTransformer.removeGroupsBySemantics("FID");
         // Get the rtx ssrcs and remove them from the mline
-        const ssrcsToRemove = [];
         fidGroups.forEach(fidGroup => {
-            const groupSsrcs = SDPUtil.parseGroupSsrcs(fidGroup);
-            const rtxSsrc = groupSsrcs[1];
-            ssrcsToRemove.push(rtxSsrc);
+            const rtxSsrc = parseSecondarySSRC(fidGroup);
+            sdpTransformer.removeSSRC(rtxSsrc);
         });
-        videoMLine.ssrcs = videoMLine.ssrcs
-            .filter(line => ssrcsToRemove.indexOf(line.id) === -1);
-        
-        return transform.write(parsedSdp);
+
+        return sdpTransformer.toRawSDP();
     }
 }

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -97,18 +97,17 @@ export default class SdpConsistency {
                     `${newPrimarySsrc} with cached ${this.cachedPrimarySsrc}`);
                 videoMLine.replaceSSRC(
                     newPrimarySsrc, this.cachedPrimarySsrc);
-                videoMLine.forEachSSRCGroup(
-                    group => {
-                        if (group.semantics === "FID") {
-                            let primarySsrc = parsePrimarySSRC(group);
-                            let rtxSsrc = parseSecondarySSRC(group);
-                            if (primarySsrc === newPrimarySsrc) {
-                                group.ssrcs =
-                                    this.cachedPrimarySsrc + " " +
-                                        rtxSsrc;
-                            }
+                for (const group of videoMLine.ssrcGroups) {
+                    if (group.semantics === "FID") {
+                        let primarySsrc = parsePrimarySSRC(group);
+                        let rtxSsrc = parseSecondarySSRC(group);
+                        if (primarySsrc === newPrimarySsrc) {
+                            group.ssrcs =
+                                this.cachedPrimarySsrc + " " +
+                                    rtxSsrc;
                         }
-                    });
+                    }
+                }
             }
         }
         return sdpTransformer.toRawSDP();

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -36,6 +36,7 @@ export default class SdpConsistency {
      *  makeVideoPrimarySsrcsConsistent
      * @param {number} primarySsrc the primarySsrc to be used
      *  in future calls to makeVideoPrimarySsrcsConsistent
+     * @throws Error if <tt>primarySsrc</tt> is not a number
      */
     setPrimarySsrc (primarySsrc) {
         if (typeof primarySsrc !== 'number') {

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -59,12 +59,12 @@ export default class SdpConsistency {
         const sdpTransformer = new SdpTransformWrap(sdpStr);
         const videoMLine = sdpTransformer.selectMedia("video");
         if (!videoMLine) {
-            logger.error("No 'video' media found in the sdp: " + sdpStr);
+            logger.error(`No 'video' media found in the sdp: ${sdpStr}`);
             return sdpStr;
         }
         if (videoMLine.direction === "inactive") {
-            logger.info("Sdp-consistency doing nothing, " +
-                "video mline is inactive");
+            logger.info(
+                "Sdp-consistency doing nothing, video mline is inactive");
             return sdpStr;
         }
         if (videoMLine.direction === "recvonly") {
@@ -74,7 +74,7 @@ export default class SdpConsistency {
                 videoMLine.addSSRCAttribute({
                     id: this.cachedPrimarySsrc,
                     attribute: "cname",
-                    value: "recvonly-" + this.cachedPrimarySsrc
+                    value: `recvonly-${this.cachedPrimarySsrc}`
                 });
             } else {
                 logger.error("No SSRC found for the recvonly video stream!");
@@ -87,11 +87,13 @@ export default class SdpConsistency {
             }
             if (!this.cachedPrimarySsrc) {
                 this.cachedPrimarySsrc = newPrimarySsrc;
-                logger.info("Sdp-consistency caching primary ssrc " +
-                    this.cachedPrimarySsrc);
+                logger.info(
+                    "Sdp-consistency caching primary ssrc "
+                    + this.cachedPrimarySsrc);
             } else {
-                logger.info("Sdp-consistency replacing new ssrc " +
-                    newPrimarySsrc + " with cached " + this.cachedPrimarySsrc);
+                logger.info(
+                    `Sdp-consistency replacing new ssrc ` +
+                    `${newPrimarySsrc} with cached ${this.cachedPrimarySsrc}`);
                 videoMLine.replaceSSRC(
                     newPrimarySsrc, this.cachedPrimarySsrc);
                 videoMLine.forEachSSRCGroup(

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -1,9 +1,11 @@
 /* global __filename */
 
-import {getLogger} from "jitsi-meet-logger";
+import { getLogger } from "jitsi-meet-logger";
+import { parsePrimarySSRC,
+         parseSecondarySSRC,
+         SdpTransformWrap } from './SdpTransformUtil';
+
 const logger = getLogger(__filename);
-import { SdpTransformWrap,
-         parsePrimarySSRC, parseSecondarySSRC } from './SdpTransformUtil';
 
 /**
  * Handles the work of keeping video ssrcs consistent across multiple

--- a/modules/xmpp/SdpTransformUtil.js
+++ b/modules/xmpp/SdpTransformUtil.js
@@ -42,7 +42,7 @@ function findGroup(mLine, groupSemantics, ssrcs) {
  * the 'sdp-transform' lib which matches given criteria or <tt>undefined</tt>
  * otherwise.
  */
-function findGroupByPrimarySSRC(mLine, groupSemantics, primarySsrc) {
+function _findGroupByPrimarySSRC(mLine, groupSemantics, primarySsrc) {
     return mLine.ssrcGroups && mLine.ssrcGroups.find(
             group => group.semantics === groupSemantics
                             && parsePrimarySSRC(group) === primarySsrc);
@@ -53,7 +53,7 @@ function findGroupByPrimarySSRC(mLine, groupSemantics, primarySsrc) {
  * @param {Object} mLine the media line object as defined by 'sdp-transform' lib
  * @return {number}
  */
-function getSSRCCount(mLine) {
+function _getSSRCCount(mLine) {
     if (!mLine.ssrcs) {
         return 0;
     } else {
@@ -182,7 +182,7 @@ class MLineWrap {
         const attribute = this._ssrcs.find(
             ssrcObj => ssrcObj.id == ssrcNumber
             && ssrcObj.attribute === attrName);
-        return attribute ? attribute.value : undefined;
+        return attribute && attribute.value;
     }
 
     /**
@@ -195,10 +195,8 @@ class MLineWrap {
             return;
         }
 
-        // FIXME it should be possible to remove those values more efficiently
-        // than with splice ?
-        this.mLine.ssrcs = this.mLine.ssrcs
-            .filter(ssrcObj => ssrcObj.id !== ssrcNum);
+        this.mLine.ssrcs
+            = this.mLine.ssrcs.filter(ssrcObj => ssrcObj.id !== ssrcNum);
     }
 
     /**
@@ -237,11 +235,10 @@ class MLineWrap {
      * Finds all groups matching given semantic's name and group's primary SSRC.
      * @param {string} semantics the name of the semantics
      * @param {number} primarySSRC the primary SSRC number to be matched
-     * @return {Array.<object>} an array of SSRC group objects as defined by
-     * the 'sdp-transform' lib.
+     * @return {Object} SSRC group object as defined by the 'sdp-transform' lib.
      */
     findGroupByPrimarySSRC(semantics, primarySSRC) {
-        return findGroupByPrimarySSRC(
+        return _findGroupByPrimarySSRC(
             this.mLine, semantics, primarySSRC);
     }
 
@@ -250,7 +247,7 @@ class MLineWrap {
      * @return {number}
      */
     getSSRCCount() {
-        return getSSRCCount(this.mLine);
+        return _getSSRCCount(this.mLine);
     }
 
     /**
@@ -272,10 +269,10 @@ class MLineWrap {
 
         if (mediaType !== 'video') {
             throw new Error(
-                "getPrimarySsrc doesn't work with '" + mediaType +"'");
+                `getPrimarySsrc doesn't work with '${mediaType}'`);
         }
 
-        const numSsrcs = getSSRCCount(this.mLine);
+        const numSsrcs = _getSSRCCount(this.mLine);
         if (numSsrcs === 1) {
             // Not using _ssrcs on purpose here
             return this.mLine.ssrcs[0].id;

--- a/modules/xmpp/SdpTransformUtil.js
+++ b/modules/xmpp/SdpTransformUtil.js
@@ -29,7 +29,7 @@ export function parseSecondarySSRC(group) {
  */
 function findGroup(mLine, groupSemantics, ssrcs) {
     return mLine.ssrcGroups && mLine.ssrcGroups.find(
-            (group) => group.semantics === groupSemantics
+            group => group.semantics === groupSemantics
                             && !ssrcs || ssrcs === group.ssrcs);
 }
 
@@ -44,7 +44,7 @@ function findGroup(mLine, groupSemantics, ssrcs) {
  */
 function findGroupByPrimarySSRC(mLine, groupSemantics, primarySsrc) {
     return mLine.ssrcGroups && mLine.ssrcGroups.find(
-            (group) => group.semantics === groupSemantics
+            group => group.semantics === groupSemantics
                             && parsePrimarySSRC(group) === primarySsrc);
 }
 
@@ -167,7 +167,7 @@ class MLineWrap {
      */
     containsSSRC(ssrcNumber) {
         return !!this._ssrcs.find(
-            (ssrcObj) =>{ return ssrcObj.id == ssrcNumber; });
+            ssrcObj => { return ssrcObj.id == ssrcNumber; });
     }
 
     /**
@@ -198,7 +198,7 @@ class MLineWrap {
         // FIXME it should be possible to remove those values more efficiently
         // than with splice ?
         this.mLine.ssrcs = this.mLine.ssrcs
-            .filter((ssrcObj) => ssrcObj.id !== ssrcNum);
+            .filter(ssrcObj => ssrcObj.id !== ssrcNum);
     }
 
     /**
@@ -275,18 +275,18 @@ class MLineWrap {
                 "getPrimarySsrc doesn't work with '" + mediaType +"'");
         }
 
-        let numSsrcs = getSSRCCount(this.mLine);
+        const numSsrcs = getSSRCCount(this.mLine);
         if (numSsrcs === 1) {
             // Not using _ssrcs on purpose here
             return this.mLine.ssrcs[0].id;
         } else {
             // Look for a SIM or FID group
             if (this.mLine.ssrcGroups) {
-                let simGroup = this.findGroup("SIM");
+                const simGroup = this.findGroup("SIM");
                 if (simGroup) {
                     return parsePrimarySSRC(simGroup);
                 }
-                let fidGroup = this.findGroup("FID");
+                const fidGroup = this.findGroup("FID");
                 if (fidGroup) {
                     return parsePrimarySSRC(fidGroup);
                 }
@@ -303,8 +303,8 @@ class MLineWrap {
      * one)
      */
     getRtxSSRC (primarySsrc) {
-        let fidGroup = this.findGroupByPrimarySSRC("FID", primarySsrc);
-        return fidGroup ? parseSecondarySSRC(fidGroup) : undefined;
+        const fidGroup = this.findGroupByPrimarySSRC("FID", primarySsrc);
+        return fidGroup && parseSecondarySSRC(fidGroup);
     }
 
     /**
@@ -327,18 +327,18 @@ class MLineWrap {
 
         if (mediaType !== 'video') {
             throw new Error(
-                "getPrimaryVideoSSRCs doesn't work with '" + mediaType +"'");
+                `getPrimaryVideoSSRCs doesn't work with ${mediaType}`);
         }
 
-        let videoSSRCs = this.getSSRCs();
+        const videoSSRCs = this.getSSRCs();
 
-        this.forEachSSRCGroup((ssrcGroupInfo) => {
+        this.forEachSSRCGroup(ssrcGroupInfo => {
             // Right now, FID groups are the only ones we parse to
             // disqualify streams.  If/when others arise we'll
             // need to add support for them here
             if (ssrcGroupInfo.semantics === "FID") {
                 // secondary FID streams should be filtered out
-                let secondarySsrc = parseSecondarySSRC(ssrcGroupInfo);
+                const secondarySsrc = parseSecondarySSRC(ssrcGroupInfo);
                 videoSSRCs.splice(
                     videoSSRCs.indexOf(secondarySsrc), 1);
             }

--- a/modules/xmpp/SdpTransformUtil.js
+++ b/modules/xmpp/SdpTransformUtil.js
@@ -1,0 +1,439 @@
+import * as transform from 'sdp-transform';
+
+/**
+ * Parses the primary SSRC of given SSRC group.
+ * @param {object} group the SSRC group object as defined by the 'sdp-transform'
+ * @return {Number} the primary SSRC number
+ */
+export function parsePrimarySSRC(group) {
+    return parseInt(group.ssrcs.split(" ")[0]);
+}
+
+/**
+ * Parses the secondary SSRC of given SSRC group.
+ * @param {object} group the SSRC group object as defined by the 'sdp-transform'
+ * @return {Number} the secondary SSRC number
+ */
+export function parseSecondarySSRC(group) {
+    return parseInt(group.ssrcs.split(" ")[1]);
+}
+
+function findGroup(mLine, groupSemantics, ssrcs) {
+    return mLine.ssrcGroups && mLine.ssrcGroups.find(
+            (group) => group.semantics === groupSemantics
+                            && !ssrcs || ssrcs === group.ssrcs);
+}
+
+function findGroupByPrimarySSRC(mLine, groupSemantics, primarySsrc) {
+    return mLine.ssrcGroups && mLine.ssrcGroups.find(
+            (group) => group.semantics === groupSemantics
+                            && parsePrimarySSRC(group) === primarySsrc);
+}
+
+function getSSRCCount(mLine) {
+    if (!mLine.ssrcs) {
+        return 0;
+    } else {
+        return mLine.ssrcs
+            .map(ssrcInfo => ssrcInfo.id)
+            .filter((ssrc, index, array) => array.indexOf(ssrc) === index)
+            .length;
+    }
+}
+
+/**
+ * Utility class for SDP manipulation using the 'sdp-transform' library.
+ *
+ * Typical use usage scenario:
+ *
+ * const transformer = new SdpTransformWrap(rawSdp);
+ * if (transformer.selectMedia('video)) {
+ *     transformer.addSSRCAttribute({
+ *         id: 2342343,
+ *         attribute: "cname",
+ *         value: "someCname"
+ *     });
+ *     rawSdp = transformer.toRawSdp();
+ * }
+ */
+export class SdpTransformWrap {
+
+    /**
+     * Creates new instance and parses the raw SDP into objects using
+     * 'sdp-transform' lib.
+     * @param {string} rawSDP the SDP in raw text format.
+     */
+    constructor(rawSDP) {
+        this.parsedSDP = transform.parse(rawSDP);
+        this.selectedMLine = null;
+    }
+
+    /**
+     * Returns the direction of currently selected media.
+     * @return {string} the media direction name as defined in the SDP.
+     */
+    get mediaDirection() {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        return this.selectedMLine.direction;
+    }
+
+    /**
+     * Modifies the direction of currently selected media.
+     * @param {string} direction the new direction to be set
+     */
+    set mediaDirection (direction) {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        this.selectedMLine.direction = direction;
+    }
+
+    /**
+     * Selects the first media SDP of given name.
+     * @param {string} mediaType the name of the media e.g. 'audio', 'video',
+     * 'data'.
+     * @return {boolean} <tt>true</tt> if the media of given type has been found
+     * and selected or <tt>false</tt> otherwise.
+     */
+    selectMedia(mediaType) {
+        this.selectedMLine
+            = this.parsedSDP.media.find(mLine => mLine.type === mediaType);
+        return !!(this.selectedMLine);
+    }
+
+    get _ssrcs () {
+        if (!this.selectedMLine.ssrcs) {
+            this.selectedMLine.ssrcs = [];
+        }
+        return this.selectedMLine.ssrcs;
+    }
+
+    /**
+     * Checks whether the currently selected media description contains given
+     * SSRC number
+     * @param {string} ssrcNumber
+     * @return {boolean} <tt>true</tt> if given SSRC has been found or
+     * <tt>false</tt> otherwise.
+     */
+    containsSSRC(ssrcNumber) {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        return !!this._ssrcs.find(
+            (ssrcObj) =>{ return ssrcObj.id == ssrcNumber; });
+    }
+
+    /**
+     * Obtains value from SSRC attribute.
+     * @param {number} ssrcNumber the SSRC number for whcih attribute is to be
+     * found
+     * @param {string} attrName the name of the SSRC attribute to be found.
+     * @return {string|undefined} the value of SSRC attribute or
+     * <tt>undefined</tt> if no such attribute exists.
+     */
+    getSSRCAttrValue(ssrcNumber, attrName) {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        const attribute = this._ssrcs.find(
+            ssrcObj => ssrcObj.id == ssrcNumber
+                && ssrcObj.attribute === attrName);
+        return attribute ? attribute.value : undefined;
+    }
+
+    /**
+     * Removes all attributes for given SSRC number.
+     * @param {number} ssrcNum the SSRC number for which all attributes will be
+     * removed.
+     */
+    removeSSRC(ssrcNum) {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        if (!this.selectedMLine.ssrcs || !this.selectedMLine.ssrcs.length) {
+            return;
+        }
+
+        // FIXME it should be possible to remove those values more efficiently
+        // than with splice ?
+        this.selectedMLine.ssrcs = this.selectedMLine.ssrcs
+            .filter((ssrcObj) => ssrcObj.id !== ssrcNum);
+    }
+
+    /**
+     * Adds SSRC attribute
+     * @param {object} ssrcObj the SSRC attribute object as defined in
+     * the 'sdp-transform' lib.
+     */
+    addSSRCAttribute(ssrcObj) {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        this._ssrcs.push(ssrcObj);
+    }
+
+    /**
+     * Finds a SSRC group matching both semantics and SSRCs in order.
+     * @param {string} semantics the name of the semantics
+     * @param {string} [ssrcs] group SSRCs as a string (like it's defined in
+     * SSRC group object of the 'sdp-transform' lib) e.g. "1232546 342344 25434"
+     * @return {object|undefined} the SSRC group object or <tt>undefined</tt> if
+     * not found.
+     */
+    findGroup(semantics, ssrcs) {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        return findGroup(this.selectedMLine, semantics, ssrcs);
+    }
+
+    /**
+     * Finds all groups matching given semantic's name.
+     * @param {string} semantics the name of the semantics
+     * @return {Array.<object>} an array of SSRC group objects as defined by
+     * the 'sdp-transform' lib.
+     */
+    findGroups(semantics) {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        return this.selectedMLine.ssrcGroups.filter(
+            group => group.semantics === semantics);
+    }
+
+    /**
+     * Finds all groups matching given semantic's name and group's primary SSRC.
+     * @param {string} semantics the name of the semantics
+     * @param {number} primarySSRC the primary SSRC number to be matched
+     * @return {Array.<object>} an array of SSRC group objects as defined by
+     * the 'sdp-transform' lib.
+     */
+    findGroupByPrimarySSRC(semantics, primarySSRC) {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        return findGroupByPrimarySSRC(
+            this.selectedMLine, semantics, primarySSRC);
+    }
+
+    /**
+     * Gets the SSRC count for the currently selected media.
+     * @return {number}
+     */
+    getSSRCCount() {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        return getSSRCCount(this.selectedMLine);
+    }
+
+    /**
+     * Checks whether the currently selected media contains any SSRC groups.
+     * @return {boolean} <tt>true</tt> if there are any SSRC groups or
+     * <tt>false</tt> otherwise.
+     */
+    containsAnySSRCGroups() {
+        return !!this.selectedMLine.ssrcGroups;
+    }
+
+    /**
+     * Finds the primary video SSRC. Currently selected media type must be
+     * 'video'.
+     * @returns {number|undefined} the primary video ssrc
+     */
+    getPrimaryVideoSsrc () {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        const mediaType = this.selectedMLine.type;
+
+        if (mediaType !== 'video') {
+            throw new Error(
+                "getPrimarySsrc doesn't work with '" + mediaType +"'");
+        }
+
+        let numSsrcs = getSSRCCount(this.selectedMLine);
+        if (numSsrcs === 1) {
+            // Not using _ssrcs on purpose here
+            return this.selectedMLine.ssrcs[0].id;
+        } else {
+            // Look for a SIM or FID group
+            if (this.selectedMLine.ssrcGroups) {
+                let simGroup = this.findGroup("SIM");
+                if (simGroup) {
+                    return parsePrimarySSRC(simGroup);
+                }
+                let fidGroup = this.findGroup("FID");
+                if (fidGroup) {
+                    return parsePrimarySSRC(fidGroup);
+                }
+            }
+        }
+    }
+
+    /**
+     * Obtains RTX SSRC from the currently selected video media line (the
+     * secondary SSRC of the first "FID" group found)
+     * @param {number} primarySsrc the video ssrc for which to find the
+     * corresponding rtx ssrc
+     * @returns {number|undefined} the rtx ssrc (or undefined if there isn't
+     * one)
+     */
+    getRtxSSRC (primarySsrc) {
+        this._assertMLineSelected();
+
+        let fidGroup = this.findGroupByPrimarySSRC("FID", primarySsrc);
+        return fidGroup ? parseSecondarySSRC(fidGroup) : undefined;
+    }
+
+    /**
+     * Obtains all SSRCs of the currently selected media line.
+     * @return {Array.<number>} an array with all SSRC as numbers.
+     */
+    getSSRCs () {
+        this._assertMLineSelected();
+
+        return this._ssrcs
+            .map(ssrcInfo => ssrcInfo.id)
+            .filter((ssrc, index, array) => array.indexOf(ssrc) === index);
+    }
+
+    /**
+     * Obtains primary video SSRCs (video media line must be selected).
+     * @return {Array.<number>} an array of all primary video SSRCs as numbers.
+     */
+    getPrimaryVideoSSRCs () {
+        this._assertMLineSelected();
+
+        const mediaType = this.selectedMLine.type;
+
+        if (mediaType !== 'video') {
+            throw new Error(
+                "getPrimaryVideoSSRCs doesn't work with '" + mediaType +"'");
+        }
+
+        let videoSSRCs = this.getSSRCs();
+
+        this.forEachSSRCGroup((ssrcGroupInfo) => {
+            // Right now, FID groups are the only ones we parse to
+            // disqualify streams.  If/when others arise we'll
+            // need to add support for them here
+            if (ssrcGroupInfo.semantics === "FID") {
+                // secondary FID streams should be filtered out
+                let secondarySsrc = parseSecondarySSRC(ssrcGroupInfo);
+                videoSSRCs.splice(
+                    videoSSRCs.indexOf(secondarySsrc), 1);
+            }
+        });
+        return videoSSRCs;
+    }
+
+    /**
+     * Checks if there is currently any media selected or throws
+     * an <tt>Error</tt> otherwise.
+     * @private
+     */
+    _assertMLineSelected() {
+        // FIXME if possible wrap all methods instead of adding this call to
+        // almost every method
+        if (!this.selectedMLine) {
+            throw new Error("No media line selected");
+        }
+    }
+
+    /**
+     * Dumps all SSRC groups of the currently selected media line to JSON.
+     */
+    dumpSSRCGroups() {
+        return JSON.stringify(this.selectedMLine.ssrcGroups);
+    }
+
+    /**
+     * Removes all SSRC groups which contain given SSRC number at any position.
+     * @param {number} ssrc the SSRC for which all matching groups are to be
+     * removed.
+     */
+    removeGroupsWithSSRC(ssrc) {
+        this._assertMLineSelected();
+
+        if (!this.selectedMLine.ssrcGroups) {
+            return;
+        }
+
+        this.selectedMLine.ssrcGroups = this.selectedMLine.ssrcGroups
+            .filter(groupInfo => groupInfo.ssrcs.indexOf(ssrc + "") === -1);
+    }
+
+    /**
+     * Removes groups that match given semantics.
+     * @param {string} semantics e.g. "SIM" or "FID"
+     */
+    removeGroupsBySemantics(semantics) {
+        this._assertMLineSelected();
+
+        if (!this.selectedMLine.ssrcGroups) {
+            return;
+        }
+
+        this.selectedMLine.ssrcGroups
+            = this.selectedMLine.ssrcGroups
+                  .filter(groupInfo => groupInfo.semantics !== semantics);
+    }
+
+    /**
+     * Replaces SSRC (does not affect SSRC groups, but only attributes).
+     * @param {number} oldSSRC the old SSRC number
+     * @param {number} newSSRC the new SSRC number
+     */
+    replaceSSRC(oldSSRC, newSSRC) {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        if (this.selectedMLine.ssrcs) {
+            this.selectedMLine.ssrcs.forEach(ssrcInfo => {
+                if (ssrcInfo.id === oldSSRC) {
+                    ssrcInfo.id = newSSRC;
+                }
+            });
+        }
+    }
+
+    /**
+     * Executes given call back for each SSRC group
+     * @param {function(object)} callback
+     */
+    forEachSSRCGroup(callback) {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        if (this.selectedMLine.ssrcGroups) {
+            this.selectedMLine.ssrcGroups.forEach(callback);
+        }
+    }
+
+    /**
+     * Converts the currently stored SDP state in this instance to raw text SDP
+     * format.
+     * @return {string}
+     */
+    toRawSDP() {
+        return transform.write(this.parsedSDP);
+    }
+
+    /**
+     * Adds given SSRC group to the currently selected media.
+     * @param {object} group the SSRC group object as defined by
+     * the 'sdp-transform' lib.
+     */
+    addSSRCGroup(group) {
+        // mLine must be selected !
+        this._assertMLineSelected();
+
+        if (!this.selectedMLine.ssrcGroups) {
+            this.selectedMLine.ssrcGroups = [];
+        }
+        this.selectedMLine.ssrcGroups.push(group);
+    }
+}


### PR DESCRIPTION
SdpTransformUtil is a utility which encapsulates common operations on 'sdp-transform' lib objects. Currently used by SdpConsistency and RtxModifier, but there are plans for adding new classes in future refactoring towards the peer to peer.