### PR TITLE
feat(xmpp): allow setting resource on room jid

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -407,7 +407,7 @@ JitsiConference.prototype.join = function(password) {
  * process.
  */
 JitsiConference.prototype.authenticateAndUpgradeRole = function(options) {
-    return authenticateAndUpgradeRole.apply(this, {
+    return authenticateAndUpgradeRole.call(this, {
         ...options,
         onCreateResource: JitsiConference.resourceCreator
     });

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -32,6 +32,7 @@ import SpeakerStatsCollector from './modules/statistics/SpeakerStatsCollector';
 import Statistics from './modules/statistics/statistics';
 import Transcriber from './modules/transcription/transcriber';
 import GlobalOnErrorHandler from './modules/util/GlobalOnErrorHandler';
+import RandomUtil from './modules/util/RandomUtil';
 import ComponentsVersions from './modules/version/ComponentsVersions';
 import VideoSIPGW from './modules/videosipgw/VideoSIPGW';
 import * as VideoSIPGWConstants from './modules/videosipgw/VideoSIPGWConstants';
@@ -223,6 +224,43 @@ export default function JitsiConference(options) {
 JitsiConference.prototype.constructor = JitsiConference;
 
 /**
+ * Create a resource for the a jid. We use the room nickname (the resource part
+ * of the occupant JID, see XEP-0045) as the endpoint ID in colibri. We require
+ * endpoint IDs to be 8 hex digits because in some cases they get serialized
+ * into a 32bit field.
+ *
+ * @param {string} jid - The id set onto the XMPP connection.
+ * @param {boolean} isAuthenticatedUser - Whether or not the user has connected
+ * to the XMPP service with a password.
+ * @returns {string}
+ * @static
+ */
+JitsiConference.resourceCreator = function(jid, isAuthenticatedUser) {
+    let mucNickname;
+
+    if (isAuthenticatedUser) {
+        // For authenticated users generate a random ID.
+        mucNickname = RandomUtil.randomHexString(8).toLowerCase();
+    } else {
+        // We try to use the first part of the node (which for anonymous users
+        // on prosody is a UUID) to match the previous behavior (and maybe make
+        // debugging easier).
+        mucNickname = Strophe.getNodeFromJid(jid).substr(0, 8)
+            .toLowerCase();
+
+        // But if this doesn't have the required format we just generate a new
+        // random nickname.
+        const re = /[0-9a-f]{8}/g;
+
+        if (!re.test(mucNickname)) {
+            mucNickname = RandomUtil.randomHexString(8).toLowerCase();
+        }
+    }
+
+    return mucNickname;
+};
+
+/**
  * Initializes the conference object properties
  * @param options {object}
  * @param options.connection {JitsiConnection} overrides this.connection
@@ -240,7 +278,11 @@ JitsiConference.prototype._init = function(options = {}) {
 
     const { config } = this.options;
 
-    this.room = this.xmpp.createRoom(this.options.name, config);
+    this.room = this.xmpp.createRoom(
+        this.options.name,
+        config,
+        JitsiConference.resourceCreator
+    );
 
     // Connection interrupted/restored listeners
     this._onIceConnectionInterrupted
@@ -364,8 +406,11 @@ JitsiConference.prototype.join = function(password) {
  * and (2) has a <tt>cancel</tt> method that allows the caller to interrupt the
  * process.
  */
-JitsiConference.prototype.authenticateAndUpgradeRole = function(...args) {
-    return authenticateAndUpgradeRole.apply(this, args);
+JitsiConference.prototype.authenticateAndUpgradeRole = function(options) {
+    return authenticateAndUpgradeRole.apply(this, {
+        ...options,
+        onCreateResource: JitsiConference.resourceCreator
+    });
 };
 
 /**

--- a/authenticateAndUpgradeRole.js
+++ b/authenticateAndUpgradeRole.js
@@ -61,6 +61,7 @@ export default function authenticateAndUpgradeRole({
     // 1. Log the specified XMPP user in.
     id,
     password,
+    onCreateResource,
 
     // 2. Let the API client/consumer know as soon as the XMPP user has been
     //    successfully logged in.
@@ -96,8 +97,11 @@ export default function authenticateAndUpgradeRole({
                 onLoginSuccessful && onLoginSuccessful();
 
                 // Now authenticate with Jicofo and get a new session ID.
-                const room
-                    = xmpp.createRoom(this.options.name, this.options.config);
+                const room = xmpp.createRoom(
+                    this.options.name,
+                    this.options.config,
+                    onCreateResource
+                );
 
                 room.moderator.authenticate()
                     .then(() => {

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -431,7 +431,7 @@ export default class XMPP extends Listenable {
         } else if (this.authenticatedUser) {
             // For authenticated users generate a random ID.
             mucNickname = RandomUtil.randomHexString(8).toLowerCase();
-        } else if (!this.authenticatedUser) {
+        } else {
             // We try to use the first part of the node (which for anonymous users on prosody is a UUID) to match
             // the previous behavior (and maybe make debugging easier).
             mucNickname = Strophe.getNodeFromJid(this.connection.jid).substr(0, 8)

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -408,9 +408,15 @@ export default class XMPP extends Listenable {
     }
 
     /**
+     * Joins or creates a muc with the provided jid, created from the passed
+     * in room name and muc host.
      *
-     * @param roomName
-     * @param options
+     * @param {string} roomName - The name of the muc to join.
+     * @param {Object} options - Configuration for how to join the muc.
+     * @param {string} [options.forcedResourceName] - A resource to set on the
+     * jid. This options should not be used if the video bridge is used, as
+     * the video bridge re-uses this value as an id.
+     * @returns {Promise} Resolves with an instance of a strophe muc.
      */
     createRoom(roomName, options) {
         let roomjid = `${roomName}@${this.options.hosts.muc}/`;
@@ -420,7 +426,9 @@ export default class XMPP extends Listenable {
         // We use the room nickname (the resourcepart of the occupant JID, see XEP-0045)
         // as the endpoint ID in colibri. We require endpoint IDs to be 8 hex digits because
         // in some cases they get serialized into a 32bit field.
-        if (this.authenticatedUser) {
+        if (options.forcedResourceName) {
+            mucNickname = options.forcedResourceName;
+        } else if (this.authenticatedUser) {
             // For authenticated users generate a random ID.
             mucNickname = RandomUtil.randomHexString(8).toLowerCase();
         } else if (!this.authenticatedUser) {
@@ -437,7 +445,7 @@ export default class XMPP extends Listenable {
             }
         }
 
-        logger.info(`JID ${this.connection.jid} using MUC nickname $mucNickname`);
+        logger.info(`JID ${this.connection.jid} using MUC nickname ${mucNickname}`);
         roomjid += mucNickname;
 
         return this.connection.emuc.createRoom(roomjid, null, options);


### PR DESCRIPTION
This functionality is being brought back for apps
that use ljm for its prosody logic but not for
video conferencing, ie Jitsi-Meet Spot. The desired
use is for Spot-TVs to be identifiable by their
jid alone and for the resource to be the part
that identifies them.