### PR TITLE
enforce preferh264 when setting the local description

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1536,6 +1536,17 @@ TraceablePeerConnection.prototype.setLocalDescription
 
     this.trace('setLocalDescription::preTransform', dumpSDP(localSdp));
 
+    if (this.options.preferH264) {
+        const parsedSdp = transform.parse(localSdp.sdp);
+        const videoMLine = parsedSdp.media.find(m => m.type === 'video');
+
+        SDPUtil.preferVideoCodec(videoMLine, 'h264');
+        localSdp.sdp = transform.write(parsedSdp);
+
+        this.trace('setLocalDescription::postTransform (preferH264)',
+            dumpSDP(localSdp));
+    }
+
     this._adjustLocalMediaDirection(localSdp);
 
     this._ensureSimulcastGroupIsLast(localSdp);


### PR DESCRIPTION
for p2p, we have to take preferh264 into account when setting the local description, since
that is the offer that will be received by the far side.  if we only do it on the remote description,
like before this change, we'll never actually end up preferring h264 in p2p