### PR TITLE
DO NOT MERGE - core: refactor initialization not to return a Promise

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -198,7 +198,7 @@ export default _mergeNamespaceAndModule({
             Statistics.sendLog(JSON.stringify(logObject));
         }
 
-        return RTC.init(options || {});
+        RTC.init(options);
     },
 
     /**
@@ -209,6 +209,17 @@ export default _mergeNamespaceAndModule({
     isDesktopSharingEnabled() {
         return RTC.isDesktopSharingEnabled();
     },
+
+    /**
+     * Returns wether the current environment supported WebRTC (for use with
+     * this library) or not.
+     *
+     * @returns {boolean} true if supported, false otherwise.
+     */
+    isWebRtcSupported() {
+        return RTC.isWebRtcSupported();
+    },
+
     setLogLevel(level) {
         Logger.setLogLevel(level);
     },

--- a/doc/API.md
+++ b/doc/API.md
@@ -74,7 +74,6 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
     - firePermissionPromptIsShownEvent - optional boolean parameter. If set to ```true```, ```JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN``` will be fired when browser shows gUM permission prompt.
 
 * ```JitsiMeetJS.enumerateDevices(callback)``` - __DEPRECATED__. Use ```JitsiMeetJS.mediaDevices.enumerateDevices(callback)``` instead.
