### PR TITLE
fix(JingleSessionPC): no media flowing after ICE restart

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1040,6 +1040,15 @@ export default class JingleSessionPC extends JingleSession {
             .find('>content>description>ssrc-group')
             .remove();
 
+        // On the JVB it's not a real ICE restart and all layers are re-initialized from scratch as Jicofo does
+        // the restart by re-allocating new channels. Chrome (or WebRTC stack) needs to have the DTLS transport layer
+        // reset to start a new handshake with fresh DTLS transport on the bridge. Make it think that the DTLS
+        // fingerprint has changed by setting an all zeros key.
+        const newFingerprint = jingleOfferElem.find('>content>transport>fingerprint');
+
+        newFingerprint.attr('hash', 'sha-1');
+        newFingerprint.text('00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00');
+
         // First set an offer with a rejected 'data' section
         this.setOfferAnswerCycle(
             jingleOfferElem,


### PR DESCRIPTION
If DTLS fingerprint remains unchanged after ice-restart there will be no media flow even thought the ICE connection will be re-established.

The workaround is to set an all zeros fingerprint on the hacky offer/answer cycle which is currently done in order to reset the data channels and the sequence number counters on the RTP receivers.