### PR TITLE
fix: Check for undefined before accessing config.p2p

### DIFF
--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -357,11 +357,13 @@ class JingleConnectionPlugin extends ConnectionPlugin {
                     }
                 });
 
-                if (this.xmpp.options.useStunTurn) {
+                const options = this.xmpp.options;
+
+                if (options.useStunTurn) {
                     this.jvbIceConfig.iceServers = iceservers;
                 }
 
-                if (this.xmpp.options.p2p.useStunTurn) {
+                if (options.p2p && options.p2p.useStunTurn) {
                     this.p2pIceConfig.iceServers = iceservers;
                 }
 

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -133,7 +133,8 @@ export default class XMPP extends Listenable {
             now);
         if (status === Strophe.Status.CONNECTED
             || status === Strophe.Status.ATTACHED) {
-            if (this.options.useStunTurn || this.options.p2p.useStunTurn) {
+            if (this.options.useStunTurn
+                || (this.options.p2p && this.options.p2p.useStunTurn)) {
                 this.connection.jingle.getStunAndTurnCredentials();
             }
 


### PR DESCRIPTION
Old config.js versions don't have the p2p property.