### PR TITLE
make AGC and HPF constraints configurable

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -60,6 +60,12 @@ let disableAEC = false;
 // Disables Noise Suppression
 let disableNS = false;
 
+// Disables Automatic Gain Control
+let disableAGC = false;
+
+// Disables High Pass Filter
+let disableHPF = false;
+
 const featureDetectionAudioEl = document.createElement('audio');
 const isAudioOutputDeviceChangeAvailable
     = typeof featureDetectionAudioEl.setSinkId !== 'undefined';
@@ -255,12 +261,12 @@ function getConstraints(um, options) {
             // if it is good enough for hangouts...
             constraints.audio.optional.push(
                 { googEchoCancellation: !disableAEC },
-                { googAutoGainControl: true },
+                { googAutoGainControl: !disableAGC },
                 { googNoiseSupression: !disableNS },
-                { googHighpassFilter: true },
+                { googHighpassFilter: !disableHPF },
                 { googNoiseSuppression2: !disableNS },
                 { googEchoCancellation2: !disableAEC },
-                { googAutoGainControl2: true }
+                { googAutoGainControl2: !disableAGC }
             );
         }
     }
@@ -736,6 +742,14 @@ class RTCUtils extends Listenable {
         if (typeof options.disableNS === 'boolean') {
             disableNS = options.disableNS;
             logger.info(`Disable NS: ${disableNS}`);
+        }
+if (typeof options.disableAGC === 'boolean') {
+            disableAGC = options.disableAGC;
+            logger.info(`Disable AGC: ${disableAGC}`);
+        }
+if (typeof options.disableHPF === 'boolean') {
+            disableHPF = options.disableHPF;
+            logger.info(`Disable HPF: ${disableHPF}`);
         }
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
Extend configurable audio constraints to Automatic Gain Control and High Pass Filter.  AGC misbehaves with certain 'pre-gained' mics and other constraints diminish quality in fullband, non-speech applications.