### PR TITLE
Adds peer connection statuses (active/inactive/interrupted/restoring).

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -15,7 +15,7 @@ import JitsiTrackError from './JitsiTrackError';
 import * as JitsiTrackErrors from './JitsiTrackErrors';
 import * as JitsiTrackEvents from './JitsiTrackEvents';
 import * as MediaType from './service/RTC/MediaType';
-import ParticipantConnectionStatus
+import ParticipantConnectionStatusHandler
     from './modules/connectivity/ParticipantConnectionStatus';
 import RTC from './modules/RTC/RTC';
 import RTCBrowserType from './modules/RTC/RTCBrowserType';
@@ -206,7 +206,7 @@ JitsiConference.prototype._init = function(options = {}) {
     }
 
     this.participantConnectionStatus
-        = new ParticipantConnectionStatus(
+        = new ParticipantConnectionStatusHandler(
                 this.rtc, this,
                 options.config.peerDisconnectedThroughRtcTimeout);
     this.participantConnectionStatus.init();

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -110,11 +110,17 @@ export const MESSAGE_RECEIVED = 'conference.messageReceived';
 
 /**
  * Event fired when JVB sends notification about interrupted/restored user's
- * ICE connection status. First argument is the ID of the participant and
- * the seconds is a boolean indicating if the connection is currently
- * active(true = active, false = interrupted).
+ * ICE connection status or we detect local problem with the video track.
+ * First argument is the ID of the participant and
+ * the seconds is a string indicating if the connection is currently
+ * - active - the connection is active
+ * - inactive - the connection is inactive, was intentionally interrupted by
+ * the bridge
+ * - interrupted - a network problem occurred
+ * - restoring - the connection was inactive and is restoring now
+ *
  * The current status value can be obtained by calling
- * JitsiParticipant.isConnectionActive().
+ * JitsiParticipant.getConnectionStatus().
  */
 export const PARTICIPANT_CONN_STATUS_CHANGED
     = 'conference.participant_conn_status_changed';

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -18,6 +18,8 @@ import * as JitsiTrackEvents from './JitsiTrackEvents';
 import Logger from 'jitsi-meet-logger';
 import * as MediaType from './service/RTC/MediaType';
 import Resolutions from './service/RTC/Resolutions';
+import { ParticipantConnectionStatus }
+    from './modules/connectivity/ParticipantConnectionStatus';
 import RTC from './modules/RTC/RTC';
 import RTCBrowserType from './modules/RTC/RTCBrowserType';
 import RTCUIHelper from './modules/RTC/RTCUIHelper';
@@ -90,6 +92,7 @@ const LibJitsiMeet = {
 
     JitsiConnection,
     constants: {
+        participantConnectionStatus: ParticipantConnectionStatus,
         sipVideoGW: VideoSIPGWConstants
     },
     events: {

--- a/JitsiParticipant.js
+++ b/JitsiParticipant.js
@@ -1,5 +1,7 @@
 /* global Strophe */
 import * as JitsiConferenceEvents from './JitsiConferenceEvents';
+import { ParticipantConnectionStatus }
+    from './modules/connectivity/ParticipantConnectionStatus';
 import * as MediaType from './service/RTC/MediaType';
 
 /**
@@ -33,7 +35,7 @@ export default class JitsiParticipant {
             video: undefined
         };
         this._hidden = hidden;
-        this._connectionStatus = null;
+        this._connectionStatus = ParticipantConnectionStatus.ACTIVE;
         this._properties = {};
     }
 

--- a/JitsiParticipant.js
+++ b/JitsiParticipant.js
@@ -33,7 +33,7 @@ export default class JitsiParticipant {
             video: undefined
         };
         this._hidden = hidden;
-        this._isConnectionActive = true;
+        this._connectionStatus = null;
         this._properties = {};
     }
 
@@ -72,22 +72,23 @@ export default class JitsiParticipant {
 
     /**
      * Updates participant's connection status.
-     * @param {boolean} isActive true if the user's connection is fine or false
-     * when the user is having connectivity issues.
+     * @param {string} state the current participant connection state.
+     * {@link ParticipantConnectionStatus}.
      * @private
      */
-    _setIsConnectionActive(isActive) {
-        this._isConnectionActive = isActive;
+    _setConnectionStatus(status) {
+        this._connectionStatus = status;
     }
 
     /**
-     * Checks participant's connectivity status.
+     * Return participant's connectivity status.
      *
-     * @returns {boolean} true if the connection is currently ok or false when
-     * the user is having connectivity issues.
+     * @returns {string} the connection status
+     * <tt>ParticipantConnectionStatus</tt> of the user.
+     * {@link ParticipantConnectionStatus}.
      */
-    isConnectionActive() {
-        return this._isConnectionActive;
+    getConnectionStatus() {
+        return this._connectionStatus;
     }
 
     /**

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -41,7 +41,7 @@ export const ParticipantConnectionStatus = {
     /**
      * Status indicating that connection is currently active.
      */
-    ACTIVE: Symbol('active'),
+    ACTIVE: 'active',
 
     /**
      * Status indicating that connection is currently inactive.
@@ -49,17 +49,17 @@ export const ParticipantConnectionStatus = {
      * like exiting lastN or adaptivity decided to drop video because of not
      * enough bandwidth.
      */
-    INACTIVE: Symbol('inactive'),
+    INACTIVE: 'inactive',
 
     /**
      * Status indicating that connection is currently interrupted.
      */
-    INTERRUPTED: Symbol('interrupted'),
+    INTERRUPTED: 'interrupted',
 
     /**
      * Status indicating that connection is currently restoring.
      */
-    RESTORING: Symbol('restoring')
+    RESTORING: 'restoring'
 };
 
 /**

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -148,6 +148,7 @@ export default class ParticipantConnectionStatusHandler {
          * A map of the "endpoint ID"(which corresponds to the resource part
          * of MUC JID(nickname)) to the restoring timeout callback IDs
          * scheduled using window.setTimeout.
+         *
          * @type {Object.<string, number>}
          */
         this.restoringTimers = [];
@@ -255,8 +256,8 @@ export default class ParticipantConnectionStatusHandler {
      * Handles RTCEvents.ENDPOINT_CONN_STATUS_CHANGED triggered when we receive
      * notification over the data channel from the bridge about endpoint's
      * connection status update.
-     * @param endpointId {string} the endpoint ID(MUC nickname/resource JID)
-     * @param isActive {boolean} true if the connection is OK or false otherwise
+     * @param {string} endpointId the endpoint ID(MUC nickname/resource JID)
+     * @param {boolean} isActive true if the connection is OK or false otherwise
      */
     onEndpointConnStatusChanged(endpointId, isActive) {
 
@@ -310,7 +311,7 @@ export default class ParticipantConnectionStatusHandler {
      * Reset the postponed "connection interrupted" event which was previously
      * scheduled as a timeout on RTC 'onmute' event.
      *
-     * @param participantId the participant for which the "connection
+     * @param {string} participantId the participant for which the "connection
      * interrupted" timeout was scheduled
      */
     clearTimeout(participantId) {
@@ -322,8 +323,8 @@ export default class ParticipantConnectionStatusHandler {
 
     /**
      * Clears the timestamp of the RTC muted event for participant's video track
-     * @param participantId the id of the conference participant which is
-     * the same as the Colibri endpoint ID of the video channel allocated for
+     * @param {string} participantId the id of the conference participant which
+     * is the same as the Colibri endpoint ID of the video channel allocated for
      * the user on the videobridge.
      */
     clearRtcMutedTimestamp(participantId) {
@@ -494,8 +495,8 @@ export default class ParticipantConnectionStatusHandler {
      * On change in Last N set check all leaving and entering participants to
      * change their corresponding statuses.
      *
-     * @param leavingLastN
-     * @param enteringLastN
+     * @param {Array<string>} leavingLastN array of ids leaving lastN.
+     * @param {Array<string>} enteringLastN array of ids entering lastN.
      * @private
      */
     _onLastNChanged(leavingLastN, enteringLastN) {
@@ -520,8 +521,8 @@ export default class ParticipantConnectionStatusHandler {
      * Clears the restoring timer for participant's video track and the
      * timestamp for entering lastN.
      *
-     * @param participantId the id of the conference participant which is
-     * the same as the Colibri endpoint ID of the video channel allocated for
+     * @param {string} participantId the id of the conference participant which
+     * is the same as the Colibri endpoint ID of the video channel allocated for
      * the user on the videobridge.
      */
     _clearRestoringTimer(participantId) {
@@ -537,8 +538,8 @@ export default class ParticipantConnectionStatusHandler {
      * timedout and there is no timer added, add new timer in order to give it
      * more time to become active or mark it as interrupted on next check.
      *
-     * @param participantId the id of the conference participant which is
-     * the same as the Colibri endpoint ID of the video channel allocated for
+     * @param {string} participantId the id of the conference participant which
+     * is the same as the Colibri endpoint ID of the video channel allocated for
      * the user on the videobridge.
      * @returns {boolean} <tt>true</tt> if the track was in restoring state
      * more than the timeout ({@link DEFAULT_RESTORING_TIMEOUT}.) in order to


### PR DESCRIPTION
The peer connection used to be check with is connection active. Adding new states like active, inactive, when the connection was intentionally stopped by the bridge, interrupted due to network problem and restoring, which is the state of a peer which was inactive as being out of lastN and is now entering lastM and eventually will become active.