### PR TITLE
M67

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -33,6 +33,7 @@ export default class BrowserCapabilities extends BrowserDetection {
         return !(
             this.isFirefox()
             || this.isEdge()
+            || this.isReactNative()
             || this.isSafariWithWebrtc()
         );
     }


### PR DESCRIPTION
With the update of react-native-webrtc to M67, the ability to stop the camera
when a track is disabled was introduced, so there is no longer a need for doing
a local O/A to remove the track for video muting.