### PR TITLE
ref(JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED): reorder args

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -616,11 +616,11 @@ JitsiConference.prototype.addTrack = function(track) {
 
 /**
  * Fires TRACK_AUDIO_LEVEL_CHANGED change conference event (for local tracks).
- * @param {TraceablePeerConnection|null} tpc
- * @param audioLevel the audio level
+ * @param {number} audioLevel the audio level
+ * @param {TraceablePeerConnection} [tpc]
  */
 JitsiConference.prototype._fireAudioLevelChangeEvent
-= function(tpc, audioLevel) {
+= function(audioLevel, tpc) {
     const activeTpc = this.getActivePeerConnection();
 
     // There will be no TraceablePeerConnection if audio levels do not come from
@@ -628,7 +628,7 @@ JitsiConference.prototype._fireAudioLevelChangeEvent
     // Audio Analyser API and emits local audio levels events through
     // JitsiTrack.setAudioLevel, but does not provide TPC instance which is
     // optional.
-    if (tpc === null || activeTpc === tpc) {
+    if (!tpc || activeTpc === tpc) {
         this.eventEmitter.emit(
             JitsiConferenceEvents.TRACK_AUDIO_LEVEL_CHANGED,
             this.myUserId(), audioLevel);
@@ -1184,7 +1184,7 @@ JitsiConference.prototype.onRemoteTrackAdded = function(track) {
         () => emitter.emit(JitsiConferenceEvents.TRACK_MUTE_CHANGED, track));
     track.addEventListener(
         JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED,
-        (tpc, audioLevel) => {
+        (audioLevel, tpc) => {
             const activeTPC = this.getActivePeerConnection();
 
             if (activeTPC === tpc) {

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -275,8 +275,7 @@ export default {
 
                         if (track.getType() === MediaType.AUDIO) {
                             Statistics.startLocalStats(mStream,
-                                track.setAudioLevel.bind(
-                                    track, null /* no TPC */));
+                                track.setAudioLevel.bind(track));
                             track.addEventListener(
                                 JitsiTrackEvents.LOCAL_TRACK_STOPPED,
                                 () => {

--- a/JitsiTrackEvents.js
+++ b/JitsiTrackEvents.js
@@ -5,6 +5,15 @@ export const LOCAL_TRACK_STOPPED = 'track.stopped';
 
 /**
  * Audio levels of a this track was changed.
+ * The first argument is a number with audio level value in range [0, 1].
+ * The second argument is a <tt>TraceablePeerConnection</tt> which is the peer
+ * connection which measured the audio level (one audio track can be added
+ * to multiple peer connection at the same time). This argument is optional for
+ * local tracks for which we can measure audio level without the peer
+ * connection (the value will be <tt>undefined</tt>).
+ *
+ * NOTE The second argument should be treated as library internal and can be
+ * removed at any time.
  */
 export const TRACK_AUDIO_LEVEL_CHANGED = 'track.audioLevelsChanged';
 

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -381,19 +381,19 @@ JitsiTrack.prototype.removeEventListener = JitsiTrack.prototype.off;
 
 /**
  * Sets the audio level for the stream
- * @param {TraceablePeerConnection|null} tpc the peerconnection instance which
- * is source for the audio level. It can be <tt>null</tt> for a local track if
- * the audio level was measured outside of the peerconnection
- * (see /modules/statistics/LocalStatsCollector.js).
  * @param {number} audioLevel value between 0 and 1
+ * @param {TraceablePeerConnection} [tpc] the peerconnection instance which
+ * is source for the audio level. It can be <tt>undefined</tt> for
+ * a local track if the audio level was measured outside of the peerconnection
+ * (see /modules/statistics/LocalStatsCollector.js).
  */
-JitsiTrack.prototype.setAudioLevel = function(tpc, audioLevel) {
+JitsiTrack.prototype.setAudioLevel = function(audioLevel, tpc) {
     if (this.audioLevel !== audioLevel) {
         this.audioLevel = audioLevel;
         this.eventEmitter.emit(
             JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED,
-            tpc,
-            audioLevel);
+            audioLevel,
+            tpc);
     }
 };
 

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -698,7 +698,7 @@ export default class RTC extends Listenable {
                 `${track} was expected to ${isLocal ? 'be' : 'not be'} local`);
         }
 
-        track.setAudioLevel(tpc, audioLevel);
+        track.setAudioLevel(audioLevel, tpc);
     }
 
     /* eslint-enable max-params */


### PR DESCRIPTION
Reorders JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED event arguments by
putting TraceablePeerConnection at the end. This way it's easier to
treat it as "library internal".