### PR TITLE
feat(BworserCapabilities): fix device change detection

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -127,7 +127,8 @@ export default class BrowserCapabilities extends BrowserDetection {
      */
     supportsDeviceChangeEvent() {
         return navigator.mediaDevices
-            && typeof navigator.mediaDevices.ondevicechange !== 'undefined';
+            && typeof navigator.mediaDevices.ondevicechange !== 'undefined'
+            && typeof navigator.mediaDevices.addEventListener !== 'undefined';
     }
 
     /**


### PR DESCRIPTION
Safari 11 has `navigator.mediaDevices.ondevicechange` but doesn't define
`navigator.mediaDevices.addEventListener`. 🤦

Fixes: https://github.com/jitsi/lib-jitsi-meet/issues/823