-* ```JitsiMeetJS.isDeviceListAvailable()``` - __DEPRECATED__. Use ```JitsiMeetJS.mediaDevices.isDeviceListAvailable()``` instead.
 * ```JitsiMeetJS.isDeviceChangeAvailable(deviceType)``` - __DEPRECATED__. Use ```JitsiMeetJS.mediaDevices.isDeviceChangeAvailable(deviceType)``` instead.
 * ```JitsiMeetJS.isDesktopSharingEnabled()``` - returns true if desktop sharing is supported and false otherwise. NOTE: that method can be used after ```JitsiMeetJS.init(options)``` is completed otherwise the result will be always null.
 * ```JitsiMeetJS.getGlobalOnErrorHandler()``` - returns function that can be used to be attached to window.onerror and if options.enableWindowOnErrorHandler is enabled returns the function used by the lib. (function(message, source, lineno, colno, error)).

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -393,19 +393,12 @@ export default class RTC extends Listenable {
 
     /**
      *
-     */
-    static isRTCReady() {
-        return RTCUtils.isRTCReady();
-    }
-
-    /**
-     *
      * @param options
      */
     static init(options = {}) {
         this.options = options;
 
-        return RTCUtils.init(this.options);
+        RTCUtils.init(this.options);
     }
 
     /**
@@ -677,6 +670,16 @@ export default class RTC extends Listenable {
      */
     static isDeviceChangeAvailable(deviceType) {
         return RTCUtils.isDeviceChangeAvailable(deviceType);
+    }
+
+    /**
+     * Returns wether the current environment supported WebRTC (for use with
+     * this library) or not.
+     *
+     * @returns {boolean} true if supported, false otherwise.
+     */
+    static isWebRtcSupported() {
+        return browser.isSupported();
     }
 
     /**

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -146,8 +146,6 @@ function initRawEnumerateDevicesWithCallback() {
 // TODO: check MS Edge
 const isDeviceChangeEventSupported = false;
 
-let rtcReady = false;
-
 /**
  *
  * @param constraints
@@ -904,169 +902,161 @@ class RTCUtils extends Listenable {
         // Initialize rawEnumerateDevicesWithCallback
         initRawEnumerateDevicesWithCallback();
 
-        return new Promise((resolve, reject) => {
-            if (browser.usesNewGumFlow()) {
-                this.RTCPeerConnectionType = window.RTCPeerConnection;
+        if (browser.usesNewGumFlow()) {
+            this.RTCPeerConnectionType = window.RTCPeerConnection;
 
-                this.getUserMedia
-                    = (constraints, successCallback, errorCallback) =>
-                        window.navigator.mediaDevices
-                            .getUserMedia(constraints)
-                            .then(stream => {
-                                successCallback && successCallback(stream);
+            this.getUserMedia
+                = (constraints, successCallback, errorCallback) =>
+                    window.navigator.mediaDevices
+                        .getUserMedia(constraints)
+                        .then(stream => {
+                            successCallback && successCallback(stream);
 
-                                return stream;
-                            })
-                            .catch(err => {
-                                errorCallback && errorCallback(err);
-
-                                return Promise.reject(err);
-                            });
-
-                this.enumerateDevices = callback =>
-                    window.navigator.mediaDevices.enumerateDevices()
-                        .then(foundDevices => {
-                            callback(foundDevices);
-
-                            return foundDevices;
+                            return stream;
                         })
                         .catch(err => {
-                            logger.error(`Error enumerating devices: ${err}`);
+                            errorCallback && errorCallback(err);
 
-                            callback([]);
-
-                            return [];
+                            return Promise.reject(err);
                         });
 
-                this.attachMediaStream
-                    = wrapAttachMediaStream((element, stream) => {
-                        if (element) {
-                            element.srcObject = stream;
-                        }
+            this.enumerateDevices = callback =>
+                window.navigator.mediaDevices.enumerateDevices()
+                    .then(foundDevices => {
+                        callback(foundDevices);
+
+                        return foundDevices;
+                    })
+                    .catch(err => {
+                        logger.error(`Error enumerating devices: ${err}`);
+
+                        callback([]);
+
+                        return [];
                     });
 
-                this.getStreamID = stream => stream.id;
-                this.getTrackID = track => track.id;
-            } else if (browser.isChrome() // this is chrome < 61
-                    || browser.isOpera()
-                    || browser.isNWJS()
-                    || browser.isElectron()
-                    || browser.isReactNative()) {
-
-                this.RTCPeerConnectionType = webkitRTCPeerConnection;
-                const getUserMedia
-                    = navigator.webkitGetUserMedia.bind(navigator);
-
-                this.getUserMedia = wrapGetUserMedia(getUserMedia);
-                this.enumerateDevices = rawEnumerateDevicesWithCallback;
-
-                this.attachMediaStream
-                    = wrapAttachMediaStream((element, stream) => {
-                        defaultSetVideoSrc(element, stream);
-
-                        return element;
-                    });
-                this.getStreamID = function(stream) {
-                    // A. MediaStreams from FF endpoints have the characters '{'
-                    // and '}' that make jQuery choke.
-                    // B. The react-native-webrtc implementation that we use on
-                    // React Native at the time of this writing returns a number
-                    // for the id of MediaStream. Let's just say that a number
-                    // contains no special characters.
-                    const id = stream.id;
-
-                    // XXX The return statement is affected by automatic
-                    // semicolon insertion (ASI). No line terminator is allowed
-                    // between the return keyword and the expression.
-                    return (
-                        typeof id === 'number'
-                            ? id
-                            : SDPUtil.filterSpecialChars(id));
-                };
-                this.getTrackID = function(track) {
-                    return track.id;
-                };
-
-                if (!webkitMediaStream.prototype.getVideoTracks) {
-                    webkitMediaStream.prototype.getVideoTracks = function() {
-                        return this.videoTracks;
-                    };
-                }
-                if (!webkitMediaStream.prototype.getAudioTracks) {
-                    webkitMediaStream.prototype.getAudioTracks = function() {
-                        return this.audioTracks;
-                    };
-                }
-            } else if (browser.isEdge()) {
-                this.RTCPeerConnectionType = ortcRTCPeerConnection;
-                this.getUserMedia
-                    = wrapGetUserMedia(
-                        navigator.mediaDevices.getUserMedia.bind(
-                            navigator.mediaDevices),
-                        true);
-                this.enumerateDevices = rawEnumerateDevicesWithCallback;
-                this.attachMediaStream
-                    = wrapAttachMediaStream((element, stream) => {
-                        defaultSetVideoSrc(element, stream);
-                    });
-
-                // ORTC does not generate remote MediaStreams so those are
-                // manually created by the ORTC shim. This means that their
-                // id (internally generated) does not match the stream id
-                // signaled into the remote SDP. Therefore, the shim adds a
-                // custom jitsiRemoteId property with the original stream id.
-                this.getStreamID = function(stream) {
-                    const id = stream.jitsiRemoteId || stream.id;
-
-                    return SDPUtil.filterSpecialChars(id);
-                };
-
-                // Remote MediaStreamTracks generated by ORTC (within a
-                // RTCRtpReceiver) have an internally/random id which does not
-                // match the track id signaled in the remote SDP. The shim adds
-                // a custom jitsi-id property with the original track id.
-                this.getTrackID = function(track) {
-                    return track.jitsiRemoteId || track.id;
-                };
-            } else {
-                rejectWithWebRTCNotSupported(
-                    'Browser does not appear to be WebRTC-capable',
-                    reject);
-
-                return;
-            }
-
-            this._initPCConstraints(options);
-
-            rtcReady = true;
-            eventEmitter.emit(RTCEvents.RTC_READY, true);
-            screenObtainer.init(
-                options, this.getUserMediaWithConstraints.bind(this));
-
-            if (this.isDeviceListAvailable()
-                    && rawEnumerateDevicesWithCallback) {
-                rawEnumerateDevicesWithCallback(ds => {
-                    availableDevices = ds.splice(0);
-
-                    logger.debug('Available devices: ', availableDevices);
-                    sendDeviceListToAnalytics(availableDevices);
-
-                    eventEmitter.emit(RTCEvents.DEVICE_LIST_AVAILABLE,
-                        availableDevices);
-
-                    if (isDeviceChangeEventSupported) {
-                        navigator.mediaDevices.addEventListener(
-                            'devicechange',
-                            () => this.enumerateDevices(
-                                    onMediaDevicesListChanged));
-                    } else {
-                        pollForAvailableMediaDevices();
+            this.attachMediaStream
+                = wrapAttachMediaStream((element, stream) => {
+                    if (element) {
+                        element.srcObject = stream;
                     }
                 });
-            }
 
-            resolve();
-        });
+            this.getStreamID = stream => stream.id;
+            this.getTrackID = track => track.id;
+        } else if (browser.isChrome() // this is chrome < 61
+                || browser.isOpera()
+                || browser.isNWJS()
+                || browser.isElectron()
+                || browser.isReactNative()) {
+
+            this.RTCPeerConnectionType = webkitRTCPeerConnection;
+            const getUserMedia
+                = navigator.webkitGetUserMedia.bind(navigator);
+
+            this.getUserMedia = wrapGetUserMedia(getUserMedia);
+            this.enumerateDevices = rawEnumerateDevicesWithCallback;
+
+            this.attachMediaStream
+                = wrapAttachMediaStream((element, stream) => {
+                    defaultSetVideoSrc(element, stream);
+
+                    return element;
+                });
+            this.getStreamID = function(stream) {
+                // A. MediaStreams from FF endpoints have the characters '{'
+                // and '}' that make jQuery choke.
+                // B. The react-native-webrtc implementation that we use on
+                // React Native at the time of this writing returns a number
+                // for the id of MediaStream. Let's just say that a number
+                // contains no special characters.
+                const id = stream.id;
+
+                // XXX The return statement is affected by automatic
+                // semicolon insertion (ASI). No line terminator is allowed
+                // between the return keyword and the expression.
+                return (
+                    typeof id === 'number'
+                        ? id
+                        : SDPUtil.filterSpecialChars(id));
+            };
+            this.getTrackID = function(track) {
+                return track.id;
+            };
+
+            if (!webkitMediaStream.prototype.getVideoTracks) {
+                webkitMediaStream.prototype.getVideoTracks = function() {
+                    return this.videoTracks;
+                };
+            }
+            if (!webkitMediaStream.prototype.getAudioTracks) {
+                webkitMediaStream.prototype.getAudioTracks = function() {
+                    return this.audioTracks;
+                };
+            }
+        } else if (browser.isEdge()) {
+            this.RTCPeerConnectionType = ortcRTCPeerConnection;
+            this.getUserMedia
+                = wrapGetUserMedia(
+                    navigator.mediaDevices.getUserMedia.bind(
+                        navigator.mediaDevices),
+                    true);
+            this.enumerateDevices = rawEnumerateDevicesWithCallback;
+            this.attachMediaStream
+                = wrapAttachMediaStream((element, stream) => {
+                    defaultSetVideoSrc(element, stream);
+                });
+
+            // ORTC does not generate remote MediaStreams so those are
+            // manually created by the ORTC shim. This means that their
+            // id (internally generated) does not match the stream id
+            // signaled into the remote SDP. Therefore, the shim adds a
+            // custom jitsiRemoteId property with the original stream id.
+            this.getStreamID = function(stream) {
+                const id = stream.jitsiRemoteId || stream.id;
+
+                return SDPUtil.filterSpecialChars(id);
+            };
+
+            // Remote MediaStreamTracks generated by ORTC (within a
+            // RTCRtpReceiver) have an internally/random id which does not
+            // match the track id signaled in the remote SDP. The shim adds
+            // a custom jitsi-id property with the original track id.
+            this.getTrackID = function(track) {
+                return track.jitsiRemoteId || track.id;
+            };
+        } else {
+            logger.error('Browser does not appear to be WebRTC-capable');
+
+            return;
+        }
+
+        this._initPCConstraints(options);
+
+        screenObtainer.init(
+            options, this.getUserMediaWithConstraints.bind(this));
+
+        if (this.isDeviceListAvailable()
+                && rawEnumerateDevicesWithCallback) {
+            rawEnumerateDevicesWithCallback(ds => {
+                availableDevices = ds.splice(0);
+
+                logger.debug('Available devices: ', availableDevices);
+                sendDeviceListToAnalytics(availableDevices);
+
+                eventEmitter.emit(RTCEvents.DEVICE_LIST_AVAILABLE,
+                    availableDevices);
+
+                if (isDeviceChangeEventSupported) {
+                    navigator.mediaDevices.addEventListener(
+                        'devicechange',
+                        () => this.enumerateDevices(
+                                onMediaDevicesListChanged));
+                } else {
+                    pollForAvailableMediaDevices();
+                }
+            });
+        }
     }
 
     /**
@@ -1627,63 +1617,17 @@ class RTCUtils extends Listenable {
     }
 
     /**
+     * Checks if its possible to enumerate available cameras/microphones.
      *
+     * @returns {boolean} true if the device listing is available or false
+     * otherwise.
      */
-    isRTCReady() {
-        return rtcReady;
-    }
-
-    /**
-     *
-     */
-    _isDeviceListAvailable() {
-        if (!rtcReady) {
-            throw new Error('WebRTC not ready yet');
-        }
-
+    isDeviceListAvailable() {
         return Boolean(
             (navigator.mediaDevices
                 && navigator.mediaDevices.enumerateDevices)
             || (typeof MediaStreamTrack !== 'undefined'
                 && MediaStreamTrack.getSources));
-    }
-
-    /**
-     * Returns a promise which can be used to make sure that the WebRTC stack
-     * has been initialized.
-     *
-     * @returns {Promise} which is resolved only if the WebRTC stack is ready.
-     * Note that currently we do not detect stack initialization failure and
-     * the promise is never rejected(unless unexpected error occurs).
-     */
-    onRTCReady() {
-        if (rtcReady) {
-            return Promise.resolve();
-        }
-
-        return new Promise(resolve => {
-            const listener = () => {
-                eventEmitter.removeListener(RTCEvents.RTC_READY, listener);
-                resolve();
-            };
-
-            eventEmitter.addListener(RTCEvents.RTC_READY, listener);
-
-            // We have no failed event, so... it either resolves or nothing
-            // happens.
-        });
-
-    }
-
-    /**
-     * Checks if its possible to enumerate available cameras/microphones.
-     *
-     * @returns {Promise<boolean>} a Promise which will be resolved only once
-     * the WebRTC stack is ready, either with true if the device listing is
-     * available available or with false otherwise.
-     */
-    isDeviceListAvailable() {
-        return this.onRTCReady().then(this._isDeviceListAvailable.bind(this));
     }
 
     /**
@@ -1830,32 +1774,6 @@ class RTCUtils extends Listenable {
             constraints.optional.push({ googSuspendBelowMinBitrate: 'true' });
         }
     }
-}
-
-/**
- * Rejects a Promise because WebRTC is not supported.
- *
- * @param {string} errorMessage - The human-readable message of the Error which
- * is the reason for the rejection.
- * @param {Function} reject - The reject function of the Promise.
- * @returns {void}
- */
-function rejectWithWebRTCNotSupported(errorMessage, reject) {
-    const error = new Error(errorMessage);
-
-    // WebRTC is not supported.
-    //
-    // XXX The Error class already has a property name which is commonly used to
-    // detail the represented error in a non-human-readable way (in contrast to
-    // the human-readable property message). I explicitly did not want to
-    // introduce a new specific property.
-    // FIXME None of the existing JitsiXXXErrors seemed to be appropriate
-    // recipients of the constant WEBRTC_NOT_SUPPORTED so I explicitly chose to
-    // leave it as a magic string at the time of this writing.
-    error.name = 'WEBRTC_NOT_SUPPORTED';
-
-    logger.error(errorMessage);
-    reject(error);
 }
 
 const rtcUtils = new RTCUtils();

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -59,6 +59,22 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
+     * Checks if the current browser is supported.
+     *
+     * @returns {boolean} true if the browser is supported, false otherwise.
+     */
+    isSupported() {
+        return this.isChrome()
+            || this.isEdge()
+            || this.isElectron()
+            || this.isFirefox()
+            || this.isNWJS()
+            || this.isOpera()
+            || this.isReactNative()
+            || this.isSafariWithWebrtc();
+    }
+
+    /**
      * Checks if the current browser triggers 'onmute'/'onunmute' events when
      * user's connection is interrupted and the video stops playback.
      * @returns {*|boolean} 'true' if the event is supported or 'false'
@@ -99,6 +115,23 @@ export default class BrowserCapabilities extends BrowserDetection {
      */
     supportsMediaStreamConstructor() {
         return !this.isReactNative();
+    }
+
+    /**
+     * Checks if the current browser supports RTP statictics collecting.
+     * Required by {@link RTPStatsCollector}.
+     *
+     * @returns {boolean} true if they are supported, false otherwise.
+     */
+    supportsRtpStatistics() {
+        return this.isChrome()
+            || this.isEdge()
+            || this.isElectron()
+            || this.isFirefox()
+            || this.isNWJS()
+            || this.isOpera()
+            || this.isReactNative()
+            || this.isSafariWithWebrtc();
     }
 
     /**

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -7,13 +7,6 @@ import * as MediaType from '../../service/RTC/MediaType';
 const GlobalOnErrorHandler = require('../util/GlobalOnErrorHandler');
 const logger = require('jitsi-meet-logger').getLogger(__filename);
 
-/* Whether we support the browser we are running into for logging statistics */
-const browserSupported = browser.isChrome()
-        || browser.isOpera() || browser.isFirefox()
-        || browser.isNWJS() || browser.isElectron()
-        || browser.isEdge()
-        || browser.isSafariWithWebrtc() || browser.isReactNative();
-
 /**
  * The lib-jitsi-meet browser-agnostic names of the browser-specific keys
  * reported by RTCPeerConnection#getStats mapped by browser.
@@ -345,7 +338,7 @@ StatsCollector.prototype.start = function(startAudioLevelStats) {
         );
     }
 
-    if (browserSupported) {
+    if (browser.isSupported()) {
         this.statsIntervalId = setInterval(
             () => {
                 // Interval updates

--- a/service/RTC/RTCEvents.js
+++ b/service/RTC/RTCEvents.js
@@ -8,7 +8,6 @@ const RTCEvents = {
      * Indicates error while create offer call.
      */
     CREATE_OFFER_FAILED: 'rtc.create_offer_failed',
-    RTC_READY: 'rtc.ready',
     DATA_CHANNEL_OPEN: 'rtc.data_channel_open',
     ENDPOINT_CONN_STATUS_CHANGED: 'rtc.endpoint_conn_status_changed',
     DOMINANT_SPEAKER_CHANGED: 'rtc.dominant_speaker_changed',


### PR DESCRIPTION
There is nothing asynchronous about the initialization process (anymore), thus
turn it into a synchronous method.

In addition, WebRTC support is absolute, it cannot change from not being
supported to being supported (as it plreviously could, thanks to Temasys) so get
rid of the ancillary logic to support that.

Last, introduce a way to check if WebRTC is supported in the current
environment: JitsiMeetJS.isWebRtcSupported().