### PR TITLE
fix(ChatRoom.spec): broken by 0f4cd357 "ignore undefined from"

### DIFF
--- a/modules/xmpp/ChatRoom.spec.js
+++ b/modules/xmpp/ChatRoom.spec.js
@@ -150,6 +150,9 @@ describe('ChatRoom', () => {
         it('parses status correctly', () => {
             const presStr = '' +
                 '<presence to="tojid" from="fromjid">' +
+                    '<x xmlns=\'http://jabber.org/protocol/muc#user\'>' +
+                        '<item jid=\'fulljid\'/>' +
+                    '</x>' +
                     '<status>status-text</status>' +
                 '</presence>';
             const pres = new DOMParser().parseFromString(presStr, 'text/xml').documentElement;
@@ -160,16 +163,17 @@ describe('ChatRoom', () => {
                 XMPPEvents.PRESENCE_RECEIVED,
                 jasmine.any(Object)
             ]);
-            expect(emitterSpy).toHaveBeenCalledWith(
+            expect(emitterSpy.calls.argsFor(1)).toEqual([
                 XMPPEvents.MUC_MEMBER_JOINED,
                 'fromjid',
                 undefined, // nick
-                undefined, // role
-                undefined, // isHiddenDomain
+                null, // role
+                false, // isHiddenDomain
                 undefined, // statsID
                 'status-text',
                 undefined,
-                undefined);
+                undefined
+            ]);
         });
 
         it('parses muc user item correctly', () => {
@@ -202,6 +206,9 @@ describe('ChatRoom', () => {
         it('parses identity correctly', () => {
             const presStr = '' +
                 '<presence to="tojid" from="fromjid">' +
+                    '<x xmlns=\'http://jabber.org/protocol/muc#user\'>' +
+                        '<item jid=\'fulljid\'/>' +
+                    '</x>' +
                     '<status>status-text</status>' +
                     '<identity>' +
                         '<user>' +
@@ -229,22 +236,26 @@ describe('ChatRoom', () => {
                 XMPPEvents.PRESENCE_RECEIVED,
                 jasmine.any(Object)
             ]);
-            expect(emitterSpy).toHaveBeenCalledWith(
+            expect(emitterSpy.calls.argsFor(1)).toEqual([
                 XMPPEvents.MUC_MEMBER_JOINED,
                 'fromjid',
                 undefined, // nick
-                undefined, // role
-                undefined, // isHiddenDomain
+                null, // role
+                false, // isHiddenDomain
                 undefined, // statsID
                 'status-text',
                 expectedIdentity,
-                undefined);
+                undefined
+            ]);
         });
 
         it('parses bot correctly', () => {
             const expectedBotType = 'some_bot_type';
             const presStr = '' +
                 '<presence to="tojid" from="fromjid">' +
+                    '<x xmlns=\'http://jabber.org/protocol/muc#user\'>' +
+                        '<item jid=\'fulljid\'/>' +
+                    '</x>' +
                     '<status>status-text</status>' +
                     `<bot type="${expectedBotType}"/>` +
                 '</presence>';
@@ -256,16 +267,17 @@ describe('ChatRoom', () => {
                 XMPPEvents.PRESENCE_RECEIVED,
                 jasmine.any(Object)
             ]);
-            expect(emitterSpy).toHaveBeenCalledWith(
+            expect(emitterSpy.calls.argsFor(1)).toEqual([
                 XMPPEvents.MUC_MEMBER_JOINED,
                 'fromjid',
                 undefined, // nick
-                undefined, // role
-                undefined, // isHiddenDomain
+                null, // role
+                false, // isHiddenDomain
                 undefined, // statsID
                 'status-text',
                 undefined,
-                expectedBotType);
+                expectedBotType
+            ]);
         });
 
     });


### PR DESCRIPTION
I don't understand full consequences of ignored presence when "jid" is undefined in https://github.com/jitsi/lib-jitsi-meet/pull/981 but here's an attempt to fix the tests.

As far as I know 'jid' is optional and it is present only in non-anonymous rooms:
https://xmpp.org/extensions/xep-0045.html#enter-nonanon

Jicofo tries to configure rooms to be non-anonymous, but I can't tell what can happen if someone joins MUC before it is re-configured by jicofo and ignores few presence updates. I guess we can take it from here and see what happens...