### PR TITLE
feat(xmpp): lower max XMPP retries to 3

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -31,7 +31,12 @@ function createConnection(token, bosh = '/http-bind') {
         bosh += `${bosh.indexOf('?') === -1 ? '?' : '&'}token=${token}`;
     }
 
-    return new Strophe.Connection(bosh);
+    const conn = new Strophe.Connection(bosh);
+
+    // The default maxRetries is 5, which is too long.
+    conn.maxRetries = 3;
+
+    return conn;
 }
 
 /**


### PR DESCRIPTION
Strophe's builtin retry mechanism uses exponential backoff, and 5 retries
results in a very long time.