### PR TITLE
feat(ScreenObtainer): fix support for old getDisplayMedia

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -304,7 +304,16 @@ const ScreenObtainer = {
      * @param errorCallback - The error callback.
      */
     obtainScreenFromGetDisplayMedia(options, callback, errorCallback) {
-        navigator.mediaDevices.getDisplayMedia({ video: true })
+        let getDisplayMedia;
+
+        if (navigator.getDisplayMedia) {
+            getDisplayMedia = navigator.getDisplayMedia.bind(navigator);
+        } else {
+            // eslint-disable-next-line max-len
+            getDisplayMedia = navigator.mediaDevices.getDisplayMedia.bind(navigator.mediaDevices);
+        }
+
+        getDisplayMedia({ video: true })
             .then(stream => {
                 let applyConstraintsPromise;
 

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -282,8 +282,8 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean} {@code true} if the browser supposrts getDisplayMedia.
      */
     supportsGetDisplayMedia() {
-        return navigator.mediaDevices
-            && navigator.mediaDevices.getDisplayMedia !== undefined;
+        return typeof navigator.getDisplayMedia !== 'undefined'
+            || typeof navigator.mediaDevices.getDisplayMedia !== 'undefined';
     }
 
     /**


### PR DESCRIPTION
Chrome 71 does not support inline installs, but has navigator.getDisplayMedia
behind a flag. Support this case.