### PR TITLE
fix(presence): clear presence status on join

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -215,6 +215,11 @@ export default class ChatRoom extends Listenable {
                 pres.c('password').t(this.password).up();
             }
             pres.up();
+
+            // Ensure a default presence tag is sent and accepted to clear any
+            // previous presence that may no longer be valid, such as with a
+            // poltergeist participant standing in for the real participant.
+            pres.c('status').t('').up();
         }
 
         parser.json2packet(this.presMap.nodes, pres);
@@ -339,9 +344,12 @@ export default class ChatRoom extends Listenable {
 
         // Parse roles.
         const member = {};
+        const $statusNode = $(pres).find('>status');
+        const hasStatusUpdate = $statusNode.length;
 
+        member.status = $statusNode.text();
         member.show = $(pres).find('>show').text();
-        member.status = $(pres).find('>status').text();
+
         const mucUserItem
             = $(pres).find(
                 '>x[xmlns="http://jabber.org/protocol/muc#user"]>item');
@@ -494,7 +502,7 @@ export default class ChatRoom extends Listenable {
         }
 
         // Trigger status message update
-        if (member.status) {
+        if (hasStatusUpdate) {
             this.eventEmitter.emit(
                 XMPPEvents.PRESENCE_STATUS,
                 from,


### PR DESCRIPTION
- Send an empty status tag in the presence when joining the muc.
- Check for the existence of a status tag on the onPresence
  handler. Accept its contents if the tag exists, even if the
  contents are empty. This will clear any presence left behind
  from a poltergeist participant.