### PR TITLE
Improve logging

### DIFF
--- a/modules/util/PrefixedLogger.js
+++ b/modules/util/PrefixedLogger.js
@@ -1,0 +1,76 @@
+/**
+ * Class adds prefix to each log message.
+ */
+export default class PrefixedLogger {
+
+    /**
+     * Create new <tt>PrefixedLogger</tt>
+     * @param {Logger} logger
+     * @param {string} prefix string which wil be added at the beginning of each
+     * log message.
+     */
+    constructor(logger, prefix) {
+        this.logger = logger;
+        this.prefix = prefix;
+    }
+
+    /**
+     * Logs on TRACE logging level.
+     * @param text
+     * @param args
+     * @constructor
+     */
+    t(text, ...args) {
+        this.logger.trace(`${this.prefix} ${text}`, args);
+    }
+
+    /**
+     * Logs on DEBUG logging level.
+     * @param text
+     * @param args
+     * @constructor
+     */
+    d(text, ...args) {
+        this.logger.debug(`${this.prefix} ${text}`, args);
+    }
+
+    /**
+     * Logs on INFO logging level.
+     * @param text
+     * @param args
+     * @constructor
+     */
+    i(text, ...args) {
+        this.logger.info(`${this.prefix} ${text}`, args);
+    }
+
+    /**
+     * Logs on LOG logging level.
+     * @param text
+     * @param args
+     * @constructor
+     */
+    l(text, ...args) {
+        this.logger.log(`${this.prefix} ${text}`, args);
+    }
+
+    /**
+     * Logs on WARN logging level.
+     * @param text
+     * @param args
+     * @constructor
+     */
+    w(text, ...args) {
+        this.logger.warn(`${this.prefix} ${text}`, args);
+    }
+
+    /**
+     * Logs on ERROR logging level.
+     * @param text
+     * @param args
+     * @constructor
+     */
+    e(text, ...args) {
+        this.logger.error(`${this.prefix} ${text}`, args);
+    }
+}

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -2166,7 +2166,8 @@ export default class JingleSessionPC extends JingleSession {
      * @return {string}
      */
     toString() {
-        return `JingleSessionPC[p2p=${this.isP2P},`
-                    + `initiator=${this.isInitiator},sid=${this.sid}]`;
+        return `JSPC[${this.isP2P ? 'p2p' : 'jvb'},`
+                    + `${this.isInitiator ? 'initiator' : 'responder'}`
+                    + `,${this.sid}]`;
     }
 }

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -2030,10 +2030,7 @@ export default class JingleSessionPC extends JingleSession {
             logger.info('Sending source-remove', remove.tree());
             this.connection.sendIQ(
                 remove, null,
-                this.newJingleErrorHandler(remove, error => {
-                    GlobalOnErrorHandler.callErrorHandler(
-                        new Error(`Jingle error: ${JSON.stringify(error)}`));
-                }), IQ_TIMEOUT);
+                this.newJingleErrorHandler(remove), IQ_TIMEOUT);
         } else {
             logger.log('removal not necessary');
         }
@@ -2055,10 +2052,7 @@ export default class JingleSessionPC extends JingleSession {
         if (containsNewSSRCs) {
             logger.info('Sending source-add', add.tree());
             this.connection.sendIQ(
-                add, null, this.newJingleErrorHandler(add, error => {
-                    GlobalOnErrorHandler.callErrorHandler(
-                        new Error(`Jingle error: ${JSON.stringify(error)}`));
-                }), IQ_TIMEOUT);
+                add, null, this.newJingleErrorHandler(add), IQ_TIMEOUT);
         } else {
             logger.log('addition not necessary');
         }
