### PR TITLE
Adjust name of the js library

### DIFF
--- a/doc/example/index.html
+++ b/doc/example/index.html
@@ -6,7 +6,7 @@
     <script src="libs/jquery-2.1.1.min.js"></script>
     <script src="libs/strophe/strophe.js"></script>
     <script src="libs/strophe/strophe.disco.min.js?v=1"></script>
-    <script src="../../lib-jitsi-meet.js"></script>
+    <script src="../../lib-jitsi-meet.min.js"></script>
     <script src="example.js" ></script>
 </head>
 <body>


### PR DESCRIPTION
After running `npm install` I end up with a minified library for lib-jitsi-meet. I had to adjust the name to get the example to run