### PR TITLE
Fix local video disappearing from local thumbnail

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -128,6 +128,13 @@ export default class JitsiLocalTrack extends JitsiTrack {
         this._realDeviceId = this.deviceId === '' ? undefined : this.deviceId;
 
         /**
+         * Set to <tt>true</tt> when there's ongoing "mute/unmute" operation in
+         * progress. Used by {@link LocalSdpMunger}.
+         * @type {boolean}
+         */
+        this.inMuteOrUnmuteProgress = true;
+
+        /**
          * Indicates that we have called RTCUtils.stopMediaStream for the
          * MediaStream related to this JitsiTrack object.
          */
@@ -334,6 +341,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
 
         let promise = Promise.resolve();
 
+        this.inMuteOrUnmuteProgress = true;
         this.dontFireRemoveEvent = false;
 
         // A function that will print info about muted status transition
@@ -406,6 +414,13 @@ export default class JitsiLocalTrack extends JitsiTrack {
 
         return promise
             .then(() => this._sendMuteStatus(mute))
+            .then(() => {
+                this.inMuteOrUnmuteProgress = false;
+            }, error => {
+                this.inMuteOrUnmuteProgress = false;
+
+                throw error;
+            })
             .then(() => {
                 this.emit(JitsiTrackEvents.TRACK_MUTE_CHANGED, this);
             });

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -350,7 +350,6 @@ export default class JitsiLocalTrack extends JitsiTrack {
                 this.track.enabled = !mute;
             }
         } else if (mute) {
-            this.dontFireRemoveEvent = true;
             promise = new Promise((resolve, reject) => {
                 logMuteInfo();
                 this._removeStreamFromConferenceAsMute(() => {

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -56,10 +56,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
             stream,
             track,
             () => {
-                if (!this.dontFireRemoveEvent) {
-                    this.emit(JitsiTrackEvents.LOCAL_TRACK_STOPPED);
-                }
-                this.dontFireRemoveEvent = false;
+                this.emit(JitsiTrackEvents.LOCAL_TRACK_STOPPED);
             } /* inactiveHandler */,
             mediaType,
             videoType);
@@ -69,7 +66,6 @@ export default class JitsiLocalTrack extends JitsiTrack {
          * @type {number}
          */
         this.rtcId = rtcId;
-        this.dontFireRemoveEvent = false;
         this.resolution = resolution;
         this.sourceId = sourceId;
         this.sourceType = sourceType;
@@ -342,7 +338,6 @@ export default class JitsiLocalTrack extends JitsiTrack {
         let promise = Promise.resolve();
 
         this.inMuteOrUnmuteProgress = true;
-        this.dontFireRemoveEvent = false;
 
         // A function that will print info about muted status transition
         const logMuteInfo = () => logger.info(`Mute ${this}: ${mute}`);
@@ -361,6 +356,8 @@ export default class JitsiLocalTrack extends JitsiTrack {
                 this._removeStreamFromConferenceAsMute(() => {
                     // FIXME: Maybe here we should set the SRC for the
                     // containers to something
+                    // We don't want any events to be fired on this stream
+                    this._unregisterHandlers();
                     this._stopMediaStream();
                     this._setStream(null);
                     resolve();

--- a/modules/RTC/LocalSdpMunger.js
+++ b/modules/RTC/LocalSdpMunger.js
@@ -65,19 +65,17 @@ export default class LocalSdpMunger {
         let modified = false;
 
         for (const videoTrack of localVideos) {
-            const isMuted = videoTrack.isMuted();
-            const muteInProgress = videoTrack.inMuteOrUnmuteProgress;
-            const shouldFakeSdp = isMuted || muteInProgress;
+            const muted = videoTrack.isMuted();
+            const { setMutedInProgress } = videoTrack;
+            const shouldFakeSdp = muted || setMutedInProgress;
 
             logger.debug(
-                `${this.tpc} ${videoTrack
-                 } isMuted: ${isMuted
-                 }, is mute in progress: ${muteInProgress
-                 } => should fake sdp ? : ${shouldFakeSdp}`);
+                `${this.tpc} ${videoTrack} muted: ${muted
+                    }, is mute/unmute in progress: ${setMutedInProgress
+                    } => should fake sdp ? : ${shouldFakeSdp}`);
 
             if (!shouldFakeSdp) {
-                // eslint-disable-next-line no-continue
-                continue;
+                continue; // eslint-disable-line no-continue
             }
 
             // Inject removed SSRCs
@@ -90,8 +88,7 @@ export default class LocalSdpMunger {
                 logger.error(
                     `No SSRCs stored for: ${videoTrack} in ${this.tpc}`);
 
-                // eslint-disable-next-line no-continue
-                continue;
+                continue; // eslint-disable-line no-continue
             }
 
             modified = true;
@@ -99,18 +96,16 @@ export default class LocalSdpMunger {
             // We need to fake sendrecv.
             // NOTE the SDP produced here goes only to Jicofo and is never set
             // as localDescription. That's why
-            // {@link TraceablePeerConnection.mediaTransferActive} is ignored
-            // here.
+            // TraceablePeerConnection.mediaTransferActive is ignored here.
             videoMLine.direction = 'sendrecv';
 
             // Check if the recvonly has MSID
             const primarySSRC = requiredSSRCs[0];
 
-            // FIXME the cname could come from the stream, but may
-            // turn out to be too complex. It is fine to come up
-            // with any value, as long as we only care about
-            // the actual SSRC values when deciding whether or not
-            // an update should be sent
+            // FIXME The cname could come from the stream, but may turn out to
+            // be too complex. It is fine to come up with any value, as long as
+            // we only care about the actual SSRC values when deciding whether
+            // or not an update should be sent.
             const primaryCname = `injected-${primarySSRC}`;
 
             for (const ssrcNum of requiredSSRCs) {
@@ -119,8 +114,8 @@ export default class LocalSdpMunger {
 
                 // Inject
                 logger.debug(
-                    `${this.tpc} injecting video SSRC: `
-                        + `${ssrcNum} for ${videoTrack}`);
+                    `${this.tpc} injecting video SSRC: ${ssrcNum} for ${
+                        videoTrack}`);
                 videoMLine.addSSRCAttribute({
                     id: ssrcNum,
                     attribute: 'cname',


### PR DESCRIPTION
Local video was being detached when rapidly muting/unmuting, because of the "track ended" event being fired and that was not handled correctly.