### PR TITLE
Allow override of the infrastructure level channel LastN value.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -52,6 +52,9 @@ const logger = getLogger(__filename);
  * @param {number} [options.config.backToP2PDelay=5] a delay given in seconds,
  * before the conference switches back to P2P, after the 3rd participant has
  * left the room.
+ * @param {number} [options.config.channelLastN=-1] The requested amount of
+ * videos are going to be delivered after the value is in effect. Set to -1 for
+ * unlimited or all available videos.
  * @constructor
  *
  * FIXME Make all methods which are called from lib-internal classes
@@ -247,6 +250,10 @@ JitsiConference.prototype._init = function(options = {}) {
             this,
             () =>
                 this.eventEmitter.emit(JitsiConferenceEvents.TALK_WHILE_MUTED));
+    }
+
+    if ('channelLastN' in options.config) {
+        this.setLastN(options.config.channelLastN);
     }
 };
 

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -181,7 +181,7 @@ JitsiConference.prototype.constructor = JitsiConference;
  * @param options.connection {JitsiConnection} overrides this.connection
  */
 JitsiConference.prototype._init = function(options = {}) {
-    // Override connection and xmpp properties (Usefull if the connection
+    // Override connection and xmpp properties (Useful if the connection
     // reloaded)
     if (options.connection) {
         this.connection = options.connection;


### PR DESCRIPTION
For debugging purposes, it's sometimes useful to override the
infrastructure level channel LastN value via the URL (i.e. by launching
https://meet.example.org/room#config.channelLastN=X). This commit
achieves this by calling the JitsiConference.setLastN method during the
Jitsi conference initialization phase.
