### PR TITLE
feat(screenshare): support remote wireless screenshare

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -27,6 +27,8 @@ import RTC from './modules/RTC/RTC';
 import browser from './modules/browser';
 import ScriptUtil from './modules/util/ScriptUtil';
 import recordingConstants from './modules/recording/recordingConstants';
+import ProxyConnectionService
+    from './modules/proxyconnection/ProxyConnectionService';
 import Statistics from './modules/statistics/statistics';
 import * as VideoSIPGWConstants from './modules/videosipgw/VideoSIPGWConstants';
 
@@ -129,6 +131,16 @@ export default _mergeNamespaceAndModule({
     version: '{#COMMIT_HASH#}',
 
     JitsiConnection,
+
+    /**
+     * {@code ProxyConnectionService} is used to connect a remote peer to a
+     * local Jitsi participant without going through a Jitsi conference. It is
+     * currently used for room integration development, specifically wireless
+     * screensharing. Its API is experimental and will likely change; usage of
+     * it is advised against.
+     */
+    ProxyConnectionService,
+
     constants: {
         participantConnectionStatus: ParticipantConnectionStatus,
         recording: recordingConstants,

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -203,6 +203,17 @@ export default class RTC extends Listenable {
     }
 
     /**
+     * Exposes the private helper for converting a WebRTC MediaStream to a
+     * JitsiLocalTrack.
+     *
+     * @param {Array<Object>} tracksInfo
+     * @returns {Array<JitsiLocalTrack>}
+     */
+    static newCreateLocalTracks(tracksInfo) {
+        return _newCreateLocalTracks(tracksInfo);
+    }
+
+    /**
      * Creates the local MediaStreams.
      * @param {object} [options] Optional parameters.
      * @param {array} options.devices The devices that will be requested.

--- a/modules/proxyconnection/ProxyConnectionPC.js
+++ b/modules/proxyconnection/ProxyConnectionPC.js
@@ -5,6 +5,7 @@ import RTCEvents from '../../service/RTC/RTCEvents';
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
 
 import JingleSessionPC from '../xmpp/JingleSessionPC';
+import { DEFAULT_STUN_SERVERS } from '../xmpp/xmpp';
 
 import { ACTIONS } from './constants';
 
@@ -22,7 +23,9 @@ export default class ProxyConnectionPC {
      * Initializes a new {@code ProxyConnectionPC} instance.
      *
      * @param {Object} options - Values to initialize the instance with.
-     * @param {boolean} options.isInitiator - If true, the local client should
+     * @param {Object} [options.iceConfig] - The {@code RTCConfiguration} to use
+     * for the peer connection.
+     * @param {boolean} [options.isInitiator] - If true, the local client should
      * send offers. If false, the local client should send answers. Defaults to
      * false.
      * @param {Function} options.onRemoteStream - Callback to invoke when a
@@ -30,14 +33,16 @@ export default class ProxyConnectionPC {
      * @param {string} options.peerJid - The jid of the remote client with which
      * the peer connection is being establish and which should receive direct
      * messages regarding peer connection updates.
-     * @param {boolean} options.receiveVideo - Whether or not the peer
+     * @param {boolean} [options.receiveVideo] - Whether or not the peer
      * connection should accept incoming video streams. Defaults to false.
      * @param {Function} options.onSendMessage - Callback to invoke when a
      * message has to be sent (signaled) out.
      */
     constructor(options = {}) {
         this._options = {
+            iceConfig: {},
             isInitiator: false,
+            receiveAudio: false,
             receiveVideo: false,
             ...options
         };
@@ -175,20 +180,11 @@ export default class ProxyConnectionPC {
          * @type {Object}
          */
         const iceConfigStub = {
+            jvb: { iceServers: [] },
             p2p: {
-                iceServers: [
-                    {
-                        urls: 'stun:stun.l.google.com:19302'
-                    },
-                    {
-                        urls: 'stun:stun1.l.google.com:19302'
-                    },
-                    {
-                        urls: 'stun:stun2.l.google.com:19302'
-                    }
-                ]
-            },
-            jvb: { iceServers: [] }
+                iceServers: DEFAULT_STUN_SERVERS,
+                ...this._options.iceConfig
+            }
         };
 
         /**
@@ -256,7 +252,7 @@ export default class ProxyConnectionPC {
             this._options.peerJid, // remoteJid
             connectionStub, // connection
             {
-                offerToReceiveAudio: false,
+                offerToReceiveAudio: this._options.receiveAudio,
                 offerToReceiveVideo: this._options.receiveVideo
             }, // mediaConstraints
             iceConfigStub, // iceConfig

--- a/modules/proxyconnection/ProxyConnectionPC.js
+++ b/modules/proxyconnection/ProxyConnectionPC.js
@@ -1,0 +1,392 @@
+import { getLogger } from 'jitsi-meet-logger';
+
+import RTC from '../RTC/RTC';
+import RTCEvents from '../../service/RTC/RTCEvents';
+import XMPPEvents from '../../service/xmpp/XMPPEvents';
+
+import JingleSessionPC from '../xmpp/JingleSessionPC';
+
+import { ACTIONS } from './constants';
+
+const logger = getLogger(__filename);
+
+/**
+ * An adapter around {@code JingleSessionPC} so its logic can be re-used without
+ * an XMPP connection. It is being re-used for consistency with the rest of the
+ * codebase and to leverage existing peer connection event handling. Also
+ * this class provides a facade to hide most of the API for
+ * {@code JingleSessionPC}.
+ */
+export default class ProxyConnectionPC {
+    /**
+     * Initializes a new {@code ProxyConnectionPC} instance.
+     *
+     * @param {Object} options - Values to initialize the instance with.
+     * @param {boolean} options.isInitiator - If true, the local client should
+     * send offers. If false, the local client should send answers. Defaults to
+     * false.
+     * @param {Function} options.onRemoteStream - Callback to invoke when a
+     * remote media stream has been received through the peer connection.
+     * @param {string} options.peerJid - The jid of the remote client with which
+     * the peer connection is being establish and which should receive direct
+     * messages regarding peer connection updates.
+     * @param {boolean} options.receiveVideo - Whether or not the peer
+     * connection should accept incoming video streams. Defaults to false.
+     * @param {Function} options.onSendMessage - Callback to invoke when a
+     * message has to be sent (signaled) out.
+     */
+    constructor(options = {}) {
+        this._options = {
+            isInitiator: false,
+            receiveVideo: false,
+            ...options
+        };
+
+        /**
+         * Instances of {@code JitsiTrack} associated with this instance of
+         * {@code ProxyConnectionPC}.
+         *
+         * @type {Array<JitsiTrack>}
+         */
+        this._tracks = [];
+
+        /**
+         * The active instance of {@code JingleSessionPC}.
+         *
+         * @type {JingleSessionPC|null}
+         */
+        this._peerConnection = null;
+
+        // Bind event handlers so they are only bound once for every instance.
+        this._onError = this._onError.bind(this);
+        this._onRemoteStream = this._onRemoteStream.bind(this);
+        this._onSendMessage = this._onSendMessage.bind(this);
+    }
+
+    /**
+     * Returns the jid of the remote peer with which this peer connection should
+     * be established with.
+     *
+     * @returns {string}
+     */
+    getPeerJid() {
+        return this._options.peerJid;
+    }
+
+    /**
+     * Updates the peer connection based on the passed in jingle.
+     *
+     * @param {Object} $jingle - An XML jingle element, wrapped in query,
+     * describing how the peer connection should be updated.
+     * @returns {void}
+     */
+    processMessage($jingle) {
+        switch ($jingle.attr('action')) {
+        case ACTIONS.ACCEPT:
+            this._onSessionAccept($jingle);
+            break;
+
+        case ACTIONS.INITIATE:
+            this._onSessionInitiate($jingle);
+            break;
+
+        case ACTIONS.TERMINATE:
+            this._onSessionTerminate($jingle);
+            break;
+
+        case ACTIONS.TRANSPORT_INFO:
+            this._onTransportInfo($jingle);
+            break;
+        }
+    }
+
+    /**
+     * Instantiates a peer connection and starts the offer/answer cycle to
+     * establish a connection with a remote peer.
+     *
+     * @param {Array<JitsiLocalTrack>} localTracks - Initial local tracks to add
+     * to add to the peer connection.
+     * @returns {void}
+     */
+    start(localTracks = []) {
+        if (this._peerConnection) {
+            return;
+        }
+
+        this._tracks = this._tracks.concat(localTracks);
+
+        this._peerConnection = this._createPeerConnection();
+
+        this._peerConnection.invite(localTracks);
+    }
+
+    /**
+     * Begins the process of disconnecting from a remote peer and cleaning up
+     * the peer connection.
+     *
+     * @returns {void}
+     */
+    stop() {
+        if (this._peerConnection) {
+            this._peerConnection.terminate();
+        }
+
+        this._onSessionTerminate();
+    }
+
+    /**
+     * Instantiates a new {@code JingleSessionPC} by stubbing out the various
+     * dependencies of {@code JingleSessionPC}.
+     *
+     * @private
+     * @returns {JingleSessionPC}
+     */
+    _createPeerConnection() {
+        /**
+         * {@code JingleSessionPC} takes in the entire jitsi-meet config.js
+         * object, which may not be accessible from the caller.
+         *
+         * @type {Object}
+         */
+        const configStub = {};
+
+        /**
+         * {@code JingleSessionPC} assumes an XMPP/Strophe connection object is
+         * passed through, which also has the jingle plugin initialized on it.
+         * This connection object is used to signal out peer connection updates
+         * via iqs, and those updates need to be piped back out to the remote
+         * peer.
+         *
+         * @type {Object}
+         */
+        const connectionStub = {
+            jingle: {
+                terminate: () => { /** no-op */ }
+            },
+            sendIQ: this._onSendMessage
+        };
+
+        /**
+         * {@code JingleSessionPC} can take in a custom ice configuration,
+         * depending on the peer connection type, peer-to-peer or other.
+         * However, {@code ProxyConnectionPC} always assume a peer-to-peer
+         * connection so the ice configuration is hard-coded with defaults.
+         *
+         * @type {Object}
+         */
+        const iceConfigStub = {
+            p2p: {
+                iceServers: [
+                    {
+                        urls: 'stun:stun.l.google.com:19302'
+                    },
+                    {
+                        urls: 'stun:stun1.l.google.com:19302'
+                    },
+                    {
+                        urls: 'stun:stun2.l.google.com:19302'
+                    }
+                ]
+            },
+            jvb: { iceServers: [] }
+        };
+
+        /**
+         * {@code JingleSessionPC} expects an instance of
+         * {@code JitsiConference}, which has an event emitter that is used
+         * to signal various connection updates that the local client should
+         * act upon. The conference instance is not a dependency of a proxy
+         * connection, but the emitted events can be relevant to the proxy
+         * connection so the event emitter is stubbed.
+         *
+         * @param {string} event - The constant for the event type.
+         * @type {Function}
+         * @returns {void}
+         */
+        const emitter = event => {
+            switch (event) {
+            case XMPPEvents.CONNECTION_ICE_FAILED:
+            case XMPPEvents.CONNECTION_FAILED:
+                this._onError(ACTIONS.CONNECTION_ERROR, event);
+                break;
+            }
+        };
+
+        /**
+         * {@code JingleSessionPC} expects an instance of
+         * {@code JitsiConference} to be passed in. {@code ProxyConnectionPC}
+         * is instantiated outside of the {@code JitsiConference}, so it must be
+         * stubbed to prevent errors.
+         *
+         * @type {Object}
+         */
+        const roomStub = {
+            addPresenceListener: () => { /** no-op */ },
+            connectionTimes: [],
+            eventEmitter: { emit: emitter },
+            getMediaPresenceInfo: () => {
+                // Errors occur if this function does not return an object
+
+                return {};
+            },
+            removePresenceListener: () => { /** no-op */ }
+        };
+
+        /**
+         * Create an instance of {@code RTC} as it is required for peer
+         * connection creation by {@code JingleSessionPC}. An existing instance
+         * of {@code RTC} from elsewhere should not be re-used because it is
+         * a stateful grouping of utilities.
+         */
+        const rtc = new RTC(this, {});
+
+        /**
+         * Add the remote track listener here as {@code JingleSessionPC} has
+         * {@code TraceablePeerConnection} which uses {@code RTC}'s event
+         * emitter.
+         */
+        rtc.addListener(
+            RTCEvents.REMOTE_TRACK_ADDED,
+            this._onRemoteStream
+        );
+
+        const peerConnection = new JingleSessionPC(
+            undefined, // sid
+            undefined, // localJid
+            this._options.peerJid, // remoteJid
+            connectionStub, // connection
+            {
+                offerToReceiveAudio: false,
+                offerToReceiveVideo: this._options.receiveVideo
+            }, // mediaConstraints
+            iceConfigStub, // iceConfig
+            true, // isP2P
+            this._options.isInitiator // isInitiator
+        );
+
+        /**
+         * An additional initialize call is necessary to properly set instance
+         * variable for calling.
+         */
+        peerConnection.initialize(roomStub, rtc, configStub);
+
+        return peerConnection;
+    }
+
+    /**
+     * Invoked when a connection related issue has been encountered.
+     *
+     * @param {string} errorType - The constant indicating the type of the error
+     * that occured.
+     * @param {string} details - Optional additional data about the error.
+     * @private
+     * @returns {void}
+     */
+    _onError(errorType, details = '') {
+        this._options.onError(this._options.peerJid, errorType, details);
+    }
+
+    /**
+     * Callback invoked when the peer connection has received a remote media
+     * stream.
+     *
+     * @param {JitsiRemoteTrack} jitsiRemoteTrack - The remote media stream
+     * wrapped in {@code JitsiRemoteTrack}.
+     * @private
+     * @returns {void}
+     */
+    _onRemoteStream(jitsiRemoteTrack) {
+        this._tracks.push(jitsiRemoteTrack);
+
+        this._options.onRemoteStream(jitsiRemoteTrack);
+    }
+
+    /**
+     * Callback invoked when {@code JingleSessionPC} needs to signal a message
+     * out to the remote peer.
+     *
+     * @param {XML} iq - The message to signal out.
+     * @private
+     * @returns {void}
+     */
+    _onSendMessage(iq) {
+        this._options.onSendMessage(this._options.peerJid, iq);
+    }
+
+    /**
+     * Callback invoked in response to an agreement to start a proxy connection.
+     * The passed in jingle element should contain an SDP answer to a previously
+     * sent SDP offer.
+     *
+     * @param {Object} $jingle - The jingle element wrapped in jQuery.
+     * @private
+     * @returns {void}
+     */
+    _onSessionAccept($jingle) {
+        if (!this._peerConnection) {
+            logger.error('Received an answer when no peer connection exists.');
+
+            return;
+        }
+
+        this._peerConnection.setAnswer($jingle);
+    }
+
+    /**
+     * Callback invoked in response to a request to start a proxy connection.
+     * The passed in jingle element should contain an SDP offer.
+     *
+     * @param {Object} $jingle - The jingle element wrapped in jQuery.
+     * @private
+     * @returns {void}
+     */
+    _onSessionInitiate($jingle) {
+        if (this._peerConnection) {
+            logger.error('Received an offer when an offer was already sent.');
+
+            return;
+        }
+
+        this._peerConnection = this._createPeerConnection();
+
+        this._peerConnection.acceptOffer(
+            $jingle,
+            () => { /** no-op */ },
+            () => this._onError(
+                this._options.peerJid,
+                ACTIONS.CONNECTION_ERROR,
+                'session initiate error'
+            )
+        );
+    }
+
+    /**
+     * Callback invoked in response to a request to disconnect an active proxy
+     * connection. Cleans up tracks and the peer connection.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onSessionTerminate() {
+        this._tracks.forEach(track => track.dispose());
+        this._tracks = [];
+
+        if (!this._peerConnection) {
+            return;
+        }
+
+        this._peerConnection.onTerminated();
+    }
+
+    /**
+     * Callback invoked in response to ICE candidates from the remote peer.
+     * The passed in jingle element should contain an ICE candidate.
+     *
+     * @param {Object} $jingle - The jingle element wrapped in jQuery.
+     * @private
+     * @returns {void}
+     */
+    _onTransportInfo($jingle) {
+        this._peerConnection.addIceCandidates($jingle);
+    }
+}

--- a/modules/proxyconnection/ProxyConnectionService.js
+++ b/modules/proxyconnection/ProxyConnectionService.js
@@ -1,0 +1,301 @@
+/* globals $ */
+
+import { getLogger } from 'jitsi-meet-logger';
+import { $iq } from 'strophe.js';
+
+import RTC from '../RTC/RTC';
+
+import ProxyConnectionPC from './ProxyConnectionPC';
+import { ACTIONS } from './constants';
+
+const logger = getLogger(__filename);
+
+/**
+ * Instantiates a new ProxyConnectionPC and ensures only one exists at a given
+ * time. Currently it assumes ProxyConnectionPC is used only for screensharing
+ * and assumes IQs to be used for communication.
+ */
+export default class ProxyConnectionService {
+    /**
+     * Initializes a new {@code ProxyConnectionService} instance.
+     *
+     * @param {Object} options - Values to initialize the instance with.
+     * @param {Function} options.onRemoteStream - Callback to invoke when a
+     * remote video stream has been received and converted to a
+     * {@code JitsiLocakTrack}. The {@code JitsiLocakTrack} will be passed in.
+     * @param {Function} options.onSendMessage - Callback to invoke when a
+     * message has to be sent (signaled) out. The arguments passed in are the
+     * jid to send the message to and the message
+     */
+    constructor(options = {}) {
+        /**
+         * Holds a reference to the collection of all callbacks.
+         *
+         * @type {Object}
+         */
+        this._options = options;
+
+        /**
+         * The active instance of {@code ProxyConnectionService}.
+         *
+         * @type {ProxyConnectionPC|null}
+         */
+        this._peerConnection = null;
+
+        // Bind event handlers so they are only bound once for every instance.
+        this._onFatalError = this._onFatalError.bind(this);
+        this._onSendMessage = this._onSendMessage.bind(this);
+        this._onRemoteStream = this._onRemoteStream.bind(this);
+    }
+
+    /**
+     * Parses a message object regarding a proxy connection to create a new
+     * proxy connection or update and existing connection.
+     *
+     * @param {Object} message - A message object regarding establishing or
+     * updating a proxy connection.
+     * @param {Object} message.data - An object containing additional message
+     * details.
+     * @param {string} message.data.iq - The stringified iq which explains how
+     * and what to update regarding the proxy connection.
+     * @param {string} message.from - The message sender's full jid. Used for
+     * sending replies.
+     * @returns {void}
+     */
+    processMessage(message) {
+        const peerJid = message.from;
+
+        if (!peerJid) {
+            return;
+        }
+
+        // If a proxy connection has already been established and messages come
+        // from another peer jid then those messages should be replied to with
+        // a rejection.
+        if (this._peerConnection
+            && this._peerConnection.getPeerJid() !== peerJid) {
+            this._onFatalError(
+                peerJid,
+                ACTIONS.CONNECTION_ERROR,
+                'rejected'
+            );
+
+            return;
+        }
+
+        const iq = this._convertStringToXML(message.data.iq);
+        const $jingle = iq && iq.find('jingle');
+        const action = $jingle && $jingle.attr('action');
+
+        if (action === ACTIONS.INITIATE) {
+            this._peerConnection = this._createPeerConnection(peerJid, {
+                isInitiator: false,
+                receiveVideo: true
+            });
+        }
+
+        // Truthy check for peer connection added to protect against possibly
+        // receiving actions before an ACTIONS.INITIATE.
+        if (this._peerConnection) {
+            this._peerConnection.processMessage($jingle);
+        }
+
+        // Take additional steps to ensure the peer connection is cleaned up
+        // if it is to be closed.
+        if (action === ACTIONS.CONNECTION_ERROR
+            || action === ACTIONS.UNAVAILABLE
+            || action === ACTIONS.TERMINATE) {
+            this._selfCloseConnection();
+        }
+
+        return;
+    }
+
+    /**
+     * Instantiates and initiates a proxy peer connection.
+     *
+     * @param {string} peerJid - The jid of the remote client that should
+     * receive messages.
+     * @param {Array<JitsiLocalTrack>} localTracks - Initial media tracks to
+     * send through to the peer.
+     * @returns {void}
+     */
+    start(peerJid, localTracks = []) {
+        this._peerConnection = this._createPeerConnection(peerJid, {
+            isInitiator: true,
+            receiveVideo: false
+        });
+
+        this._peerConnection.start(localTracks);
+    }
+
+    /**
+     * Terminates any active proxy peer connection.
+     *
+     * @returns {void}
+     */
+    stop() {
+        if (this._peerConnection) {
+            this._peerConnection.stop();
+        }
+
+        this._peerConnection = null;
+    }
+
+    /**
+     * Transforms a stringified xML into a XML wrapped in jQuery.
+     *
+     * @param {string} xml - The XML in string form.
+     * @private
+     * @returns {Object|null} A jQuery version of the xml. Null will be returned
+     * if an error is encountered during transformation.
+     */
+    _convertStringToXML(xml) {
+        try {
+            const xmlDom = new DOMParser().parseFromString(xml, 'text/xml');
+
+            return $(xmlDom);
+        } catch (e) {
+            logger.error('Attempted to convert incorrectly formatted xml');
+
+            return null;
+        }
+    }
+
+    /**
+     * Helper for creating an instance of {@code ProxyConnectionPC}.
+     *
+     * @param {string} peerJid - The jid of the remote peer with which the
+     * {@code ProxyConnectionPC} will be established with.
+     * @param {Object} options - Additional defaults to instantiate the
+     * {@code ProxyConnectionPC} with. See the constructor of ProxyConnectionPC
+     * for more details.
+     * @private
+     * @returns {ProxyConnectionPC}
+     */
+    _createPeerConnection(peerJid, options = {}) {
+        if (!peerJid) {
+            throw new Error('Cannot create ProxyConnectionPC without a peer.');
+        }
+
+        const pcOptions = {
+            onError: this._onFatalError,
+            onRemoteStream: this._onRemoteStream,
+            onSendMessage: this._onSendMessage,
+            peerJid,
+            ...options
+        };
+
+        return new ProxyConnectionPC(pcOptions);
+    }
+
+    /**
+     * Callback invoked when an error occurs that should cause
+     * {@code ProxyConnectionPC} to be closed if the peer is currently
+     * connected. Sends an error message/reply back to the peer.
+     *
+     * @param {string} peerJid - The peer jid with which the connection was
+     * attempted or started, and to which an iq with error details should be
+     * sent.
+     * @param {string} errorType - The constant indicating the type of the error
+     * that occured.
+     * @param {string} details - Optional additional data about the error.
+     * @private
+     * @returns {void}
+     */
+    _onFatalError(peerJid, errorType, details = '') {
+        logger.error(
+            'Received a proxy connection error', peerJid, errorType, details);
+
+        const iq = $iq({
+            to: peerJid,
+            type: 'set'
+        })
+            .c('jingle', {
+                xmlns: 'urn:xmpp:jingle:1',
+                action: errorType
+            })
+            .c('details')
+            .t(details)
+            .up();
+
+        this._onSendMessage(peerJid, iq);
+
+        if (this._peerConnection
+            && this._peerConnection.getPeerJid() === peerJid) {
+            this._selfCloseConnection();
+        }
+    }
+
+    /**
+     * Callback invoked when the remote peer of the {@code ProxyConnectionPC}
+     * has offered a media stream. The stream is converted into a
+     * {@code JitsiLocalTrack} for local usage if the {@code onRemoteStream}
+     * callback is defined.
+     *
+     * @param {JitsiRemoteTrack} jitsiRemoteTrack - The {@code JitsiRemoteTrack}
+     * for the peer's media stream.
+     * @private
+     * @returns {void}
+     */
+    _onRemoteStream(jitsiRemoteTrack) {
+        if (!this._options.onRemoteStream) {
+            logger.error('Remote track received withou callback to handle it.');
+
+            return;
+        }
+
+        // Grab the webrtc media stream and pipe it through the same processing
+        // that would occur for a locally obtained media stream.
+        const mediaStream = jitsiRemoteTrack.getOriginalStream();
+        const jitsiLocalTracks = RTC.newCreateLocalTracks(
+            [
+                {
+                    deviceId:
+                        `proxy:${this._peerConnection.getPeerJid()}`,
+                    mediaType: 'video',
+                    videoType: 'desktop',
+                    stream: mediaStream,
+                    track: mediaStream.getVideoTracks()[0]
+                }
+            ]);
+
+        this._options.onRemoteStream(jitsiLocalTracks[0]);
+    }
+
+    /**
+     * Formats and forwards a message an iq to be sent to a peer jid.
+     *
+     * @param {string} peerJid - The jid the iq should be sent to.
+     * @param {Object} iq - The iq which would be sent to the peer jid.
+     * @private
+     * @returns {void}
+     */
+    _onSendMessage(peerJid, iq) {
+        if (!this._options.onSendMessage) {
+            return;
+        }
+
+        try {
+            const stringifiedIq
+                = new XMLSerializer().serializeToString(iq.nodeTree || iq);
+
+            this._options.onSendMessage(peerJid, { iq: stringifiedIq });
+        } catch (e) {
+            logger.error('Attempted to send an incorrectly formatted iq.');
+        }
+    }
+
+    /**
+     * Invoked when preemptively closing the {@code ProxyConnectionPC}.
+     *
+     * @private
+     * @returns {void}
+     */
+    _selfCloseConnection() {
+        this.stop();
+
+        this._options.onConnectionClosed
+            && this._options.onConnectionClosed();
+    }
+}

--- a/modules/proxyconnection/constants.js
+++ b/modules/proxyconnection/constants.js
@@ -1,0 +1,12 @@
+/**
+ * The know jingle actions that can be sent and should be acted upon by
+ * {@code ProxyConnectionService} and {@code ProxyConnectionPC}.
+ */
+export const ACTIONS = {
+    ACCEPT: 'session-accept',
+    CONNECTION_ERROR: 'connection-error-encountered',
+    INITIATE: 'session-initiate',
+    TERMINATE: 'session-terminate',
+    TRANSPORT_INFO: 'transport-info',
+    UNAVAILABLE: 'unavailable'
+};

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -41,6 +41,16 @@ function createConnection(token, bosh = '/http-bind') {
     return conn;
 }
 
+// FIXME: remove once we have a default config template. -saghul
+/**
+ * A list of ice servers to use by default for P2P.
+ */
+export const DEFAULT_STUN_SERVERS = [
+    { urls: 'stun:stun.l.google.com:19302' },
+    { urls: 'stun:stun1.l.google.com:19302' },
+    { urls: 'stun:stun2.l.google.com:19302' }
+];
+
 /**
  * The name of the field used to recognize a chat message as carrying a JSON
  * payload from another endpoint.
@@ -507,15 +517,8 @@ export default class XMPP extends Listenable {
             p2p: { iceServers: [ ] }
         };
 
-        // FIXME: remove once we have a default config template. -saghul
-        const defaultStunServers = [
-            { urls: 'stun:stun.l.google.com:19302' },
-            { urls: 'stun:stun1.l.google.com:19302' },
-            { urls: 'stun:stun2.l.google.com:19302' }
-        ];
-
         const p2pStunServers = (this.options.p2p
-            && this.options.p2p.stunServers) || defaultStunServers;
+            && this.options.p2p.stunServers) || DEFAULT_STUN_SERVERS;
 
         if (Array.isArray(p2pStunServers)) {
             logger.info('P2P STUN servers: ', p2pStunServers);


### PR DESCRIPTION
- ProxyConnectionService is exposed and meant to be the
  facade for creating and updating a peer connection with
  another peer, outside of the muc.
- ProxyConnectionPC wraps JingleSessionPC so the peer
  connection handling can be reused.