### PR TITLE
fix(gum): handle NotAllowedError

### DIFF
--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -74,6 +74,7 @@ function JitsiTrackError(error, options, devices) {
         };
 
         switch (error.name) {
+        case 'NotAllowedError':
         case 'PermissionDeniedError':
         case 'SecurityError':
             this.name = JitsiTrackErrors.PERMISSION_DENIED;

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1190,9 +1190,8 @@ class RTCUtils extends Listenable {
     _newGetUserMediaWithConstraints(umDevices, constraints = {}) {
         return new Promise((resolve, reject) => {
             try {
-                this.getUserMedia(
-                    constraints,
-                    stream => {
+                this.getUserMedia(constraints)
+                    .then(stream => {
                         logger.log('onUserMediaSuccess');
 
                         // TODO(brian): Is this call needed? Why is this
@@ -1201,8 +1200,8 @@ class RTCUtils extends Listenable {
                         setAvailableDevices(umDevices, stream);
 
                         resolve(stream);
-                    },
-                    error => {
+                    })
+                    .catch(error => {
                         logger.warn('Failed to get access to local media. '
                             + ` ${error} ${constraints} `);
 


### PR DESCRIPTION
This is a two part fix:
- In the new gum flow, this.getUserMedia supports promises
  and rejections were not getting caught. So change
  _newGetUserMediaWithConstraints to be promise based instead
  of callback.
- The error name returned from blocked device permissions is
  NotAllowedError, as adapter shims PermissionDeniedError
  to be NotAllowedError.