### PR TITLE
feat(TPC): append TPC ID to stream IDs

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -19,6 +19,12 @@ import VideoType from '../../service/RTC/VideoType';
 
 const logger = getLogger(__filename);
 
+/**
+ * The counter used to generated id numbers assigned to peer connections
+ * @type {number}
+ */
+let peerConnectionIdCounter = 1;
+
 let rtcTrackIdCounter = 0;
 
 /**
@@ -113,12 +119,6 @@ export default class RTC extends Listenable {
          * @type {Map.<number, TraceablePeerConnection>}
          */
         this.peerConnections = new Map();
-
-        /**
-         * The counter used to generated id numbers assigned to peer connections
-         * @type {number}
-         */
-        this.peerConnectionIdCounter = 1;
 
         this.localTracks = [];
 
@@ -444,13 +444,13 @@ export default class RTC extends Listenable {
         const newConnection
             = new TraceablePeerConnection(
                 this,
-                this.peerConnectionIdCounter,
+                peerConnectionIdCounter,
                 signaling,
                 iceConfig, pcConstraints,
                 isP2P, options);
 
         this.peerConnections.set(newConnection.id, newConnection);
-        this.peerConnectionIdCounter += 1;
+        peerConnectionIdCounter += 1;
 
         return newConnection;
     }

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1210,6 +1210,9 @@ const getters = {
         // happening (check setLocalDescription impl).
         desc = enforceSendRecv(desc);
 
+        // See the method's doc for more info about this transformation.
+        desc = this.localSdpMunger.transformStreamIdentifiers(desc);
+
         return desc;
     },
     remoteDescription() {

--- a/modules/util/MathUtil.js
+++ b/modules/util/MathUtil.js
@@ -1,0 +1,19 @@
+
+
+/**
+ * The method will increase the given number by 1. If the given counter is equal
+ * or greater to {@link Number.MAX_SAFE_INTEGER} then it will be rolled back to
+ * 1.
+ * @param {number} number - An integer counter value to be incremented.
+ * @return {number} the next counter value increased by 1 (see the description
+ * above for exception).
+ */
+export function safeCounterIncrement(number) {
+    let nextValue = number;
+
+    if (number >= Number.MAX_SAFE_INTEGER) {
+        nextValue = 0;
+    }
+
+    return nextValue + 1;
+}


### PR DESCRIPTION
This commit will append "-" + tpc.id to every local 'MSID', 'cname',
'label' and 'mslabel', before feeding the local SDP to the Jingle layer.
It will make stream IDs unique across TraceablePeerConnection instances
and prevent from conflicts in some corner cases.

For example this will fix a problem where if the client drops
the conference without leaving the XMPP MUC gracefully and will join
the conference again without recreating the local tracks it would lead
to the MSID conflict, because the stream is still advertised by
"the ghost" participant.