### PR TITLE
fix(screenshare): defensively check for getDisplayMedia

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -278,12 +278,14 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
-     * Checks if the browser supposrts getDisplayMedia.
-     * @returns {boolean} {@code true} if the browser supposrts getDisplayMedia.
+     * Checks if the browser supports getDisplayMedia.
+     * @returns {boolean} {@code true} if the browser supports getDisplayMedia.
      */
     supportsGetDisplayMedia() {
         return typeof navigator.getDisplayMedia !== 'undefined'
-            || typeof navigator.mediaDevices.getDisplayMedia !== 'undefined';
+            || (typeof navigator.mediaDevices !== 'undefined'
+                && typeof navigator.mediaDevices.getDisplayMedia
+                    !== 'undefined');
     }
 
     /**


### PR DESCRIPTION
jitsi-meet-spot currently supports mobile browsers. A
line should be drawn somewhere but maybe not here.
Chrome iOS does not have navigator.mediaDevices so add
a truthy check before checking for getDisplayMedia.