### PR TITLE
fix(caps): validate sha before caching features

### DIFF
--- a/modules/xmpp/Caps.js
+++ b/modules/xmpp/Caps.js
@@ -154,7 +154,7 @@ export default class Caps extends Listenable {
                         const receivedNode = `${user.node}#${sha}`;
 
                         if (receivedNode !== node) {
-                            logger.error(`Expected node ${node} but received ${
+                            logger.warn(`Expected node ${node} but received ${
                                 receivedNode}`);
                         }
 

--- a/modules/xmpp/Caps.js
+++ b/modules/xmpp/Caps.js
@@ -5,6 +5,8 @@ import { b64_sha1, Strophe } from 'strophe.js'; // eslint-disable-line camelcase
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
 import Listenable from '../util/Listenable';
 
+const logger = require('jitsi-meet-logger').getLogger(__filename);
+
 /**
  * The property
  */
@@ -25,6 +27,29 @@ function compareIdentities(a, b) {
     );
 
     return res;
+}
+
+/**
+ * Produces a sha-1 from provided identity and features values.
+ *
+ * @param {Array<Object>} identities - The identity objects.
+ * @param {Array<string>} features - The features.
+ * @returns {string}
+ */
+function generateSha(identities, features) {
+    const sortedIdentities = identities.sort(compareIdentities).reduce(
+        (accumulatedValue, identity) => `${
+            IDENTITY_PROPERTIES.reduce(
+                (tmp, key, idx) =>
+                    tmp
+                        + (idx === 0 ? '' : '/')
+                        + identity[key],
+                '')
+        }<`, '');
+    const sortedFeatures = features.sort().reduce(
+        (tmp, feature) => `${tmp + feature}<`, '');
+
+    return b64_sha1(sortedIdentities + sortedFeatures);
 }
 
 /**
@@ -120,10 +145,20 @@ export default class Caps extends Listenable {
             const node = user ? `${user.node}#${user.version}` : null;
 
             return this._getDiscoInfo(jid, node, timeout)
-                .then(({ features }) => {
+                .then(({ features, identities }) => {
                     if (user) {
-                        // TODO: Maybe use the version + node + hash as keys?
-                        this.versionToCapabilities[user.version] = features;
+                        const sha = generateSha(
+                            Array.from(identities),
+                            Array.from(features)
+                        );
+                        const receivedNode = `${user.node}#${sha}`;
+
+                        if (receivedNode !== node) {
+                            logger.error(`Expected node ${node} but received ${
+                                receivedNode}`);
+                        }
+
+                        this.versionToCapabilities[receivedNode] = features;
                     }
 
                     return features;
@@ -225,23 +260,9 @@ export default class Caps extends Listenable {
      * Generates the value for the "ver" attribute.
      */
     _generateVersion() {
-        const identities
-          = this.disco._identities.sort(compareIdentities).reduce(
-              (accumulatedValue, identity) =>
-                  `${
-                      IDENTITY_PROPERTIES.reduce(
-                          (tmp, key, idx) =>
-                              tmp
-                                  + (idx === 0 ? '' : '/')
-                                  + identity[key],
-                          '')
-                  }<`,
-              '');
-        const features
-            = this.disco._features.sort().reduce(
-                (tmp, feature) => `${tmp + feature}<`, '');
+        this.version
+            = generateSha(this.disco._identities, this.disco._features);
 
-        this.version = b64_sha1(identities + features);
         this._notifyVersionChanged();
     }
 

--- a/modules/xmpp/Caps.js
+++ b/modules/xmpp/Caps.js
@@ -153,15 +153,22 @@ export default class Caps extends Listenable {
                         );
                         const receivedNode = `${user.node}#${sha}`;
 
-                        if (receivedNode !== node) {
-                            logger.warn(`Expected node ${node} but received ${
-                                receivedNode}`);
+                        if (receivedNode === node) {
+                            this.versionToCapabilities[receivedNode] = features;
+
+                            return features;
                         }
 
-                        this.versionToCapabilities[receivedNode] = features;
-                    }
+                        // Check once if it has been cached asynchronously.
+                        if (this.versionToCapabilities[receivedNode]) {
+                            return this.versionToCapabilities[receivedNode];
+                        }
 
-                    return features;
+                        logger.error(`Expected node ${node} but received ${
+                            receivedNode}`);
+
+                        return Promise.reject('Feature version mismatch');
+                    }
                 });
         }
 


### PR DESCRIPTION
Attemps to fix this race condition:
1. Web client joins a conference
2. Electron client joins the same conference.
3. Web client requests capabilities of Electron
   using version 1111.
4. Electron adds remote control capability,
   settings its version to 2222.
5. Electron responds to web client's requests
   but with features of 2222.
6. Web client caches request under 1111.