### PR TITLE
fix(migration): do not do double offer-answer for Chrome 63 and up

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -16,6 +16,7 @@ import SDPDiffer from './SDPDiffer';
 import SDPUtil from './SDPUtil';
 import SignalingLayerImpl from './SignalingLayerImpl';
 
+import browser from '../browser';
 import Statistics from '../statistics/statistics';
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
 import GlobalOnErrorHandler from '../util/GlobalOnErrorHandler';
@@ -956,11 +957,27 @@ export default class JingleSessionPC extends JingleSession {
      * @param failure function(error) called when we fail to accept new offer.
      */
     replaceTransport(jingleOfferElem, success, failure) {
+        this.room.eventEmitter.emit(XMPPEvents.ICE_RESTARTING, this);
+
+        // Starting on Chrome version 63, having to do a double offer-answer
+        // cycle is not needed to establish a connection with the new bridge.
+        if (browser.isChrome() && browser.isVersionGreaterThan('62')) {
+            this.setOfferAnswerCycle(
+                jingleOfferElem,
+                () => {
+                    const localSDP
+                        = new SDP(this.peerconnection.localDescription.sdp);
+
+                    this.sendTransportAccept(localSDP, success, failure);
+                },
+                failure);
+
+            return;
+        }
 
         // We need to first set an offer without the 'data' section to have the
         // SCTP stack cleaned up. After that the original offer is set to have
         // the SCTP connection established with the new bridge.
-        this.room.eventEmitter.emit(XMPPEvents.ICE_RESTARTING, this);
         const originalOffer = jingleOfferElem.clone();
 
         jingleOfferElem.find('>content[name=\'data\']').remove();


### PR DESCRIPTION
When switching bridges, removing the "data" section from the SDP
and doing a double offer-answer results in an error starting on
Chrome 63. So on 63 and up, do a single off-answer without
removing the "data" section.