### PR TITLE
fix(tracks): set remote tracks to default to videoType camera

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -12,6 +12,7 @@ import RTC from './RTC';
 import RTCUtils from './RTCUtils';
 import browser from '../browser';
 import RTCEvents from '../../service/RTC/RTCEvents';
+import VideoType from '../../service/RTC/VideoType';
 import RtxModifier from '../xmpp/RtxModifier';
 
 // FIXME SDP tools should end up in some kind of util module
@@ -709,7 +710,11 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track) {
     }
 
     const muted = peerMediaInfo.muted;
-    const videoType = peerMediaInfo.videoType; // can be undefined
+
+    // peerMediaInfo.videoType can be undefined so set a default type in case
+    // there is logic depending on type existing and rely on a presence update
+    // to come in to update to the correct type.
+    const videoType = peerMediaInfo.videoType || VideoType.CAMERA;
 
     this._createRemoteTrack(
         ownerEndpointId, stream, track, mediaType, videoType, trackSsrc, muted);


### PR DESCRIPTION
This fix resolves a race condition exposed by 1bd6ee4b. Before 1bd6ee4b,
JitsiConference#replaceTrack would call JingleSessionPC#replaceTrack to update
remote participants with a new local track through jingle and then call
JitsiConference#sendCommand to update remote participants with the local track's
videoType through presence. However, replaceTrack would not be waited on for
success or failure, and instead sendCommand would end up getting fired first,
then replaceTrack completing. So remote participants would end up usually
getting the videoType first through the sendCommand call and then the track
update through the replaceTrack call.

With the promisification of JitsiConference#replaceTrack, the order of execution
is guaranteed to be JingleSessionPC#replaceTrack and then
JitsiConference#sendCommand, thereby making it more likely that the track update
comes in first and then the videoType update. (Although network conditions could
still modify the order of reception.) This causes a period of time when a remote
track update could be received without a known videoType, such as when the
remote participant joined as video muted and has un-video muted. For now default
to type CAMERA to avoid logic relying on videoType existence from blowing up.