### PR TITLE
Modify error handling for missing video m-lines and local description

### DIFF
--- a/modules/RTC/LocalSdpMunger.js
+++ b/modules/RTC/LocalSdpMunger.js
@@ -55,7 +55,7 @@ export default class LocalSdpMunger {
         const videoMLine = transformer.selectMedia('video');
 
         if (!videoMLine) {
-            logger.error(
+            logger.debug(
                 `${this.tpc} unable to hack local video track SDP`
                     + '- no "video" media');
 

--- a/modules/RTC/LocalSdpMunger.js
+++ b/modules/RTC/LocalSdpMunger.js
@@ -167,8 +167,9 @@ export default class LocalSdpMunger {
      *
      * @param {object} desc the WebRTC SDP object instance for the local
      * description.
+     * @returns {RTCSessionDescription}
      */
-    maybeMungeLocalSdp(desc) {
+    maybeAddMutedLocalVideoTracksToSDP(desc) {
         if (!desc || !(desc instanceof RTCSessionDescription)) {
             throw new Error('Incorrect type, expected RTCSessionDescription');
         }

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1173,10 +1173,16 @@ const getters = {
     localDescription() {
         let desc = this.peerconnection.localDescription;
 
+        if (!desc) {
+            logger.debug('getLocalDescription no localDescription found');
+
+            return {};
+        }
+
         this.trace('getLocalDescription::preTransform', dumpSDP(desc));
 
         // if we're running on FF, transform to Plan B first.
-        if (desc && RTCBrowserType.usesUnifiedPlan()) {
+        if (RTCBrowserType.usesUnifiedPlan()) {
             desc = this.interop.toPlanB(desc);
             this.trace('getLocalDescription::postTransform (Plan B)',
                 dumpSDP(desc));
@@ -1202,7 +1208,7 @@ const getters = {
         // happening (check setLocalDescription impl).
         desc = enforceSendRecv(desc);
 
-        return desc || {};
+        return desc;
     },
     remoteDescription() {
         let desc = this.peerconnection.remoteDescription;

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1193,7 +1193,7 @@ const getters = {
         }
 
         if (RTCBrowserType.doesVideoMuteByStreamRemove()) {
-            desc = this.localSdpMunger.maybeMungeLocalSdp(desc);
+            desc = this.localSdpMunger.maybeAddMutedLocalVideoTracksToSDP(desc);
             logger.debug(
                 'getLocalDescription::postTransform (munge local SDP)', desc);
         }

--- a/modules/xmpp/RtxModifier.js
+++ b/modules/xmpp/RtxModifier.js
@@ -116,7 +116,7 @@ export default class RtxModifier {
         const videoMLine = sdpTransformer.selectMedia('video');
 
         if (!videoMLine) {
-            logger.error(`No 'video' media found in the sdp: ${sdpStr}`);
+            logger.debug(`No 'video' media found in the sdp: ${sdpStr}`);
 
             return sdpStr;
         }
@@ -205,7 +205,7 @@ export default class RtxModifier {
         const videoMLine = sdpTransformer.selectMedia('video');
 
         if (!videoMLine) {
-            logger.error(`No 'video' media found in the sdp: ${sdpStr}`);
+            logger.debug(`No 'video' media found in the sdp: ${sdpStr}`);
 
             return sdpStr;
         }

--- a/modules/xmpp/SDPUtil.js
+++ b/modules/xmpp/SDPUtil.js
@@ -573,7 +573,7 @@ const SDPUtil = {
     preferVideoCodec(videoMLine, codecName) {
         let payloadType = null;
 
-        if (!codecName) {
+        if (!videoMLine || !codecName) {
             return;
         }
 
@@ -613,7 +613,7 @@ const SDPUtil = {
      * @param {string} codecName the name of the codec which will be stripped.
      */
     stripVideoCodec(videoMLine, codecName) {
-        if (!codecName) {
+        if (!videoMLine || !codecName) {
             return;
         }
 

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -76,7 +76,7 @@ export default class SdpConsistency {
         const videoMLine = sdpTransformer.selectMedia('video');
 
         if (!videoMLine) {
-            logger.error(
+            logger.debug(
                 `${this.logPrefix} no 'video' media found in the sdp: `
                     + `${sdpStr}`);
 


### PR DESCRIPTION
Safari will be audio only and error handling for missing video or local description has to be modified to prevent renegotiations from being halted by an error.