### PR TITLE
Use media direction in P2P

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1904,23 +1904,6 @@ JitsiConference.prototype._acceptP2PIncomingCall
 };
 
 /**
- * Attaches local tracks back to the JVB connection.
- * @private
- */
-JitsiConference.prototype._attachLocalTracksToJvbSession = function() {
-    const localTracks = this.getLocalTracks();
-
-    logger.info(`Attaching ${localTracks} to JVB`);
-    this.jvbJingleSession.attachLocalTracks(localTracks).then(
-        () => {
-            logger.info(`Attach ${localTracks} to JVB success!`);
-        },
-        error => {
-            logger.error(`Attach ${localTracks} to JVB failed!`, error);
-        });
-};
-
-/**
  * Adds remote tracks to the conference associated with the JVB session.
  * @private
  */
@@ -1985,33 +1968,14 @@ JitsiConference.prototype._onIceConnectionEstablished
     // Add remote tracks
     this._addRemoteP2PTracks();
 
-    // Remove local tracks from JVB PC
-    // But only if it has started
+    // Stop media transfer over the JVB connection
     if (this.jvbJingleSession) {
-        this._detachLocalTracksFromJvbSession();
+        this._suspendMediaTransferForJvbConnection();
     }
 
     // Start remote stats
     logger.info('Starting remote stats with p2p connection');
     this._startRemoteStats();
-};
-
-/**
- * Detaches local tracks from the JVB connection.
- * @private
- */
-JitsiConference.prototype._detachLocalTracksFromJvbSession = function() {
-    const localTracks = this.getLocalTracks();
-
-    logger.info(`Detaching local tracks from JVB: ${localTracks}`);
-    this.jvbJingleSession.detachLocalTracks(localTracks).then(
-        () => {
-            logger.info(`Detach local tracks from JVB done!${localTracks}`);
-        },
-        error => {
-            logger.info(
-                `Detach local tracks from JVB failed!${localTracks}`, error);
-        });
 };
 
 /**
@@ -2066,6 +2030,23 @@ JitsiConference.prototype._removeRemoteTracks
         logger.info(`Removing remote ${sessionNickname} track: ${track}`);
         this.rtc.eventEmitter.emit(RTCEvents.REMOTE_TRACK_REMOVED, track);
     }
+};
+
+/**
+ * Resumes media transfer over the JVB connection.
+ * @private
+ */
+JitsiConference.prototype._resumeMediaTransferForJvbConnection = function() {
+    logger.info('Resuming media transfer over the JVB connection...');
+    this.jvbJingleSession.setMediaTransferActive(true).then(
+        () => {
+            logger.info('Resumed media transfer over the JVB connection!');
+        },
+        error => {
+            logger.error(
+                'Failed to resume media transfer over the JVB connection:',
+                error);
+        });
 };
 
 /**
@@ -2142,6 +2123,23 @@ JitsiConference.prototype._startP2PSession = function(peerJid) {
         },
         error => {
             logger.error(`Failed to add ${localTracks} to P2P`, error);
+        });
+};
+
+/**
+ * Suspends media transfer over the JVB connection.
+ * @private
+ */
+JitsiConference.prototype._suspendMediaTransferForJvbConnection = function() {
+    logger.info('Suspending media transfer over the JVB connection...');
+    this.jvbJingleSession.setMediaTransferActive(false).then(
+        () => {
+            logger.info('Suspended media transfer over the JVB connection !');
+        },
+        error => {
+            logger.error(
+                'Failed to suspend media transfer over the JVB connection:',
+                error);
         });
 };
 
