### PR TITLE
remove jitsiRegionInfo from lib-jitsi-meet

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1308,8 +1308,10 @@ JitsiConference.prototype.onIncomingCall
     // add info whether call is cross-region
     let crossRegion = null;
 
-    if (window.jitsiAnalyticsPermanentProperties) {
-        crossRegion = window.jitsiAnalyticsPermanentProperties.CrossRegion;
+    // TODO: remove deprecated cross region property from this specific event
+    // once all existing deployments include analytics changes
+    if (window.jitsiDeploymentInfo) {
+        crossRegion = window.jitsiDeploymentInfo.CrossRegion;
     }
     Statistics.analytics.sendEvent(
         'session.initiate', {

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1308,8 +1308,8 @@ JitsiConference.prototype.onIncomingCall
     // add info whether call is cross-region
     let crossRegion = null;
 
-    if (window.jitsiRegionInfo) {
-        crossRegion = window.jitsiRegionInfo.CrossRegion;
+    if (window.jitsiAnalyticsPermanentProperties) {
+        crossRegion = window.jitsiAnalyticsPermanentProperties.CrossRegion;
     }
     Statistics.analytics.sendEvent(
         'session.initiate', {

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -129,13 +129,14 @@ export default {
         }
 
         // Log deployment-specific information, if available.
-        if (window.jitsiAnalyticsPermanentProperties
-            && Object.keys(window.jitsiAnalyticsPermanentProperties).length > 0) {
+        const aprops = window.jitsiAnalyticsPermanentProperties;
+
+        if (aprops && Object.keys(aprops).length > 0) {
             const logObject = {};
 
-            for (const attr in window.jitsiAnalyticsPermanentProperties) {
-                if (window.jitsiAnalyticsPermanentProperties.hasOwnProperty(attr)) {
-                    logObject[attr] = window.jitsiAnalyticsPermanentProperties[attr];
+            for (const attr in aprops) {
+                if (aprops.hasOwnProperty(attr)) {
+                    logObject[attr] = aprops[attr];
                 }
             }
 

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -129,13 +129,13 @@ export default {
         }
 
         // Log deployment-specific information, if available.
-        if (window.jitsiRegionInfo
-            && Object.keys(window.jitsiRegionInfo).length > 0) {
+        if (window.jitsiAnalyticsPermanentProperties
+            && Object.keys(window.jitsiAnalyticsPermanentProperties).length > 0) {
             const logObject = {};
 
-            for (const attr in window.jitsiRegionInfo) {
-                if (window.jitsiRegionInfo.hasOwnProperty(attr)) {
-                    logObject[attr] = window.jitsiRegionInfo[attr];
+            for (const attr in window.jitsiAnalyticsPermanentProperties) {
+                if (window.jitsiAnalyticsPermanentProperties.hasOwnProperty(attr)) {
+                    logObject[attr] = window.jitsiAnalyticsPermanentProperties[attr];
                 }
             }
 

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -129,7 +129,8 @@ export default {
         }
 
         // Log deployment-specific information, if available.
-        const aprops = window.jitsiAnalyticsPermanentProperties;
+        // Defined outside the application by individual deployments
+        const aprops = window.jitsiDeploymentInfo;
 
         if (aprops && Object.keys(aprops).length > 0) {
             const logObject = {};

--- a/connection_optimization/external_connect.js
+++ b/connection_optimization/external_connect.js
@@ -41,16 +41,6 @@ function createConnectionExternally( // eslint-disable-line no-unused-vars
             if (xhttp.status == HTTP_STATUS_OK) {
                 try {
                     var data = JSON.parse(xhttp.responseText);
-
-                    var proxyRegion = xhttp.getResponseHeader('X-Proxy-Region');
-                    var jitsiRegion = xhttp.getResponseHeader('X-Jitsi-Region');
-                    window.jitsiRegionInfo = {
-                        'ProxyRegion' : proxyRegion,
-                        'Region' : jitsiRegion,
-                        'Shard' : xhttp.getResponseHeader('X-Jitsi-Shard'),
-                        'CrossRegion': proxyRegion !== jitsiRegion ? 1 : 0
-                    };
-
                     successCallback(data);
                 } catch (e) {
                     error_callback(e);


### PR DESCRIPTION
Use new global property window.jitsiAnalyticsPermanentProperties to report deployment-specific properties
no longer need to set jitsiRegionInfo from external_connect, instead rely on new global property from Jitsi meet local.html, can be customized by deployment