### PR TITLE
ref(JitsiLocalTrack): get rid of 'setMutedInProgress'

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -321,15 +321,6 @@ export default class JitsiLocalTrack extends JitsiTrack {
 
         let promise = Promise.resolve();
 
-        /**
-         * Set to <tt>true</tt> when there's ongoing "mute/unmute" operation in
-         * progress. Used by {@link LocalSdpMunger}.
-         *
-         * @public
-         * @type {boolean}
-         */
-        this.setMutedInProgress = true;
-
         // A function that will print info about muted status transition
         const logMuteInfo = () => logger.info(`Mute ${this}: ${muted}`);
 
@@ -400,15 +391,6 @@ export default class JitsiLocalTrack extends JitsiTrack {
 
         return promise
             .then(() => this._sendMuteStatus(muted))
-            .then(
-                /* onFulfilled */ () => {
-                    this.setMutedInProgress = false;
-                },
-                /* onRejected */ error => {
-                    this.setMutedInProgress = false;
-
-                    throw error;
-                })
             .then(() => this.emit(TRACK_MUTE_CHANGED, this));
     }
 

--- a/modules/RTC/LocalSdpMunger.js
+++ b/modules/RTC/LocalSdpMunger.js
@@ -66,12 +66,18 @@ export default class LocalSdpMunger {
 
         for (const videoTrack of localVideos) {
             const muted = videoTrack.isMuted();
-            const { setMutedInProgress } = videoTrack;
-            const shouldFakeSdp = muted || setMutedInProgress;
+            const mediaStream = videoTrack.getOriginalStream();
+
+            // During the mute/unmute operation there are periods of time when
+            // the track's underlying MediaStream is not added yet to
+            // the PeerConnection. The SDP needs to be munged in such case.
+            const isInPeerConnection
+                = mediaStream && this.tpc.isMediaStreamInPc(mediaStream);
+            const shouldFakeSdp = muted || !isInPeerConnection;
 
             logger.debug(
                 `${this.tpc} ${videoTrack} muted: ${muted
-                    }, is mute/unmute in progress: ${setMutedInProgress
+                    }, is in PeerConnection: ${isInPeerConnection
                     } => should fake sdp ? : ${shouldFakeSdp}`);
 
             if (!shouldFakeSdp) {

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1746,7 +1746,8 @@ export default class JingleSessionPC extends JingleSession {
 
         if (Object.keys(addedMedia).length) {
             logger.error(
-                `Some SSRC were added on ${operationName}`, addedMedia);
+                `${this} - some SSRC were added on ${operationName}`,
+                addedMedia);
 
             return false;
         }
@@ -1756,7 +1757,8 @@ export default class JingleSessionPC extends JingleSession {
 
         if (Object.keys(removedMedia).length) {
             logger.error(
-                `Some SSRCs were removed on ${operationName}`, removedMedia);
+                `${this} - some SSRCs were removed on ${operationName}`,
+                removedMedia);
 
             return false;
         }


### PR DESCRIPTION
The 'setMutedInProgress' flag is unreliable and it can lead to weird
situations when mute operation is in progress, but the removal from
JingleSessionPC is waiting on the queue. In such case LocalSdpMunger
will fake SDP even if the track is in the PeerConnection which may
confuse some parts of the SDP transformation chain.

For example RtxModifier will not attempt to inject Rtx group description
if it sees that the SSRC are already there. But it can happen that even
though the SSRCs are there they do not contain valid track ID, because
the track has changed.

The LocalSdpMunger is supposed to fake the SDP only when the video
MediaStream is not in the PeerConnection. So this commit implements just
that: a way to tell if JitsiLocalTrack's stream is currently in
the PeerConnection (added through TraceablePeerConnection).