### PR TITLE
Uses transport date only from succeeded pair.

### DIFF
--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -472,7 +472,8 @@ StatsCollector.prototype.processStatsReport = function() {
         }
 
         if (now.type === 'candidatepair') {
-            if (now.state === 'succeeded') {
+            // we need succeeded pairs only
+            if (now.state !== 'succeeded') {
                 continue;
             }
 


### PR DESCRIPTION
 Fixes an issue, where on FF we show a lot of addresses and ports (apparently not the correct one).