### PR TITLE
fix(permission-prompt): Use labels to predict if the prompt will not …

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -248,6 +248,18 @@ export default {
                         RTCBrowserType.getBrowserName());
                 }
             }, USER_MEDIA_PERMISSION_PROMPT_TIMEOUT);
+
+            // The call to gum is not guaranteed to complete within
+            // USER_MEDIA_PERMISSION_PROMPT_TIMEOUT. On supported browsers,
+            // checking for permission prompt display can at least prevent some
+            // erroneous cases of firing the PERMISSION_PROMPT_IS_SHOWN event in
+            // the case of slow gum.
+            RTC.mightShowPermissionPrompt()
+                .then(mightShowPermissionPrompt => {
+                    if (!promiseFulfilled) {
+                        promiseFulfilled = !mightShowPermissionPrompt;
+                    }
+                });
         }
 
         if (!window.connectionTimes) {

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -618,6 +618,16 @@ export default class RTC extends Listenable {
     }
 
     /**
+     * Returns whether or not the permission prompt for user media might
+     * display.
+     *
+     * @returns {Promise<boolean>}
+     */
+    static mightShowPermissionPrompt() {
+        return RTCUtils.mightShowPermissionPrompt();
+    }
+
+    /**
      * A method to handle stopping of the stream.
      * One point to handle the differences in various implementations.
      * @param mediaStream MediaStream object to stop.


### PR DESCRIPTION
…display

In Firefox, getUserMedia for audio and video can take longer than
USER_MEDIA_PERMISSION_PROMPT_TIMEOUT, causing an event to fire stating the
permission prompt is displayed even when it is not. On my machine,
getUserMedia for audio and video would take between 200ms and 700ms. Due to
the variance, relying on the timeout alone to know about permission prompt
display might not be sufficient. One way to know if permission has been
granted, thereby knowing the prompt will not display, is by executing
enumerateDevices and seeing if devices have labels. The call to enumerate
is consistently and significantly faster that getUserMedia. This will
not work on temasys though because enumerateDevices will always return
labels.