### PR TITLE
fix(screenshare): specify source type for fake and proxy

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1329,7 +1329,10 @@ class RTCUtils extends Listenable {
 
                         return applyConstrainsPromise
                             .then(() => {
-                                return { stream };
+                                return {
+                                    sourceType: 'device',
+                                    stream
+                                };
                             });
                     });
             }

--- a/modules/proxyconnection/ProxyConnectionService.js
+++ b/modules/proxyconnection/ProxyConnectionService.js
@@ -270,6 +270,7 @@ export default class ProxyConnectionService {
                     deviceId:
                         `proxy:${this._peerConnection.getPeerJid()}`,
                     mediaType: isVideo ? MediaType.VIDEO : MediaType.AUDIO,
+                    sourceType: 'proxy',
                     stream: mediaStream,
                     track: mediaStream.getVideoTracks()[0],
                     videoType


### PR DESCRIPTION
Spot is the consumer of screensharing using a camera
input and through a proxy connection. To differentiate
which one is active, declare a source type on the
created "desktop" stream.