### PR TITLE
ref(recording): change implementation to match VideoSIPGW

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -39,6 +39,7 @@ import Statistics from './modules/statistics/statistics';
 import TalkMutedDetection from './modules/TalkMutedDetection';
 import Transcriber from './modules/transcription/transcriber';
 import VideoType from './service/RTC/VideoType';
+import RecordingManager from './modules/recording/RecordingManager';
 import VideoSIPGW from './modules/videosipgw/VideoSIPGW';
 import * as VideoSIPGWConstants from './modules/videosipgw/VideoSIPGWConstants';
 import * as XMPPEvents from './service/xmpp/XMPPEvents';
@@ -200,6 +201,7 @@ export default function JitsiConference(options) {
     this.p2pJingleSession = null;
 
     this.videoSIPGWHandler = new VideoSIPGW(this.room);
+    this.recordingManager = new RecordingManager(this.room);
 }
 
 // FIXME convert JitsiConference to ES6 - ASAP !
@@ -1752,7 +1754,7 @@ JitsiConference.prototype.sendTones = function(tones, duration, pause) {
  */
 JitsiConference.prototype.startRecording = function(options) {
     if (this.room) {
-        return this.room.startRecording(options);
+        return this.recordingManager.startRecording(options);
     }
 
     return Promise.reject(new Error('The conference is not created yet!'));
@@ -1767,7 +1769,7 @@ JitsiConference.prototype.startRecording = function(options) {
  */
 JitsiConference.prototype.stopRecording = function(sessionID) {
     if (this.room) {
-        return this.room.stopRecording(sessionID);
+        return this.recordingManager.stopRecording(sessionID);
     }
 
     return Promise.reject(new Error('The conference is not created yet!'));

--- a/modules/recording/RecordingManager.js
+++ b/modules/recording/RecordingManager.js
@@ -13,8 +13,8 @@ const logger = getLogger(__filename);
  */
 class RecordingManager {
     /**
-     * Initialize RecordingManager with other objects that are necessary for
-     * starting a recording.
+     * Initialize {@code RecordingManager} with other objects that are necessary
+     * for starting a recording.
      *
      * @param {ChatRoom} chatRoom - The chat room to handle.
      * @returns {void}

--- a/modules/recording/recordingManager.js
+++ b/modules/recording/recordingManager.js
@@ -8,32 +8,30 @@ import recordingXMLUtils from './recordingXMLUtils';
 const logger = getLogger(__filename);
 
 /**
- * A singleton responsible for starting and stopping recording sessions and
- * emitting state updates for them.
+ * A class responsible for starting and stopping recording sessions and emitting
+ * state updates for them.
  */
-const recordingManager = {
+class RecordingManager {
     /**
-     * All known recording sessions from the current conference.
-     */
-    _sessions: {},
-
-    /**
-     * Initialize recordingManager with other objects that are necessary for
+     * Initialize RecordingManager with other objects that are necessary for
      * starting a recording.
      *
-     * @param {Object} eventEmitter - The eventEmitter to be used for
-     * broadcasting recording state changes.
-     * @param {Object} connection - The MUC connection used for sending out
-     * messages regarding recording.
-     * @param {string} focusMucJid - The ID of the conference (MUC) the focus
-     * is in.
+     * @param {ChatRoom} chatRoom - The chat room to handle.
      * @returns {void}
      */
-    init(eventEmitter, connection, focusMucJid) {
-        this._eventEmitter = eventEmitter;
-        this._connection = connection;
-        this._focusMucJid = focusMucJid;
-    },
+    constructor(chatRoom) {
+        /**
+         * All known recording sessions from the current conference.
+         */
+        this._sessions = {};
+
+        this._chatRoom = chatRoom;
+
+        this.onPresence = this.onPresence.bind(this);
+
+        this._chatRoom.eventEmitter.addListener(
+            XMPPEvents.PRESENCE_RECEIVED, this.onPresence);
+    }
 
     /**
      * Finds an existing recording session by session ID.
@@ -43,38 +41,27 @@ const recordingManager = {
      */
     getSession(sessionID) {
         return this._sessions[sessionID];
-    },
+    }
 
     /**
      * Callback to invoke to parse through a presence update to find recording
      * related updates (from Jibri participant doing the recording and the
      * focus which controls recording).
      *
-     * @param {Node} presence - An XMPP presence update.
-     * @param {boolean} isHiddenDomain - Whether or not the presence update
-     * comes from a participant that is trusted but not visible, as would be the
-     * case with the Jibri recorder participant.
+     * @param {Object} event - The presence data from the pubsub event.
+     * @param {Node} event.presence - An XMPP presence update.
+     * @param {boolean} event.fromHiddenDomain - Whether or not the update comes
+     * from a participant that is trusted but not visible, as would be the case
+     * with the Jibri recorder participant.
      * @returns {void}
      */
-    onPresence(presence, isHiddenDomain) {
+    onPresence({ fromHiddenDomain, presence }) {
         if (recordingXMLUtils.isFromFocus(presence)) {
             this._handleFocusPresence(presence);
-        } else if (isHiddenDomain) {
+        } else if (fromHiddenDomain) {
             this._handleJibriPresence(presence);
         }
-    },
-
-    /**
-     * Sets the currently known ID of the conference (MUC). This method exists
-     * in case the ID is not known at init time.
-     *
-     * @param {string} focusMucJid - The ID of the conference (MUC) the focus
-     * is in.
-     * @returns {void}
-     */
-    setFocusMucJid(focusMucJid) {
-        this._focusMucJid = focusMucJid;
-    },
+    }
 
     /**
      * Start a recording session.
@@ -93,12 +80,12 @@ const recordingManager = {
     startRecording(options) {
         const session = new JibriSession({
             ...options,
-            connection: this._connection
+            connection: this._chatRoom.connection
         });
 
         return session.start({
             broadcastId: options.broadcastId,
-            focusMucJid: this._focusMucJid,
+            focusMucJid: this._chatRoom.focusMucJid,
             streamId: options.streamId
         })
             .then(() => {
@@ -118,7 +105,7 @@ const recordingManager = {
 
                 return Promise.reject(error);
             });
-    },
+    }
 
     /**
      * Stop a recording session.
@@ -132,11 +119,11 @@ const recordingManager = {
         const session = this.getSession(sessionID);
 
         if (session) {
-            return session.stop({ focusMucJid: this._focusMucJid });
+            return session.stop({ focusMucJid: this._chatRoom.focusMucJid });
         }
 
         return Promise.reject(new Error('Could not find session'));
-    },
+    }
 
     /**
      * Stores a reference to the passed in JibriSession.
@@ -146,7 +133,7 @@ const recordingManager = {
      */
     _addSession(session) {
         this._sessions[session.getID()] = session;
-    },
+    }
 
     /**
      * Create a new instance of a recording session and stores a reference to
@@ -159,8 +146,8 @@ const recordingManager = {
      */
     _createSession(sessionID, status, mode) {
         const session = new JibriSession({
-            connection: this._connection,
-            focusMucJid: this._focusMucJid,
+            connection: this._chatRoom.connection,
+            focusMucJid: this._chatRoom.focusMucJid,
             mode,
             sessionID,
             status
@@ -169,7 +156,7 @@ const recordingManager = {
         this._addSession(session);
 
         return session;
-    },
+    }
 
     /**
      * Notifies listeners of an update to a recording session.
@@ -177,8 +164,9 @@ const recordingManager = {
      * @param {JibriSession} session - The session that has been updated.
      */
     _emitSessionUpdate(session) {
-        this._eventEmitter.emit(XMPPEvents.RECORDER_STATE_CHANGED, session);
-    },
+        this._chatRoom.eventEmitter.emit(
+            XMPPEvents.RECORDER_STATE_CHANGED, session);
+    }
 
     /**
      * Parses presence to update an existing JibriSession or to create a new
@@ -222,7 +210,7 @@ const recordingManager = {
         }
 
         this._emitSessionUpdate(session);
-    },
+    }
 
     /**
      * Handles updates from the Jibri which can broadcast a YouTube URL that
@@ -252,6 +240,6 @@ const recordingManager = {
 
         this._emitSessionUpdate(session);
     }
-};
+}
 
-export default recordingManager;
+export default RecordingManager;

--- a/modules/xmpp/ChatRoom.spec.js
+++ b/modules/xmpp/ChatRoom.spec.js
@@ -155,7 +155,11 @@ describe('ChatRoom', () => {
             const pres = new DOMParser().parseFromString(presStr, 'text/xml').documentElement;
 
             room.onPresence(pres);
-            expect(emitterSpy.calls.count()).toEqual(1);
+            expect(emitterSpy.calls.count()).toEqual(2);
+            expect(emitterSpy.calls.argsFor(0)).toEqual([
+                XMPPEvents.PRESENCE_RECEIVED,
+                jasmine.any(Object)
+            ]);
             expect(emitterSpy).toHaveBeenCalledWith(
                 XMPPEvents.MUC_MEMBER_JOINED,
                 'fromjid',
@@ -177,7 +181,11 @@ describe('ChatRoom', () => {
             const pres = new DOMParser().parseFromString(presStr, 'text/xml').documentElement;
 
             room.onPresence(pres);
-            expect(emitterSpy.calls.count()).toEqual(1);
+            expect(emitterSpy.calls.count()).toEqual(2);
+            expect(emitterSpy.calls.argsFor(0)).toEqual([
+                XMPPEvents.PRESENCE_RECEIVED,
+                jasmine.any(Object)
+            ]);
             expect(emitterSpy).toHaveBeenCalledWith(
                 XMPPEvents.MUC_MEMBER_JOINED,
                 'fromjid',
@@ -214,7 +222,11 @@ describe('ChatRoom', () => {
             };
 
             room.onPresence(pres);
-            expect(emitterSpy.calls.count()).toEqual(1);
+            expect(emitterSpy.calls.count()).toEqual(2);
+            expect(emitterSpy.calls.argsFor(0)).toEqual([
+                XMPPEvents.PRESENCE_RECEIVED,
+                jasmine.any(Object)
+            ]);
             expect(emitterSpy).toHaveBeenCalledWith(
                 XMPPEvents.MUC_MEMBER_JOINED,
                 'fromjid',

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -148,6 +148,7 @@ const XMPPEvents = {
      * Indicates that phone number changed.
      */
     PHONE_NUMBER_CHANGED: 'conference.phoneNumberChanged',
+    PRESENCE_RECEIVED: 'xmpp.presence_received',
     PRESENCE_STATUS: 'xmpp.presence_status',
     PROMPT_FOR_LOGIN: 'xmpp.prompt_for_login',
 


### PR DESCRIPTION
VideoSIPGW takes in a chat room and uses instance variables
on the chat room. RecordingManager has been changed to
mirror this approach because of the case where jitsi is
deployed on a domain requiring authentication. In that
case, the initial chat room is created and fails, a
new chat room (connection) is created for authentication,
authentication is put onto the failed chat room, and the
failed chat room is used. As such, recordingManager
should not be tied to chat room creation itself but
rather tied to the first chat room.