### PR TITLE
Change the RTCBundlePolicy to 'max-bundle' for all peerconnections

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -509,6 +509,11 @@ export default class RTC extends Listenable {
             iceConfig.sdpSemantics = 'plan-b';
         }
 
+        // Set the RTCBundlePolicy to max-bundle so that only one set of ice candidates is generated.
+        // The default policy generates separate ice candidates for audio and video connections.
+        // This change is necessary for Unified plan to work properly on Chrome and Safari.
+        iceConfig.bundlePolicy = 'max-bundle';
+
         peerConnectionIdCounter = safeCounterIncrement(peerConnectionIdCounter);
 
         const newConnection


### PR DESCRIPTION
Set the RTCBundlePolicy to max-bundle so that only one set of ice candidates is generated.
The default policy generates separate ice candidates for audio and video connections.
This change is necessary for Unified plan to work properly on Chrome and Safari.