### PR TITLE
remove analytics event for peer conn status, not used

### DIFF
--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -384,10 +384,6 @@ export default class ParticipantConnectionStatusHandler {
                     status: newStatus
                 }));
 
-            // and analytics
-            Statistics.analytics.sendEvent('peer.conn.status',
-                { label: newStatus });
-
             this.conference.eventEmitter.emit(
                 JitsiConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED,
                 endpointId, newStatus);


### PR DESCRIPTION
This PR removes a single event (peer.conn.status) from all analytics output.  This event isn't used anywhere, and is overly chatty.