### PR TITLE
feat(TPC): fix handling layer suspension when RTPSender is not supported

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2428,6 +2428,12 @@ TraceablePeerConnection.prototype.generateNewStreamSSRCInfo = function(track) {
 };
 
 const handleLayerSuspension = function(peerConnection, isSelected) {
+    if (!peerConnection.getSenders) {
+        logger.debug('Browser doesn\'t support RTPSender');
+
+        return;
+    }
+
     const videoSender = peerConnection.getSenders()
         .find(sender => sender.track.kind === 'video');
 


### PR DESCRIPTION
Just skip it in such environments, such as React Native.