### PR TITLE
Skips p2p with bot participants and re-initiate when they leave.

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -258,6 +258,8 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
 
     chatRoom.addListener(XMPPEvents.MUC_MEMBER_JOINED,
         conference.onMemberJoined.bind(conference));
+    chatRoom.addListener(XMPPEvents.MUC_MEMBER_BOT_TYPE_CHANGED,
+        conference._onMemberBotTypeChanged.bind(conference));
     chatRoom.addListener(XMPPEvents.MUC_MEMBER_LEFT,
         conference.onMemberLeft.bind(conference));
     this.chatRoomForwarder.forward(XMPPEvents.MUC_LEFT,

--- a/modules/xmpp/ChatRoom.spec.js
+++ b/modules/xmpp/ChatRoom.spec.js
@@ -168,6 +168,7 @@ describe('ChatRoom', () => {
                 undefined, // isHiddenDomain
                 undefined, // statsID
                 'status-text',
+                undefined,
                 undefined);
         });
 
@@ -193,6 +194,7 @@ describe('ChatRoom', () => {
                 'role-attr', // role
                 jasmine.any(Boolean), // isHiddenDomain
                 undefined, // statsID
+                undefined,
                 undefined,
                 undefined);
         });
@@ -235,7 +237,35 @@ describe('ChatRoom', () => {
                 undefined, // isHiddenDomain
                 undefined, // statsID
                 'status-text',
-                expectedIdentity);
+                expectedIdentity,
+                undefined);
+        });
+
+        it('parses bot correctly', () => {
+            const expectedBotType = 'some_bot_type';
+            const presStr = '' +
+                '<presence to="tojid" from="fromjid">' +
+                    '<status>status-text</status>' +
+                    `<bot type="${expectedBotType}"/>` +
+                '</presence>';
+            const pres = new DOMParser().parseFromString(presStr, 'text/xml').documentElement;
+
+            room.onPresence(pres);
+            expect(emitterSpy.calls.count()).toEqual(2);
+            expect(emitterSpy.calls.argsFor(0)).toEqual([
+                XMPPEvents.PRESENCE_RECEIVED,
+                jasmine.any(Object)
+            ]);
+            expect(emitterSpy).toHaveBeenCalledWith(
+                XMPPEvents.MUC_MEMBER_JOINED,
+                'fromjid',
+                undefined, // nick
+                undefined, // role
+                undefined, // isHiddenDomain
+                undefined, // statsID
+                'status-text',
+                undefined,
+                expectedBotType);
         });
 
     });

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -101,6 +101,9 @@ const XMPPEvents = {
     // received.
     PRIVATE_MESSAGE_RECEIVED: 'xmpp.private_message_received',
 
+    // Designates an event indicating that a bot participant type had changed
+    MUC_MEMBER_BOT_TYPE_CHANGED: 'xmpp.muc_member_bot_type_changed',
+
     // Designates an event indicating that the XMPP MUC was destroyed.
     MUC_DESTROYED: 'xmpp.muc_destroyed',
 


### PR DESCRIPTION
Depends on https://github.com/jitsi/jitsi-meet/pull/3182, but after merging this will update jitsi-meet PR with the lib-jitsi-meet hash.