### PR TITLE
Modifying room password protection

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1018,9 +1018,9 @@ export default class ChatRoom extends Listenable {
                         .up();
                     formsubmit
                         .c('field',
-                             {'var':'muc#roomconfig_passwordprotectedroom'})
+                             { 'var': 'muc#roomconfig_passwordprotectedroom' })
                         .c('value')
-                        .t(key === null || key.length === 0?'0':'1')
+                        .t(key === null || key.length === 0 ? '0' : '1')
                         .up()
                         .up();
 

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1016,6 +1016,12 @@ export default class ChatRoom extends Listenable {
                         .t(key)
                         .up()
                         .up();
+                    formsubmit
+                        .c('field', { 'var': 'muc#roomconfig_passwordprotectedroom' })
+                        .c('value')
+                        .t( (key == null || key.length === 0) ? '0' : '1' )
+                        .up()
+                        .up();
 
                     // Fixes a bug in prosody 0.9.+
                     // https://prosody.im/issues/issue/373
@@ -1026,7 +1032,6 @@ export default class ChatRoom extends Listenable {
                         .up()
                         .up();
 
-                    // FIXME: is muc#roomconfig_passwordprotectedroom required?
                     this.connection.sendIQ(formsubmit, onSuccess, onError);
                 } else {
                     onNotSupported();

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1019,7 +1019,7 @@ export default class ChatRoom extends Listenable {
                     formsubmit
                         .c('field', { 'var': 'muc#roomconfig_passwordprotectedroom' })
                         .c('value')
-                        .t( (key == null || key.length === 0) ? '0' : '1' )
+                        .t( (key === null || key.length === 0) ? '0' : '1' )
                         .up()
                         .up();
 

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1017,9 +1017,10 @@ export default class ChatRoom extends Listenable {
                         .up()
                         .up();
                     formsubmit
-                        .c('field', { 'var': 'muc#roomconfig_passwordprotectedroom' })
+                        .c('field',
+                             {'var':'muc#roomconfig_passwordprotectedroom'})
                         .c('value')
-                        .t( (key === null || key.length === 0) ? '0' : '1' )
+                        .t(key === null || key.length === 0?'0':'1')
                         .up()
                         .up();
 

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1018,7 +1018,7 @@ export default class ChatRoom extends Listenable {
                         .up();
 
                     // Fixes a bug in prosody 0.9.+
-                    // https://code.google.com/p/lxmppd/issues/detail?id=373
+                    // https://prosody.im/issues/issue/373
                     formsubmit
                         .c('field', { 'var': 'muc#roomconfig_whois' })
                         .c('value')


### PR DESCRIPTION
When modifying the room protection (setting or unsetting a password), the `muc#roomconfig_passwordprotectedroom` field should always be defined. This fixes issue #512.

