### PR TITLE
build: run webpack on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "webpack": "1.14.0"
   },
   "scripts": {
-    "install": "webpack -p",
     "lint": "jshint . && eslint . && flow",
+    "postinstall": "webpack -p",
     "test": "karma start karma.conf.js",
     "validate": "npm ls"
   },


### PR DESCRIPTION
The net effect is the same, with the bonus that it avoids problems when running
yarn.