### PR TITLE
fix(JitsiConference): reduce verbosity level

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2264,7 +2264,7 @@ JitsiConference.prototype._resumeMediaTransferForJvbConnection = function() {
  */
 JitsiConference.prototype._setP2PStatus = function(newStatus) {
     if (this.p2p === newStatus) {
-        logger.error(`Called _setP2PStatus with the same status: ${newStatus}`);
+        logger.debug(`Called _setP2PStatus with the same status: ${newStatus}`);
 
         return;
     }


### PR DESCRIPTION
There are scenarios when it's ok to call setP2PStatus again with
the same value. For example when P2P is stopped, before it starts with
the A/B testing mode enabled. It's only important to know that it
happened, but it's not an error, because the code will not execute
and return immediately.