### PR TITLE
fix(migration): reject the data channel to restart it

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -978,16 +978,17 @@ export default class JingleSessionPC extends JingleSession {
     replaceTransport(jingleOfferElem, success, failure) {
         this.room.eventEmitter.emit(XMPPEvents.ICE_RESTARTING, this);
 
-        // We need to first set an offer without the 'data' section to have the
-        // SCTP stack cleaned up. After that the original offer is set to have
-        // the SCTP connection established with the new bridge.
+        // We need to first reject the 'data' section to have the SCTP stack
+        // cleaned up to signal the known data channel is now invalid. After
+        // that the original offer is set to have the SCTP connection
+        // established with the new bridge.
         const originalOffer = jingleOfferElem.clone();
 
         jingleOfferElem
             .find('>content[name=\'data\']')
             .attr('senders', 'rejected');
 
-        // First set an offer without the 'data' section
+        // First set an offer with a rejected 'data' section
         this.setOfferAnswerCycle(
             jingleOfferElem,
             () => {

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -16,7 +16,6 @@ import SDPDiffer from './SDPDiffer';
 import SDPUtil from './SDPUtil';
 import SignalingLayerImpl from './SignalingLayerImpl';
 
-import browser from '../browser';
 import RTCEvents from '../../service/RTC/RTCEvents';
 import Statistics from '../statistics/statistics';
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
@@ -979,28 +978,14 @@ export default class JingleSessionPC extends JingleSession {
     replaceTransport(jingleOfferElem, success, failure) {
         this.room.eventEmitter.emit(XMPPEvents.ICE_RESTARTING, this);
 
-        // Starting on Chrome version 63, having to do a double offer-answer
-        // cycle is not needed to establish a connection with the new bridge.
-        if (browser.isChrome() && browser.isVersionGreaterThan('62')) {
-            this.setOfferAnswerCycle(
-                jingleOfferElem,
-                () => {
-                    const localSDP
-                        = new SDP(this.peerconnection.localDescription.sdp);
-
-                    this.sendTransportAccept(localSDP, success, failure);
-                },
-                failure);
-
-            return;
-        }
-
         // We need to first set an offer without the 'data' section to have the
         // SCTP stack cleaned up. After that the original offer is set to have
         // the SCTP connection established with the new bridge.
         const originalOffer = jingleOfferElem.clone();
 
-        jingleOfferElem.find('>content[name=\'data\']').remove();
+        jingleOfferElem
+            .find('>content[name=\'data\']')
+            .attr('senders', 'rejected');
 
         // First set an offer without the 'data' section
         this.setOfferAnswerCycle(

--- a/modules/xmpp/SDP.js
+++ b/modules/xmpp/SDP.js
@@ -636,7 +636,8 @@ SDP.prototype.jingle2media = function(content) {
         tmp.proto = 'RTP/AVPF';
     }
     if (sctp.length) {
-        media += `m=application 1 DTLS/SCTP ${sctp.attr('number')}\r\n`;
+        media += `m=application ${tmp.port} DTLS/SCTP ${
+            sctp.attr('number')}\r\n`;
         media += `a=sctpmap:${sctp.attr('number')} ${sctp.attr('protocol')}`;
 
         const streamCount = sctp.attr('streams');


### PR DESCRIPTION
I've been looking at this with Brian (who has been doing most of the leg work...) and while this works we do not understand exactly why yet. The bridge is getting the sdp without the data channel but it is unknown where that is getting stripped.

Starting on chrome 63, an error occurs when renegotiating
with the new bridge on bridge migration when the SDP sections
do not match, which occurs when removing the data channel
section. Not doing the double renegotiate prevents the data
channel from being reopened. The way around this, while still
avoing the error, is to reject the data channel section instead
of removing it to trigger a new data channel.
