### PR TITLE
Add check for iOS WebViews in screen sharing adapter

### DIFF
--- a/modules/RTC/adapter.screenshare.js
+++ b/modules/RTC/adapter.screenshare.js
@@ -373,6 +373,16 @@ AdapterJS.parseWebrtcDetectedBrowser = function () {
     webrtcDetectedType      = isMobile.length === 0 ? 'plugin' : null;
     webrtcDetectedDCSupport = isMobile.length === 0 ? 'SCTP' : null;
 
+  // Detect WebView on iOS (does not support WebRTC yet)
+  } else if (/(iPhone|iPod|iPad).*AppleWebKit(?!.*Safari)/i.test(navigator.userAgent)) {
+    hasMatch = navigator.userAgent.match(/AppleWebKit\/([0-9]+)\./) || [];
+
+    webrtcDetectedBrowser   = 'safari';
+    webrtcDetectedVersion   = parseInt(hasMatch[1] || '0', 10);
+    webrtcMinimumVersion    = 0;
+    webrtcDetectedType      = null;
+    webrtcDetectedDCSupport = null;
+
   }
 
   window.webrtcDetectedBrowser   = webrtcDetectedBrowser;


### PR DESCRIPTION
Loading lib-jitsi-meet on an iOS WebView (UIWebView & WKWebView) currently fails due to its user agent string not matching any of the existing checks. This causes the script to fail due to undefined `webrtcDetected...` variables.

This adds a check for those webviews and sets detection variables similar to Safari.