### PR TITLE
fix(presence): emit display name change when cleared

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -537,12 +537,10 @@ export default class ChatRoom extends Listenable {
                             ? Strophe.getResourceFromJid(from)
                             : member.nick;
 
-                    if (displayName && displayName.length > 0) {
-                        this.eventEmitter.emit(
-                            XMPPEvents.DISPLAY_NAME_CHANGED,
-                            from,
-                            displayName);
-                    }
+                    this.eventEmitter.emit(
+                        XMPPEvents.DISPLAY_NAME_CHANGED,
+                        from,
+                        displayName);
                 }
                 break;
             case 'bridgeNotAvailable':


### PR DESCRIPTION
Currently when a participant removes the local display name, other clients are not updating their UIs because displayName in the nickname presence update is undefined.