### PR TITLE
fix(analytics): initialize permanentProperties inline

### DIFF
--- a/modules/statistics/AnalyticsAdapter.js
+++ b/modules/statistics/AnalyticsAdapter.js
@@ -70,9 +70,10 @@ class AnalyticsAdapter {
         /**
          * Map of properties that will be added to every event
          */
-        this.permanentProperties = Object.create(null);
-        this.addPermanentProperties(
-            { callstatsname: Settings.callStatsUserName });
+        this.permanentProperties = {
+            callstatsname: Settings.callStatsUserName
+        };
+
         this.analyticsHandlers.add(cacheAnalytics);
     }
 
@@ -122,8 +123,7 @@ class AnalyticsAdapter {
      * @param {Object} properties the map of properties
      */
     addPermanentProperties(properties) {
-        this.permanentProperties
-            = Object.assign(this.permanentProperties, properties);
+        Object.assign(this.permanentProperties, properties);
     }
 }
 


### PR DESCRIPTION
AnalyticsAdapter is initialized on file load. The constructor
calls a method that calls Object.assign. All this happens
before jitsi-meet has loaded polyfills. So, instead
initialize permanentProperties inline with the expected
values, avoiding Object.assign.