### PR TITLE
Respect enableRemb and enableTcc for P2P.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2196,6 +2196,15 @@ TraceablePeerConnection.prototype._createOfferOrAnswer = function(
             this.trace(
                 `create${logName}OnSuccess::preTransform`, dumpSDP(resultSdp));
 
+            if (isOffer) {
+                if (!this.options.enableRemb) {
+                    removeRemb(resultSdp);
+                }
+                if (!this.options.enableTcc) {
+                    removeTcc(resultSdp);
+                }
+            }
+
             // if we're using unified plan, transform to Plan B.
             if (browser.usesUnifiedPlan()) {
                 // eslint-disable-next-line no-param-reassign
@@ -2504,3 +2513,31 @@ TraceablePeerConnection.prototype.setIsSelected = function(isSelected) {
 TraceablePeerConnection.prototype.toString = function() {
     return `TPC[${this.id},p2p:${this.isP2P}]`;
 };
+
+/**
+ * Removes the REMB rtcp-fb and the abs-send-time RTP header extention from the
+ * {RTCSessionDescription} that is specified as a parameter.
+ *
+ * @param {RTCSessionDescription} desc - The RTCSessionDescription
+ * to remove the REMB rtcp-fb and the abs-send-time RTP header extension.
+ */
+function removeRemb(desc) {
+    desc.sdp = desc.sdp
+        .replace(/a=rtcp-fb:\d+ goog-remb\r\n/g, '')
+        // eslint-disable-next-line
+        .replace(/a=extmap:\d+ http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/abs-send-time\r\n/g, '');
+}
+
+/**
+ * Removes the transport-cc rtcp-fb and TCC RTP header extention from the
+ * {RTCSessionDescription} that is specified as a parameter.
+ *
+ * @param {RTCSessionDescription} desc - The RTCSessionDescription
+ * to remove the transport-cc rtcp-fb and the TCC RTP header extension.
+ */
+function removeTcc(desc) {
+    desc.sdp = desc.sdp
+        .replace(/a=rtcp-fb:\d+ transport-cc\r\n/g, '')
+        // eslint-disable-next-line
+        .replace(/a=extmap:5 http:\/\/www.ietf.org\/id\/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\n/g, '');
+}

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -259,6 +259,14 @@ export default class JingleSessionPC extends JingleSession {
             pcOptions.maxstats = DEFAULT_MAX_STATS;
         }
 
+        if (this.room.options.enableRemb) {
+            pcOptions.enableRemb = this.room.options.enableRemb;
+        }
+
+        if (this.room.options.enableTcc) {
+            pcOptions.enableTcc = this.room.options.enableTcc;
+        }
+
         if (this.isP2P) {
             // simulcast needs to be disabled for P2P (121) calls
             pcOptions.disableSimulcast = true;


### PR DESCRIPTION
Please do not merge this yet, I would also like to provide a knob for overriding the googCpuOveruseDetection option.


What would people think if in the meet config.js included a config.pcConfiguration (https://www.w3.org/TR/webrtc/#rtcconfiguration-dictionary) instead of the various options that we have now (config.stunServers, config.googIPv6). This would allow us to override/experiment any available peer-connection configuration parameter.