### PR TITLE
Always uses 8 hex digits for the MUC nickname/endpoint ID.

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -409,7 +409,7 @@ export default class XMPP extends Listenable {
         // as the endpoint ID in colibri. We require endpoint IDs to be 8 hex digits because
         // in some cases they get serialized into a 32bit field.
         if (this.authenticatedUser) {
-            // Authenticated users h
+            // For authenticated users generate a random ID.
             mucNickname = RandomUtil.randomHexString(8).toLowerCase();
         }
         else (!this.authenticatedUser) {
@@ -424,7 +424,7 @@ export default class XMPP extends Listenable {
             }
         }
 
-        logger.info(`Using MUC nickname $mucNickname`);
+        logger.info(`JID ${this.connection.jid} using MUC nickname $mucNickname`);
         roomjid += mucNickname;
 
         return this.connection.emuc.createRoom(roomjid, null, options);

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -411,15 +411,16 @@ export default class XMPP extends Listenable {
         if (this.authenticatedUser) {
             // For authenticated users generate a random ID.
             mucNickname = RandomUtil.randomHexString(8).toLowerCase();
-        }
-        else (!this.authenticatedUser) {
+        } else if (!this.authenticatedUser) {
             // We try to use the first part of the node (which for anonymous users on prosody is a UUID) to match
             // the previous behavior (and maybe make debugging easier).
-            mucNickname = Strophe.getNodeFromJid(this.connection.jid).substr(0, 8).toLowerCase();
+            mucNickname = Strophe.getNodeFromJid(this.connection.jid).substr(0, 8)
+                .toLowerCase();
 
             // But if this doesn't have the required format we just generate a new random nickname.
-            let re = /[0-9a-f]{8}/g;
-            if (!re.test(mucNuckname)) {
+            const re = /[0-9a-f]{8}/g;
+
+            if (!re.test(mucNickname)) {
                 mucNickname = RandomUtil.randomHexString(8).toLowerCase();
             }
         }


### PR DESCRIPTION
With Octo we need to have all colibri endpoint IDs be 8 hex digits. This PR ensures this by:
1. Disabling the 'useNicks' option which allowed a value from config.js to be prepended to the nickname
2. Disabling prepending the node (part before @) for authenticated users.

In practice this means that jibri will get a new random ID instead of "recorder-xxxxxx" (the x's here being random), and the 'useNicks' option will cease to work. As far as I am aware the 'useNicks' option is not used anywhere, apart from debugging, and nothing depends on the nickname for jibri starting with "recorder" or anything similar for other authenticated users.

If there is a need, we can continue to support the 'useNicks' option, but not together with Octo (we could make that configurable in jicofo). 