### PR TITLE
fix(presence): send latest presence on conference join

### DIFF
--- a/modules/xmpp/Caps.js
+++ b/modules/xmpp/Caps.js
@@ -5,6 +5,8 @@ import { b64_sha1, Strophe } from 'strophe.js'; // eslint-disable-line camelcase
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
 import Listenable from '../util/Listenable';
 
+const logger = require('jitsi-meet-logger').getLogger(__filename);
+
 /**
  * The property
  */
@@ -51,6 +53,7 @@ export default class Caps extends Listenable {
         this.jidToVersion = Object.create(null);
         this.version = '';
         this.rooms = new Set();
+        this._roomJidToMucJoinHandlers = {};
 
         const emuc = connection.emuc;
 
@@ -183,6 +186,19 @@ export default class Caps extends Listenable {
      */
     _addChatRoom(room) {
         this.rooms.add(room);
+
+        const { myroomjid } = room;
+        const fixVersionIfOutdated = () => {
+            if (this.jidToVersion[myroomjid]
+                && this.jidToVersion[myroomjid].version !== this.version) {
+                logger.warn('Mismatched caps version detected on muc join.');
+                room.sendPresence();
+            }
+        };
+
+        this._roomJidToMucJoinHandlers[myroomjid] = fixVersionIfOutdated;
+
+        room.addListener(XMPPEvents.MUC_JOINED, fixVersionIfOutdated);
         room.addListener(XMPPEvents.MUC_MEMBER_LEFT, this._onMucMemberLeft);
         this._fixChatRoomPresenceMap(room);
     }
@@ -194,6 +210,12 @@ export default class Caps extends Listenable {
      */
     _removeChatRoom(room) {
         this.rooms.delete(room);
+
+        const joinHandler = this._roomJidToMucJoinHandlers[room.myroomjid];
+
+        delete this._roomJidToMucJoinHandlers[room.myroomjid];
+        room.removeListener(XMPPEvents.MUC_JOINED, joinHandler);
+
         room.removeListener(XMPPEvents.MUC_MEMBER_LEFT, this._onMucMemberLeft);
     }
 

--- a/modules/xmpp/Caps.js
+++ b/modules/xmpp/Caps.js
@@ -5,8 +5,6 @@ import { b64_sha1, Strophe } from 'strophe.js'; // eslint-disable-line camelcase
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
 import Listenable from '../util/Listenable';
 
-const logger = require('jitsi-meet-logger').getLogger(__filename);
-
 /**
  * The property
  */
@@ -53,7 +51,6 @@ export default class Caps extends Listenable {
         this.jidToVersion = Object.create(null);
         this.version = '';
         this.rooms = new Set();
-        this._roomJidToMucJoinHandlers = {};
 
         const emuc = connection.emuc;
 
@@ -186,19 +183,6 @@ export default class Caps extends Listenable {
      */
     _addChatRoom(room) {
         this.rooms.add(room);
-
-        const { myroomjid } = room;
-        const fixVersionIfOutdated = () => {
-            if (this.jidToVersion[myroomjid]
-                && this.jidToVersion[myroomjid].version !== this.version) {
-                logger.warn('Mismatched caps version detected on muc join.');
-                room.sendPresence();
-            }
-        };
-
-        this._roomJidToMucJoinHandlers[myroomjid] = fixVersionIfOutdated;
-
-        room.addListener(XMPPEvents.MUC_JOINED, fixVersionIfOutdated);
         room.addListener(XMPPEvents.MUC_MEMBER_LEFT, this._onMucMemberLeft);
         this._fixChatRoomPresenceMap(room);
     }
@@ -210,12 +194,6 @@ export default class Caps extends Listenable {
      */
     _removeChatRoom(room) {
         this.rooms.delete(room);
-
-        const joinHandler = this._roomJidToMucJoinHandlers[room.myroomjid];
-
-        delete this._roomJidToMucJoinHandlers[room.myroomjid];
-        room.removeListener(XMPPEvents.MUC_JOINED, joinHandler);
-
         room.removeListener(XMPPEvents.MUC_MEMBER_LEFT, this._onMucMemberLeft);
     }
 

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -460,6 +460,10 @@ export default class ChatRoom extends Listenable {
                     this.locked = true;
                 }
 
+                // Re-send presence in case any presence updates were added,
+                // but blocked from sending, during the join process.
+                this.sendPresence();
+
                 this.eventEmitter.emit(XMPPEvents.MUC_JOINED);
             }
         } else if (this.members[from] === undefined) {

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -460,10 +460,6 @@ export default class ChatRoom extends Listenable {
                     this.locked = true;
                 }
 
-                // Re-send presence in case any presence updates were added,
-                // but blocked from sending, during the join process.
-                this.sendPresence();
-
                 this.eventEmitter.emit(XMPPEvents.MUC_JOINED);
             }
         } else if (this.members[from] === undefined) {


### PR DESCRIPTION
Attempts to fix the following issue:
1. Electron user starts the conference join process.
2. Electron user adds remote control capability and
   attempts to send presence.
3. Electron user presence send is blocked because the
   conference has not been joined.
4. Electron user joins the conference.
5. The remote control capability is not emitted until
   some other presence change triggers another
   presence send. Until then, other uses will not see
   remote control option available for the electron
   user.