### PR TITLE
Allows unavailable presences to contain a ignore tag.

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -618,6 +618,11 @@ export default class ChatRoom extends Listenable {
      * @param from
      */
     onPresenceUnavailable(pres, from) {
+        // ignore presence
+        if ($(pres).find('>ignore[xmlns="http://jitsi.org/jitmeet/"]').length) {
+            return true;
+        }
+
         // room destroyed ?
         if ($(pres).find('>x[xmlns="http://jabber.org/protocol/muc#user"]'
             + '>destroy').length) {


### PR DESCRIPTION
If we detect a custom <ignore tag in presence unavailable we ignore those presences and do not process them.