### PR TITLE
fix(presence): do not escape xml values

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -30,7 +30,10 @@ export const parser = {
             const text = Strophe.getText(child);
 
             if (text) {
-                node.value = text;
+                // Using Strophe.getText will do work for traversing all direct
+                // child text nodes but returns an escaped value, which is not
+                // desirable at this point.
+                node.value = Strophe.xmlunescape(text);
             }
             nodes.push(node);
             this.packet2JSON(child, node.children);


### PR DESCRIPTION
When receiving presence, the XML is converted to JSON. In
the process, Strophe.getText is used, which calls its
xmlescape utility function. This is not desired as the
raw value is desired, especially for display name.

Note: this issue only affects presence as it is the only
place that call the helper packet2JSON, which is the only
place that calls Strophe.getText.