### PR TITLE
build: drop babel-pollyfill dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "babel-core": "6.24.0",
     "babel-eslint": "7.2.1",
     "babel-loader": "6.4.1",
-    "babel-polyfill": "6.23.0",
     "babel-preset-es2015": "6.24.0",
     "eslint": "3.18.0",
     "eslint-plugin-flowtype": "2.30.4",


### PR DESCRIPTION
It's not used anymore.