### PR TITLE
Switches camera id to mandatory when using old gum flow.

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -38,10 +38,12 @@ const logger = Logger.getLogger(__filename);
 const USER_MEDIA_PERMISSION_PROMPT_TIMEOUT = 1000;
 
 /**
- * Gets a lower resolution and if there is none left other than the requested
- * returns null.
+ * Gets the next lowest desirable resolution to try for a camera.  If the given
+ * resolution is already the lowest acceptable resolution, returns null.
  *
- * @param resolution the resolution to get.
+ * @param resolution the current resolution
+ * @return the next lowest resolution from the given one, or null if it is
+ * already the lowest acceptable resolution.
  */
 function getLowerResolution(resolution) {
     if (!Resolutions[resolution]) {
@@ -356,11 +358,9 @@ export default {
                     // use
                     if (originalOptions
                         && error.gum.constraints
-                        && error.gum.constraints
                         && error.gum.constraints.video
                         && error.gum.constraints.video.mandatory
-                        && error.gum.constraints.video.mandatory.sourceId
-                            === options.cameraDeviceId) {
+                        && error.gum.constraints.video.mandatory.sourceId) {
                         originalOptions.cameraDeviceId = undefined;
 
                         return this.createLocalTracks(originalOptions);

--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -91,6 +91,9 @@ function JitsiTrackError(error, options, devices) {
         case 'OverconstrainedError': {
             const constraintName = error.constraintName || error.constraint;
 
+            // we treat deviceId as unsupported resolution, as we want to
+            // retry and finally if everything fails to remove deviceId from
+            // mandatory constraints
             if (options
                     && options.video
                     && (!devices || devices.indexOf('video') > -1)
@@ -99,7 +102,8 @@ function JitsiTrackError(error, options, devices) {
                         || constraintName === 'minHeight'
                         || constraintName === 'maxHeight'
                         || constraintName === 'width'
-                        || constraintName === 'height')) {
+                        || constraintName === 'height'
+                        || constraintName === 'deviceId')) {
                 this.name = JitsiTrackErrors.UNSUPPORTED_RESOLUTION;
                 this.message
                     = TRACK_ERROR_TO_MESSAGE_MAP[this.name]

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -243,9 +243,7 @@ function getConstraints(um, options = {}) {
             }
 
             // Old style.
-            constraints.video.optional.push({
-                sourceId: options.cameraDeviceId
-            });
+            constraints.video.mandatory.sourceId = options.cameraDeviceId;
         } else {
             // Prefer the front i.e. user-facing camera (to the back i.e.
             // environment-facing camera, for example).


### PR DESCRIPTION
When it fails we retry with different resolutions, and if that doesn't work we remove device id and let gum to decide which device to use.