### PR TITLE
feat(large-video): helper for detecting background video support

### DIFF
--- a/modules/RTC/RTCUIHelper.js
+++ b/modules/RTC/RTCUIHelper.js
@@ -55,6 +55,18 @@ const RTCUIHelper = {
     },
 
     /**
+     * Returns whether or not applying filter effects to video elements is known
+     * to cause issues, be it performance (Firefox) or having no effect
+     * (Temsasys).
+     *
+     * @returns {boolean}
+     */
+    isVideoFilterSupported() {
+        return !RTCBrowserType.isFirefox()
+            && !RTCBrowserType.isTemasysPluginUsed();
+    },
+
+    /**
      * Sets 'volume' property of given HTML element displaying RTC audio or
      * video stream.
      * @param streamElement HTML element to which the RTC stream is attached to.


### PR DESCRIPTION
The background behind large video is not performant on all
browsers. On Firefox it drops FPS and on temasys the background
effect doesn't even work.