### PR TITLE
fix(JingleSessionPC): prevent from queueing tasks after close

### DIFF
--- a/modules/util/AsyncQueue.js
+++ b/modules/util/AsyncQueue.js
@@ -1,0 +1,55 @@
+import async from 'async';
+
+/**
+ * A queue for async task execution.
+ */
+export default class AsyncQueue {
+    /**
+     * Creates new instance.
+     */
+    constructor() {
+        this.modificationQueue = async.queue(this._processQueueTasks.bind(this), 1);
+        this.stopped = false;
+    }
+
+    /**
+     * Internal task processing implementation which makes things work.
+     */
+    _processQueueTasks(task, finishedCallback) {
+        task(finishedCallback);
+    }
+
+    /**
+     * The 'workFunction' function will be given a callback it MUST call with either:
+     *  1) No arguments if it was successful or
+     *  2) An error argument if there was an error
+     * If the task wants to process the success or failure of the task, it
+     * should pass the {@code callback} to the push function, e.g.:
+     * queue.push(task, (err) => {
+     *     if (err) {
+     *         // error handling
+     *     } else {
+     *         // success handling
+     *     }
+     * });
+     *
+     * @param {function} workFunction - The task to be execute. See the description above.
+     * @param {function} [callback] - Optional callback to be called after the task has been executed.
+     */
+    push(workFunction, callback) {
+        if (this.stopped) {
+            callback && callback('The queue has been stopped');
+
+            return;
+        }
+        this.modificationQueue.push(workFunction, callback);
+    }
+
+    /**
+     * Shutdowns the queue. All already queued tasks will execute, but no future tasks can be added. If a task is added
+     * after the queue has been shutdown then the callback will be called with an error.
+     */
+    shutdown() {
+        this.stopped = true;
+    }
+}

--- a/modules/util/AsyncQueue.js
+++ b/modules/util/AsyncQueue.js
@@ -20,7 +20,7 @@ export default class AsyncQueue {
     }
 
     /**
-     * The 'workFunction' function will be given a callback it MUST call with either:
+     * The 'task' function will be given a callback it MUST call with either:
      *  1) No arguments if it was successful or
      *  2) An error argument if there was an error
      * If the task wants to process the success or failure of the task, it
@@ -33,16 +33,16 @@ export default class AsyncQueue {
      *     }
      * });
      *
-     * @param {function} workFunction - The task to be execute. See the description above.
+     * @param {function} task - The task to be executed. See the description above.
      * @param {function} [callback] - Optional callback to be called after the task has been executed.
      */
-    push(workFunction, callback) {
+    push(task, callback) {
         if (this._stopped) {
             callback && callback(new Error('The queue has been stopped'));
 
             return;
         }
-        this._queue.push(workFunction, callback);
+        this._queue.push(task, callback);
     }
 
     /**

--- a/modules/util/AsyncQueue.js
+++ b/modules/util/AsyncQueue.js
@@ -38,7 +38,7 @@ export default class AsyncQueue {
      */
     push(workFunction, callback) {
         if (this._stopped) {
-            callback && callback('The queue has been stopped');
+            callback && callback(new Error('The queue has been stopped'));
 
             return;
         }

--- a/modules/util/AsyncQueue.js
+++ b/modules/util/AsyncQueue.js
@@ -13,6 +13,13 @@ export default class AsyncQueue {
     }
 
     /**
+     * Removes any pending tasks from the queue.
+     */
+    clear() {
+        this._queue.kill();
+    }
+
+    /**
      * Internal task processing implementation which makes things work.
      */
     _processQueueTasks(task, finishedCallback) {

--- a/modules/util/AsyncQueue.js
+++ b/modules/util/AsyncQueue.js
@@ -8,8 +8,8 @@ export default class AsyncQueue {
      * Creates new instance.
      */
     constructor() {
-        this.modificationQueue = async.queue(this._processQueueTasks.bind(this), 1);
-        this.stopped = false;
+        this._queue = async.queue(this._processQueueTasks.bind(this), 1);
+        this._stopped = false;
     }
 
     /**
@@ -37,12 +37,12 @@ export default class AsyncQueue {
      * @param {function} [callback] - Optional callback to be called after the task has been executed.
      */
     push(workFunction, callback) {
-        if (this.stopped) {
+        if (this._stopped) {
             callback && callback('The queue has been stopped');
 
             return;
         }
-        this.modificationQueue.push(workFunction, callback);
+        this._queue.push(workFunction, callback);
     }
 
     /**
@@ -50,6 +50,6 @@ export default class AsyncQueue {
      * after the queue has been shutdown then the callback will be called with an error.
      */
     shutdown() {
-        this.stopped = true;
+        this._stopped = true;
     }
 }

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -2207,6 +2207,9 @@ export default class JingleSessionPC extends JingleSession {
         this.peerconnection.onnegotiationneeded = null;
         this.peerconnection.onsignalingstatechange = null;
 
+        // Remove any pending tasks from the queue
+        this.modificationQueue.clear();
+
         this.modificationQueue.push(finishCallback => {
             // The signaling layer will remove it's listeners
             this.signalingLayer.setChatRoom(null);
@@ -2215,6 +2218,8 @@ export default class JingleSessionPC extends JingleSession {
             this.peerconnection && this.peerconnection.close();
             finishCallback();
         });
+
+        // No more tasks can go in after the close task
         this.modificationQueue.shutdown();
     }
 

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -309,7 +309,7 @@ export default class JingleSessionPC extends JingleSession {
                     pcOptions);
 
         this.peerconnection.onicecandidate = ev => {
-            if (!ev || !this._assertNotEnded()) {
+            if (!ev) {
                 // There was an incomplete check for ev before which left
                 // the last line of the function unprotected from a potential
                 // throw of an exception. Consequently, it may be argued that
@@ -365,9 +365,6 @@ export default class JingleSessionPC extends JingleSession {
         // "closed" instead.
         // I suppose at some point this will be moved to onconnectionstatechange
         this.peerconnection.onsignalingstatechange = () => {
-            if (!this.peerconnection || !this._assertNotEnded()) {
-                return;
-            }
             if (this.peerconnection.signalingState === 'stable') {
                 this.wasstable = true;
             } else if (this.peerconnection.signalingState === 'closed'
@@ -383,9 +380,6 @@ export default class JingleSessionPC extends JingleSession {
          * the value of RTCPeerConnection.iceConnectionState changes.
          */
         this.peerconnection.oniceconnectionstatechange = () => {
-            if (!this.peerconnection || !this._assertNotEnded()) {
-                return;
-            }
             const now = window.performance.now();
 
             if (!this.isP2P) {
@@ -2207,6 +2201,11 @@ export default class JingleSessionPC extends JingleSession {
     close() {
         this.state = JingleSessionState.ENDED;
         this.establishmentDuration = undefined;
+
+        this.peerconnection.onicecandidate = null;
+        this.peerconnection.oniceconnectionstatechange = null;
+        this.peerconnection.onnegotiationneeded = null;
+        this.peerconnection.onsignalingstatechange = null;
 
         this.modificationQueue.push(finishCallback => {
             // The signaling layer will remove it's listeners


### PR DESCRIPTION
Also do not execute any peerconnection callbacks like 'oniceconnectionstatechange', 'onicecandidate' etc. after close.