### PR TITLE
ref(sdp): Do not add recvonly SSRC for muted video tracks.

### DIFF
--- a/modules/RTC/LocalSdpMunger.js
+++ b/modules/RTC/LocalSdpMunger.js
@@ -93,14 +93,6 @@ export default class LocalSdpMunger {
                 // eslint-disable-next-line no-continue
                 continue;
             }
-            if (!videoMLine.getSSRCCount()) {
-                logger.error(
-                    `${this.tpc} - no video SSRCs found`
-                        + '(should be at least the recv-only one)');
-
-                // eslint-disable-next-line no-continue
-                continue;
-            }
 
             modified = true;
 

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -35,6 +35,7 @@ export default class SdpConsistency {
      */
     clearVideoSsrcCache() {
         this.cachedPrimarySsrc = null;
+        this.injectRecvOnly = false;
     }
 
     /**
@@ -81,17 +82,18 @@ export default class SdpConsistency {
 
             return sdpStr;
         }
+
         if (videoMLine.direction === 'recvonly') {
             // If the mline is recvonly, we'll add the primary
             //  ssrc as a recvonly ssrc
-            if (this.cachedPrimarySsrc) {
+            if (this.cachedPrimarySsrc && this.injectRecvOnly) {
                 videoMLine.addSSRCAttribute({
                     id: this.cachedPrimarySsrc,
                     attribute: 'cname',
                     value: `recvonly-${this.cachedPrimarySsrc}`
                 });
             } else {
-                logger.error(
+                logger.info(
                     `${this.logPrefix} no SSRC found for the recvonly video`
                         + 'stream!');
             }
@@ -129,6 +131,8 @@ export default class SdpConsistency {
                     `${this.logPrefix} sdp-consistency caching primary ssrc`
                         + `${this.cachedPrimarySsrc}`);
             }
+
+            this.injectRecvOnly = true;
         }
 
         return sdpTransformer.toRawSDP();


### PR DESCRIPTION
Currently, when a participant joins hidden/video muted, we add a
recvonly SSRC so that the client sends RTCP reports with that SSRC. This
SSRC doesn't have neither simulcast nor RTX enabled. When the user
decides to enable his video camera, we "enhance" this SSRC with params
for RTX and simulcast. However, Chrome does not take into account these
new params because of
https://bugs.chromium.org/p/webrtc/issues/detail?id=7555. By not adding
a recvonly SSRC, we activate the default behavior in Chrome which is to
send RTCP reports with SSRC 1. So, when the user decides to enable his
video camera, instead of updating/enhancing the existing SSRC, we
initalize the primary SSRC with the correct params.