### PR TITLE
fix(connection-status): pass expected args to type change listener

### DIFF
--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -506,7 +506,7 @@ export default class ParticipantConnectionStatusHandler {
                 this._onSignallingMuteChanged);
             remoteTrack.on(
                 JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED,
-                this._onTrackVideoTypeChanged);
+                videoType => this._onTrackVideoTypeChanged(remoteTrack, videoType));
         }
     }
 
@@ -528,9 +528,6 @@ export default class ParticipantConnectionStatusHandler {
             remoteTrack.off(
                 JitsiTrackEvents.TRACK_MUTE_CHANGED,
                 this._onSignallingMuteChanged);
-            remoteTrack.off(
-                JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED,
-                this._onTrackVideoTypeChanged);
 
             this.clearTimeout(endpointId);
             this.clearRtcMutedTimestamp(endpointId);


### PR DESCRIPTION
The event TRACK_VIDEOTYPE_CHANGED passes only the video type
along, not the track.

This does remove a listener removal call. Alternatives thought of
- keep a cache of attached listeners to call off from
- change TRACK_VIDEOTYPE_CHANGED to pass "this" or the track ID as a second argument (added second to preserve backwards compatibiltiy)