### PR TITLE
feat(recording): show the YouTube live stream URL

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1265,6 +1265,19 @@ JitsiConference.prototype.onDisplayNameChanged = function(jid, displayName) {
 };
 
 /**
+ * Callback invoked when a known live stream URL has been updated.
+ *
+ * @params {*} ...args - Information regarding which participant has an updated
+ * live stream URL and what that live stream URL is.
+ * @returns {void}
+ */
+JitsiConference.prototype.onLiveStreamURLChange = function(...args) {
+    this.eventEmitter.emit(
+        JitsiConferenceEvents.LIVE_STREAM_URL_CHANGED,
+        ...args);
+};
+
+/**
  * Notifies this JitsiConference that a JitsiRemoteTrack was added into
  * the conference.
  *

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -266,6 +266,9 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
     chatRoom.addListener(XMPPEvents.DISPLAY_NAME_CHANGED,
         conference.onDisplayNameChanged.bind(conference));
 
+    chatRoom.addListener(XMPPEvents.LIVE_STREAM_URL_CHANGE,
+        conference.onLiveStreamURLChange.bind(conference));
+
     chatRoom.addListener(XMPPEvents.LOCAL_ROLE_CHANGED, role => {
         conference.onLocalRoleChanged(role);
 

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -116,6 +116,11 @@ export const KICKED = 'conference.kicked';
 export const LAST_N_ENDPOINTS_CHANGED = 'conference.lastNEndpointsChanged';
 
 /**
+ * A known participant's live stream URL has changed.
+ */
+export const LIVE_STREAM_URL_CHANGED = 'conference.liveStreamURLChanged';
+
+/**
  * Indicates that the room has been locked or unlocked.
  */
 export const LOCK_STATE_CHANGED = 'conference.lock_state_changed';

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -425,8 +425,9 @@ export default class ChatRoom extends Listenable {
             const liveStreamViewURLItem
                 = pres.getElementsByTagName('live-stream-view-url')[0];
 
-            member.liveStreamViewURL
-                = liveStreamViewURLItem && liveStreamViewURLItem.textContent;
+            if (liveStreamViewURLItem) {
+                member.liveStreamViewURL = liveStreamViewURLItem.textContent;
+            }
         }
 
         const xEl = pres.querySelector('x');

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -418,6 +418,17 @@ export default class ChatRoom extends Listenable {
                 && this.options.hiddenDomain
                     === jid.substring(jid.indexOf('@') + 1, jid.indexOf('/'));
 
+        // Check isHiddenDomain as a way to verify a live stream URL is from a
+        // trusted source. This prevents users from trying to display arbitrary
+        // live stream URLs.
+        if (member.isHiddenDomain) {
+            const liveStreamViewURLItem
+                = pres.getElementsByTagName('live-stream-view-url')[0];
+
+            member.liveStreamViewURL
+                = liveStreamViewURLItem && liveStreamViewURLItem.textContent;
+        }
+
         const xEl = pres.querySelector('x');
 
         if (xEl) {
@@ -517,6 +528,13 @@ export default class ChatRoom extends Listenable {
                     member.status,
                     member.identity);
 
+                if (member.liveStreamViewURL) {
+                    this.eventEmitter.emit(
+                        XMPPEvents.LIVE_STREAM_URL_CHANGE,
+                        from,
+                        member.liveStreamViewURL);
+                }
+
                 // we are reporting the status with the join
                 // so we do not want a second event about status update
                 hasStatusUpdate = false;
@@ -556,6 +574,15 @@ export default class ChatRoom extends Listenable {
                 hasStatusUpdate = true;
                 memberOfThis.status = member.status;
             }
+
+            if (memberOfThis.liveStreamViewURL !== member.liveStreamViewURL) {
+                memberOfThis.liveStreamViewURL = member.liveStreamViewURL;
+                this.eventEmitter.emit(
+                    XMPPEvents.LIVE_STREAM_URL_CHANGE,
+                    from,
+                    member.liveStreamViewURL);
+            }
+
         }
 
         // after we had fired member or room joined events, lets fire events
@@ -754,7 +781,6 @@ export default class ChatRoom extends Listenable {
      * whether this is the focus that left
      */
     onParticipantLeft(jid, skipEvents) {
-
         delete this.lastPresences[jid];
 
         if (skipEvents) {
@@ -812,6 +838,13 @@ export default class ChatRoom extends Listenable {
         const membersKeys = Object.keys(this.members);
 
         if (!isSelfPresence) {
+            if (this.members[from].liveStreamViewURL) {
+                this.eventEmitter.emit(
+                    XMPPEvents.LIVE_STREAM_URL_CHANGE,
+                    from,
+                    undefined);
+            }
+
             delete this.members[from];
             this.onParticipantLeft(from, false);
         } else if (membersKeys.length > 0) {

--- a/modules/xmpp/recording.js
+++ b/modules/xmpp/recording.js
@@ -191,7 +191,8 @@ Recording.prototype.setRecordingJibri = function(
                 'streamid':
                     this.type === Recording.types.JIBRI
                         ? options.streamId
-                        : undefined
+                        : undefined,
+                you_tube_broadcast_id: options.broadcastId
             })
             .up();
 

--- a/modules/xmpp/recording.js
+++ b/modules/xmpp/recording.js
@@ -192,7 +192,7 @@ Recording.prototype.setRecordingJibri = function(
                     this.type === Recording.types.JIBRI
                         ? options.streamId
                         : undefined,
-                you_tube_broadcast_id: options.broadcastId
+                'you_tube_broadcast_id': options.broadcastId
             })
             .up();
 

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -90,6 +90,10 @@ const XMPPEvents = {
     // Designates an event indicating that we were kicked from the XMPP MUC.
     KICKED: 'xmpp.kicked',
 
+    // Designates an event indicating that a participant's live stream URL has
+    // been updated.
+    LIVE_STREAM_URL_CHANGE: 'xmpp.live_stream_url_changed',
+
     // Designates an event indicating that our role in the XMPP MUC has changed.
     LOCAL_ROLE_CHANGED: 'xmpp.localrole_changed',
 


### PR DESCRIPTION
- Pass you_tube_broadcast_id to Jibri so it can create a
  YouTube link for the live stream.
- Emit the liveStreamViewURL (the YouTube link) when it
  is received from the participant doing the recording.