### PR TITLE
Report average RTP stats to anayltics

### DIFF
--- a/modules/RTC/RTCBrowserType.js
+++ b/modules/RTC/RTCBrowserType.js
@@ -208,6 +208,17 @@ const RTCBrowserType = {
     },
 
     /**
+     * Checks if the current browser reports upload and download bandwidth
+     * statistics.
+     * @return {boolean}
+     */
+    supportsBandwidthStatistics() {
+        // FIXME bandwidth stats are currently not implemented for FF on our
+        // side, but not sure if not possible ?
+        return !RTCBrowserType.isFirefox();
+    },
+
+    /**
      * Whether jitsi-meet supports simulcast on the current browser.
      * @returns {boolean}
      */

--- a/modules/RTC/RTCBrowserType.js
+++ b/modules/RTC/RTCBrowserType.js
@@ -219,6 +219,23 @@ const RTCBrowserType = {
     },
 
     /**
+     * Checks if the current browser reports round trip time statistics for
+     * the ICE candidate pair.
+     * @return {boolean}
+     */
+    supportsRTTStatistics() {
+        // Firefox does not seem to report RTT for ICE candidate pair:
+        // eslint-disable-next-line max-len
+        // https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats-currentroundtriptime
+        // It does report mozRTT for RTP streams, but at the time of this
+        // writing it's value does not make sense most of the time
+        // (is reported as 1):
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1241066
+        // For Chrome and others we rely on 'googRtt'.
+        return !RTCBrowserType.isFirefox();
+    },
+
+    /**
      * Whether jitsi-meet supports simulcast on the current browser.
      * @returns {boolean}
      */

