### PR TITLE
Enable sending JSON messages via MUC

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2292,10 +2292,15 @@ JitsiConference.prototype.sendMessage = function(
         let elementName = 'body';
 
         if (messageType === 'object') {
-            try {
+            elementName = 'json-message';
+
+            // Mark as valid JSON message if not already
+            if (!messageToSend.hasOwnProperty(JITSI_MEET_MUC_TYPE)) {
                 messageToSend[JITSI_MEET_MUC_TYPE] = '';
+            }
+
+            try {
                 messageToSend = JSON.stringify(messageToSend);
-                elementName = 'json-message';
             } catch (e) {
                 logger.error('Can not send a message, stringify failed: ', e);
 


### PR DESCRIPTION
To allow clients sending JSON messages -for examples in polls- the `sendMessage` should only add the `JITSI_MEET_MUC_TYPE` if it was not present in the message. Otherwise it override the original message type.