### PR TITLE
feat(RTC): fix using 720p resolution by default

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1079,6 +1079,8 @@ class RTCUtils extends Listenable {
             };
 
             options.devices = options.devices || [ 'audio', 'video' ];
+            options.resolution = options.resolution || '720';
+
             if (!screenObtainer.isSupported()
                 && options.devices.indexOf('desktop') !== -1) {
                 reject(new Error('Desktop sharing is not supported!'));
@@ -1131,7 +1133,7 @@ class RTCUtils extends Listenable {
                         options.devices.indexOf('desktop'),
                         1);
                 }
-                options.resolution = options.resolution || '360';
+
                 if (options.devices.length) {
                     this.getUserMediaWithConstraints(
                         options.devices,


### PR DESCRIPTION
The default was still 360p if the option was missing from config.js. In
addition, move the logic outside of a browser check, so all browsers get
glorious HD by default.