### PR TITLE
fix: ensure container is defined while attaching a track

### DIFF
--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -253,7 +253,7 @@ JitsiTrack.prototype._maybeFireTrackAttached = function(container) {
  *          library. That's the case when Temasys plugin is in use.
  */
 JitsiTrack.prototype.attach = function(container) {
-    let c;
+    let c = container;
 
     if (this.stream) {
         c = RTCUtils.attachMediaStream(container, this.stream);


### PR DESCRIPTION
For muted tracks, it is possible for undefined to get pushed
into the track's internal containers reference. The fix is
to immediately set the internal container variable in .attach()
to the passed in container value.