### PR TITLE
feat(JitsiConference): add 'getConnection' getter

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -442,6 +442,13 @@ JitsiConference.prototype.getName = function() {
 };
 
 /**
+ * Returns the {@link JitsiConnection} used by this this conference.
+ */
+JitsiConference.prototype.getConnection = function() {
+    return this.connection;
+};
+
+/**
  * Check if authentication is enabled for this conference.
  */
 JitsiConference.prototype.isAuthEnabled = function() {


### PR DESCRIPTION
Adds a getter to retrieve JitsiConnection instance used by the JitsiConference.