### PR TITLE
fix(JitsiLocalTrack): Remove unnecessary mute operation

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -735,10 +735,6 @@ JitsiConference.prototype._setupNewTrack = function(newTrack) {
     }
     this.rtc.addLocalTrack(newTrack);
 
-    if (newTrack.startMuted) {
-        newTrack.mute();
-    }
-
     // ensure that we're sharing proper "is muted" state
     if (newTrack.isAudioTrack()) {
         this.room.setAudioMute(newTrack.isMuted());

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -68,7 +68,6 @@ function JitsiLocalTrack(
     }
 
     this.deviceId = deviceId;
-    this.startMuted = false;
     this.storedMSID = this.getMSID();
     this.inMuteOrUnmuteProgress = false;
 
@@ -320,17 +319,6 @@ JitsiLocalTrack.prototype._setMute = function(mute) {
 
     let promise = Promise.resolve();
     const self = this;
-
-    // Local track can be used out of conference, so we need to handle that
-    // case and mark that track should start muted or not when added to
-    // conference.
-    // Pawel: track's muted status should be taken into account when track is
-    // being added to the conference/JingleSessionPC/TraceablePeerConnection.
-    // There's no need to add such fields. It is logical that when muted track
-    // is being added to a conference it "starts muted"...
-    if (!this.conference || !this.conference.room) {
-        this.startMuted = mute;
-    }
 
     this.dontFireRemoveEvent = false;
 


### PR DESCRIPTION
When muted track was added to conference "mute" operation was
executed again which was not executing anything because the state
of the track was already muted.