### PR TITLE
request 1080p for chrome >= 61

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -269,8 +269,15 @@ export default {
         window.connectionTimes['obtainPermissions.start']
             = window.performance.now();
 
+        if (!this._inResolutionRollback
+                && RTCBrowserType.isChrome()
+                && RTCBrowserType.getChromeVersion() >= 61) {
+            options.resolution = '1080';
+        }
+
         return RTC.obtainAudioAndVideoPermissions(options || {})
             .then(tracks => {
+                this._inResolutionRollback = false;
                 promiseFulfilled = true;
 
                 window.connectionTimes['obtainPermissions.end']
@@ -315,6 +322,7 @@ export default {
                 promiseFulfilled = true;
 
                 if (error.name === JitsiTrackErrors.UNSUPPORTED_RESOLUTION) {
+                    this._inResolutionRollback = true;
                     const oldResolution = options.resolution || '720';
                     const newResolution = getLowerResolution(oldResolution);
 


### PR DESCRIPTION
there was a bug in chrome that caused video to stop sending when we requested 1080p,
that bug has been fixed so start requesting 1080p video for chrome versions >= 61