### PR TITLE
Enables desktop sharing when using opera.

### DIFF
--- a/modules/RTC/RTCBrowserType.js
+++ b/modules/RTC/RTCBrowserType.js
@@ -182,6 +182,14 @@ const RTCBrowserType = {
     },
 
     /**
+     * Returns Opera version.
+     * @returns {number|null}
+     */
+    getOperaVersion() {
+        return RTCBrowserType.isOpera() ? browserVersion : null;
+    },
+
+    /**
      * Returns Internet Explorer version.
      *
      * @returns {number|null}


### PR DESCRIPTION
To install the chrome webstore extension, the user must already have installed "Download Chrome Extension". On missing extension we open a popup window which allows the user to add the extension and then install it.
<img width="600" alt="screen shot 2017-10-17 at 00 01 41" src="https://user-images.githubusercontent.com/3263098/31647582-bb2c78da-b2ce-11e7-8954-a1982d7e2ceb.png">
<img width="727" alt="screen shot 2017-10-17 at 00 01 51" src="https://user-images.githubusercontent.com/3263098/31647585-c224c408-b2ce-11e7-9622-04ef8dbf1195.png">
<img width="503" alt="screen shot 2017-10-17 at 00 02 13" src="https://user-images.githubusercontent.com/3263098/31647588-c5b99ec2-b2ce-11e7-81c2-9b827567db83.png">
<img width="430" alt="screen shot 2017-10-17 at 00 02 34" src="https://user-images.githubusercontent.com/3263098/31647589-c998ccd4-b2ce-11e7-892d-39e26263c685.png">
<img width="623" alt="screen shot 2017-10-17 at 00 02 49" src="https://user-images.githubusercontent.com/3263098/31647594-cd345eb2-b2ce-11e7-840f-abb39c198a2b.png">
