### PR TITLE
Add error description

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1086,7 +1086,7 @@ JitsiConference.prototype.isModerator = function() {
  */
 JitsiConference.prototype.lock = function(password) {
     if (!this.isModerator()) {
-        throw new Error('You are not moderator.');
+        return Promise.reject('You are not moderator.');
     }
 
     return new Promise((resolve, reject) => {

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1086,7 +1086,7 @@ JitsiConference.prototype.isModerator = function() {
  */
 JitsiConference.prototype.lock = function(password) {
     if (!this.isModerator()) {
-        return Promise.reject();
+        throw new Error('You are not moderator.');
     }
 
     return new Promise((resolve, reject) => {

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1086,7 +1086,7 @@ JitsiConference.prototype.isModerator = function() {
  */
 JitsiConference.prototype.lock = function(password) {
     if (!this.isModerator()) {
-        return Promise.reject('You are not moderator.');
+        return Promise.reject(new Error('You are not moderator.'));
     }
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
For now, a developer as a user of the library doesn't see any errors when using .lock() method without moderator role except promise rejection without any error. I've added error throwing with description to clarify the issue for users.