### PR TITLE
Sends the bare jid of the room on call out.

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1137,7 +1137,7 @@ export default class ChatRoom extends Listenable {
      */
     dial(number) {
         return this.connection.rayo.dial(number, 'fromnumber',
-            Strophe.getNodeFromJid(this.myroomjid), this.password,
+            Strophe.getBareJidFromJid(this.myroomjid), this.password,
             this.focusMucJid);
     }
 


### PR DESCRIPTION
Sending the bare jid, speeds call setup as otherwise jigasi needs to do a feature discovery finding the conference component address and use it to construct the room address to join.