### PR TITLE
feat(callstats): don't inlcude react-native-callstats

### DIFF
--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -350,18 +350,10 @@ export default class CallStats {
             throw new Error('CallStats backend has been initialized already!');
         }
         try {
-            // In react-native we need to import the callstats module, but
-            // imports are only allowed at top-level, so we must use require
-            // here. Sigh.
-            const CallStatsBackend
-                = browser.isReactNative()
-                    ? require('react-native-callstats/callstats')
-                    : callstats;
+            const CallStatsBackend = callstats;
 
             CallStats.backend = new CallStatsBackend();
-
             CallStats._traceAndCatchBackendCalls(CallStats.backend);
-
             CallStats.userID = {
                 aliasName: options.aliasName,
                 userName: options.userName

--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,11 +1699,6 @@
         }
       }
     },
-    "base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
-    },
     "base64-arraybuffer": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
@@ -5039,11 +5034,6 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
-    "jssha": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/jssha/-/jssha-2.3.1.tgz",
-      "integrity": "sha1-FHshJTaQNcpLL30hDcU58Amz3po="
-    },
     "karma": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-3.0.0.tgz",
@@ -7185,15 +7175,6 @@
             "safer-buffer": ">= 2.1.2 < 3"
           }
         }
-      }
-    },
-    "react-native-callstats": {
-      "version": "3.53.4",
-      "resolved": "https://registry.npmjs.org/react-native-callstats/-/react-native-callstats-3.53.4.tgz",
-      "integrity": "sha512-LN6CVKHSVTz+CJ6hGuGaxC2bbknoIACEMYLKZ/dcTMEepibaac3bZ+Evilgq0ot+E1BBBFkOo9hiOUU1cgqLXQ==",
-      "requires": {
-        "base-64": "0.1.0",
-        "jssha": "^2.2.0"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "jitsi-meet-logger": "github:jitsi/jitsi-meet-logger#6fff754a77a56ab52499f3559105a15886942a1e",
     "js-utils": "github:jitsi/js-utils#446497893023aa8dec403e0e4e35a22cae6bc87d",
     "lodash.isequal": "4.5.0",
-    "react-native-callstats": "3.53.4",
     "sdp-transform": "2.3.0",
     "strophe.js": "1.2.15",
     "strophejs-plugin-disco": "0.0.2",


### PR DESCRIPTION
It should be provided by the environment, just like on web. This avoids bundling
callstats on web, where it won't be used (we dynamically download it).

This reduces the bundle size from about 1MB to 675KB, almost 40%.