### PR TITLE
fix(muting): do not re-assign value of local track containers

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -421,7 +421,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
                     throw new JitsiTrackError(TRACK_NO_STREAM_FOUND);
                 }
 
-                this.containers = this.containers.map(
+                this.containers.map(
                     cont => RTCUtils.attachMediaStream(cont, this.stream));
 
                 return this._addStreamToConferenceAsUnmute();


### PR DESCRIPTION
RTCUtils.attachMediaStream was changed not to return elements;
instead it returns undefined by default. When mapping over
containers and call RTCUtils.attachMediaStream, containers
would be changed to undefined.