### PR TITLE
Removes obsolete config.token.

### DIFF
--- a/doc/tokens.md
+++ b/doc/tokens.md
@@ -46,7 +46,7 @@ JitsiMeetJS.init(initOptions).then(function(){
 
 In order to start jitsi-meet conference with token you need to specify the token as URL param:
 ```
-https://example.com/angrywhalesgrowhigh#config.token="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"
+https://example.com/angrywhalesgrowhigh?jwt="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"
 ```
 At current level of integration every user that joins the conference has to provide the token and not just the one who
 creates the room. It should be possible to change that by using second anonymous domain, but that hasn't been tested
@@ -109,7 +109,7 @@ VirtualHost "jitmeet.example.com"
     									   -- generator and the plugin
 ```
 
-\3. Enable token verification plugin in your MUC component config section:
+\3. Enable room name token verification plugin in your MUC component config section:
 
 ```lua
 Component "conference.jitmeet.example.com" "muc"

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -297,7 +297,7 @@ export default class XMPP extends Listenable {
 
             if (this.options.hosts.anonymousdomain
                     && (window.location.search.indexOf('login=true') !== -1
-                        || this.options.token)) {
+                        || this.token)) {
                 configDomain = this.options.hosts.domain;
             }
 


### PR DESCRIPTION
Token is passed as parameter when creating JitsiConnection and we no longer use it from the options passed to the connection.