### PR TITLE
feat(xmpp): include credentials in CONNECTION_FAILED

### DIFF
--- a/authenticateAndUpgradeRole.js
+++ b/authenticateAndUpgradeRole.js
@@ -15,6 +15,11 @@ import XMPP from './modules/xmpp/xmpp';
  * returned by Jicofo on authentication attempt. See
  * {@link https://xmpp.org/rfcs/rfc3920.html#streams-error}.
  * @property {String} [message] - More details about the error.
+ * @property {Object} [credentials] - The credentials that failed
+ * the authentication.
+ * @property {String} [credentials.jid] - The XMPP ID part of the credentials.
+ * @property {string} [credentials.password] - The password part of
+ * the credentials.
  *
  * NOTE If neither one of the errors is present, then the operation has been
  * canceled.
@@ -119,10 +124,11 @@ export default function authenticateAndUpgradeRole({
             });
         xmpp.addListener(
             CONNECTION_FAILED,
-            (connectionError, message) => {
+            (connectionError, message, credentials) => {
                 reject({
                     connectionError,
-                    message
+                    message,
+                    credentials
                 });
                 xmpp = undefined;
             });

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -357,7 +357,9 @@ Moderator.prototype.allocateConferenceFocus = function(callback) {
 Moderator.prototype._allocateConferenceFocusError = function(error, callback) {
     // If the session is invalid, remove and try again without session ID to get
     // a new one
-    const invalidSession = $(error).find('>error>session-invalid').length;
+    const invalidSession
+        = $(error).find('>error>session-invalid').length
+            || $(error).find('>error>not-acceptable').length;
 
     if (invalidSession) {
         logger.info('Session expired! - removing');

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -119,11 +119,16 @@ export default class XMPP extends Listenable {
 
     /**
      * Receive connection status changes and handles them.
-     * @password {string} the password passed in connect method
-     * @status the connection status
-     * @msg message
+     *
+     * @param {Object} credentials
+     * @param {string} credentials.jid - The user's XMPP ID passed in
+     * the connect method. Eg. 'user@xmpp.com'.
+     * @param {string} credentials.password - The password passed in the connect
+     * method.
+     * @param {string} status - One of Strophe's connection status strings.
+     * @param {string} [msg] - The connection error message provided by Strophe.
      */
-    connectionHandler(password, status, msg) {
+    connectionHandler(credentials = { }, status, msg) {
         const now = window.performance.now();
         const statusStr = Strophe.getStatusString(status).toLowerCase();
 
@@ -153,7 +158,7 @@ export default class XMPP extends Listenable {
                     }
                 });
 
-            if (password) {
+            if (credentials.password) {
                 this.authenticatedUser = true;
             }
             if (this.connection && this.connection.connected
@@ -216,8 +221,11 @@ export default class XMPP extends Listenable {
             }
         } else if (status === Strophe.Status.AUTHFAIL) {
             // wrong password or username, prompt user
-            this.eventEmitter.emit(JitsiConnectionEvents.CONNECTION_FAILED,
-                JitsiConnectionErrors.PASSWORD_REQUIRED);
+            this.eventEmitter.emit(
+                JitsiConnectionEvents.CONNECTION_FAILED,
+                JitsiConnectionErrors.PASSWORD_REQUIRED,
+                msg,
+                credentials);
 
         }
     }
@@ -258,8 +266,14 @@ export default class XMPP extends Listenable {
         this.anonymousConnectionFailed = false;
         this.connectionFailed = false;
         this.lastErrorMsg = undefined;
-        this.connection.connect(jid, password,
-            this.connectionHandler.bind(this, password));
+        this.connection.connect(
+            jid,
+            password,
+            this.connectionHandler
+                .bind(this, {
+                    jid,
+                    password
+                }));
     }
 
     /**
@@ -275,7 +289,11 @@ export default class XMPP extends Listenable {
         logger.log(`(TIME) Strophe Attaching\t:${now}`);
         this.connection.attach(options.jid, options.sid,
             parseInt(options.rid, 10) + 1,
-            this.connectionHandler.bind(this, options.password));
+            this.connectionHandler
+                .bind(this, {
+                    jid: options.jid,
+                    password: options.password
+                }));
     }
 
     /**


### PR DESCRIPTION
Will include user's credentials in the CONNECTION_FAILED/PASSWORD_REQUIRED error event.