### PR TITLE
Detects msid changes in sdp.

### DIFF
--- a/modules/xmpp/SDPDiffer.js
+++ b/modules/xmpp/SDPDiffer.js
@@ -84,6 +84,26 @@ SDPDiffer.prototype.getNewMedia = function() {
                     };
                 }
                 newMedia[othersMediaIdx].ssrcs[ssrc] = othersMedia.ssrcs[ssrc];
+            } else if (othersMedia.ssrcs[ssrc].lines
+                        && myMedia.ssrcs[ssrc].lines) {
+                // we want to detect just changes in adding/removing msid
+                const myContainMsid = myMedia.ssrcs[ssrc].lines.find(
+                    line => line.indexOf('msid') !== -1) !== undefined;
+                const newContainMsid = othersMedia.ssrcs[ssrc].lines.find(
+                    line => line.indexOf('msid') !== -1) !== undefined;
+
+                if (myContainMsid !== newContainMsid) {
+                    if (!newMedia[othersMediaIdx]) {
+                        newMedia[othersMediaIdx] = {
+                            mediaindex: othersMedia.mediaindex,
+                            mid: othersMedia.mid,
+                            ssrcs: {},
+                            ssrcGroups: []
+                        };
+                    }
+                    newMedia[othersMediaIdx].ssrcs[ssrc]
+                        = othersMedia.ssrcs[ssrc];
+                }
             }
         });
 


### PR DESCRIPTION
The case where we had created recvonly streams (start muted on FF) and we are unmuting, this creates a sendrecv stream and adds msid, we need to signal msid so listeners to be notified and create appropriate audio/video element and to start receiving the stream.