### PR TITLE
ref(video-quality): cache max frame height and send on channel open

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -165,10 +165,10 @@ export default class RTC extends Listenable {
          * The number representing the maximum video height the local client
          * should receive from the bridge.
          *
-         * @type {number|null}
+         * @type {number|undefined}
          * @private
          */
-        this._maxFrameHeight = null;
+        this._maxFrameHeight = undefined;
 
         /**
          * The endpoint ID of currently pinned participant or <tt>null</tt> if
@@ -260,11 +260,17 @@ export default class RTC extends Listenable {
                     this._pinnedEndpoint);
                 this._channel.sendSelectedEndpointMessage(
                     this._selectedEndpoint);
+
+                if (typeof this._maxFrameHeight !== 'undefined') {
+                    this._channel.sendReceiverVideoConstraintMessage(
+                        this._maxFrameHeight);
+                }
             } catch (error) {
                 GlobalOnErrorHandler.callErrorHandler(error);
                 logger.error(
                     `Cannot send selected(${this._selectedEndpoint})`
-                    + `pinned(${this._pinnedEndpoint}) endpoint message.`,
+                    + `pinned(${this._pinnedEndpoint})`
+                    + `frameHeight(${this._maxFrameHeight}) endpoint message`,
                     error);
             }
 

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -162,6 +162,15 @@ export default class RTC extends Listenable {
         this._lastNEndpoints = null;
 
         /**
+         * The number representing the maximum video height the local client
+         * should receive from the bridge.
+         *
+         * @type {number|null}
+         * @private
+         */
+        this._maxFrameHeight = null;
+
+        /**
          * The endpoint ID of currently pinned participant or <tt>null</tt> if
          * no user is pinned.
          * @type {string|null}
@@ -327,14 +336,17 @@ export default class RTC extends Listenable {
 
     /**
      * Sets the maximum video size the local participant should receive from
-     * remote participants. Will no-op if no data channel has been established.
+     * remote participants. Will cache the value and send it through the channel
+     * once it is created.
      *
      * @param {number} maxFrameHeightPixels the maximum frame height, in pixels,
      * this receiver is willing to receive.
      * @returns {void}
      */
     setReceiverVideoConstraint(maxFrameHeight) {
-        if (this._channel) {
+        this._maxFrameHeight = maxFrameHeight;
+
+        if (this._channel && this._channelOpen) {
             this._channel.sendReceiverVideoConstraintMessage(maxFrameHeight);
         }
     }


### PR DESCRIPTION
Currently it is possible to try to change the max receive video
frame height before the data channel is open. In that case an error
will be thrown. This change makes it so that the desired frame height
is saved and sent on channel open, avoiding the thrown error the
max receive video frame height logic is exercised through the
JitsiConference api.