### PR TITLE
feat(analytics): shield handler execution

### DIFF
--- a/modules/statistics/AnalyticsAdapter.js
+++ b/modules/statistics/AnalyticsAdapter.js
@@ -304,7 +304,13 @@ class AnalyticsAdapter {
             // not at the time we receive it.
             this._appendPermanentProperties(event);
 
-            this.analyticsHandlers.forEach(handler => handler.sendEvent(event));
+            for (const handler of this.analyticsHandlers) {
+                try {
+                    handler.sendEvent(event);
+                } catch (e) {
+                    logger.warn(`Error sending analytics event: ${e}`);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Avoid throwing an exception if an analytics handler throws one. Emit a warning
though, so the problem can be eventually caught and fixed in the handler.