### PR TITLE
Video suspend abtest

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -624,7 +624,7 @@ export default class RTC extends Listenable {
         const pcConstraints
             = isP2P ? RTCUtils.p2pPcConstraints : RTCUtils.pcConstraints;
 
-        return Object.assign({}, pcConstraints);
+        return JSON.parse(JSON.stringify(pcConstraints));
     }
 
     /**

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -436,11 +436,11 @@ export default class RTC extends Listenable {
     createPeerConnection(signaling, iceConfig, isP2P, options) {
         const pcConstraints = RTC.getPCConstraints(isP2P);
 
-        if (typeof options.forceSuspendVideo !== 'undefined') {
-            RTCUtils.setSuspendVideo(pcConstraints, options.forceSuspendVideo);
+        if (typeof options.abtestSuspendVideo !== 'undefined') {
+            RTCUtils.setSuspendVideo(pcConstraints, options.abtestSuspendVideo);
 
             Statistics.analytics.addPermanentProperties(
-                { abtestP2PSuspendVideo: options.forceSuspendVideo });
+                { abtestSuspendVideo: options.abtestSuspendVideo });
         }
 
         const newConnection

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1117,36 +1117,10 @@ class RTCUtils extends Listenable {
                     { googSuspendBelowMinBitrate: true });
             }
 
-            /**
-             * This option is used to enable the suspend video only for
-             * part of the users on the P2P peer connection. The value of
-             * the option is the ratio:
-             * (users with suspended video enabled)/(all users).
-             *
-             * Note: The option is not documented because it is temporary
-             * and only for internal testing purpose.
-             *
-             * @type {number}
-             */
-            const forceP2PSuspendVideoRatio
-                = (options.testing || {}).forceP2PSuspendVideoRatio;
-
-            // If <tt>forceP2PSuspendVideoRatio</tt> is invalid (not a
-            // number) fallback to the default behavior (enabled for every
-            // user).
-            if (typeof forceP2PSuspendVideoRatio !== 'number'
-                    || Math.random() < forceP2PSuspendVideoRatio) {
-                logger.info(`Enable suspend video mode for p2p (ratio=${
-                    forceP2PSuspendVideoRatio})`);
-
-                Statistics.analytics.addPermanentProperties({
-                    forceP2PSuspendVideo: true
-                });
-
-                this.p2pPcConstraints.optional.push({
-                    googSuspendBelowMinBitrate: true
-                });
-            }
+            // There's no reason not to use this for p2p
+            this.p2pPcConstraints.optional.push({
+                googSuspendBelowMinBitrate: true
+            });
         }
 
         this.p2pPcConstraints = this.p2pPcConstraints || this.pcConstraints;

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1755,6 +1755,30 @@ class RTCUtils extends Listenable {
 
         return { deviceList };
     }
+
+    /**
+     * Configures the given PeerConnection constraints to either enable or
+     * disable (according to the value of the 'enable' parameter) the
+     * 'googSuspendBelowMinBitrate' option.
+     * @param constraints the constraints on which to operate.
+     * @param enable {boolean} whether to enable or disable the suspend video
+     * option.
+     */
+    setSuspendVideo(constraints, enable) {
+        if (!constraints.optional) {
+            constraints.optional = [];
+        }
+
+        // Get rid of all "googSuspendBelowMinBitrate" constraints (we assume
+        // that the elements of constraints.optional contain a single property).
+        constraints.optional
+            = constraints.optional.filter(
+                c => !c.hasOwnProperty('googSuspendBelowMinBitrate'));
+
+        if (enable) {
+            constraints.optional.push({ googSuspendBelowMinBitrate: 'true' });
+        }
+    }
 }
 
 /**

--- a/modules/util/StringUtils.js
+++ b/modules/util/StringUtils.js
@@ -1,0 +1,24 @@
+/**
+ * Implements a simple hash code for a string (see
+ * https://en.wikipedia.org/wiki/Java_hashCode()).
+ *
+ * @param {string} The string to return a hash of.
+ * @return {Number} the integer hash code of the string.
+ */
+function integerHash(string) {
+    if (!string) {
+        return 0;
+    }
+
+    let char, hash = 0, i;
+
+    for (i = 0; i < string.length; i++) {
+        char = string.charCodeAt(i);
+        hash += char * Math.pow(31, string.length - 1 - i);
+        hash = Math.abs(hash | 0); // eslint-disable-line no-bitwise
+    }
+
+    return hash;
+}
+
+module.exports = { integerHash };

