### PR TITLE
fix(RTPStatsCollector): this.stop is 'undefined'

### DIFF
--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -331,7 +331,7 @@ StatsCollector.prototype.start = function(startAudioLevelStats) {
                         self.baselineAudioLevelsReport
                             = self.currentAudioLevelsReport;
                     },
-                    self.errorCallback
+                    error => self.errorCallback(error)
                 );
             },
             self.audioLevelsIntervalMilis
@@ -369,7 +369,7 @@ StatsCollector.prototype.start = function(startAudioLevelStats) {
 
                         self.previousStatsReport = self.currentStatsReport;
                     },
-                    self.errorCallback
+                    error => self.errorCallback(error)
                 );
             },
             self.statsIntervalMilis


### PR DESCRIPTION
The 'self.errorCallback' was passed incorrectly - it should have been bound to 'self' eventually, but now the arrow function is the preferred way.