### PR TITLE
fix(screenshare): constraints use desktopSharingFrameRate option

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1021,10 +1021,10 @@ class RTCUtils extends Listenable {
      * @param {Object} options
      * @param {Object} options.desktopSharingExtensionExternalInstallation
      * @param {string[]} options.desktopSharingSources
-     * @param {Object} options.gumOptions.frameRate
-     * @param {Object} options.gumOptions.frameRate.min - Minimum fps
-     * @param {Object} options.gumOptions.frameRate.max - Maximum fps
-     * @returns {Promise} A promise which will be resolved with an object whic
+     * @param {Object} options.desktopSharingFrameRate
+     * @param {Object} options.desktopSharingFrameRate.min - Minimum fps
+     * @param {Object} options.desktopSharingFrameRate.max - Maximum fps
+     * @returns {Promise} A promise which will be resolved with an object which
      * contains the acquired display stream. If desktop sharing is not supported
      * then a rejected promise will be returned.
      */
@@ -1036,8 +1036,8 @@ class RTCUtils extends Listenable {
 
         const {
             desktopSharingExtensionExternalInstallation,
-            desktopSharingSources,
-            gumOptions
+            desktopSharingFrameRate,
+            desktopSharingSources
         } = options;
 
         return new Promise((resolve, reject) => {
@@ -1045,7 +1045,9 @@ class RTCUtils extends Listenable {
                 {
                     ...desktopSharingExtensionExternalInstallation,
                     desktopSharingSources,
-                    gumOptions,
+                    gumOptions: {
+                        frameRate: desktopSharingFrameRate
+                    },
                     trackOptions: getTrackSSConstraints(options)
                 },
                 stream => {
@@ -1331,9 +1333,7 @@ class RTCUtils extends Listenable {
             return this._newGetDesktopMedia({
                 desktopSharingExtensionExternalInstallation,
                 desktopSharingSources,
-                gumOptions: {
-                    frameRate: desktopSharingFrameRate
-                }
+                desktopSharingFrameRate
             });
         }.bind(this);
 


### PR DESCRIPTION
Actually pass in the option to getTrackSSConstraints so it gets
applied to the desktop track.