### PR TITLE
ref: open WebRTC DataChannel

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -74,6 +74,17 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
         // else: there are no DataChannels in P2P session (at least for now)
     });
 
+    chatRoom.addListener(
+        XMPPEvents.ICE_RESTART_SUCCESS,
+        (jingleSession, offerIq) => {
+            // The JVB data chanel needs to be reopened in case the conference
+            // has been moved to a new bridge.
+            !jingleSession.isP2P
+                && conference._setBridgeChannel(
+                    offerIq, jingleSession.peerconnection);
+        });
+
+
     chatRoom.addListener(XMPPEvents.AUDIO_MUTED_BY_FOCUS,
         () => {
             // TODO: Add a way to differentiate between commands which caused

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -49,16 +49,15 @@ export default class BridgeChannel {
         // If a RTCPeerConnection is given, listen for new RTCDataChannel
         // event.
         if (peerconnection) {
-            peerconnection.ondatachannel = event => {
-                // NOTE: We assume that the "onDataChannel" event just fires
-                // once.
+            const datachannel
+                = peerconnection.createDataChannel(
+                    'JVB data channel', {
+                        protocol: 'http://jitsi.org/protocols/colibri'
+                    });
 
-                const datachannel = event.channel;
-
-                // Handle the RTCDataChannel.
-                this._handleChannel(datachannel);
-                this._mode = 'datachannel';
-            };
+            // Handle the RTCDataChannel.
+            this._handleChannel(datachannel);
+            this._mode = 'datachannel';
 
         // Otherwise create a WebSocket connection.
         } else if (wsUrl) {

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1000,6 +1000,11 @@ export default class JingleSessionPC extends JingleSession {
                             = new SDP(this.peerconnection.localDescription.sdp);
 
                         this.sendTransportAccept(localSDP, success, failure);
+
+                        this.room.eventEmitter.emit(
+                            XMPPEvents.ICE_RESTART_SUCCESS,
+                            this,
+                            originalOffer);
                     },
                     failure);
             },

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -76,6 +76,12 @@ const XMPPEvents = {
      */
     ICE_RESTARTING: 'rtc.ice_restarting',
 
+    /**
+     * Event fired after the 'transport-replace' message has been processed
+     * and the new offer has been set successfully.
+     */
+    ICE_RESTART_SUCCESS: 'rtc.ice_restart_success',
+
     /* Event fired when XMPP error is returned to any request, it is meant to be
      * used to report 'signaling' errors to CallStats
      *


### PR DESCRIPTION
DEPENDS ON: https://github.com/jitsi/jitsi-videobridge/pull/723

Changes the behavior to actively open new WebRTC Data Channel instead of waiting for the JVB to do it.
Adds ICE_RESTART_SUCCESS event used to re-initialize the data channel in case of ICE restart where the conference could have been moved to another bridge.