### PR TITLE
feat(JSPC): ICE establishment time

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -352,7 +352,7 @@ export default class JingleSessionPC extends JingleSession {
 
                     eventName += this.isInitiator ? 'initiator.' : 'responder.';
                     Statistics.analytics.sendEvent(
-                        `${eventName}checkDuration`,
+                        `${eventName}checksDuration`,
                         {
                             value: now - this._iceCheckingStartedTimestamp
                         });
@@ -361,10 +361,9 @@ export default class JingleSessionPC extends JingleSession {
                     // started first (scenarios are different for initiator
                     // vs responder)
                     const iceStarted
-                        = this._gatheringStartedTimestamp
-                            < this._iceCheckingStartedTimestamp
-                                ? this._gatheringStartedTimestamp
-                                : this._iceCheckingStartedTimestamp;
+                        = Math.min(
+                            this._iceCheckingStartedTimestamp,
+                            this._gatheringStartedTimestamp);
 
                     Statistics.analytics.sendEvent(
                         `${eventName}establishmentDuration`,

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -351,11 +351,25 @@ export default class JingleSessionPC extends JingleSession {
                     let eventName = this.isP2P ? 'p2p.ice.' : 'ice.';
 
                     eventName += this.isInitiator ? 'initiator.' : 'responder.';
-                    eventName += 'checksDuration';
                     Statistics.analytics.sendEvent(
-                        eventName,
+                        `${eventName}checkDuration`,
                         {
                             value: now - this._iceCheckingStartedTimestamp
+                        });
+
+                    // Switch between ICE gathering and ICE checking whichever
+                    // started first (scenarios are different for initiator
+                    // vs responder)
+                    const iceStarted
+                        = this._gatheringStartedTimestamp
+                            < this._iceCheckingStartedTimestamp
+                                ? this._gatheringStartedTimestamp
+                                : this._iceCheckingStartedTimestamp;
+
+                    Statistics.analytics.sendEvent(
+                        `${eventName}establishmentDuration`,
+                        {
+                            value: now - iceStarted
                         });
                     this.wasConnected = true;
                     this.room.eventEmitter.emit(


### PR DESCRIPTION
Will report total ICE establishment time under
'ice.initiator.establishmentDuration' and
'ice.responder.establishmentDuration' ('p2p.' prefix added for P2P).
It's the amount of time between the time when either checking or
gathering started (whichever starts first) and when ICE entered
'connected' for the first time.