### PR TITLE
fix(gum): skip retry if using new gum flow

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -322,7 +322,8 @@ export default {
             .catch(error => {
                 promiseFulfilled = true;
 
-                if (error.name === JitsiTrackErrors.UNSUPPORTED_RESOLUTION) {
+                if (error.name === JitsiTrackErrors.UNSUPPORTED_RESOLUTION
+                    && !RTCBrowserType.usesNewGumFlow()) {
                     const oldResolution = options.resolution || '720';
                     const newResolution = getLowerResolution(oldResolution);
 


### PR DESCRIPTION
The error handling block for unsupported resolution can be
skipped because native gum should be doing automatic retries
at lower resolutions and leaving in the handling will only
cause an infinite loop. Analytics for the error still get
sent in the error handling directly below the retry logic.