### PR TITLE
Add Chromium based Edge (Chredge) to the list of webrtc-capable browsers

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -61,6 +61,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      */
     isChromiumBased() {
         return this.isChrome()
+            || this.isChromiumBasedEdge()
             || this.isElectron()
             || this.isNWJS()
             || this.isOpera();
@@ -104,7 +105,6 @@ export default class BrowserCapabilities extends BrowserDetection {
      */
     isSupported() {
         return this.isChromiumBased()
-            || this.isChromiumBasedEdge()
             || this.isFirefox()
             || this.isReactNative()
             || this.isSafariWithWebrtc();
@@ -299,10 +299,6 @@ export default class BrowserCapabilities extends BrowserDetection {
             return this._getChromiumBasedVersion() >= REQUIRED_CHROME_VERSION;
         }
 
-        if (this.isChromiumBasedEdge()) {
-            return true;
-        }
-
         return false;
     }
 
@@ -334,8 +330,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     supportsSdpSemantics() {
-        return (this.isChromiumBased() && this._getChromiumBasedVersion() >= 65)
-            || this.isChromiumBasedEdge();
+        return this.isChromiumBased() && this._getChromiumBasedVersion() >= 65;
     }
 
     /**

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -67,6 +67,15 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
+     * Checks if the current browser is Edge that is Chromium based.
+     */
+    isChromiumBasedEdge() {
+        const REQUIRED_EDGE_VERSION = 72;
+
+        return this.isEdge() && this.isVersionGreaterThan(REQUIRED_EDGE_VERSION);
+    }
+
+    /**
      * Checks if current browser is a Safari and a version of Safari that
      * supports native webrtc.
      *
@@ -95,6 +104,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      */
     isSupported() {
         return this.isChromiumBased()
+            || this.isChromiumBasedEdge()
             || this.isFirefox()
             || this.isReactNative()
             || this.isSafariWithWebrtc();
@@ -289,6 +299,10 @@ export default class BrowserCapabilities extends BrowserDetection {
             return this._getChromiumBasedVersion() >= REQUIRED_CHROME_VERSION;
         }
 
+        if (this.isChromiumBasedEdge()) {
+            return true;
+        }
+
         return false;
     }
 
@@ -320,7 +334,8 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     supportsSdpSemantics() {
-        return this.isChromiumBased() && this._getChromiumBasedVersion() >= 65;
+        return (this.isChromiumBased() && this._getChromiumBasedVersion() >= 65)
+            || this.isChromiumBasedEdge();
     }
 
     /**


### PR DESCRIPTION
The older version of Bowser (<2.0) reported Edge beta as chrome but now in Bowser 2.7, it comes back as Edge which is not in the list of supported browsers.
We now check if the Edge version > 72 to determine if it is Chromium based Edge (Chredge).
Chredge is added to the list of webrtc-capable browsers but we still display the warning that it is not one of the fully supported browsers.