### PR TITLE
move the tpc transform logs to debug

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -213,7 +213,9 @@ export default function TraceablePeerConnection(
 
     // override as desired
     this.trace = (what, info) => {
-        /* logger.warn('WTRACE', what, info);
+        logger.debug(what, info);
+
+        /*
         if (info && RTCBrowserType.isIExplorer()) {
             if (info.length > 1024) {
                 logger.warn('WTRACE', what, info.substr(1024));


### PR DESCRIPTION
jitsi-meet has been changed to have tpc.js on info by default, so these
logs still won't show by default.