### PR TITLE
edge: Ensure "unsupported" is triggered for now (until fully supported)

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -864,6 +864,15 @@ class RTCUtils extends Listenable {
                     };
                 }
             } else if (RTCBrowserType.isEdge()) {
+                // TODO: Remove when EDGE is fully supported. For now ensure
+                // that, if EDGE is detected, it's just unsupported.
+                if (RTCBrowserType.isEdge()) {
+                    rejectWithWebRTCNotSupported(
+                        'Microsoft EDGE not yet supported', reject);
+
+                    return;
+                }
+
                 // TODO: Uncomment when done. For now use the Edge native
                 // RTCPeerConnection.
                 // this.peerconnection = ortcRTCPeerConnection;


### PR DESCRIPTION
Even if EDGE does support getUserMedia and some kind of limited RTCPeerConnection, it does not work yet (work in progress), so ensure that EDGE is identified as an unsupported browser for now.