### PR TITLE
feat(h264): add ability to disable H.264

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -56,6 +56,7 @@ The ```options``` parameter is JS object with the following properties:
     - `callStatsCustomScriptUrl` - (optional) custom url to access callstats client script
     - `callStatsConfIDNamespace` - (optional) a namespace to prepend the callstats conference ID with. Defaults to the window.location.hostname
     - `disableRtx` - (optional) boolean property (default to false).  Enables/disable the use of RTX.
+    - `disableH264` - (optional) boolean property (default to false).  If enabled, strips the H.264 codec from the local SDP.
     - `preferH264` - (optional) boolean property (default to false).  Enables/disable preferring the first instance of an h264 codec in an offer by moving it to the front of the codec list.
 
 * ```JitsiMeetJS.JitsiConnection``` - the ```JitsiConnection``` constructor. You can use that to create new server connection.

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -374,6 +374,8 @@ export default class RTC extends Listenable {
      *      the simulcast.
      * @param {boolean} options.disableRtx If set to 'true' will disable the
      *      RTX.
+     * @param {boolean} options.disableH264 If set to 'true' H264 will be
+     *      disabled by removing it from the SDP.
      * @param {boolean} options.preferH264 If set to 'true' H264 will be
      *      preferred over other video codecs.
      * @return {TraceablePeerConnection}

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -45,6 +45,8 @@ const SIM_LAYER_RIDS = [ SIM_LAYER_1_RID, SIM_LAYER_2_RID, SIM_LAYER_3_RID ];
  * @param {boolean} options.disableRtx if set to 'true' will disable the RTX
  * @param {boolean} options.enableFirefoxSimulcast if set to 'true' will enable
  * experimental simulcast support on Firefox.
+ * @param {boolean} options.disableH264 If set to 'true' H264 will be
+ *      disabled by removing it from the SDP.
  * @param {boolean} options.preferH264 if set to 'true' H264 will be preferred
  * over other video codecs.
  *
@@ -1572,14 +1574,19 @@ TraceablePeerConnection.prototype.setLocalDescription = function(
 
     this.trace('setLocalDescription::preTransform', dumpSDP(localSdp));
 
-    if (this.options.preferH264) {
+    if (this.options.disableH264 || this.options.preferH264) {
         const parsedSdp = transform.parse(localSdp.sdp);
         const videoMLine = parsedSdp.media.find(m => m.type === 'video');
 
-        SDPUtil.preferVideoCodec(videoMLine, 'h264');
+        if (this.options.disableH264) {
+            SDPUtil.stripVideoCodec(videoMLine, 'h264');
+        } else {
+            SDPUtil.preferVideoCodec(videoMLine, 'h264');
+        }
+
         localSdp.sdp = transform.write(parsedSdp);
 
-        this.trace('setLocalDescription::postTransform (preferH264)',
+        this.trace('setLocalDescription::postTransform (H264)',
             dumpSDP(localSdp));
     }
 

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -247,6 +247,8 @@ export default class JingleSessionPC extends JingleSession {
                     // simulcast needs to be disabled for P2P (121) calls
                     disableSimulcast: true,
                     disableRtx: this.room.options.disableRtx,
+                    disableH264: this.room.options.p2p
+                        && this.room.options.p2p.disableH264,
                     preferH264: this.room.options.p2p
                         && this.room.options.p2p.preferH264
                 });
@@ -259,8 +261,10 @@ export default class JingleSessionPC extends JingleSession {
                     // H264 does not support simulcast, so it needs to be
                     // disabled.
                     disableSimulcast: this.room.options.disableSimulcast
-                        || this.room.options.preferH264,
+                        || (this.room.options.preferH264
+                            && !this.room.options.disableH264),
                     disableRtx: this.room.options.disableRtx,
+                    disableH264: this.room.options.disableH264,
                     preferH264: this.room.options.preferH264,
                     enableFirefoxSimulcast: this.room.options.testing
                         && this.room.options.testing.enableFirefoxSimulcast

--- a/modules/xmpp/SDPUtil.js
+++ b/modules/xmpp/SDPUtil.js
@@ -595,6 +595,61 @@ const SDPUtil = {
             payloadTypes.unshift(payloadType);
             videoMLine.payloads = payloadTypes.join(' ');
         }
+    },
+
+    /**
+     * Strips the given codec from the given mline. All related RTX payload
+     * types are also stripped. If the resulting mline would have no codecs,
+     * it's disabled.
+     *
+     * @param {object} videoMLine the video mline object from an sdp as parsed
+     * by transform.parse.
+     * @param {string} codecName the name of the codec which will be stripped.
+     */
+    stripVideoCodec(videoMLine, codecName) {
+        if (!codecName) {
+            return;
+        }
+
+        const removePts = [];
+
+        for (const rtp of videoMLine.rtp) {
+            if (rtp.codec
+                && rtp.codec.toLowerCase() === codecName.toLowerCase()) {
+                removePts.push(rtp.payload);
+            }
+        }
+
+        if (removePts.length > 0) {
+            // We also need to remove the payload types that are related to RTX
+            // for the codecs we want to disable.
+            const rtxApts = removePts.map(item => `apt=${item}`);
+            const rtxPts = videoMLine.fmtp.filter(
+                item => rtxApts.indexOf(item.config) !== -1);
+
+            removePts.push(...rtxPts.map(item => item.payload));
+
+            const allPts = videoMLine.payloads.split(' ').map(Number);
+            const keepPts = allPts.filter(pt => removePts.indexOf(pt) === -1);
+
+            if (keepPts.length === 0) {
+                // There are no other video codecs, disable the stream.
+                videoMLine.port = 0;
+                videoMLine.direction = 'inactive';
+                videoMLine.payloads = '*';
+            } else {
+                videoMLine.payloads = keepPts.join(' ');
+            }
+
+            videoMLine.rtp = videoMLine.rtp.filter(
+                item => keepPts.indexOf(item.payload) !== -1);
+            videoMLine.fmtp = videoMLine.fmtp.filter(
+                item => keepPts.indexOf(item.payload) !== -1);
+            if (videoMLine.rtcpFb) {
+                videoMLine.rtcpFb = videoMLine.rtcpFb.filter(
+                    item => keepPts.indexOf(item.payload) !== -1);
+            }
+        }
     }
 };
 

--- a/modules/xmpp/SDPUtil.spec.js
+++ b/modules/xmpp/SDPUtil.spec.js
@@ -22,4 +22,17 @@ describe('SDPUtil', () => {
             expect(newPayloadTypesOrder[0]).toEqual(126);
         });
     });
+
+    describe('stripVideoCodec', () => {
+        it('should remove a codec', () => {
+            const sdp = SampleSdpStrings.multiCodecVideoSdp;
+            const videoMLine = sdp.media.find(m => m.type === 'video');
+
+            SDPUtil.stripVideoCodec(videoMLine, 'H264');
+            const newPayloadTypes = videoMLine.payloads.split(' ').map(Number);
+
+            expect(newPayloadTypes.length).toEqual(1);
+            expect(newPayloadTypes[0]).toEqual(100);
+        });
+    });
 });


### PR DESCRIPTION
This is performed by stripping all traces of H.264 from the local SDP before
passing it to `setLocalDescription`.