### PR TITLE
Add a check for "undefined" RTCStatsReport objects

### DIFF
--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -443,6 +443,11 @@ StatsCollector.prototype.processStatsReport = function() {
         }
         const now = this.currentStatsReport[idx];
 
+        // The browser API may return "undefined" values in the array
+        if (!now) {
+            continue;
+        }
+
         try {
             const receiveBandwidth = getStatValue(now, 'receiveBandwidth');
             const sendBandwidth = getStatValue(now, 'sendBandwidth');


### PR DESCRIPTION
My JavaScript monitoring tool regularly reports failures inside the `processStatsReport` function in `RTPStatsCollector.js`

The Chrome `getStats` API returns a `RTCStatsResponse` on success, whose result method returns a list of `RTCStatReport` objects.

It appears that sometimes the list of `RTCStatReport` objects may include `undefined` objects.

This PR adds a check for this, and skips trying to process `undefined` objects.