### PR TITLE
Summary: Fix the issue that local tracks won't be added to session

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1145,20 +1145,21 @@ JitsiConference.prototype.replaceTrack = function(oldTrack, newTrack) {
             return Promise.reject(
                 new JitsiTrackError(JitsiTrackErrors.TRACK_IS_DISPOSED));
         }
+        this.onLocalTrackRemoved(oldTrack);
     }
     if (newTrack) {
         if (newTrack.disposed) {
             return Promise.reject(
                 new JitsiTrackError(JitsiTrackErrors.TRACK_IS_DISPOSED));
         }
+        // Now handle the addition of the newTrack at the
+        // JitsiConference level
+        this._setupNewTrack(newTrack);
     }
 
     // Now replace the stream at the lower levels
     return this._doReplaceTrack(oldTrack, newTrack)
         .then(() => {
-            oldTrack && this.onLocalTrackRemoved(oldTrack);
-            newTrack && this._setupNewTrack(newTrack);
-
             // Send 'VideoTypeMessage' on the bridge channel when a video track is added/removed.
             if (oldTrack?.isVideoTrack() || newTrack?.isVideoTrack()) {
                 this._sendBridgeVideoTypeMessage(newTrack);


### PR DESCRIPTION
when we invoke JitsiConference.addTrack, we will add the track to session first and then cache the track to JitsiConference.rtc. This scenario could not cover all the cases and will cause remote device could not get local device‘s tracks. JitsiConference.p2pJingleSession may initialize after JitsiConference._doReplaceTrack executes and before JitsiConference._setupNewTrack executes. In this case, p2pJingleSession will initialize with empty localtracks in JitsiConference.rtc.

In this fix, I cache the track to JitsiConference.rtc before JitsiConference._doReplaceTrack, so that p2pJingleSession could initialize with the localtracks.

Please have a look when you are available. Thanks~