### PR TITLE
ref(ParticipantConnectionStatus): bump frozen timeout to 10 sec

### DIFF
--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -23,7 +23,7 @@ const DEFAULT_NOT_IN_LAST_N_TIMEOUT = 500;
  *
  * @type {number}
  */
-const DEFAULT_RTC_MUTE_TIMEOUT = 2000;
+const DEFAULT_RTC_MUTE_TIMEOUT = 10000;
 
 /**
  * The time to wait a track to be restored. Track which was out of lastN
@@ -33,7 +33,7 @@ const DEFAULT_RTC_MUTE_TIMEOUT = 2000;
  * interrupted.
  * @type {number}
  */
-const DEFAULT_RESTORING_TIMEOUT = 5000;
+const DEFAULT_RESTORING_TIMEOUT = 10000;
 
 /**
  * Participant connection statuses.


### PR DESCRIPTION
The idea is to not show the frozen video indication for intermittent failures which can be confusing to users.