### PR TITLE
Fix errors with sending final logs batch to CallStats

### DIFF
--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -182,8 +182,8 @@ export default class CallStats {
             logger.warn('No error is passed!');
             _error = new Error('Unknown error');
         }
-        if (CallStats.initialized) {
-            CallStats.backend.reportError(pc, cs && cs.confID, type, _error);
+        if (CallStats.initialized && cs) {
+            CallStats.backend.reportError(pc, cs.confID, type, _error);
         } else {
             CallStats.reportsQueue.push({
                 type: reportType.ERROR,
@@ -212,7 +212,7 @@ export default class CallStats {
         const pc = cs && cs.peerconnection;
         const confID = cs && cs.confID;
 
-        if (CallStats.initialized) {
+        if (CallStats.initialized && cs) {
             CallStats.backend.sendFabricEvent(pc, event, confID, eventData);
         } else {
             CallStats.reportsQueue.push({

--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -578,6 +578,7 @@ export default class CallStats {
                 CallStats.backend.fabricEvent.fabricTerminated,
                 this.confID);
         }
+        CallStats.fabrics.delete(this);
     }
 
     /**


### PR DESCRIPTION
Will emit BEFORE_STATISTICS_DISPOSED event, before the last CallStats fabric is terminated to make sure that the final logs batch is reported correctly.

Also adds a check for CallStats instance to queue events when the backend has been initialised, but there is no CallStats instance available to report on. This fixes errors printed to the console, after the call has ended.