### PR TITLE
fix(JitsiConf...): stop P2P on JVB121

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2104,12 +2104,8 @@ JitsiConference.prototype._onIceConnectionEstablished
         && typeof forceJVB121Ratio === 'number'
         && Math.random() < forceJVB121Ratio) {
         logger.info(`Forcing JVB 121 mode (ratio=${forceJVB121Ratio})...`);
-        this._rejectIncomingCall(
-            jingleSession, {
-                reasonTag: 'decline',
-                reasonMsg: 'force JVB121'
-            });
         Statistics.analytics.addPermanentProperties({ forceJvb121: true });
+        this._stopP2PSession('decline', 'force JVB121');
 
         return;
     }


### PR DESCRIPTION
The P2P session must be stopped with '_stopP2PSession' once accepted.

Fixes the problem with CallStats not being disposed when in 'forced JVB 121' mode.