### PR TITLE
feat(JitsiLocalTrack): make mute/unmute more resilient

### DIFF
--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -32,8 +32,6 @@ TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.TRACK_IS_DISPOSED]
     = 'Track has been already disposed';
 TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.TRACK_NO_STREAM_FOUND]
     = 'Track does not have an associated Media Stream';
-TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.TRACK_MUTE_UNMUTE_IN_PROGRESS]
-    = 'Track mute/unmute process is currently in progress';
 TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.NO_DATA_FROM_SOURCE]
     = 'The track has stopped receiving data from it\'s source';
 

--- a/JitsiTrackErrors.js
+++ b/JitsiTrackErrors.js
@@ -81,12 +81,6 @@ export const PERMISSION_DENIED = 'gum.permission_denied';
 export const TRACK_IS_DISPOSED = 'track.track_is_disposed';
 
 /**
- * An error which indicates that track is currently in progress of muting or
- * unmuting itself.
- */
-export const TRACK_MUTE_UNMUTE_IN_PROGRESS = 'track.mute_unmute_inprogress';
-
-/**
  * An error which indicates that track has no MediaStream associated.
  */
 export const TRACK_NO_STREAM_FOUND = 'track.no_stream_found';

--- a/doc/API.md
+++ b/doc/API.md
@@ -175,7 +175,6 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
         - CONSTRAINT_FAILED - getUserMedia-related error, indicates that some of requested constraints in getUserMedia call were not satisfied.
         - TRACK_IS_DISPOSED - an error which indicates that track has been already disposed and cannot be longer used.
         - TRACK_NO_STREAM_FOUND - an error which indicates that track has no MediaStream associated.
-        - TRACK_MUTE_UNMUTE_IN_PROGRESS - an error which indicates that track is currently in progress of muting or unmuting itself.
         - CHROME_EXTENSION_GENERIC_ERROR - generic error for jidesha extension for Chrome.
         - CHROME_EXTENSION_USER_CANCELED - an error which indicates that user canceled screen sharing window selection dialog in jidesha extension for Chrome.
         - CHROME_EXTENSION_INSTALLATION_ERROR - an error which indicates that the jidesha extension for Chrome is failed to install.


### PR DESCRIPTION
Instead of failing with an error if another operation is in progress, which is
impossible to know as a user, chain them using the primises API.