### PR TITLE
fix(stats): Enable stats on temasys

### DIFF
--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -72,30 +72,53 @@ JitsiRemoteTrack.prototype = Object.create(JitsiTrack.prototype);
 JitsiRemoteTrack.prototype.constructor = JitsiRemoteTrack;
 
 JitsiRemoteTrack.prototype._bindMuteHandlers = function() {
-    // Bind 'onmute'
+    // Use feature detection for finding what event handling function is
+    // supported. On Internet Explorer, which uses uses temasys/firebreath, the
+    // track will have attachEvent instead of addEventListener.
+    //
     // FIXME it would be better to use recently added '_setHandler' method, but
     // 1. It does not allow to set more than one handler to the event
     // 2. It does mix MediaStream('inactive') with MediaStreamTrack events
     // 3. Allowing to bind more than one event handler requires too much
     //    refactoring around camera issues detection.
-    this.track.addEventListener('mute', () => {
+    if (this.track.addEventListener) {
+        this.track.addEventListener('mute', () => this._onTrackMute());
+        this.track.addEventListener('unmute', () => this._onTrackUnmute());
+    } else if (this.track.attachEvent) {
+        // FIXME Internet Explorer is not emitting out mute/unmute events.
+        this.track.attachEvent('onmute', () => this._onTrackMute());
+        this.track.attachEvent('onunmute', () => this._onTrackUnmute());
+    }
+};
 
-        logger.debug(
-            `"onmute" event(${Date.now()}): `,
-            this.getParticipantId(), this.getType(), this.getSSRC());
+/**
+ * Callback invoked when the track is muted. Emits an event notifying listeners
+ * of the mute event.
+ *
+ * @private
+ * @returns {void}
+ */
+JitsiRemoteTrack.prototype._onTrackMute = function() {
+    logger.debug(
+        `"onmute" event(${Date.now()}): `,
+        this.getParticipantId(), this.getType(), this.getSSRC());
 
-        this.rtc.eventEmitter.emit(RTCEvents.REMOTE_TRACK_MUTE, this);
-    });
+    this.rtc.eventEmitter.emit(RTCEvents.REMOTE_TRACK_MUTE, this);
+};
 
-    // Bind 'onunmute'
-    this.track.addEventListener('unmute', () => {
+/**
+ * Callback invoked when the track is unmuted. Emits an event notifying
+ * listeners of the mute event.
+ *
+ * @private
+ * @returns {void}
+ */
+JitsiRemoteTrack.prototype._onTrackUnmute = function() {
+    logger.debug(
+        `"onunmute" event(${Date.now()}): `,
+        this.getParticipantId(), this.getType(), this.getSSRC());
 
-        logger.debug(
-            `"onunmute" event(${Date.now()}): `,
-            this.getParticipantId(), this.getType(), this.getSSRC());
-
-        this.rtc.eventEmitter.emit(RTCEvents.REMOTE_TRACK_UNMUTE, this);
-    });
+    this.rtc.eventEmitter.emit(RTCEvents.REMOTE_TRACK_UNMUTE, this);
 };
 
 /**

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -7,7 +7,8 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
 /* Whether we support the browser we are running into for logging statistics */
 const browserSupported = RTCBrowserType.isChrome()
         || RTCBrowserType.isOpera() || RTCBrowserType.isFirefox()
-        || RTCBrowserType.isNWJS() || RTCBrowserType.isElectron();
+        || RTCBrowserType.isNWJS() || RTCBrowserType.isElectron()
+        || RTCBrowserType.isTemasysPluginUsed();
 
 /**
  * The lib-jitsi-meet browser-agnostic names of the browser-specific keys


### PR DESCRIPTION
Temasys has support for local stats so add it to the supported browser list. In order for stats to display on Internet Explorer, a script error had to be addressed. Internet Explorer tracks returned by temasys do not have addEventListener.