### PR TITLE
Partially reverts 24bda8e and uses domain/roomname to report to cs.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -352,10 +352,12 @@ JitsiConference.prototype._init = function(options = {}) {
 
         this.statistics = new Statistics(this.xmpp, {
             callStatsAliasName,
+            callStatsConfIDNamespace: this.connection.options.hosts.domain,
             confID: config.confID || `${this.connection.options.hosts.domain}/${this.options.name}`,
             customScriptUrl: config.callStatsCustomScriptUrl,
             callStatsID: config.callStatsID,
             callStatsSecret: config.callStatsSecret,
+            roomName: this.options.name,
             swapUserNameAndAlias: config.enableStatsID,
             applicationName: config.applicationName,
             getWiFiStatsMethod: config.getWiFiStatsMethod

--- a/doc/API.md
+++ b/doc/API.md
@@ -50,6 +50,7 @@ The ```options``` parameter is JS object with the following properties:
     - `disableThirdPartyRequests` - if true - callstats will be disabled and the callstats API won't be included.
     - `enableAnalyticsLogging` - boolean property (default false). Enables/disables analytics logging.
     - `callStatsCustomScriptUrl` - (optional) custom url to access callstats client script
+    - `callStatsConfIDNamespace` - (optional) a namespace to prepend the callstats conference ID with. Defaults to the window.location.hostname
     - `disableRtx` - (optional) boolean property (default to false).  Enables/disable the use of RTX.
     - `disableH264` - (optional) boolean property (default to false).  If enabled, strips the H.264 codec from the local SDP.
     - `preferH264` - (optional) boolean property (default to false).  Enables/disable preferring the first instance of an h264 codec in an offer by moving it to the front of the codec list.

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -130,11 +130,14 @@ Statistics.init = function(options) {
  * callstats.
  * @property {string} callStatsAliasName - The alias name to use when
  * initializing callstats.
+ * @property {string} callStatsConfIDNamespace - A namespace to prepend the
+ * callstats conference ID with.
  * @property {string} confID - The callstats conference ID to use.
  * @property {string} callStatsID - Callstats credentials - the id.
  * @property {string} callStatsSecret - Callstats credentials - the secret.
  * @property {string} customScriptUrl - A custom lib url to use when downloading
  * callstats library.
+ * @property {string} roomName - The room name we are currently in.
  * @property {boolean} swapUserNameAndAlias - Whether to swap the places of
  * username and alias when initiating callstats.
  */
@@ -171,6 +174,10 @@ export default function Statistics(xmpp, options) {
 
         if (!this.options.confID) {
             logger.warn('"confID" is not defined');
+        }
+
+        if (!this.options.callStatsConfIDNamespace) {
+            logger.warn('"callStatsConfIDNamespace" is not defined');
         }
     }
 
@@ -367,7 +374,7 @@ Statistics.prototype.startCallStats = function(tpc, remoteUserID) {
         = new CallStats(
             tpc,
             {
-                confID: this.options.confID,
+                confID: this._getCallStatsConfID(),
                 remoteUserID
             });
 
@@ -390,6 +397,19 @@ Statistics._getAllCallStatsInstances = function() {
     }
 
     return csInstances;
+};
+
+/**
+ * Constructs the CallStats conference ID based on the options currently
+ * configured in this instance.
+ * @return {string}
+ * @private
+ */
+Statistics.prototype._getCallStatsConfID = function() {
+    // The conference ID is case sensitive!!!
+    return this.options.callStatsConfIDNamespace
+        ? `${this.options.callStatsConfIDNamespace}/${this.options.roomName}`
+        : this.options.roomName;
 };
 
 /**
@@ -683,7 +703,7 @@ Statistics.prototype.sendFeedback = function(overall, comment) {
             comment
         });
 
-    return CallStats.sendFeedback(this.options.confID, overall, comment);
+    return CallStats.sendFeedback(this._getCallStatsConfID(), overall, comment);
 };
 
 Statistics.LOCAL_JID = require('../../service/statistics/constants').LOCAL_JID;


### PR DESCRIPTION
To be sure we always report room name in small case and as mobile and jigasi report this way it will take time for them to adopt which leads to wrong stats.