@@ -2097,18 +2091,16 @@ export default class JingleSessionPC extends JingleSession {
                 if (errorReasonSel.length) {
                     error.reason = errorReasonSel[0].tagName;
                 }
+
+                const errorMsgSel = errorElSel.find('>text');
+
+                if (errorMsgSel.length) {
+                    error.msg = errorMsgSel.text();
+                }
             }
 
             if (!errResponse) {
                 error.reason = 'timeout';
-            }
-
-            error.source = request;
-            if (request && typeof request.tree === 'function') {
-                error.source = request.tree();
-            }
-            if (error.source && error.source.outerHTML) {
-                error.source = error.source.outerHTML;
             }
 
             error.session = this.toString();
@@ -2122,10 +2114,11 @@ export default class JingleSessionPC extends JingleSession {
                 // it will first send us 'session-terminate' (we enter ENDED)
                 // and then follow with 'item-not-found' for the queued requests
                 // We don't want to have that logged on error level.
-                logger.debug('Jingle error', error);
+                logger.debug(`Jingle error: ${JSON.stringify(error)}`);
             } else {
                 GlobalOnErrorHandler.callErrorHandler(
-                    new Error(`Jingle error: ${JSON.stringify(error)}`));
+                    new Error(
+                        `Jingle error: ${JSON.stringify(error)}`));
             }
         };
     }

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -1,6 +1,7 @@
 /* global __filename */
 
 import { getLogger } from 'jitsi-meet-logger';
+import PrefixedLogger from '../util/PrefixedLogger';
 import {
     parsePrimarySSRC,
     parseSecondarySSRC,
@@ -25,7 +26,7 @@ export default class SdpConsistency {
      */
     constructor(logPrefix) {
         this.clearVideoSsrcCache();
-        this.logPrefix = logPrefix;
+        this.log = new PrefixedLogger(logger, logPrefix);
     }
 
     /**
@@ -76,9 +77,7 @@ export default class SdpConsistency {
         const videoMLine = sdpTransformer.selectMedia('video');
 
         if (!videoMLine) {
-            logger.error(
-                `${this.logPrefix} no 'video' media found in the sdp: `
-                    + `${sdpStr}`);
+            this.log.e(`No 'video' media found in the sdp: ${sdpStr}`);
 
             return sdpStr;
         }
@@ -93,23 +92,19 @@ export default class SdpConsistency {
                     value: `recvonly-${this.cachedPrimarySsrc}`
                 });
             } else {
-                logger.info(
-                    `${this.logPrefix} no SSRC found for the recvonly video`
-                        + 'stream!');
+                this.log.i('No SSRC found for the recvonly video stream!');
             }
         } else {
             const newPrimarySsrc = videoMLine.getPrimaryVideoSsrc();
 
             if (!newPrimarySsrc) {
-                logger.info(
-                    `${this.logPrefix} sdp-consistency couldn't`
-                        + ' parse new primary ssrc');
+                this.log.i('Sdp-consistency couldn\'t parse new primary ssrc');
 
                 return sdpStr;
             }
             if (this.cachedPrimarySsrc) {
-                logger.info(
-                    `${this.logPrefix} sdp-consistency replacing new ssrc`
+                this.log.i(
+                    'Sdp-consistency replacing new ssrc'
                         + `${newPrimarySsrc} with cached `
                         + `${this.cachedPrimarySsrc}`);
                 videoMLine.replaceSSRC(newPrimarySsrc, this.cachedPrimarySsrc);
@@ -127,8 +122,8 @@ export default class SdpConsistency {
                 }
             } else {
                 this.cachedPrimarySsrc = newPrimarySsrc;
-                logger.info(
-                    `${this.logPrefix} sdp-consistency caching primary ssrc`
+                this.log.i(
+                    'Sdp-consistency caching primary ssrc'
                         + `${this.cachedPrimarySsrc}`);
             }
 


### PR DESCRIPTION
This PR fixes few cases when on Jingle error whole objects with cyclic references were logged which could sometimes crash the app on iOS react-native.

Also adds PrefixedLogger which will append JingleSessionPC/PeerConnection's identifier to log messages of it's subcomponents. This makes debugging much easier when there are both P2P and JVB sessions active.