### PR TITLE
Add a version check to force user interaction to unmute for older Firefox only

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -107,7 +107,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     isUserInteractionRequiredForUnmute() {
-        return this.isFirefox() || this.isSafari();
+        return (this.isFirefox() && this.isVersionLessThan('68')) || this.isSafari();
     }
 
     /**


### PR DESCRIPTION
Since version 68 , Firefox considers non-secure origins for getUserMedia request :
https://wiki.mozilla.org/Media/WebRTC/ReleaseNotes/68 : bug 1335740 Disable getUserMedia on non-secure origins.
So lib-jitsi-meet don't need to require a user interaction to unmute media for Firefox 68 and later.