### PR TITLE
fix(chat): use querySelector over querySelectorAll

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -418,7 +418,7 @@ export default class ChatRoom extends Listenable {
                 && this.options.hiddenDomain
                     === jid.substring(jid.indexOf('@') + 1, jid.indexOf('/'));
 
-        const xEl = pres.querySelectorAll('x')[0];
+        const xEl = pres.querySelector('x');
 
         if (xEl) {
             xEl.remove();


### PR DESCRIPTION
react-native does not support querySelectorAll. jitsi-meet's
react-native does have a polyfill for querySelector so use
that instead.