### PR TITLE
[RN] Do not mandate window.location

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -289,21 +289,29 @@ export default class XMPP extends Listenable {
             password
         };
         if (!jid) {
-            let configDomain
-                = this.options.hosts.anonymousdomain
-                    || this.options.hosts.domain;
+            const { anonymousdomain, domain } = this.options.hosts;
+            let configDomain = anonymousdomain || domain;
 
             // Force authenticated domain if room is appended with '?login=true'
             // or if we're joining with the token
 
-            if (this.options.hosts.anonymousdomain
-                    && (window.location.search.indexOf('login=true') !== -1
-                        || this.token)) {
-                configDomain = this.options.hosts.domain;
+            // FIXME Do not rely on window.location because (1) React Native
+            // does not have a window.location by default and (2) here we cannot
+            // know for sure that query/search has not be stripped from
+            // window.location by the time the following executes.
+            const windowLocation = window.location;
+
+            if (anonymousdomain) {
+                const search = windowLocation && windowLocation.search;
+
+                if ((search && search.indexOf('login=true') !== -1)
+                        || this.token) {
+                    configDomain = domain;
+                }
             }
 
             // eslint-disable-next-line no-param-reassign
-            jid = configDomain || window.location.hostname;
+            jid = configDomain || (windowLocation && windowLocation.hostname);
         }
 
         return this._connect(jid, password);


### PR DESCRIPTION
1. Leave a `FIXME` in the source code that states that `window.location` and `window.location.search` are not good because (1) React Native does not have a window.location by default and (2) query/search cannot possibly be guaranteed given that we strip it for the purposes of display.

2. Anyway, do not throw for now if `window.location` or `window.location.search` doesn't exist.