### PR TITLE
fix(audio-output): update sinkIds on load and device list change

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -178,14 +178,12 @@ export default class RTC extends Listenable {
         // tracks handle this event by themselves.
         if (RTCUtils.isDeviceChangeAvailable('output')) {
             RTCUtils.addListener(RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED,
-                deviceId => {
-                    const remoteAudioTracks
-                        = this.getRemoteTracks(MediaType.AUDIO);
+                deviceId => this._updateAudioOutputForAudioTracks(deviceId));
 
-                    for (const track of remoteAudioTracks) {
-                        track.setAudioOutput(deviceId);
-                    }
-                });
+            RTCUtils.addListener(
+                RTCEvents.DEVICE_LIST_CHANGED,
+                () => this._updateAudioOutputForAudioTracks(
+                    RTCUtils.getAudioOutputDevice()));
         }
     }
 
@@ -852,5 +850,21 @@ export default class RTC extends Listenable {
     isInLastN(id) {
         return !this._lastNEndpoints // lastNEndpoints not initialised yet.
             || this._lastNEndpoints.indexOf(id) > -1;
+    }
+
+    /**
+     * Updates the target audio output device for all remote audio tracks.
+     *
+     * @param {string} deviceId - The device id of the audio ouput device to
+     * use for all remote tracks.
+     * @private
+     * @returns {void}
+     */
+    _updateAudioOutputForAudioTracks(deviceId) {
+        const remoteAudioTracks = this.getRemoteTracks(MediaType.AUDIO);
+
+        for (const track of remoteAudioTracks) {
+            track.setAudioOutput(deviceId);
+        }
     }
 }

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -899,13 +899,15 @@ class RTCUtils extends Listenable {
                             return [];
                         });
 
-                this.attachMediaStream = (element, stream) => {
-                    if (element) {
-                        element.srcObject = stream;
-                    }
+                this.attachMediaStream
+                    = wrapAttachMediaStream((element, stream) => {
+                        if (element) {
+                            element.srcObject = stream;
+                        }
 
-                    return element;
-                };
+                        return element;
+                    });
+
                 this.getStreamID = stream => stream.id;
                 this.getTrackID = track => track.id;
             } else if (RTCBrowserType.isOpera()


### PR DESCRIPTION
When a mac's default audio output is changed, audio elements
are not being updated with the new default. A default audio
output change in the OS fires a DEVICE_LIST_CHANGED event,
so use that to always update the sinkId.

Also, use wrapAttachMediaStream for newGumFlow to be ensure
the proper sinkId is set on audio elements being coupled
a remote track.