### PR TITLE
fix(adapter): inject h264 into safari's remote description

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1806,10 +1806,15 @@ TraceablePeerConnection.prototype.setRemoteDescription = function(
 };
 
 /**
- * Inserts an H264 payload into the description if not already present.
+ * Inserts an H264 payload into the description if not already present. This is
+ * need for Safari WebRTC, which errors when no supported video codec is found
+ * in the offer. Related bug reports:
+ * https://bugs.webkit.org/show_bug.cgi?id=173141
+ * https://bugs.chromium.org/p/webrtc/issues/detail?id=4957
  *
  * @param {RTCSessionDescription} description - An RTCSessionDescription
  * to inject with an H264 payload.
+ * @private
  * @returns {RTCSessionDescription}
  */
 TraceablePeerConnection.prototype._injectH264IfNotPresent = function(
@@ -1818,7 +1823,7 @@ TraceablePeerConnection.prototype._injectH264IfNotPresent = function(
     const videoMLine = parsedSdp.media.find(m => m.type === 'video');
 
     if (!videoMLine) {
-        logger.debug('No videoMLine found, no need tp inject H264.');
+        logger.debug('No videoMLine found, no need to inject H264.');
 
         return description;
     }

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1774,9 +1774,9 @@ TraceablePeerConnection.prototype.setRemoteDescription = function(
     }
 
     // Safari WebRTC errors when no supported video codec is found in the offer.
-    // To prevent the error, inject h264 into the video mLine.
+    // To prevent the error, inject H264 into the video mLine.
     if (RTCBrowserType.usesNewGumFlow() && RTCBrowserType.isSafari()) {
-        logger.debug('Maybe injecting h264 into the remote description');
+        logger.debug('Maybe injecting H264 into the remote description');
 
         // eslint-disable-next-line no-param-reassign
         description = this._injectH264IfNotPresent(description);
@@ -1806,10 +1806,10 @@ TraceablePeerConnection.prototype.setRemoteDescription = function(
 };
 
 /**
- * Inserts an h264 payload into the description if not already present.
+ * Inserts an H264 payload into the description if not already present.
  *
  * @param {RTCSessionDescription} description - An RTCSessionDescription
- * to inject with an h264 payload.
+ * to inject with an H264 payload.
  * @returns {RTCSessionDescription}
  */
 TraceablePeerConnection.prototype._injectH264IfNotPresent = function(
@@ -1818,7 +1818,7 @@ TraceablePeerConnection.prototype._injectH264IfNotPresent = function(
     const videoMLine = parsedSdp.media.find(m => m.type === 'video');
 
     if (videoMLine.rtp.some(rtp => rtp.codec.toLowerCase() === 'h264')) {
-        logger.debug('h264 codec found in video mLine, no need to inject.');
+        logger.debug('H264 codec found in video mLine, no need to inject.');
 
         return description;
     }
@@ -1843,7 +1843,7 @@ TraceablePeerConnection.prototype._injectH264IfNotPresent = function(
     }
 
     rtp.push({
-        codec: 'h264',
+        codec: 'H264',
         payload: dummyPayloadType,
         rate: 90000
     });
@@ -1856,7 +1856,7 @@ TraceablePeerConnection.prototype._injectH264IfNotPresent = function(
     });
 
     logger.debug(
-        `Injecting h264 payload type ${dummyPayloadType} into video mLine.`);
+        `Injecting H264 payload type ${dummyPayloadType} into video mLine.`);
 
     return new RTCSessionDescription({
         type: description.type,

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1817,6 +1817,12 @@ TraceablePeerConnection.prototype._injectH264IfNotPresent = function(
     const parsedSdp = transform.parse(description.sdp);
     const videoMLine = parsedSdp.media.find(m => m.type === 'video');
 
+    if (!videoMLine) {
+        logger.debug('No videoMLine found, no need tp inject H264.');
+
+        return description;
+    }
+
     if (videoMLine.rtp.some(rtp => rtp.codec.toLowerCase() === 'h264')) {
         logger.debug('H264 codec found in video mLine, no need to inject.');
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1774,9 +1774,9 @@ TraceablePeerConnection.prototype.setRemoteDescription = function(
     }
 
     // Safari WebRTC errors when no supported video codec is found in the offer.
-    // To prevent the error, inject H264 into the video mLine.
+    // To prevent the error, inject h264 into the video mLine.
     if (RTCBrowserType.usesNewGumFlow() && RTCBrowserType.isSafari()) {
-        logger.debug('Maybe injecting H264 into the remote description');
+        logger.debug('Maybe injecting h264 into the remote description');
 
         // eslint-disable-next-line no-param-reassign
         description = this._injectH264IfNotPresent(description);
@@ -1806,10 +1806,10 @@ TraceablePeerConnection.prototype.setRemoteDescription = function(
 };
 
 /**
- * Inserts an H264 payload into the description if not already present.
+ * Inserts an h264 payload into the description if not already present.
  *
  * @param {RTCSessionDescription} description - An RTCSessionDescription
- * to inject with an H264 payload.
+ * to inject with an h264 payload.
  * @returns {RTCSessionDescription}
  */
 TraceablePeerConnection.prototype._injectH264IfNotPresent = function(
@@ -1818,7 +1818,7 @@ TraceablePeerConnection.prototype._injectH264IfNotPresent = function(
     const videoMLine = parsedSdp.media.find(m => m.type === 'video');
 
     if (videoMLine.rtp.some(rtp => rtp.codec.toLowerCase() === 'h264')) {
-        logger.debug('H264 codec found in video mLine, no need to inject.');
+        logger.debug('h264 codec found in video mLine, no need to inject.');
 
         return description;
     }
@@ -1843,7 +1843,7 @@ TraceablePeerConnection.prototype._injectH264IfNotPresent = function(
     }
 
     rtp.push({
-        codec: 'H264',
+        codec: 'h264',
         payload: dummyPayloadType,
         rate: 90000
     });
@@ -1856,7 +1856,7 @@ TraceablePeerConnection.prototype._injectH264IfNotPresent = function(
     });
 
     logger.debug(
-        `Injecting H264 payload type ${dummyPayloadType} into video mLine.`);
+        `Injecting h264 payload type ${dummyPayloadType} into video mLine.`);
 
     return new RTCSessionDescription({
         type: description.type,

--- a/modules/RTC/TraceablePeerConnection.spec.js
+++ b/modules/RTC/TraceablePeerConnection.spec.js
@@ -1,0 +1,51 @@
+import transform from 'sdp-transform';
+
+import { multiCodecVideoSdp, plainVideoSdp } from '../xmpp/SampleSdpStrings';
+
+import TraceablePeerConnection from './TraceablePeerConnection';
+
+describe('TraceablePeerConnection', () => {
+    describe('_injectH264IfNotPresent', () => {
+        // Store the method-in-test in a convenience variable.
+        const injectFunction
+            = TraceablePeerConnection.prototype._injectH264IfNotPresent;
+        const MockSessionDescription = function({ sdp }) {
+            this.sdp = sdp;
+        };
+        const originalSessionDescription = window.originalSessionDescription;
+
+        beforeEach(() => {
+            window.RTCSessionDescription = MockSessionDescription;
+        });
+
+        afterEach(() => {
+            window.RTCSessionDescription = originalSessionDescription;
+        });
+
+        it('adds h264', () => {
+            const sessionDescription = new MockSessionDescription({
+                sdp: transform.write(plainVideoSdp)
+            });
+            const { sdp } = injectFunction(sessionDescription);
+            const expectedH264Payload = [
+                'm=video 9 RTP/SAVPF 100 127',
+                'a=rtpmap:127 H264/90000',
+                'a=fmtp:127 level-asymmetry-allowed=1;'
+                    + 'packetization-mode=1;'
+                    + 'profile-level-id=42e01f'
+            ];
+
+            expectedH264Payload.forEach(h264Description =>
+                expect(sdp.indexOf(h264Description) > -1).toBe(true));
+        });
+
+        it('does not modify the description if H264 is present', () => {
+            const sessionDescription = new MockSessionDescription({
+                sdp: transform.write(multiCodecVideoSdp)
+            });
+            const result = injectFunction(sessionDescription);
+
+            expect(result).toEqual(sessionDescription);
+        });
+    });
+});

--- a/modules/RTC/TraceablePeerConnection.spec.js
+++ b/modules/RTC/TraceablePeerConnection.spec.js
@@ -29,7 +29,7 @@ describe('TraceablePeerConnection', () => {
             const { sdp } = injectFunction(sessionDescription);
             const expectedH264Payload = [
                 'm=video 9 RTP/SAVPF 100 127',
-                'a=rtpmap:127 h264/90000',
+                'a=rtpmap:127 H264/90000',
                 'a=fmtp:127 level-asymmetry-allowed=1;'
                     + 'packetization-mode=1;'
                     + 'profile-level-id=42e01f'

--- a/modules/RTC/TraceablePeerConnection.spec.js
+++ b/modules/RTC/TraceablePeerConnection.spec.js
@@ -29,7 +29,7 @@ describe('TraceablePeerConnection', () => {
             const { sdp } = injectFunction(sessionDescription);
             const expectedH264Payload = [
                 'm=video 9 RTP/SAVPF 100 127',
-                'a=rtpmap:127 H264/90000',
+                'a=rtpmap:127 h264/90000',
                 'a=fmtp:127 level-asymmetry-allowed=1;'
                     + 'packetization-mode=1;'
                     + 'profile-level-id=42e01f'


### PR DESCRIPTION
Safari will fail to set its remote description if no
supported video codecs are found. This can happen with
config.p2p.disableH264 set to true, as browsers will strip
H264 from their offers. To get around this problem in a way
that can be removed once this is fixed on Safari's side,
add a function to inject H265 before setting the remote
description.