### PR TITLE
Fix OverconstrainedError handling in Firefox

### DIFF
--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -88,7 +88,7 @@ function JitsiTrackError(error, options, devices) {
             break;
         case 'ConstraintNotSatisfiedError':
         case 'OverconstrainedError': {
-            const constraintName = error.constraintName;
+            const constraintName = error.constraintName || error.constraint;
 
             if (options
                     && options.video


### PR DESCRIPTION
Firefox uses "constraint" as the key in the error:

```
[modules/RTC/RTCUtils.js] <value/<>:  Failed to get access to local media. Error
MediaStreamError { name: "OverconstrainedError", message: "Constraints could be
not satisfied.", constraint: "width", stack: "" } Object { audio: false, video:
Object }  lib-jitsi-meet.min.js:6:10419
```