### PR TITLE
Fixes getDisplayMedia after moving it to nvaigator.mediaDevices.

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -423,7 +423,7 @@ const ScreenObtainer = {
      * @param errorCallback - The error callback.
      */
     obtainScreenFromGetDisplayMedia(options, callback, errorCallback) {
-        navigator.getDisplayMedia({ video: true })
+        navigator.mediaDevices.getDisplayMedia({ video: true })
             .then(stream => {
                 let applyConstraintsPromise;
 

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -282,7 +282,8 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean} {@code true} if the browser supposrts getDisplayMedia.
      */
     supportsGetDisplayMedia() {
-        return navigator.getDisplayMedia !== undefined;
+        return navigator.mediaDevices
+            && navigator.mediaDevices.getDisplayMedia !== undefined;
     }
 
     /**


### PR DESCRIPTION
getDisplayMedia moved to navigator.mediaDevices and no longer works, falling back to inline installations.
https://github.com/w3c/mediacapture-screen-share/pull/86