### PR TITLE
feat(1080p): support on chrome using adapter

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -249,7 +249,7 @@ export default {
      *     A promise that returns an array of created JitsiTracks if resolved,
      *     or a JitsiConferenceError if rejected.
      */
-    createLocalTracks(options, firePermissionPromptIsShownEvent) {
+    createLocalTracks(options = {}, firePermissionPromptIsShownEvent) {
         let promiseFulfilled = false;
 
         if (firePermissionPromptIsShownEvent === true) {
@@ -268,7 +268,7 @@ export default {
         window.connectionTimes['obtainPermissions.start']
             = window.performance.now();
 
-        return RTC.obtainAudioAndVideoPermissions(options || {})
+        return RTC.obtainAudioAndVideoPermissions(options)
             .then(tracks => {
                 promiseFulfilled = true;
 

--- a/modules/RTC/RTCBrowserType.js
+++ b/modules/RTC/RTCBrowserType.js
@@ -156,6 +156,19 @@ const RTCBrowserType = {
     },
 
     /**
+     * Returns whether or not the current browser should be using the new
+     * getUserMedia flow, which utilizes the adapter shim. This method should
+     * be temporary and used while migrating all browsers to use adapter and
+     * the new getUserMedia.
+     *
+     * @returns {boolean}
+     */
+    usesNewGumFlow() {
+        return RTCBrowserType.isChrome()
+            && RTCBrowserType.getChromeVersion() >= 61;
+    },
+
+    /**
      * Checks if the current browser triggers 'onmute'/'onunmute' events when
      * user's connection is interrupted and the video stops playback.
      * @returns {*|boolean} 'true' if the event is supported or 'false'

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2137,8 +2137,20 @@ TraceablePeerConnection.prototype.addIceCandidate = function(
      */
 };
 
+/**
+ * Obtains call-related stats from the peer connection.
+ *
+ * @param {Function} callback - The function to invoke after successfully
+ * obtaining stats.
+ * @param {Function} errback - The function to invoke after failing to obtain
+ * stats.
+ * @returns {void}
+ */
 TraceablePeerConnection.prototype.getStats = function(callback, errback) {
     // TODO: Is this the correct way to handle Opera, Temasys?
+    // TODO (brian): After moving all browsers to adapter, check if adapter is
+    // accounting for different getStats apis, making the browser-checking-if
+    // unnecessary.
     if (RTCBrowserType.isFirefox()
             || RTCBrowserType.isTemasysPluginUsed()
             || RTCBrowserType.isReactNative()) {

--- a/modules/connectivity/ConnectionQuality.js
+++ b/modules/connectivity/ConnectionQuality.js
@@ -399,16 +399,6 @@ export default class ConnectionQuality {
             jvbRTT: this._localStats.jvbRTT
         };
 
-        // TODO: It looks like the remote participants don't really "care"
-        // about the resolution, and they look at their local rendered
-        // resolution instead. Consider removing this.
-        const localVideoTrack
-            = this._conference.getLocalVideoTrack();
-
-        if (localVideoTrack && localVideoTrack.resolution) {
-            data.resolution = localVideoTrack.resolution;
-        }
-
         try {
             this._conference.broadcastEndpointMessage({
                 type: STATS_MESSAGE_TYPE,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "sdp-transform": "2.3.0",
     "strophe.js": "1.2.14",
     "strophejs-plugin-disco": "0.0.2",
+    "webrtc-adapter": "webrtc/adapter#1eec19782b4058d186341263e7d049cea3e3290a",
     "yaeti": "1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- Add a new browser check so adapter shim usage can be gated.
- Get track resolution for stats from the track itself to account
  for browser resolution fallback logic. Do this only if
  we can be sure adapter has shimmed it in.
- Create a new getUserMediaFlow, with RTC being the orchestration
  for various RTCUtils calls.
- Remove connection quality stat "resolution" which was being
  emitted but not used but listeners.