### PR TITLE
ignore undefined from jid

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -480,6 +480,8 @@ export default class ChatRoom extends Listenable {
 
                 this.eventEmitter.emit(XMPPEvents.MUC_JOINED);
             }
+        } else if (jid === undefined) {
+            logger.info('Ignoring member with undefined JID');
         } else if (this.members[from] === undefined) {
             // new participant
             this.members[from] = member;


### PR DESCRIPTION
As discussed [here](https://community.jitsi.org/t/focus-user-visible-in-meet-conference/19997/7) presence stanzas not containing the muc presence extension create artifact users in the conference with the default nick. 

By ignoring presences with an undefined jid in the ChatRoom presence handler, this is avoided. Other presence processing remains untouched.

Thank you for your support @damencho  :) 