### PR TITLE
tpc: use the peerconnection type constructor from RTCUtils

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -746,7 +746,7 @@ class RTCUtils extends Listenable {
 
                     return;
                 }
-                this.peerconnection = mozRTCPeerConnection;
+                this.RTCPeerConnectionType = mozRTCPeerConnection;
                 this.getUserMedia
                     = wrapGetUserMedia(
                         navigator.mozGetUserMedia.bind(navigator));
@@ -800,7 +800,7 @@ class RTCUtils extends Listenable {
                     || RTCBrowserType.isElectron()
                     || RTCBrowserType.isReactNative()) {
 
-                this.peerconnection = webkitRTCPeerConnection;
+                this.RTCPeerConnectionType = webkitRTCPeerConnection;
                 const getUserMedia
                     = navigator.webkitGetUserMedia.bind(navigator);
 
@@ -875,8 +875,8 @@ class RTCUtils extends Listenable {
 
                 // TODO: Uncomment when done. For now use the Edge native
                 // RTCPeerConnection.
-                // this.peerconnection = ortcRTCPeerConnection;
-                this.peerconnection = RTCPeerConnection;
+                // this.RTCPeerConnectionType = ortcRTCPeerConnection;
+                this.RTCPeerConnectionType = RTCPeerConnection;
                 this.getUserMedia
                     = wrapGetUserMedia(
                         navigator.mediaDevices.getUserMedia.bind(
@@ -905,7 +905,7 @@ class RTCUtils extends Listenable {
             } else if (RTCBrowserType.isTemasysPluginUsed()) {
                 // Detect IE/Safari
                 const webRTCReadyCb = () => {
-                    this.peerconnection = RTCPeerConnection;
+                    this.RTCPeerConnectionType = RTCPeerConnection;
                     this.getUserMedia = window.getUserMedia;
                     this.enumerateDevices
                         = enumerateDevicesThroughMediaStreamTrack;

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1,5 +1,4 @@
-/* global __filename, mozRTCPeerConnection, webkitRTCPeerConnection,
-    RTCPeerConnection, RTCSessionDescription */
+/* global __filename, RTCSessionDescription */
 
 import { getLogger } from 'jitsi-meet-logger';
 import transform from 'sdp-transform';
@@ -9,6 +8,7 @@ import JitsiRemoteTrack from './JitsiRemoteTrack';
 import * as MediaType from '../../service/RTC/MediaType';
 import LocalSdpMunger from './LocalSdpMunger';
 import RTC from './RTC';
+import RTCUtils from './RTCUtils';
 import RTCBrowserType from './RTCBrowserType';
 import RTCEvents from '../../service/RTC/RTCEvents';
 import RtxModifier from '../xmpp/RtxModifier';
@@ -150,21 +150,9 @@ export default function TraceablePeerConnection(
         SignalingEvents.PEER_MUTED_CHANGED,
         this._peerMutedChanged);
     this.options = options;
-    let RTCPeerConnectionType = null;
 
-    if (RTCBrowserType.isFirefox()) {
-        RTCPeerConnectionType = mozRTCPeerConnection;
-    } else if (RTCBrowserType.isEdge()) {
-        // TODO: Uncomment when done. For now use the Edge native
-        // RTCPeerConnection.
-        // RTCPeerConnectionType = ortcRTCPeerConnection;
-        RTCPeerConnectionType = RTCPeerConnection;
-    } else if (RTCBrowserType.isTemasysPluginUsed()) {
-        RTCPeerConnectionType = RTCPeerConnection;
-    } else {
-        RTCPeerConnectionType = webkitRTCPeerConnection;
-    }
-    this.peerconnection = new RTCPeerConnectionType(iceConfig, constraints);
+    this.peerconnection
+        = new RTCUtils.RTCPeerConnectionType(iceConfig, constraints);
     this.updateLog = [];
     this.stats = {};
     this.statsinterval = null;


### PR DESCRIPTION
Avoids having to do browser checks twice.

Fixes: #423