### PR TITLE
fix: Use RTCIceServer.ulrs instead of RTCIceServer.url

### DIFF
--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -312,15 +312,15 @@ class JingleConnectionPlugin extends ConnectionPlugin {
 
                     switch (type) {
                     case 'stun':
-                        dict.url = `stun:${el.attr('host')}`;
+                        dict.urls = `stun:${el.attr('host')}`;
                         if (el.attr('port')) {
-                            dict.url += `:${el.attr('port')}`;
+                            dict.urls += `:${el.attr('port')}`;
                         }
                         iceservers.push(dict);
                         break;
                     case 'turn':
                     case 'turns': {
-                        dict.url = `${type}:`;
+                        dict.urls = `${type}:`;
                         const username = el.attr('username');
 
                         // https://code.google.com/p/webrtc/issues/detail
@@ -332,22 +332,22 @@ class JingleConnectionPlugin extends ConnectionPlugin {
                                     /Chrom(e|ium)\/([0-9]+)\./);
 
                             if (match && parseInt(match[2], 10) < 28) {
-                                dict.url += `${username}@`;
+                                dict.urls += `${username}@`;
                             } else {
                                 // only works in M28
                                 dict.username = username;
                             }
                         }
-                        dict.url += el.attr('host');
+                        dict.urls += el.attr('host');
                         const port = el.attr('port');
 
                         if (port) {
-                            dict.url += `:${el.attr('port')}`;
+                            dict.urls += `:${el.attr('port')}`;
                         }
                         const transport = el.attr('transport');
 
                         if (transport && transport !== 'udp') {
-                            dict.url += `?transport=${transport}`;
+                            dict.urls += `?transport=${transport}`;
                         }
 
                         dict.credential = el.attr('password')
@@ -364,7 +364,7 @@ class JingleConnectionPlugin extends ConnectionPlugin {
                     // we want to filter and leave only tcp/turns candidates
                     // which make sense for the jvb connections
                     this.jvbIceConfig.iceServers
-                        = iceservers.filter(s => s.url.startsWith('turns'));
+                        = iceservers.filter(s => s.urls.startsWith('turns'));
                 }
 
                 if (options.p2p && options.p2p.useStunTurn) {


### PR DESCRIPTION
As per the WebRTC spec, the RTCIceServer dictionary needs to have `urls` as member instead of `url`. Use of `url` is deprecated and the browsers currently throw a warning.
https://www.w3.org/TR/webrtc/#rtciceserver-dictionary