### PR TITLE
P2P video track added later

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1958,8 +1958,6 @@ JitsiConference.prototype._onIceConnectionRestored = function(session) {
  */
 JitsiConference.prototype._acceptP2PIncomingCall
 = function(jingleSession, jingleOffer) {
-    jingleSession.setSSRCOwnerJid(this.room.myroomjid);
-
     this.isP2PConnectionInterrupted = false;
 
     // Accept the offer
@@ -2222,8 +2220,6 @@ JitsiConference.prototype._startP2PSession = function(peerJid) {
         = this.xmpp.connection.jingle.newP2PJingleSession(
                 this.room.myroomjid,
                 peerJid);
-    this.p2pJingleSession.setSSRCOwnerJid(this.room.myroomjid);
-
     logger.info('Created new P2P JingleSession', this.room.myroomjid, peerJid);
 
     this.p2pJingleSession.initialize(true /* initiator */, this.room, this.rtc);


### PR DESCRIPTION
The P2P will break and never receive video in case a video track is not added, before the initial offer/answer. That's because we'll sent the media direction as recvonly and it is never updated on the remote side after initial offer/answer. We need to always advertise 'sendrecv' through Jingle. This used to work fine in JVB connection, because it's Jicofo that creates the offer and the media direction is always 'sendrecv'.

Also simplifies signalling for SSRC ownership in P2P where we can always assume that the remote peer owns all SSRCs. Without the fix P2P connection will fail to process 'source-add' notifications.