### PR TITLE
Remove references to undefined dispose method

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -618,8 +618,6 @@ export default class ChatRoom extends Listenable {
                 reason = reasonSelect.text();
             }
 
-            this._dispose();
-
             this.eventEmitter.emit(XMPPEvents.MUC_DESTROYED, reason);
             this.connection.emuc.doLeave(this.roomjid);
 
@@ -666,7 +664,6 @@ export default class ChatRoom extends Listenable {
         }
 
         if (isKick && this.myroomjid === from) {
-            this._dispose();
             this.eventEmitter.emit(XMPPEvents.KICKED);
         }
     }


### PR DESCRIPTION
The xmpp kicked event wasn't being emitted because of an undefined method being referenced.