### PR TITLE
firefox 54 crashes if we insert the rid simulcast receive lines in th…

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1663,10 +1663,12 @@ TraceablePeerConnection.prototype.setRemoteDescription
                 'setRemoteDescription::postTransform (Plan A)',
                 dumpSDP(description));
 
-        // eslint-disable-next-line no-param-reassign
-        description = this._insertUnifiedPlanSimulcastReceive(description);
-        this.trace('setRemoteDescription::postTransform (sim receive)',
-            dumpSDP(description));
+        if (this.isSimulcastOn()) {
+            // eslint-disable-next-line no-param-reassign
+            description = this._insertUnifiedPlanSimulcastReceive(description);
+            this.trace('setRemoteDescription::postTransform (sim receive)',
+                dumpSDP(description));
+        }
     } else {
         // Plan B
         // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
…e remote description, so only do that if simulcast is turned on (which is still experimental for firefox and not enabled by default)