### PR TITLE
Fixed exporting the DTMF manager

### DIFF
--- a/modules/DTMF/JitsiDTMFManager.js
+++ b/modules/DTMF/JitsiDTMFManager.js
@@ -19,3 +19,5 @@ function JitsiDTMFManager(localAudio, peerConnection) {
 JitsiDTMFManager.prototype.sendTones = function(tones, duration, pause) {
     this.dtmfSender.insertDTMF(tones, duration || 200, pause || 200);
 };
+
+export default JitsiDTMFManager;


### PR DESCRIPTION
Fixed: "Uncaught TypeError: y.a is not a constructor" (JitsiDTMFManager is undefined)