### PR TITLE
fix(xmpp): allow to close the connection while connecting

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -429,9 +429,7 @@ export default class XMPP extends Listenable {
      * disconnect from the XMPP server (e.g. beforeunload, unload).
      */
     disconnect(ev) {
-        if (this.disconnectInProgress
-                || !this.connection
-                || !this.connection.connected) {
+        if (this.disconnectInProgress || !this.connection) {
             this.eventEmitter.emit(JitsiConnectionEvents.WRONG_STATE);
 
             return;


### PR DESCRIPTION
User may decide to abort the connection while it's stuck at connecting.

This is required to fix a corner case on mobile where if there's no network connectivity while the connection is being established if the user will try to hang up it will have no effect. The connection may eventually be established which will then lead to weird side effects. In case it fails the reload screen will be displayed even though the user has decided to leave the conference.