### PR TITLE
fix: Don't remove the TURN port if it's the default.

### DIFF
--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -349,7 +349,7 @@ class JingleConnectionPlugin extends ConnectionPlugin {
                         dict.url += el.attr('host');
                         const port = el.attr('port');
 
-                        if (port && port !== '3478') {
+                        if (port) {
                             dict.url += `:${el.attr('port')}`;
                         }
                         const transport = el.attr('transport');


### PR DESCRIPTION
3478 is default for TURN, but not for TURNS. Reported by @damencho.