@@ -2239,8 +2237,7 @@ JitsiConference.prototype._stopP2PSession
 
     // Swap remote tracks, but only if the P2P has been fully established
     if (wasP2PEstablished) {
-        // Add local track to JVB
-        this._attachLocalTracksToJvbSession();
+        this._resumeMediaTransferForJvbConnection();
 
         // Remove remote P2P tracks
         this._removeRemoteP2PTracks();

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -73,13 +73,6 @@ function JitsiLocalTrack(
     this.inMuteOrUnmuteProgress = false;
 
     /**
-     * An array which stores the peer connection to which this local track is
-     * currently attached to. See {@link TraceablePeerConnection.attachTrack}.
-     * @type {Set<TraceablePeerConnection>}
-     */
-    this.peerConnections = new Set();
-
-    /**
      * The facing mode of the camera from which this JitsiLocalTrack instance
      * was obtained.
      */
@@ -157,34 +150,6 @@ function JitsiLocalTrack(
 
 JitsiLocalTrack.prototype = Object.create(JitsiTrack.prototype);
 JitsiLocalTrack.prototype.constructor = JitsiLocalTrack;
-
-JitsiLocalTrack.prototype._addPeerConnection = function(tpc) {
-    if (this._isAttachedToPC(tpc)) {
-        logger.error(`${tpc} has been associated with ${this} already !`);
-    } else {
-        this.peerConnections.add(tpc);
-    }
-};
-
-JitsiLocalTrack.prototype._removePeerConnection = function(tpc) {
-    if (this._isAttachedToPC(tpc)) {
-        this.peerConnections.delete(tpc);
-    } else {
-        logger.error(`${tpc} is not associated with ${this}`);
-    }
-};
-
-/**
- * Checks whether or not this instance is attached to given
- * <tt>TraceablePeerConnection</tt>. See
- * {@link TraceablePeerConnection.attachTrack} for more info.
- * @param {TraceablePeerConnection.attachTrack} tpc
- * @return {boolean} <tt>true</tt> if this tracks is currently attached to given
- * peer connection or <tt>false</tt> otherwise.
- */
-JitsiLocalTrack.prototype._isAttachedToPC = function(tpc) {
-    return this.peerConnections.has(tpc);
-};
 
 /**
  * Returns if associated MediaStreamTrack is in the 'ended' state

--- a/modules/RTC/LocalSdpMunger.js
+++ b/modules/RTC/LocalSdpMunger.js
@@ -50,7 +50,7 @@ export default class LocalSdpMunger {
             return false;
         } else if (localVideos.length !== 1) {
             logger.error(
-                'There is more than 1 video track ! '
+                `${this.tpc} there is more than 1 video track ! `
                     + 'Strange things may happen !', localVideos);
         }
 
@@ -58,7 +58,8 @@ export default class LocalSdpMunger {
 
         if (!videoMLine) {
             logger.error(
-                'Unable to hack local video track SDP - no "video" media');
+                `${this.tpc} unable to hack local video track SDP`
+                    + '- no "video" media');
 
             return false;
         }
@@ -71,7 +72,7 @@ export default class LocalSdpMunger {
             const shouldFakeSdp = isMuted || muteInProgress;
 
             logger.debug(
-                `${videoTrack
+                `${this.tpc} ${videoTrack
                  } isMuted: ${isMuted
                  }, is mute in progress: ${muteInProgress
                  } => should fake sdp ? : ${shouldFakeSdp}`);
@@ -96,8 +97,8 @@ export default class LocalSdpMunger {
             }
             if (!videoMLine.getSSRCCount()) {
                 logger.error(
-                    'No video SSRCs found '
-                        + '(should be at least the recv-only one');
+                    `${this.tpc} - no video SSRCs found`
+                        + '(should be at least the recv-only one)');
 
                 // eslint-disable-next-line no-continue
                 continue;
@@ -128,7 +129,8 @@ export default class LocalSdpMunger {
 
                 // Inject
                 logger.debug(
-                    `Injecting video SSRC: ${ssrcNum} for ${videoTrack}`);
+                    `${this.tpc} injecting video SSRC: `
+                        + `${ssrcNum} for ${videoTrack}`);
                 videoMLine.addSSRCAttribute({
                     id: ssrcNum,
                     attribute: 'cname',
@@ -149,7 +151,8 @@ export default class LocalSdpMunger {
                 if (!videoMLine.findGroup(group.semantics, group.ssrcs)) {
                     // Inject the group
                     logger.debug(
-                        `Injecting SIM group for ${videoTrack}`, group);
+                        `${this.tpc} injecting SIM group for ${videoTrack}`,
+                        group);
                     videoMLine.addSSRCGroup(group);
                 }
             }

--- a/modules/RTC/RTCBrowserType.js
+++ b/modules/RTC/RTCBrowserType.js
@@ -119,7 +119,7 @@ const RTCBrowserType = {
      * otherwise.
      */
     isP2PSupported() {
-        return !RTCBrowserType.isFirefox() && !RTCBrowserType.isReactNative();
+        return !RTCBrowserType.isReactNative();
     },
 
     /**

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -348,10 +348,8 @@ TraceablePeerConnection.prototype.getConnectionState = function() {
  */
 TraceablePeerConnection.prototype._getDesiredMediaDirection
 = function(mediaType) {
-    const anyLocalTracks = this.hasAnyTracksOfType(mediaType);
-
     if (this.mediaTransferActive) {
-        return anyLocalTracks ? 'sendrecv' : 'recvonly';
+        return this.hasAnyTracksOfType(mediaType) ? 'sendrecv' : 'recvonly';
     }
 
     return 'inactive';

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -174,7 +174,7 @@ function TraceablePeerConnection(
 
     this.simulcast = new Simulcast({ numOfLayers: SIMULCAST_LAYERS,
         explodeRemoteSimulcast: false });
-    this.sdpConsistency = new SdpConsistency(this);
+    this.sdpConsistency = new SdpConsistency(this.toString());
 
     /**
      * Munges local SDP provided to the Jingle Session in order to prevent from

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1613,18 +1613,15 @@ TraceablePeerConnection.prototype._createOfferOrAnswer
              *  complain about unmapped ssrcs)
              */
             if (!RTCBrowserType.isFirefox()) {
-                const isVideoRecvOnly
-                    = !this.hasAnyTracksOfType(MediaType.VIDEO);
-
                 // If there are no local video tracks, then a "recvonly"
                 // SSRC needs to be generated
-                if (isVideoRecvOnly
+                if (!this.hasAnyTracksOfType(MediaType.VIDEO)
                     && !this.sdpConsistency.hasPrimarySsrcCached()) {
                     this.generateRecvonlySsrc();
                 }
                 resultSdp.sdp
                     = this.sdpConsistency.makeVideoPrimarySsrcsConsistent(
-                        resultSdp.sdp, isVideoRecvOnly);
+                        resultSdp.sdp);
                 this.trace(
                     `create${logName}OnSuccess::postTransform `
                          + '(make primary audio/video ssrcs consistent)',

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -174,7 +174,7 @@ function TraceablePeerConnection(
 
     this.simulcast = new Simulcast({ numOfLayers: SIMULCAST_LAYERS,
         explodeRemoteSimulcast: false });
-    this.sdpConsistency = new SdpConsistency();
+    this.sdpConsistency = new SdpConsistency(this);
 
     /**
      * Munges local SDP provided to the Jingle Session in order to prevent from
@@ -1479,7 +1479,7 @@ TraceablePeerConnection.prototype.setRemoteDescription
 TraceablePeerConnection.prototype.generateRecvonlySsrc = function() {
     const newSSRC = SDPUtil.generateSsrc();
 
-    logger.info(`Generated new recvonly SSRC: ${newSSRC}`);
+    logger.info(`${this} generated new recvonly SSRC: ${newSSRC}`);
     this.sdpConsistency.setPrimarySsrc(newSSRC);
 };
 

--- a/modules/xmpp/RtxModifier.js
+++ b/modules/xmpp/RtxModifier.js
@@ -133,10 +133,8 @@ export default class RtxModifier {
      *  {@link SdpTransformWrap} has been modified or <tt>false</tt> otherwise.
      */
     modifyRtxSsrcs2(videoMLine) {
-        if (videoMLine.direction === 'inactive'
-            || videoMLine.direction === 'recvonly') {
-            logger.debug('RtxModifier doing nothing, video '
-                + 'm line is inactive or recvonly');
+        if (videoMLine.direction === 'recvonly') {
+            logger.debug('RtxModifier doing nothing, video m line is recvonly');
 
             return false;
         }
@@ -211,10 +209,8 @@ export default class RtxModifier {
 
             return sdpStr;
         }
-        if (videoMLine.direction === 'inactive'
-                || videoMLine.direction === 'recvonly') {
-            logger.debug('RtxModifier doing nothing, video '
-                + 'm line is inactive or recvonly');
+        if (videoMLine.direction === 'recvonly') {
+            logger.debug('RtxModifier doing nothing, video m line is recvonly');
 
             return sdpStr;
         }

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -19,9 +19,11 @@ const logger = getLogger(__filename);
 export default class SdpConsistency {
     /**
      * Constructor
+     * @param {TraceablePeerConnection} tpc parent peer connection instance
      */
-    constructor() {
+    constructor(tpc) {
         this.clearVideoSsrcCache();
+        this.tpc = tpc;
     }
 
     /**
@@ -73,7 +75,8 @@ export default class SdpConsistency {
         const videoMLine = sdpTransformer.selectMedia('video');
 
         if (!videoMLine) {
-            logger.error(`No 'video' media found in the sdp: ${sdpStr}`);
+            logger.error(
+                `${this.tpc} no 'video' media found in the sdp: ${sdpStr}`);
 
             return sdpStr;
         }
@@ -87,20 +90,24 @@ export default class SdpConsistency {
                     value: `recvonly-${this.cachedPrimarySsrc}`
                 });
             } else {
-                logger.error('No SSRC found for the recvonly video stream!');
+                logger.error(
+                    `${this.tpc} no SSRC found for the recvonly video stream!`);
             }
         } else {
             const newPrimarySsrc = videoMLine.getPrimaryVideoSsrc();
 
             if (!newPrimarySsrc) {
-                logger.info('Sdp-consistency couldn\'t parse new primary ssrc');
+                logger.info(
+                    `${this.tpc} sdp-consistency couldn't`
+                        + ' parse new primary ssrc');
 
                 return sdpStr;
             }
             if (this.cachedPrimarySsrc) {
                 logger.info(
-                    `Sdp-consistency replacing new ssrc ${newPrimarySsrc
-                        } with cached ${this.cachedPrimarySsrc}`);
+                    `${this.tpc} sdp-consistency replacing new ssrc`
+                        + `${newPrimarySsrc} with cached `
+                        + `${this.cachedPrimarySsrc}`);
                 videoMLine.replaceSSRC(newPrimarySsrc, this.cachedPrimarySsrc);
                 for (const group of videoMLine.ssrcGroups) {
                     if (group.semantics === 'FID') {
@@ -117,8 +124,8 @@ export default class SdpConsistency {
             } else {
                 this.cachedPrimarySsrc = newPrimarySsrc;
                 logger.info(
-                    `Sdp-consistency caching primary ssrc ${
-                        this.cachedPrimarySsrc}`);
+                    `${this.tpc} sdp-consistency caching primary ssrc`
+                        + `${this.cachedPrimarySsrc}`);
             }
         }
 

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -65,12 +65,10 @@ export default class SdpConsistency {
      *   to match the ones previously cached
      * @param {string} sdpStr the sdp string to (potentially)
      *  change to make the video ssrcs consistent
-     * @param {boolean} isVideoRecvOnly <tt>true</tt> if the video media
-     * is currently in the receive only mode (does not send any video tracks).
      * @returns {string} a (potentially) modified sdp string
      *  with ssrcs consistent with this class' cache
      */
-    makeVideoPrimarySsrcsConsistent(sdpStr, isVideoRecvOnly) {
+    makeVideoPrimarySsrcsConsistent(sdpStr) {
         const sdpTransformer = new SdpTransformWrap(sdpStr);
         const videoMLine = sdpTransformer.selectMedia('video');
 
@@ -80,7 +78,7 @@ export default class SdpConsistency {
 
             return sdpStr;
         }
-        if (isVideoRecvOnly) {
+        if (videoMLine.direction === 'recvonly') {
             // If the mline is recvonly, we'll add the primary
             //  ssrc as a recvonly ssrc
             if (this.cachedPrimarySsrc) {

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -22,12 +22,6 @@ export default class SdpConsistency {
      */
     constructor() {
         this.clearVideoSsrcCache();
-
-        /**
-         * Cached audio SSRC.
-         * @type {number|null}
-         */
-        this.cachedAudioSSRC = null;
     }
 
     /**
@@ -70,12 +64,6 @@ export default class SdpConsistency {
 
         if (!videoMLine) {
             logger.error(`No 'video' media found in the sdp: ${sdpStr}`);
-
-            return sdpStr;
-        }
-        if (videoMLine.direction === 'inactive') {
-            logger.info(
-                'Sdp-consistency doing nothing, video mline is inactive');
 
             return sdpStr;
         }
@@ -122,54 +110,6 @@ export default class SdpConsistency {
                     `Sdp-consistency caching primary ssrc ${
                         this.cachedPrimarySsrc}`);
             }
-        }
-
-        return sdpTransformer.toRawSDP();
-    }
-
-    /**
-     * Makes sure that audio SSRC is preserved between "detach" and "attach"
-     *  operations. The code assumes there can be only 1 audio track added to
-     *  the peer connection at a time.
-     * @param {string} sdpStr the sdp string to (potentially)
-     *  change to make the audio ssrc consistent
-     * @returns {string} a (potentially) modified sdp string
-     *  with ssrcs consistent with this class' cache
-     */
-    makeAudioSSRCConsistent(sdpStr) {
-        const sdpTransformer = new SdpTransformWrap(sdpStr);
-        const audioMLine = sdpTransformer.selectMedia('audio');
-
-        if (!audioMLine) {
-            logger.error(`No 'audio' media found in the sdp: ${sdpStr}`);
-
-            return sdpStr;
-        }
-        if (audioMLine.direction === 'inactive') {
-            logger.info(
-                'Sdp-consistency doing nothing, audio mline is inactive');
-
-            return sdpStr;
-        }
-
-        const audioSSRCObj = audioMLine.findSSRCByMSID(null);
-
-        if (audioSSRCObj) {
-            if (this.cachedAudioSSRC) {
-                const oldSSRC = audioSSRCObj.id;
-
-                if (oldSSRC !== this.cachedAudioSSRC) {
-                    logger.info(
-                        `Replacing audio SSRC ${
-                            oldSSRC} with ${this.cachedAudioSSRC}`);
-                    audioMLine.replaceSSRC(oldSSRC, this.cachedAudioSSRC);
-                }
-            } else {
-                this.cachedAudioSSRC = audioSSRCObj.id;
-                logger.info(`Storing audio SSRC: ${this.cachedAudioSSRC}`);
-            }
-        } else {
-            logger.info('Doing nothing - no audio stream in the SDP');
         }
 
         return sdpTransformer.toRawSDP();

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -48,6 +48,14 @@ export default class SdpConsistency {
     }
 
     /**
+     * Checks whether or not there is a primary video SSRC cached already.
+     * @return {boolean}
+     */
+    hasPrimarySsrcCached() {
+        return Boolean(this.cachedPrimarySsrc);
+    }
+
+    /**
      * Given an sdp string, either:
      *  1) record the primary video and primary rtx ssrcs to be
      *   used in future calls to makeVideoPrimarySsrcsConsistent or
@@ -55,10 +63,12 @@ export default class SdpConsistency {
      *   to match the ones previously cached
      * @param {string} sdpStr the sdp string to (potentially)
      *  change to make the video ssrcs consistent
+     * @param {boolean} isVideoRecvOnly <tt>true</tt> if the video media
+     * is currently in the receive only mode (does not send any video tracks).
      * @returns {string} a (potentially) modified sdp string
      *  with ssrcs consistent with this class' cache
      */
-    makeVideoPrimarySsrcsConsistent(sdpStr) {
+    makeVideoPrimarySsrcsConsistent(sdpStr, isVideoRecvOnly) {
         const sdpTransformer = new SdpTransformWrap(sdpStr);
         const videoMLine = sdpTransformer.selectMedia('video');
 
@@ -67,7 +77,7 @@ export default class SdpConsistency {
 
             return sdpStr;
         }
-        if (videoMLine.direction === 'recvonly') {
+        if (isVideoRecvOnly) {
             // If the mline is recvonly, we'll add the primary
             //  ssrc as a recvonly ssrc
             if (this.cachedPrimarySsrc) {

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -19,11 +19,13 @@ const logger = getLogger(__filename);
 export default class SdpConsistency {
     /**
      * Constructor
-     * @param {TraceablePeerConnection} tpc parent peer connection instance
+     * @param {string} logPrefix the log prefix appended to every logged
+     * message, currently used to distinguish for which
+     * <tt>TraceablePeerConnection</tt> the instance works.
      */
-    constructor(tpc) {
+    constructor(logPrefix) {
         this.clearVideoSsrcCache();
-        this.tpc = tpc;
+        this.logPrefix = logPrefix;
     }
 
     /**
@@ -74,7 +76,8 @@ export default class SdpConsistency {
 
         if (!videoMLine) {
             logger.error(
-                `${this.tpc} no 'video' media found in the sdp: ${sdpStr}`);
+                `${this.logPrefix} no 'video' media found in the sdp: `
+                    + `${sdpStr}`);
 
             return sdpStr;
         }
@@ -89,21 +92,22 @@ export default class SdpConsistency {
                 });
             } else {
                 logger.error(
-                    `${this.tpc} no SSRC found for the recvonly video stream!`);
+                    `${this.logPrefix} no SSRC found for the recvonly video`
+                        + 'stream!');
             }
         } else {
             const newPrimarySsrc = videoMLine.getPrimaryVideoSsrc();
 
             if (!newPrimarySsrc) {
                 logger.info(
-                    `${this.tpc} sdp-consistency couldn't`
+                    `${this.logPrefix} sdp-consistency couldn't`
                         + ' parse new primary ssrc');
 
                 return sdpStr;
             }
             if (this.cachedPrimarySsrc) {
                 logger.info(
-                    `${this.tpc} sdp-consistency replacing new ssrc`
+                    `${this.logPrefix} sdp-consistency replacing new ssrc`
                         + `${newPrimarySsrc} with cached `
                         + `${this.cachedPrimarySsrc}`);
                 videoMLine.replaceSSRC(newPrimarySsrc, this.cachedPrimarySsrc);
@@ -122,7 +126,7 @@ export default class SdpConsistency {
             } else {
                 this.cachedPrimarySsrc = newPrimarySsrc;
                 logger.info(
-                    `${this.tpc} sdp-consistency caching primary ssrc`
+                    `${this.logPrefix} sdp-consistency caching primary ssrc`
                         + `${this.cachedPrimarySsrc}`);
             }
         }


### PR DESCRIPTION
Get rid of detach/attach methods and use SDP direction 'inactive' to stop sending data on JVB connection when switching to P2P.