### PR TITLE
fix(stats): lazy initialization for statistics Sets

### DIFF
--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -62,6 +62,12 @@ const reportType = {
 };
 
 /**
+ * Set of currently existing {@link CallStats} instances.
+ * @type {Set<CallStats>}
+ */
+let _fabrics;
+
+/**
  * An instance of this class is a wrapper for the CallStats API fabric. A fabric
  * reports one peer connection the the CallStats backend and is allocated with
  * {@link callstats.addNewFabric}. It has a bunch of instance methods for
@@ -298,6 +304,19 @@ export default class CallStats {
         };
 
         /* eslint-enable max-params */
+    }
+
+    /**
+     * Returns the Set with the currently existing {@link CallStats} instances.
+     * Lazily initializes the Set to allow any Set polyfills to be applied.
+     * @type {Set<CallStats>}
+     */
+    static get fabrics() {
+        if (!_fabrics) {
+            _fabrics = new Set();
+        }
+
+        return _fabrics;
     }
 
     /**
@@ -703,9 +722,3 @@ CallStats.callStatsSecret = null;
  * @type {object}
  */
 CallStats.userID = null;
-
-/**
- * Set of currently existing {@link CallStats} instances.
- * @type {Set<CallStats>}
- */
-CallStats.fabrics = new Set();

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -11,6 +11,12 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
 const ScriptUtil = require('../util/ScriptUtil');
 
 /**
+ * Stores all active {@link Statistics} instances.
+ * @type {Set<Statistics>}
+ */
+let _instances;
+
+/**
  * True if callstats API is loaded
  */
 let isCallstatsLoaded = false;
@@ -124,11 +130,20 @@ Statistics.audioLevelsInterval = 200;
 Statistics.disableThirdPartyRequests = false;
 Statistics.analytics = analytics;
 
-/**
- * Stores all active {@link Statistics} instances.
- * @type {Set<Statistics>}
- */
-Statistics.instances = new Set();
+Object.defineProperty(Statistics, 'instances', {
+    /**
+     * Returns the Set holding all active {@link Statistics} instances. Lazily
+     * initializes the Set to allow any Set polyfills to be applied.
+     * @type {Set<Statistics>}
+     */
+    get() {
+        if (!_instances) {
+            _instances = new Set();
+        }
+
+        return _instances;
+    }
+});
 
 Statistics.prototype.startRemoteStats = function(peerconnection) {
     this.stopRemoteStats();


### PR DESCRIPTION
Internet Explorer is throwing an error when doing a for...of over
Sets. This is because IE needs a Set polyfill, which may be applied
after lib-jitsi-meet has loaded. However, lib-jitsi-meet on load
creates two Sets, one for CallStats.fabrics and another for
Statistics.instances. When the polyfill is then applied, the two
existing Sets do not get new methods. The fix is to lazily
initialize the Sets to allow for polyfills to be applied.

~~Internet Explorer is throwing an error when doing a for...of over
sets. Set.prototype.values() is also throwing an error...so the
compromise was ensuring the sets being iterated over are indeed
arrays.~~

~~I'm open to changing this fix or more opinions on what to try out.
I don't completely understand right now why iterating over sets
would be broken on IE and why values would also be broken.~~