--- a/modules/connectivity/ConnectionQuality.js
+++ b/modules/connectivity/ConnectionQuality.js
@@ -396,7 +396,11 @@ export default class ConnectionQuality {
         const data = {
             bitrate: this._localStats.bitrate,
             packetLoss: this._localStats.packetLoss,
-            connectionQuality: this._localStats.connectionQuality
+            connectionQuality: this._localStats.connectionQuality,
+            jvbRTT: this._localStats.transport
+                    && this._localStats.transport.length
+                    && !this._localStats.transport[0].p2p
+                        ? this._localStats.transport[0].rtt : undefined
         };
 
         // TODO: It looks like the remote participants don't really "care"
@@ -477,7 +481,8 @@ export default class ConnectionQuality {
         this._remoteStats[id] = {
             bitrate: data.bitrate,
             packetLoss: data.packetLoss,
-            connectionQuality: data.connectionQuality
+            connectionQuality: data.connectionQuality,
+            jvbRTT: data.jvbRTT
         };
 
         this.eventEmitter.emit(

--- a/modules/statistics/AvgRTPStatsReporter.js
+++ b/modules/statistics/AvgRTPStatsReporter.js
@@ -185,6 +185,14 @@ export default class AvgRTPStatsReporter {
         this._avgRemoteFPS = new AverageStatReport('stat.avg.framerate.remote');
 
         /**
+         * Average round trip time reported by the ICE candidate pair.
+         * FIXME currently reported only for P2P
+         * @type {AverageStatReport}
+         * @private
+         */
+        this._avgRTT = new AverageStatReport('stat.avg.rtt');
+
+        /**
          * Average FPS for local video
          * @type {AverageStatReport}
          * @private
@@ -281,6 +289,15 @@ export default class AvgRTPStatsReporter {
         this._avgPacketLossTotal.addNext(packetLoss.total);
         this._avgCQ.addNext(data.connectionQuality);
 
+        if (RTCBrowserType.supportsRTTStatistics()) {
+            // FIXME implement JVB end-to-end RTT
+            if (isP2P && data.transport && data.transport.length) {
+                this._avgRTT.addNext(data.transport[0].rtt);
+            } else {
+                this._avgRTT.reset();
+            }
+        }
+
         if (frameRate) {
             this._avgRemoteFPS.addNext(
                 this._calculateAvgVideoFps(frameRate, false /* remote */));
@@ -303,6 +320,11 @@ export default class AvgRTPStatsReporter {
             this._avgRemoteFPS.report(isP2P);
             this._avgLocalFPS.report(isP2P);
             this._avgCQ.report(isP2P);
+
+            // FIXME implement JVB end-to-end RTT
+            if (isP2P && RTCBrowserType.supportsRTTStatistics()) {
+                this._avgRTT.report(isP2P);
+            }
 
             this._resetAvgStats();
         }
@@ -358,6 +380,7 @@ export default class AvgRTPStatsReporter {
         this._avgRemoteFPS.reset();
         this._avgLocalFPS.reset();
         this._avgCQ.reset();
+        this._avgRTT.reset();
         this._sampleIdx = 0;
     }
 

--- a/modules/statistics/AvgRTPStatsReporter.js
+++ b/modules/statistics/AvgRTPStatsReporter.js
@@ -4,6 +4,7 @@ import { getLogger } from 'jitsi-meet-logger';
 import * as ConnectionQualityEvents
     from '../../service/connectivity/ConnectionQualityEvents';
 import * as ConferenceEvents from '../../JitsiConferenceEvents';
+import RTCBrowserType from '../RTC/RTCBrowserType';
 import Statistics from './statistics';
 
 const logger = getLogger(__filename);
@@ -32,7 +33,8 @@ class AverageStatReport {
     addNext(nextValue) {
         if (typeof nextValue !== 'number') {
             logger.error(
-                `${this.name} - invalid value for idx: ${this.count}`);
+                `${this.name} - invalid value for idx: ${this.count}`,
+                nextValue);
 
             return;
         }
@@ -268,8 +270,12 @@ export default class AvgRTPStatsReporter {
 
         this._avgBitrateUp.addNext(bitrate.upload);
         this._avgBitrateDown.addNext(bitrate.download);
-        this._avgBandwidthUp.addNext(bandwidth.upload);
-        this._avgBandwidthDown.addNext(bandwidth.download);
+
+        if (RTCBrowserType.supportsBandwidthStatistics()) {
+            this._avgBandwidthUp.addNext(bandwidth.upload);
+            this._avgBandwidthDown.addNext(bandwidth.download);
+        }
+
         this._avgPacketLossUp.addNext(packetLoss.upload);
         this._avgPacketLossDown.addNext(packetLoss.download);
         this._avgPacketLossTotal.addNext(packetLoss.total);
@@ -287,8 +293,10 @@ export default class AvgRTPStatsReporter {
         if (this._sampleIdx >= this._n) {
             this._avgBitrateUp.report(isP2P);
             this._avgBitrateDown.report(isP2P);
-            this._avgBandwidthUp.report(isP2P);
-            this._avgBandwidthDown.report(isP2P);
+            if (RTCBrowserType.supportsBandwidthStatistics()) {
+                this._avgBandwidthUp.report(isP2P);
+                this._avgBandwidthDown.report(isP2P);
+            }
             this._avgPacketLossUp.report(isP2P);
             this._avgPacketLossDown.report(isP2P);
             this._avgPacketLossTotal.report(isP2P);

--- a/modules/statistics/AvgRTPStatsReporter.js
+++ b/modules/statistics/AvgRTPStatsReporter.js
@@ -1,0 +1,371 @@
+/* global __filename */
+
+import { getLogger } from 'jitsi-meet-logger';
+import * as ConnectionQualityEvents
+    from '../../service/connectivity/ConnectionQualityEvents';
+import * as ConferenceEvents from '../../JitsiConferenceEvents';
+import Statistics from './statistics';
+
+const logger = getLogger(__filename);
+
+/**
+ * This will calculate an average for one, named stat and submit it to
+ * the analytics module when requested. It automatically counts the samples.
+ */
+class AverageStatReport {
+    /**
+     * Creates new <tt>AverageStatReport</tt> for given name.
+     * @param {string} name that's the name of the event that will be reported
+     * to the analytics module.
+     */
+    constructor(name) {
+        this.name = name;
+        this.count = 0;
+        this.sum = 0;
+    }
+
+    /**
+     * Adds the next value that will be included in the average when
+     * {@link calculate} is called.
+     * @param {number} nextValue
+     */
+    addNext(nextValue) {
+        if (typeof nextValue !== 'number') {
+            logger.error(
+                `${this.name} - invalid value for idx: ${this.count}`);
+
+            return;
+        }
+        this.sum += nextValue;
+        this.count += 1;
+    }
+
+    /**
+     * Calculates an average for the samples collected using {@link addNext}.
+     * @return {number|NaN} an average of all collected samples or <tt>NaN</tt>
+     * if no samples were collected.
+     */
+    calculate() {
+        return this.sum / this.count;
+    }
+
+    /**
+     * Calculates an average and submit the report to the analytics module.
+     * @param {boolean} isP2P indicates if the report is to be submitted for
+     * the P2P connection (when conference is currently in the P2P mode). This
+     * will add 'p2p.' prefix to the name of the event. All averages should be
+     * cleared when the conference switches, between P2P and JVB modes.
+     */
+    report(isP2P) {
+        Statistics.analytics.sendEvent(
+            `${isP2P ? 'p2p.' : ''}${this.name}`,
+            { value: this.calculate() });
+    }
+
+    /**
+     * Clears all memory of any samples collected, so that new average can be
+     * calculated using this instance.
+     */
+    reset() {
+        this.sum = 0;
+        this.count = 0;
+    }
+}
+
+/**
+ * Reports average RTP statistics values (arithmetic mean) to the analytics
+ * module for things like bit rate, bandwidth, packet loss etc. It keeps track
+ * of the P2P vs JVB conference modes and submits the values under different
+ * namespaces (the events for P2P mode have 'p2p.' prefix). Every switch between
+ * P2P mode resets the data collected so far and averages are calculated from
+ * scratch.
+ */
+export default class AvgRTPStatsReporter {
+    /**
+     * Creates new instance of <tt>AvgRTPStatsReporter</tt>
+     * @param {JitsiConference} conference
+     * @param {number} n the number of samples, before arithmetic mean is to be
+     * calculated and values submitted to the analytics module.
+     */
+    constructor(conference, n) {
+        /**
+         * How many {@link ConnectionQualityEvents.LOCAL_STATS_UPDATED} samples
+         * are to be included in arithmetic mean calculation.
+         * @type {number}
+         * @private
+         */
+        this._n = n;
+
+        if (n > 0) {
+            logger.info(`Avg RTP stats will be calculated every ${n} samples`);
+        } else {
+            logger.info('Avg RTP stats reports are disabled.');
+
+            // Do not initialize
+            return;
+        }
+
+        /**
+         * The current sample index. Starts from 0 and goes up to {@link _n})
+         * when analytics report will be submitted.
+         * @type {number}
+         * @private
+         */
+        this._sampleIdx = 0;
+
+        /**
+         * The conference for which stats will be collected and reported.
+         * @type {JitsiConference}
+         * @private
+         */
+        this._conference = conference;
+
+        /**
+         * Average upload bitrate
+         * @type {AverageStatReport}
+         * @private
+         */
+        this._avgBitrateUp = new AverageStatReport('stat.avg.bitrate.upload');
+
+        /**
+         * Average download bitrate
+         * @type {AverageStatReport}
+         * @private
+         */
+        this._avgBitrateDown
+            = new AverageStatReport('stat.avg.bitrate.download');
+
+        /**
+         * Average upload bandwidth
+         * @type {AverageStatReport}
+         * @private
+         */
+        this._avgBandwidthUp
+            = new AverageStatReport('stat.avg.bandwidth.upload');
+
+        /**
+         * Average download bandwidth
+         * @type {AverageStatReport}
+         * @private
+         */
+        this._avgBandwidthDown
+            = new AverageStatReport('stat.avg.bandwidth.download');
+
+        /**
+         * Average total packet loss
+         * @type {AverageStatReport}
+         * @private
+         */
+        this._avgPacketLossTotal
+            = new AverageStatReport('stat.avg.packetloss.total');
+
+        /**
+         * Average upload packet loss
+         * @type {AverageStatReport}
+         * @private
+         */
+        this._avgPacketLossUp
+            = new AverageStatReport('stat.avg.packetloss.upload');
+
+        /**
+         * Average download packet loss
+         * @type {AverageStatReport}
+         * @private
+         */
+        this._avgPacketLossDown
+            = new AverageStatReport('stat.avg.packetloss.download');
+
+        /**
+         * Average FPS for remote videos
+         * @type {AverageStatReport}
+         * @private
+         */
+        this._avgRemoteFPS = new AverageStatReport('stat.avg.framerate.remote');
+
+        /**
+         * Average FPS for local video
+         * @type {AverageStatReport}
+         * @private
+         */
+        this._avgLocalFPS = new AverageStatReport('stat.avg.framerate.local');
+
+        /**
+         * Average connection quality as defined by
+         * the {@link ConnectionQuality} module.
+         * @type {AverageStatReport}
+         * @private
+         */
+        this._avgCQ = new AverageStatReport('stat.avg.cq');
+
+        this._onLocalStatsUpdated = data => this._calculateAvgStats(data);
+        conference.on(
+            ConnectionQualityEvents.LOCAL_STATS_UPDATED,
+            this._onLocalStatsUpdated);
+
+        this._onP2PStatusChanged = () => {
+            logger.debug('Resetting average stats calculation');
+            this._resetAvgStats();
+        };
+        conference.on(
+            ConferenceEvents.P2P_STATUS,
+            this._onP2PStatusChanged);
+    }
+
+    /**
+     * Processes next batch of stats reported on
+     * {@link ConnectionQualityEvents.LOCAL_STATS_UPDATED}.
+     * @param {go figure} data
+     * @private
+     */
+    _calculateAvgStats(data) {
+
+        const isP2P = this._conference.isP2PActive();
+        const peerCount = this._conference.getParticipants().length;
+
+        if (!isP2P && peerCount < 2) {
+
+            // There's no point in collecting stats for a JVB conference of 1.
+            // That happens for short period of time after everyone leaves
+            // the room, until Jicofo terminates the session.
+            return;
+        }
+
+        /* Uncomment to figure out stats structure
+        for (const key in data) {
+            if (data.hasOwnProperty(key)) {
+                logger.info(`local stat ${key}: `, data[key]);
+            }
+        } */
+
+        if (!data) {
+            logger.error('No stats');
+
+            return;
+        }
+
+        const bitrate = data.bitrate;
+        const bandwidth = data.bandwidth;
+        const packetLoss = data.packetLoss;
+        const frameRate = data.framerate;
+
+        if (!bitrate) {
+            logger.error('No "bitrate"');
+
+            return;
+        } else if (!bandwidth) {
+            logger.error('No "bandwidth"');
+
+            return;
+        } else if (!packetLoss) {
+            logger.error('No "packetloss"');
+
+            return;
+        } else if (!frameRate) {
+            logger.error('No "framerate"');
+
+            return;
+        }
+
+        this._avgBitrateUp.addNext(bitrate.upload);
+        this._avgBitrateDown.addNext(bitrate.download);
+        this._avgBandwidthUp.addNext(bandwidth.upload);
+        this._avgBandwidthDown.addNext(bandwidth.download);
+        this._avgPacketLossUp.addNext(packetLoss.upload);
+        this._avgPacketLossDown.addNext(packetLoss.download);
+        this._avgPacketLossTotal.addNext(packetLoss.total);
+        this._avgCQ.addNext(data.connectionQuality);
+
+        if (frameRate) {
+            this._avgRemoteFPS.addNext(
+                this._calculateAvgVideoFps(frameRate, false /* remote */));
+            this._avgLocalFPS.addNext(
+                this._calculateAvgVideoFps(frameRate, true /* local */));
+        }
+
+        this._sampleIdx += 1;
+
+        if (this._sampleIdx >= this._n) {
+            this._avgBitrateUp.report(isP2P);
+            this._avgBitrateDown.report(isP2P);
+            this._avgBandwidthUp.report(isP2P);
+            this._avgBandwidthDown.report(isP2P);
+            this._avgPacketLossUp.report(isP2P);
+            this._avgPacketLossDown.report(isP2P);
+            this._avgPacketLossTotal.report(isP2P);
+            this._avgRemoteFPS.report(isP2P);
+            this._avgLocalFPS.report(isP2P);
+            this._avgCQ.report(isP2P);
+
+            this._resetAvgStats();
+        }
+    }
+
+    /**
+     * Calculates average FPS for the report
+     * @param {go figure} frameRate
+     * @param {boolean} isLocal if the average is to be calculated for the local
+     * video or <tt>false</tt> if for remote videos.
+     * @return {number|NaN} average FPS or <tt>NaN</tt> if there are no samples.
+     * @private
+     */
+    _calculateAvgVideoFps(frameRate, isLocal) {
+        let peerCount = 0;
+        let subFrameAvg = 0;
+        const myID = this._conference.myUserId();
+
+        for (const peerID of Object.keys(frameRate)) {
+            if (isLocal ? peerID === myID : peerID !== myID) {
+                const videos = frameRate[peerID];
+                const ssrcs = Object.keys(videos);
+
+                if (ssrcs.length) {
+                    let peerAvg = 0;
+
+                    for (const ssrc of ssrcs) {
+                        peerAvg += parseInt(videos[ssrc], 10);
+                    }
+
+                    peerAvg /= ssrcs.length;
+
+                    subFrameAvg += peerAvg;
+                    peerCount += 1;
+                }
+            }
+        }
+
+        return subFrameAvg / peerCount;
+    }
+
+    /**
+     * Reset cache of all averages and {@link _sampleIdx}.
+     * @private
+     */
+    _resetAvgStats() {
+        this._avgBitrateUp.reset();
+        this._avgBitrateDown.reset();
+        this._avgBandwidthUp.reset();
+        this._avgBandwidthDown.reset();
+        this._avgPacketLossUp.reset();
+        this._avgPacketLossDown.reset();
+        this._avgRemoteFPS.reset();
+        this._avgLocalFPS.reset();
+        this._avgCQ.reset();
+        this._sampleIdx = 0;
+    }
+
+    /**
+     * Unregisters all event listeners and stops working.
+     */
+    dispose() {
+        if (this._onP2PStatusChanged) {
+            this._conference.off(
+                ConferenceEvents.P2P_STATUS,
+                this._onP2PStatusChanged);
+        }
+        if (this._onLocalStatsUpdated) {
+            this._conference.off(
+                ConnectionQualityEvents.LOCAL_STATS_UPDATED,
+                this._onLocalStatsUpdated);
+        }
+    }
+}

--- a/modules/statistics/AvgRTPStatsReporter.js
+++ b/modules/statistics/AvgRTPStatsReporter.js
@@ -222,7 +222,7 @@ export default class AvgRTPStatsReporter {
         const isP2P = this._conference.isP2PActive();
         const peerCount = this._conference.getParticipants().length;
 
-        if (!isP2P && peerCount < 2) {
+        if (!isP2P && peerCount < 1) {
 
             // There's no point in collecting stats for a JVB conference of 1.
             // That happens for short period of time after everyone leaves

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -44,7 +44,8 @@ KEYS_BY_BROWSER_TYPE[RTCBrowserType.RTC_BROWSER_CHROME] = {
     'googFrameRateReceived': 'googFrameRateReceived',
     'googFrameRateSent': 'googFrameRateSent',
     'audioInputLevel': 'audioInputLevel',
-    'audioOutputLevel': 'audioOutputLevel'
+    'audioOutputLevel': 'audioOutputLevel',
+    'currentRoundTripTime': 'googRtt'
 };
 KEYS_BY_BROWSER_TYPE[RTCBrowserType.RTC_BROWSER_OPERA]
     = KEYS_BY_BROWSER_TYPE[RTCBrowserType.RTC_BROWSER_CHROME];
@@ -457,13 +458,14 @@ StatsCollector.prototype.processStatsReport = function() {
         } catch (e) { /* not supported*/ }
 
         if (now.type === 'googCandidatePair') {
-            let active, ip, localip, type;
+            let active, ip, localip, rtt, type;
 
             try {
                 ip = getStatValue(now, 'remoteAddress');
                 type = getStatValue(now, 'transportType');
                 localip = getStatValue(now, 'localAddress');
                 active = getStatValue(now, 'activeConnection');
+                rtt = getNonNegativeStat(now, 'currentRoundTripTime');
             } catch (e) { /* not supported*/ }
             if (!ip || !type || !localip || active !== 'true') {
                 continue;
@@ -481,7 +483,8 @@ StatsCollector.prototype.processStatsReport = function() {
                     ip,
                     type,
                     localip,
-                    p2p: this.peerconnection.isP2P
+                    p2p: this.peerconnection.isP2P,
+                    rtt
                 });
             }
             continue;


### PR DESCRIPTION
AvgRTPStatsReporter will calculate arithmetic means of 'n' samples
and submit the values to the analytics module. The 'n' value is
configurable through 'avgRtpStatsN' conference config option. When set
to non-positive value the AvgRTPStatsReporter will be disabled.

The following values are reported:
- average upload bitrate => 'stat.avg.bitrate.upload'
- average download bitrate => 'stat.avg.bitrate.download'
- average upload bandwidth => 'stat.avg.bandwidth.upload'
- average download bandwidth => 'stat.avg.bandwidth.download'
- average total packet loss => 'stat.avg.packetloss.total'
- average upload packet loss => 'stat.avg.packetloss.upload'
- average download packet loss => 'stat.avg.packetloss.download'
- average FPS for remote videos => 'stat.avg.framerate.remote'
- average FPS for local video => 'stat.avg.framerate.local'
- average connection quality as defined by
  the ConnectionQuality module => 'stat.avg.cq'

If the conference runs in P2P mode 'p2p.' prefix will be added to
the event's name. Any pending calculations are wiped out on every switch
between P2P and JVB modes and samples have to be collected from
the start.