### PR TITLE
Prevent error after kick user

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -247,7 +247,6 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
         JitsiConferenceEvents.KICKED);
     chatRoom.addListener(XMPPEvents.KICKED,
         () => {
-            conference.room = null;
             conference.leave();
         });
     chatRoom.addListener(XMPPEvents.SUSPEND_DETECTED,


### PR DESCRIPTION
This simple change helps to prevent `'The conference is has been already left'` error after kick. 
`Conference.leave` will detach chatRoom instance itself.