--- a/modules/xmpp/JingleSession.js
+++ b/modules/xmpp/JingleSession.js
@@ -164,5 +164,12 @@ export default class JingleSession {
      */
     acceptOffer(jingle, success, failure) {}
 
+    /**
+     * Returns the JID of the initiator of the jingle session.
+     */
+    _getInitiatorJid() {
+        return this.isInitiator ? this.localJid : this.remoteJid;
+    }
+
     /* eslint-enable no-unused-vars, no-empty-function */
 }

--- a/modules/xmpp/JingleSession.js
+++ b/modules/xmpp/JingleSession.js
@@ -17,7 +17,7 @@ export default class JingleSession {
      * Creates new <tt>JingleSession</tt>.
      * @param {string} sid the Jingle session identifier
      * @param {string} localJid our JID
-     * @param {string} peerjid the JID of the remote peer
+     * @param {string} remoteJid the JID of the remote peer
      * @param {Strophe.Connection} connection the XMPP connection
      * @param {Object} mediaConstraints the media constraints object passed to
      * the PeerConnection onCreateAnswer/Offer as defined by the WebRTC.
@@ -27,13 +27,13 @@ export default class JingleSession {
     constructor(
             sid,
             localJid,
-            peerjid,
+            remoteJid,
             connection,
             mediaConstraints,
             iceConfig) {
         this.sid = sid;
         this.localJid = localJid;
-        this.peerjid = peerjid;
+        this.remoteJid = remoteJid;
         this.connection = connection;
         this.mediaConstraints = mediaConstraints;
         this.iceConfig = iceConfig;
@@ -89,8 +89,8 @@ export default class JingleSession {
         this.room = room;
         this.rtc = rtc;
         this.state = JingleSessionState.PENDING;
-        this.initiator = isInitiator ? this.localJid : this.peerjid;
-        this.responder = isInitiator ? this.peerjid : this.localJid;
+        this.initiator = isInitiator ? this.localJid : this.remoteJid;
+        this.responder = isInitiator ? this.remoteJid : this.localJid;
         this.doInitialize();
     }
 

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -252,10 +252,10 @@ export default class JingleSessionPC extends JingleSession {
             pcOptions.preferH264
                 = this.room.options.p2p && this.room.options.p2p.preferH264;
 
-            const forceSuspendVideo = this._forceSuspendVideo();
+            const abtestSuspendVideo = this._abtestSuspendVideoEnabled();
 
-            if (typeof forceSuspendVideo !== 'undefined') {
-                pcOptions.forceSuspendVideo = forceSuspendVideo;
+            if (typeof abtestSuspendVideo !== 'undefined') {
+                pcOptions.abtestSuspendVideo = abtestSuspendVideo;
             }
         } else {
             // H264 does not support simulcast, so it needs to be disabled.
@@ -2189,7 +2189,7 @@ export default class JingleSessionPC extends JingleSession {
      * configuration, returns undefined. Otherwise returns a boolean which
      * indicates whether the suspend video option should be enabled or disabled.
      */
-    _forceSuspendVideo() {
+    _abtestSuspendVideoEnabled() {
         if (!this.room.options.abTesting
             || !this.room.options.abTesting.enableSuspendVideoTest) {
             return;

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -96,9 +96,9 @@ class JingleConnectionPlugin extends ConnectionPlugin {
             }
 
             // local jid is not checked
-            if (fromJid !== sess.peerjid) {
+            if (fromJid !== sess.remoteJid) {
                 logger.warn(
-                    'jid mismatch for session id', sid, sess.peerjid, iq);
+                    'jid mismatch for session id', sid, sess.remoteJid, iq);
                 ack.attrs({ type: 'error' });
                 ack.c('error', { type: 'cancel' })
                     .c('item-not-found', {
@@ -114,7 +114,7 @@ class JingleConnectionPlugin extends ConnectionPlugin {
             }
         } else if (sess !== undefined) {
             // Existing session with same session id. This might be out-of-order
-            // if the sess.peerjid is the same as from.
+            // if the sess.remoteJid is the same as from.
             ack.attrs({ type: 'error' });
             ack.c('error', { type: 'cancel' })
                 .c('service-unavailable', {


### PR DESCRIPTION
Re-implements the "suspend video " A/B test. 

The test is enabled if config.abTesting.enableSuspendVideoTest==true.

If the test is disabled the previous behavior is preserved, and no properties are added to the analytics events.

If the test is enabled, the two participants in a p2p call will agree on a boolean value based on the JID of the Jingle initiator (which is essentially selected randomly). If the agreed-upon value is true, the suspend video option will be enabled; otherwise, it will be disabled. The two participants will include this value in analytics events with the "abtestP2PSuspendVideo" property.