### PR TITLE
Add display name to chat message meta

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -687,7 +687,9 @@ JitsiConference.prototype.removeCommandListener = function(command) {
 JitsiConference.prototype.sendTextMessage = function(
         message, elementName = 'body') {
     if (this.room) {
-        this.room.sendMessage(message, elementName);
+        const displayName = (this.room.getFromPresence('nick') || {}).value;
+
+        this.room.sendMessage(message, elementName, displayName);
     }
 };
 

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -307,7 +307,7 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
 
             conference.eventEmitter.emit(
                 JitsiConferenceEvents.MESSAGE_RECEIVED,
-                id, txt, ts);
+                id, txt, ts, displayName);
         });
 
     chatRoom.addListener(

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1079,6 +1079,16 @@ export default class ChatRoom extends Listenable {
     }
 
     /**
+     * Retreives a value from the presence map.
+     *
+     * @param {string} key - The key to find the value for.
+     * @returns {Object?}
+     */
+    getFromPresence(key) {
+        return this.presMap.nodes.find(node => key === node.tagName);
+    }
+
+    /**
      *
      * @param key
      */


### PR DESCRIPTION
This change persists the display name in the chat message itself, so we'll have a display name for messages after rejoin (old participant details lost)