### PR TITLE
Call Analytics' handler dispose() if exists.

### DIFF
--- a/modules/statistics/AnalyticsAdapter.js
+++ b/modules/statistics/AnalyticsAdapter.js
@@ -107,14 +107,14 @@ class AnalyticsAdapter {
     dispose() {
         logger.warn('Disposing of analytics adapter.');
         
-        if (this.analyticsHandlers && this.analyticsHandlers.length > 0) {
+        if (this.analyticsHandlers && this.analyticsHandlers.size > 0) {
             this.analyticsHandlers.forEach(handler => {
                 if ( typeof handler.dispose === 'function' ) {
                     handler.dispose();
                 }
             });
         }
-        
+
         this.setAnalyticsHandlers([]);
         this.disposed = true;
     }

--- a/modules/statistics/AnalyticsAdapter.js
+++ b/modules/statistics/AnalyticsAdapter.js
@@ -106,6 +106,15 @@ class AnalyticsAdapter {
      */
     dispose() {
         logger.warn('Disposing of analytics adapter.');
+        
+        if (this.analyticsHandlers && this.analyticsHandlers.length > 0) {
+            this.analyticsHandlers.forEach(handler => {
+                if ( typeof handler.dispose === 'function' ) {
+                    handler.dispose();
+                }
+            });
+        }
+        
         this.setAnalyticsHandlers([]);
         this.disposed = true;
     }


### PR DESCRIPTION
If a custom handler has a dispose() function implemented, it will be called if the AnalyticsAdapter's dispose is also called.