### PR TITLE
fix: remove obsolete warnings

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2388,8 +2388,11 @@ TraceablePeerConnection.prototype._processLocalSSRCsMap = function(ssrcMap) {
                     `The local SSRC(${newSSRCNum}) for ${track} ${trackMSID}`
                      + `is still up to date in ${this}`);
             }
-        } else {
-            logger.warn(`No local track matched with: ${trackMSID} in ${this}`);
+        } else if (!track.isVideoTrack() && !track.isMuted()) {
+            // It is normal to find no SSRCs for a muted video track in
+            // the local SDP as the recv-only SSRC is no longer munged in.
+            // So log the warning only if it's not a muted video track.
+            logger.warn(`No SSRCs found in the local SDP for ${track} MSID: ${trackMSID} in ${this}`);
         }
     }
 };

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -815,18 +815,6 @@ StatsCollector.prototype._processAndEmitReport = function() {
             } else {
                 logger.error(`No participant ID returned by ${track}`);
             }
-        } else if (this.peerconnection.isP2P) {
-            // NOTE For JVB connection there are JVB tracks reported in
-            // the stats, but they do not have corresponding JitsiRemoteTrack
-            // instances stored in TPC. It is not trivial to figure out that
-            // a SSRC belongs to JVB, so we print this error ony for the P2P
-            // connection for the time being.
-            //
-            // Also there will be reports for tracks removed from the session,
-            // for the users who have left the conference.
-            logger.error(
-                `JitsiTrack not found for SSRC ${ssrc}`
-                    + ` in ${this.peerconnection}`);
         }
 
         ssrcStats.resetBitrate();


### PR DESCRIPTION
In TraceablePeerConnection: we're no longer injecting a recvonly SSRC
when the local video track is muted, so it's normal that there is no
SSRC found in the local SDP when it's muted.

About RTPStatsCollector: at the time of adding this log statement a case
was missed when local audio track could be replaced in the P2P
connection when a new audio device is selected.