### PR TITLE
fix(presenter mode): Resolve promise instead of throwing error when presenter track is unmuted

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -525,6 +525,10 @@ export default class JitsiLocalTrack extends JitsiTrack {
             }
 
             promise.then(streamsInfo => {
+                // Do not add the presenter track to the conference
+                if (this.getType() === 'presenter') {
+                    return Promise.resolve();
+                }
                 const mediaType = this.getType();
                 const streamInfo
                     = browser.usesNewGumFlow()

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -525,11 +525,8 @@ export default class JitsiLocalTrack extends JitsiTrack {
             }
 
             promise.then(streamsInfo => {
-                // Do not add the presenter track to the conference
-                if (this.getType() === 'presenter') {
-                    return Promise.resolve();
-                }
-                const mediaType = this.getType();
+                // The track kind for presenter track is video as well.
+                const mediaType = this.getType() === MediaType.PRESENTER ? MediaType.VIDEO : this.getType();
                 const streamInfo
                     = browser.usesNewGumFlow()
                         ? streamsInfo.find(

--- a/service/RTC/MediaType.js
+++ b/service/RTC/MediaType.js
@@ -4,6 +4,11 @@
 export const AUDIO = 'audio';
 
 /**
+ * The presenter type.
+ */
+export const PRESENTER = 'presenter';
+
+/**
  * The video type.
  */
 export const VIDEO = 'video';


### PR DESCRIPTION
When the presenter track is unmuted, we do not need to add the track to the conference.
Currently, the lib tries to lookup for the presenter stream by comparing the MediaStreamTrack kind to that of the JitsiLocalTrack media type which is different from "video". When the stream is not found, it throws a TRACK_NO_STREAM_FOUND error. 
We now resolve the promise immediately and not proceed with adding tracks to the conference if the track media type is set to "presenter".