### PR TITLE
fix(permission-prompt): increase timeout for displaying permission pr…

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -33,7 +33,7 @@ const logger = Logger.getLogger(__filename);
 
 // The amount of time to wait until firing
 // JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN event
-const USER_MEDIA_PERMISSION_PROMPT_TIMEOUT = 500;
+const USER_MEDIA_PERMISSION_PROMPT_TIMEOUT = 1000;
 
 /**
  *


### PR DESCRIPTION
…ompt

Firefox's getUserMedia can take longer than 500ms to complete. This
causes the permission prompt timeout to fire even if the user has
given permission to audio and video. There may not be a reliable
way right now to check if the user has given permission to both
audio and video so dumbly increase the timeout instead.

@hristoterezov, I increased the timeout to 1000ms... I don't even think this
is reliable enough. Let's give this a couple days and maybe a better answer
will come up. Maybe even increase the timeout just for firefox?