### PR TITLE
feat: Adds a config.gatherStats parameter.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -185,9 +185,10 @@ export default function TraceablePeerConnection(
     this.statsinterval = null;
 
     /**
-     * @type {number}
+     * @type {number} The max number of stats to keep in this.stats. Limit to
+     * 300 values, i.e. 5 minutes; set to 0 to disable
      */
-    this.maxstats = 0;
+    this.maxstats = options.maxstats;
     const Interop = require('sdp-interop').Interop;
 
     this.interop = new Interop();

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -29,6 +29,12 @@ const logger = getLogger(__filename);
  */
 const IQ_TIMEOUT = 10000;
 
+/*
+ * The default number of samples (per stat) to keep when webrtc stats gathering
+ * is enabled in TraceablePeerConnection.
+ */
+const DEFAULT_MAX_STATS = 300;
+
 /**
  *
  */
@@ -247,6 +253,10 @@ export default class JingleSessionPC extends JingleSession {
         this.wasstable = false;
 
         const pcOptions = { disableRtx: this.room.options.disableRtx };
+
+        if (this.room.options.gatherStats) {
+            pcOptions.maxstats = DEFAULT_MAX_STATS;
+        }
 
         if (this.isP2P) {
             // simulcast needs to be disabled for P2P (121) calls


### PR DESCRIPTION
This PR exposes the stats gathering functionality that's already built-in the TraceablePeerConnection that has it gather stats from the wrapped PeerConnection. This is useful in debug scenarios as it allows to extract and process the stats.

Please don't merge this yet, it's WIP and I haven't tested it yet.