### PR TITLE
fix(RTC): Pass options allowing GUM to work with config

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1552,27 +1552,27 @@ const rtcUtils = new RTCUtils();
 
 /**
  *
- * @param options
+ * @param context Execution context, containing options and callbacks
  */
-function obtainDevices(options) {
-    if (!options.devices || options.devices.length === 0) {
-        return options.successCallback(options.streams || {});
+function obtainDevices(context) {
+    if (!context.devices || context.devices.length === 0) {
+        return context.successCallback(context.streams || {});
     }
 
-    const device = options.devices.splice(0, 1);
+    const device = context.devices.splice(0, 1);
 
-    options.deviceGUM[device](options.options)
+    context.deviceGUM[device](context.options)
         .then(stream => {
-            options.streams = options.streams || {};
-            options.streams[device] = stream;
-            obtainDevices(options);
+            context.streams = context.streams || {};
+            context.streams[device] = stream;
+            obtainDevices(context);
         }, error => {
-            Object.keys(options.streams).forEach(
-                d => rtcUtils.stopMediaStream(options.streams[d]));
+            Object.keys(context.streams).forEach(
+                d => rtcUtils.stopMediaStream(context.streams[d]));
             logger.error(
                 `failed to obtain ${device} stream - stop`, error);
 
-            options.errorCallback(error);
+            context.errorCallback(error);
         });
 }
 

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1218,7 +1218,6 @@ class RTCUtils extends Listenable {
 
             obtainDevices({
                 options,
-                devices: options.devices,
                 streams: {},
                 successCallback: resolve,
                 errorCallback: reject,
@@ -1555,11 +1554,11 @@ const rtcUtils = new RTCUtils();
  * @param context Execution context, containing options and callbacks
  */
 function obtainDevices(context) {
-    if (!context.devices || context.devices.length === 0) {
+    if (!context.options.devices || context.options.devices.length === 0) {
         return context.successCallback(context.streams || {});
     }
 
-    const device = context.devices.splice(0, 1);
+    const device = context.options.devices.splice(0, 1);
 
     context.deviceGUM[device](context.options)
         .then(stream => {

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1217,6 +1217,7 @@ class RTCUtils extends Listenable {
             };
 
             obtainDevices({
+                options,
                 devices: options.devices,
                 streams: {},
                 successCallback: resolve,
@@ -1560,7 +1561,7 @@ function obtainDevices(options) {
 
     const device = options.devices.splice(0, 1);
 
-    options.deviceGUM[device]()
+    options.deviceGUM[device](options.options)
         .then(stream => {
             options.streams = options.streams || {};
             options.streams[device] = stream;


### PR DESCRIPTION
With this change, an Android device will adhere to the value defined in the 'resolution' value of config.js, something it currently does not.

The only functional change is in the first commit. The other commits refactor the solution a bit, to clean things up.