### PR TITLE
[RN] Delay the generating of machineId

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -462,7 +462,7 @@ export default {
      * @returns {string} the machine id
      */
     getMachineId() {
-        return Settings.getMachineId();
+        return Settings.machineId;
     },
 
     /**

--- a/modules/settings/Settings.js
+++ b/modules/settings/Settings.js
@@ -3,39 +3,99 @@ const logger = getLogger(__filename);
 
 import UsernameGenerator from '../util/UsernameGenerator';
 
+let _callStatsUserName;
+
+let _machineId;
+
 /**
- * Gets the localStorage of the browser. (Technically, gets the localStorage of
- * the global object because there may be no browser but React Native for
- * example).
- * @returns {Storage} the local Storage object (if any)
+ *
  */
-function getLocalStorage() {
+export default {
+    /**
+     * Returns fake username for callstats
+     * @returns {string} fake username for callstats
+     */
+    get callStatsUserName() {
+        if (!_callStatsUserName) {
+            const localStorage = getLocalStorage();
 
-    // eslint-disable-next-line no-invalid-this
-    const global = typeof window === 'undefined' ? this : window;
-    let storage;
+            if (localStorage) {
+                _callStatsUserName = localStorage.getItem('callStatsUserName');
+            }
+            if (!_callStatsUserName) {
+                _callStatsUserName = generateCallStatsUserName();
+                if (localStorage) {
+                    localStorage.setItem(
+                        'callStatsUserName',
+                        _callStatsUserName);
+                }
+            }
+        }
 
-    try {
-        storage = global.localStorage;
-    } catch (error) {
-        logger.error(error);
+        return _callStatsUserName;
+    },
+
+    /**
+     * Returns current machine id.
+     * @returns {string} machine id
+     */
+    get machineId() {
+        if (!_machineId) {
+            const localStorage = getLocalStorage();
+
+            if (localStorage) {
+                _machineId = localStorage.getItem('jitsiMeetId');
+            }
+            if (!_machineId) {
+                _machineId = generateJitsiMeetId();
+                if (localStorage) {
+                    localStorage.setItem('jitsiMeetId', _machineId);
+                }
+            }
+        }
+
+        return _machineId;
+    },
+
+    /**
+     * Returns current session id.
+     * @returns {string} current session id
+     */
+    get sessionId() {
+        // We may update sessionId in localStorage from another JitsiConference
+        // instance and that's why we should always re-read it.
+        const localStorage = getLocalStorage();
+
+        return localStorage ? localStorage.getItem('sessionId') : undefined;
+    },
+
+    /**
+     * Save current session id.
+     * @param {string} sessionId session id
+     */
+    set sessionId(sessionId) {
+        const localStorage = getLocalStorage();
+
+        if (localStorage) {
+            if (sessionId) {
+                localStorage.setItem('sessionId', sessionId);
+            } else {
+                localStorage.removeItem('sessionId');
+            }
+        }
     }
-
-    return storage;
-}
+};
 
 /**
- *
+ * Generate fake username for callstats.
+ * @returns {string} fake random username
  */
-function _p8() {
-    return `${Math.random().toString(16)}000000000`.substr(2, 8);
-}
+function generateCallStatsUserName() {
+    const username = UsernameGenerator.generateUsername();
 
-/**
- *
- */
-function generateUniqueId() {
-    return _p8() + _p8() + _p8() + _p8();
+    logger.log('generated callstats uid', username);
+
+    return username;
 }
 
 /**
@@ -51,105 +111,34 @@ function generateJitsiMeetId() {
 }
 
 /**
- * Generate fake username for callstats.
- * @returns {string} fake random username
+ * Gets the localStorage of the browser. (Technically, gets the localStorage of
+ * the global object because there may be no browser but React Native for
+ * example).
+ * @returns {Storage} the local Storage object (if any)
  */
-function generateCallStatsUsername() {
-    const username = UsernameGenerator.generateUsername();
+function getLocalStorage() {
+    let storage;
 
-    logger.log('generated callstats uid', username);
+    try {
+        // eslint-disable-next-line no-invalid-this
+        storage = (window || this).localStorage;
+    } catch (error) {
+        logger.error(error);
+    }
 
-    return username;
+    return storage;
 }
 
 /**
  *
  */
-class Settings {
-    /**
-     *
-     */
-    constructor() {
-        const localStorage = getLocalStorage();
-
-        if (localStorage) {
-            this.userId
-                = localStorage.getItem('jitsiMeetId') || generateJitsiMeetId();
-            this.callStatsUserName
-                = localStorage.getItem('callStatsUserName')
-                    || generateCallStatsUsername();
-
-            this.save();
-        } else {
-            logger.log('localStorage is not supported');
-            this.userId = generateJitsiMeetId();
-            this.callStatsUserName = generateCallStatsUsername();
-        }
-    }
-
-    /**
-     * Save settings to localStorage if browser supports that.
-     */
-    save() {
-        const localStorage = getLocalStorage();
-
-        if (localStorage) {
-            localStorage.setItem('jitsiMeetId', this.userId);
-            localStorage.setItem('callStatsUserName', this.callStatsUserName);
-        }
-    }
-
-    /**
-     * Returns current machine id.
-     * @returns {string} machine id
-     */
-    getMachineId() {
-        return this.userId;
-    }
-
-    /**
-     * Returns fake username for callstats
-     * @returns {string} fake username for callstats
-     */
-    getCallStatsUserName() {
-        return this.callStatsUserName;
-    }
-
-    /**
-     * Save current session id.
-     * @param {string} sessionId session id
-     */
-    setSessionId(sessionId) {
-        const localStorage = getLocalStorage();
-
-        if (localStorage) {
-            if (sessionId) {
-                localStorage.setItem('sessionId', sessionId);
-            } else {
-                localStorage.removeItem('sessionId');
-            }
-        }
-    }
-
-    /**
-     * Clear current session id.
-     */
-    clearSessionId() {
-        this.setSessionId(undefined);
-    }
-
-    /**
-     * Returns current session id.
-     * @returns {string} current session id
-     */
-    getSessionId() {
-        // We may update sessionId in localStorage from another JitsiConference
-        // instance and that's why we should always re-read it.
-        const localStorage = getLocalStorage();
-
-
-        return localStorage ? localStorage.getItem('sessionId') : undefined;
-    }
+function generateUniqueId() {
+    return _p8() + _p8() + _p8() + _p8();
 }
 
-export default new Settings();
+/**
+ *
+ */
+function _p8() {
+    return `${Math.random().toString(16)}000000000`.substr(2, 8);
+}

--- a/modules/statistics/AnalyticsAdapter.js
+++ b/modules/statistics/AnalyticsAdapter.js
@@ -70,7 +70,7 @@ class AnalyticsAdapter {
         this.permanentProperties = Object.create(null);
 
         this.addPermanentProperties(
-            { callstatsname: Settings.getCallStatsUserName() });
+            { callstatsname: Settings.callStatsUserName });
     }
 
     /**

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -310,7 +310,7 @@ Statistics.prototype.startCallStats = function(tpc, remoteUserID) {
     }
 
     if (!CallStats.isBackendInitialized()) {
-        const userName = Settings.getCallStatsUserName();
+        const userName = Settings.callStatsUserName;
 
         if (!CallStats.initBackend({
             callStatsID: this.options.callStatsID,

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -78,7 +78,7 @@ export default function Moderator(roomName, xmpp, emitter, options) {
 
                 return;
             }
-            Settings.setSessionId(event.data.sessionId);
+            Settings.sessionId = event.data.sessionId;
 
             // After popup is closed we will authenticate
         }
@@ -143,8 +143,8 @@ Moderator.prototype.createConferenceIq = function() {
         type: 'set' });
 
     // Session Id used for authentication
-    const sessionId = Settings.getSessionId();
-    const machineUID = Settings.getMachineId();
+    const { sessionId } = Settings;
+    const machineUID = Settings.machineId;
 
     logger.info(`Session ID: ${sessionId} machine UID: ${machineUID}`);
 
@@ -276,7 +276,7 @@ Moderator.prototype.parseSessionId = function(resultIq) {
 
     if (sessionId) {
         logger.info(`Received sessionId:  ${sessionId}`);
-        Settings.setSessionId(sessionId);
+        Settings.sessionId = sessionId;
     }
 };
 
@@ -363,7 +363,7 @@ Moderator.prototype._allocateConferenceFocusError = function(error, callback) {
 
     if (invalidSession) {
         logger.info('Session expired! - removing');
-        Settings.clearSessionId();
+        Settings.sessionId = undefined;
     }
     if ($(error).find('>error>graceful-shutdown').length) {
         this.eventEmitter.emit(XMPPEvents.GRACEFUL_SHUTDOWN);
@@ -495,7 +495,7 @@ Moderator.prototype._getLoginUrl = function(popup, urlCb, failureCb) {
     const attrs = {
         xmlns: 'http://jitsi.org/protocol/focus',
         room: this.roomName,
-        'machine-uid': Settings.getMachineId()
+        'machine-uid': Settings.machineId
     };
     let str = 'auth url'; // for logger
 
@@ -542,7 +542,7 @@ Moderator.prototype.getPopupLoginUrl = function(urlCallback, failureCallback) {
 Moderator.prototype.logout = function(callback) {
     const iq = $iq({ to: this.getFocusComponent(),
         type: 'set' });
-    const sessionId = Settings.getSessionId();
+    const { sessionId } = Settings;
 
     if (!sessionId) {
         callback();
@@ -563,7 +563,7 @@ Moderator.prototype.logout = function(callback) {
                 logoutUrl = decodeURIComponent(logoutUrl);
             }
             logger.info(`Log out OK, url: ${logoutUrl}`, result);
-            Settings.clearSessionId();
+            Settings.sessionId = undefined;
             callback(logoutUrl);
         },
         error => {


### PR DESCRIPTION
Because the implementation of LocalStorage in jitsi-meet at the time
of this writing is asynchronous with respect to loading and saving,
delay the generation of machineId in order to allow LocalStorage to
load any previously saved value.