### PR TITLE
Uses optional statsId to report to callstats and push it to presence.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1145,17 +1145,17 @@ JitsiConference.prototype.muteParticipant = function(id) {
  * @param role the role of the participant in the MUC
  * @param isHidden indicates if this is a hidden participant (system
  * participant for example a recorder).
- * @param statsId the participant statsId (optional)
+ * @param statsID the participant statsID (optional)
  */
 JitsiConference.prototype.onMemberJoined = function(
-        jid, nick, role, isHidden, statsId) {
+        jid, nick, role, isHidden, statsID) {
     const id = Strophe.getResourceFromJid(jid);
 
     if (id === 'focus' || this.myUserId() === id) {
         return;
     }
     const participant
-        = new JitsiParticipant(jid, this, nick, isHidden, statsId);
+        = new JitsiParticipant(jid, this, nick, isHidden, statsID);
 
     participant._role = role;
     this.participants[id] = participant;
@@ -2124,7 +2124,7 @@ JitsiConference.prototype._acceptP2PIncomingCall = function(
         const participant = this.participants[remoteID];
 
         if (participant) {
-            remoteID = participant.getStatsId() || remoteID;
+            remoteID = participant.getStatsID() || remoteID;
         }
     }
 
@@ -2420,7 +2420,7 @@ JitsiConference.prototype._startP2PSession = function(peerJid) {
         const participant = this.participants[remoteID];
 
         if (participant) {
-            remoteID = participant.getStatsId() || remoteID;
+            remoteID = participant.getStatsID() || remoteID;
         }
     }
 

--- a/JitsiParticipant.js
+++ b/JitsiParticipant.js
@@ -20,9 +20,9 @@ export default class JitsiParticipant {
      * @param displayName
      * @param {Boolean} hidden - True if the new JitsiParticipant instance is to
      * represent a hidden participant; otherwise, false.
-     * @param {string} starsId - optional participant statsId
+     * @param {string} statsID - optional participant statsID
      */
-    constructor(jid, conference, displayName, hidden, statsId) {
+    constructor(jid, conference, displayName, hidden, statsID) {
         this._jid = jid;
         this._id = Strophe.getResourceFromJid(jid);
         this._conference = conference;
@@ -36,7 +36,7 @@ export default class JitsiParticipant {
             video: undefined
         };
         this._hidden = hidden;
-        this._statsId = statsId;
+        this._statsID = statsID;
         this._connectionStatus = ParticipantConnectionStatus.ACTIVE;
         this._properties = {};
     }
@@ -156,8 +156,8 @@ export default class JitsiParticipant {
     /**
      * @returns {String} The stats ID of this participant.
      */
-    getStatsId() {
-        return this._statsId;
+    getStatsID() {
+        return this._statsID;
     }
 
     /**

--- a/JitsiParticipant.js
+++ b/JitsiParticipant.js
@@ -20,8 +20,9 @@ export default class JitsiParticipant {
      * @param displayName
      * @param {Boolean} hidden - True if the new JitsiParticipant instance is to
      * represent a hidden participant; otherwise, false.
+     * @param {string} starsId - optional participant statsId
      */
-    constructor(jid, conference, displayName, hidden) {
+    constructor(jid, conference, displayName, hidden, statsId) {
         this._jid = jid;
         this._id = Strophe.getResourceFromJid(jid);
         this._conference = conference;
@@ -35,6 +36,7 @@ export default class JitsiParticipant {
             video: undefined
         };
         this._hidden = hidden;
+        this._statsId = statsId;
         this._connectionStatus = ParticipantConnectionStatus.ACTIVE;
         this._properties = {};
     }
@@ -149,6 +151,13 @@ export default class JitsiParticipant {
      */
     getDisplayName() {
         return this._displayName;
+    }
+
+    /**
+     * @returns {String} The stats ID of this participant.
+     */
+    getStatsId() {
+        return this._statsId;
     }
 
     /**

--- a/doc/API.md
+++ b/doc/API.md
@@ -224,7 +224,7 @@ This objects represents the server connection. You can create new ```JitsiConnec
         5. callStatsSecret - callstats credentials
         6. enableTalkWhileMuted - boolean property. Enables/disables talk while muted detection, by default the value is false/disabled.
         7. ignoreStartMuted - ignores start muted events coming from jicofo.
-        8. enableStatsID - enables sending callstatsUsername as stats-id in presence, jicofo and videobridge will use it as endpointID to report stats
+        8. enableStatsID - enables sending callStatsUsername as stats-id in presence, jicofo and videobridge will use it as endpointID to report stats
         9. enableDisplayNameInStats - enables sending the users display name, if set, to callstats as alias of the endpointID stats 
 
         **NOTE: if 4 and 5 are set the library is going to send events to callstats. Otherwise the callstats integration will be disabled.**

--- a/doc/API.md
+++ b/doc/API.md
@@ -223,7 +223,10 @@ This objects represents the server connection. You can create new ```JitsiConnec
         4. callStatsID - callstats credentials
         5. callStatsSecret - callstats credentials
         6. enableTalkWhileMuted - boolean property. Enables/disables talk while muted detection, by default the value is false/disabled.
-        7. ignoreStartMuted - ignores start muted events coming from jicofo. 
+        7. ignoreStartMuted - ignores start muted events coming from jicofo.
+        8. enableStatsID - enables sending callstatsUsername as stats-id in presence, jicofo and videobridge will use it as endpointID to report stats
+        9. enableDisplayNameInStats - enables sending the users display name, if set, to callstats as alias of the endpointID stats 
+
         **NOTE: if 4 and 5 are set the library is going to send events to callstats. Otherwise the callstats integration will be disabled.**
 
 5. addEventListener(event, listener) - Subscribes the passed listener to the event.

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -318,8 +318,10 @@ Statistics.prototype.startCallStats = function(tpc, remoteUserID) {
         if (!CallStats.initBackend({
             callStatsID: this.options.callStatsID,
             callStatsSecret: this.options.callStatsSecret,
-            userName,
-            aliasName: this.options.callStatsAliasName
+            userName: this.options.swapUserNameAndAlias
+                ? this.options.callStatsAliasName : userName,
+            aliasName: this.options.swapUserNameAndAlias
+                ? userName : this.options.callStatsAliasName
         })) {
 
             // Backend initialization failed bad

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -7,6 +7,7 @@ import Listenable from '../util/Listenable';
 import * as MediaType from '../../service/RTC/MediaType';
 import Moderator from './moderator';
 import Recorder from './recording';
+import Settings from '../settings/Settings';
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
 
 const logger = getLogger(__filename);
@@ -194,6 +195,13 @@ export default class ChatRoom extends Listenable {
             'value': navigator.userAgent,
             'attributes': { xmlns: 'http://jitsi.org/jitmeet/user-agent' }
         });
+
+        if (options.enableStatsID) {
+            this.presMap.nodes.push({
+                'tagName': 'stats-id',
+                'value': Settings.callStatsUserName
+            });
+        }
 
         // We need to broadcast 'videomuted' status from the beginning, cause
         // Jicofo makes decisions based on that. Initialize it with 'false'
@@ -441,6 +449,9 @@ export default class ChatRoom extends Listenable {
             case 'userId':
                 member.id = node.value;
                 break;
+            case 'stats-id':
+                member.statsId = node.value;
+                break;
             }
         }
 
@@ -477,7 +488,11 @@ export default class ChatRoom extends Listenable {
             } else {
                 this.eventEmitter.emit(
                     XMPPEvents.MUC_MEMBER_JOINED,
-                    from, member.nick, member.role, member.isHiddenDomain);
+                    from,
+                    member.nick,
+                    member.role,
+                    member.isHiddenDomain,
+                    member.statsId);
             }
 
             hasStatusUpdate = member.status !== undefined;

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -450,7 +450,7 @@ export default class ChatRoom extends Listenable {
                 member.id = node.value;
                 break;
             case 'stats-id':
-                member.statsId = node.value;
+                member.statsID = node.value;
                 break;
             }
         }
@@ -492,7 +492,7 @@ export default class ChatRoom extends Listenable {
                     member.nick,
                     member.role,
                     member.isHiddenDomain,
-                    member.statsId);
+                    member.statsID);
             }
 
             hasStatusUpdate = member.status !== undefined;


### PR DESCRIPTION
The feature is behind a flag which is disabled by default.