### PR TITLE
Fix listener issues in emuc Strophe plugin and JitsiConference

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -638,10 +638,11 @@ JitsiConference.prototype.addCommandListener = function(command, handler) {
 /**
   * Removes command  listener
   * @param command {String} the name of the command
+  * @param handler {Function} handler to remove for the command
   */
-JitsiConference.prototype.removeCommandListener = function(command) {
+JitsiConference.prototype.removeCommandListener = function(command, handler) {
     if (this.room) {
-        this.room.removePresenceListener(command);
+        this.room.removePresenceListener(command, handler);
     }
 };
 

--- a/modules/xmpp/strophe.emuc.js
+++ b/modules/xmpp/strophe.emuc.js
@@ -91,7 +91,7 @@ class MucConnectionPlugin extends ConnectionPluginListenable {
         const room = this.rooms[Strophe.getBareJidFromJid(from)];
 
         if (!room) {
-            return;
+            return true;
         }
 
         // Parse status.
@@ -114,7 +114,7 @@ class MucConnectionPlugin extends ConnectionPluginListenable {
         const room = this.rooms[Strophe.getBareJidFromJid(from)];
 
         if (!room) {
-            return;
+            return true;
         }
 
         room.onPresenceUnavailable(pres, from);
@@ -131,7 +131,7 @@ class MucConnectionPlugin extends ConnectionPluginListenable {
         const room = this.rooms[Strophe.getBareJidFromJid(from)];
 
         if (!room) {
-            return;
+            return true;
         }
 
         room.onPresenceError(pres, from);
@@ -149,7 +149,7 @@ class MucConnectionPlugin extends ConnectionPluginListenable {
         const room = this.rooms[Strophe.getBareJidFromJid(from)];
 
         if (!room) {
-            return;
+            return true;
         }
 
         room.onMessage(msg, from);
@@ -165,10 +165,9 @@ class MucConnectionPlugin extends ConnectionPluginListenable {
         const from = iq.getAttribute('from');
         const room = this.rooms[Strophe.getBareJidFromJid(from)];
 
-        // XXX What are the semantics of the return value? Why is it sometimes
-        // undefined and sometimes a boolean?
+        // Returning false would result in the listener being deregistered by Strophe
         if (!room) {
-            return;
+            return true;
         }
 
         room.onMute(iq);


### PR DESCRIPTION
* If a presence message was received from a room which the Emuc plugin did not know about, it would return undefined, causing Strophe to deregister the listener. Since this is by no means a fatal error, I modified the listeners to return true in such cases as well.
* the "removeCommandListener" method in JitsiConference did not have a handler argument, even though the underlying implementation in ChatRoom required one, so the call actually did not remove anything.