### PR TITLE
fix: never miss 'ondatachannel' event

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -150,12 +150,6 @@ export default class JingleSessionPC extends JingleSession {
          */
         this._gatheringReported = false;
 
-        /**
-         * WebSocket URL for the bridge channel with the videobridge.
-         * @type {string}
-         */
-        this.bridgeWebSocketUrl = null;
-
         this.lasticecandidate = false;
         this.closed = false;
 
@@ -676,22 +670,6 @@ export default class JingleSessionPC extends JingleSession {
                     });
             }
         });
-    }
-
-    /**
-     * Reads the "url" parameter in the <web-socket> tag of the jingle offer iq
-     * and stores it into this.bridgeWebSocketUrl.
-     * @param contets
-     */
-    readBridgeWebSocketUrl(contents) {
-        const webSocket
-            = $(contents)
-                .find('transport>web-socket')
-                .first();
-
-        if (webSocket.length === 1) {
-            this.bridgeWebSocketUrl = webSocket[0].getAttribute('url');
-        }
     }
 
     /**
@@ -1417,7 +1395,6 @@ export default class JingleSessionPC extends JingleSession {
 
         remoteSdp.fromJingle(offerIq);
         this.readSsrcInfo($(offerIq).find('>content'));
-        this.readBridgeWebSocketUrl($(offerIq).find('>content'));
 
         return remoteSdp;
     }


### PR DESCRIPTION
The 'ondatachannel' even listener must be set as soon as
the TraceablePeerConnection is created and before the offer is accepted.
We've observed situations where the ondatachannel event was missed,
because the listener is bound too late from the JingleSessionPC
'acceptOffer' success callback.