### PR TITLE
Reports ssrc to callstats when screen sharing is started.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -892,13 +892,6 @@ JitsiConference.prototype._setupNewTrack = function(newTrack) {
 
     newTrack._setConference(this);
 
-    // send event for starting screen sharing
-    // FIXME: we assume we have only one screen sharing track
-    // if we change this we need to fix this check
-    if (newTrack.isVideoTrack() && newTrack.videoType === VideoType.DESKTOP) {
-        this.statistics.sendScreenSharingEvent(true);
-    }
-
     this.eventEmitter.emit(JitsiConferenceEvents.TRACK_ADDED, newTrack);
 };
 

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -19,6 +19,7 @@ import * as JitsiConferenceErrors from './JitsiConferenceErrors';
 import * as JitsiConferenceEvents from './JitsiConferenceEvents';
 import * as MediaType from './service/RTC/MediaType';
 import RTCEvents from './service/RTC/RTCEvents';
+import VideoType from './service/RTC/VideoType';
 import Statistics from './modules/statistics/statistics';
 import XMPPEvents from './service/xmpp/XMPPEvents';
 
@@ -522,27 +523,36 @@ JitsiConferenceEventManager.prototype.setupRTCListeners = function() {
             }
         });
 
-    if (conference.statistics) {
-        rtc.addListener(RTCEvents.CREATE_ANSWER_FAILED,
-            (e, tpc) => {
-                conference.statistics.sendCreateAnswerFailed(e, tpc);
-            });
+    rtc.addListener(RTCEvents.CREATE_ANSWER_FAILED,
+        (e, tpc) => {
+            conference.statistics.sendCreateAnswerFailed(e, tpc);
+        });
 
-        rtc.addListener(RTCEvents.CREATE_OFFER_FAILED,
-            (e, tpc) => {
-                conference.statistics.sendCreateOfferFailed(e, tpc);
-            });
+    rtc.addListener(RTCEvents.CREATE_OFFER_FAILED,
+        (e, tpc) => {
+            conference.statistics.sendCreateOfferFailed(e, tpc);
+        });
 
-        rtc.addListener(RTCEvents.SET_LOCAL_DESCRIPTION_FAILED,
-            (e, tpc) => {
-                conference.statistics.sendSetLocalDescFailed(e, tpc);
-            });
+    rtc.addListener(RTCEvents.SET_LOCAL_DESCRIPTION_FAILED,
+        (e, tpc) => {
+            conference.statistics.sendSetLocalDescFailed(e, tpc);
+        });
 
-        rtc.addListener(RTCEvents.SET_REMOTE_DESCRIPTION_FAILED,
-            (e, tpc) => {
-                conference.statistics.sendSetRemoteDescFailed(e, tpc);
-            });
-    }
+    rtc.addListener(RTCEvents.SET_REMOTE_DESCRIPTION_FAILED,
+        (e, tpc) => {
+            conference.statistics.sendSetRemoteDescFailed(e, tpc);
+        });
+
+    rtc.addListener(RTCEvents.LOCAL_TRACK_SSRC_UPDATED,
+        (track, ssrc) => {
+            // when starting screen sharing, the track is created and when
+            // we do set local description and we process the ssrc we
+            // will be notified for it and we will report it with the event
+            // for screen sharing
+            if (track.isVideoTrack() && track.videoType === VideoType.DESKTOP) {
+                conference.statistics.sendScreenSharingEvent(true, ssrc);
+            }
+        });
 };
 
 /**

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2238,6 +2238,9 @@ TraceablePeerConnection.prototype._processLocalSSRCsMap = function(ssrcMap) {
                         } with: `, newSSRC);
                 }
                 this.localSSRCs.set(track.rtcId, newSSRC);
+
+                this.eventEmitter.emit(
+                    RTCEvents.LOCAL_TRACK_SSRC_UPDATED, track, newSSRCNum);
             } else {
                 logger.debug(
                     `The local SSRC(${newSSRCNum}) for ${track} ${trackMSID}`

--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -689,11 +689,20 @@ export default class CallStats {
      * Notifies CallStats for screen sharing events
      * @param {boolean} start true for starting screen sharing and
      * false for not stopping
+     * @param {string|null} ssrc - optional ssrc value, used only when
+     * starting screen sharing.
      */
-    sendScreenSharingEvent(start) {
+    sendScreenSharingEvent(start, ssrc) {
+        let eventData;
+
+        if (ssrc) {
+            eventData = { ssrc };
+        }
+
         CallStats._reportEvent(
             this,
-            start ? fabricEvent.screenShareStart : fabricEvent.screenShareStop);
+            start ? fabricEvent.screenShareStart : fabricEvent.screenShareStop,
+            eventData);
     }
 
     /**

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -488,12 +488,15 @@ Statistics.prototype.sendMuteEvent = function(tpc, muted, type) {
  * Notifies CallStats for screen sharing events
  * @param start {boolean} true for starting screen sharing and
  * false for not stopping
+ * @param {string|null} ssrc - optional ssrc value, used only when
+ * starting screen sharing.
  */
-Statistics.prototype.sendScreenSharingEvent = function(start) {
-    for (const cs of this.callsStatsInstances.values()) {
-        cs.sendScreenSharingEvent(start);
-    }
-};
+Statistics.prototype.sendScreenSharingEvent
+    = function(start, ssrc) {
+        for (const cs of this.callsStatsInstances.values()) {
+            cs.sendScreenSharingEvent(start, ssrc);
+        }
+    };
 
 /**
  * Notifies the statistics module that we are now the dominant speaker of the

--- a/service/RTC/RTCEvents.js
+++ b/service/RTC/RTCEvents.js
@@ -21,6 +21,15 @@ const RTCEvents = {
      * The first argument is the value passed to {@link RTC.setLastN}.
      */
     LASTN_VALUE_CHANGED: 'rtc.lastn_value_changed',
+
+    /**
+     * Event emitted when ssrc for a local track is extracted and stored
+     * in {@link TraceablePeerConnection}.
+     * @param {JitsiLocalTrack} track which ssrc was updated
+     * @param {string} ssrc that was stored
+     */
+    LOCAL_TRACK_SSRC_UPDATED: 'rtc.local_track_ssrc_updated',
+
     AVAILABLE_DEVICES_CHANGED: 'rtc.available_devices_changed',
     TRACK_ATTACHED: 'rtc.track_attached',
 


### PR DESCRIPTION
Adds rtc.LOCAL_TRACK_SSRC_UPDATED event to be emitted when ssrc is updated for a local track.
Fixes adding rtc listeners for CREATE_ANSWER_FAILED, CREATE_OFFER_FAILED, SET_LOCAL_DESCRIPTION_FAILED, SET_REMOTE_DESCRIPTION_FAILED.