### PR TITLE
fix(ie11): do not call JSON.stringify with temasys ice candidate

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2257,7 +2257,15 @@ TraceablePeerConnection.prototype.addIceCandidate = function(
         successCallback,
         failureCallback) {
     // var self = this;
-    this.trace('addIceCandidate', JSON.stringify(candidate, null, ' '));
+
+    // Calling JSON.stringify with temasys objects causes a stack overflow, so
+    // instead pick out values to log.
+    this.trace('addIceCandidate', JSON.stringify({
+        candidate: candidate.candidate,
+        sdpMid: candidate.sdpMid,
+        sdpMLineIndex: candidate.sdpMLineIndex,
+        usernameFragment: candidate.usernameFragment
+    }, null, ' '));
     this.peerconnection.addIceCandidate(
         candidate, successCallback, failureCallback);
 


### PR DESCRIPTION
Calling JSON.stringify on a temasys object causes a stack overflow.
The result is that the JingleSessionPC's work queue never gets
cleared so future work, like video muting, will not get called.
Instead of passing in the candidate directly, manually do
what chrome's implementation of candidate.toJSON does.