### PR TITLE
fix(peerconnection): create a new description to modify sdp

### DIFF
--- a/modules/RTC/LocalSdpMunger.js
+++ b/modules/RTC/LocalSdpMunger.js
@@ -169,19 +169,19 @@ export default class LocalSdpMunger {
      * description.
      */
     maybeMungeLocalSdp(desc) {
-        // Nothing to be done in early stage when localDescription
-        // is not available yet
-        if (!desc || !desc.sdp) {
-            return;
+        if (!desc || !(desc instanceof RTCSessionDescription)) {
+            throw new Error('Incorrect type, expected RTCSessionDescription');
         }
 
         const transformer = new SdpTransformWrap(desc.sdp);
 
         if (this._addMutedLocalVideoTracksToSDP(transformer)) {
-            // Write
-            desc.sdp = transformer.toRawSDP();
-
-            // logger.info("Post TRANSFORM: ", desc.sdp);
+            return new RTCSessionDescription({
+                type: desc.type,
+                sdp: transformer.toRawSDP()
+            });
         }
+
+        return desc;
     }
 }


### PR DESCRIPTION
Firefox has deprecated modifying a description's sdp through
re-assignment. Safari (without temasys) does not allow it.
As such, wherever the sdp has to be modified instead create
a new description with the modified sdp.