### PR TITLE
Remove code for old gUM flow and use newGumFlow on all clients.

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -32,7 +32,6 @@ import ScriptUtil from './modules/util/ScriptUtil';
 import * as VideoSIPGWConstants from './modules/videosipgw/VideoSIPGWConstants';
 import AudioMixer from './modules/webaudio/AudioMixer';
 import * as MediaType from './service/RTC/MediaType';
-import Resolutions from './service/RTC/Resolutions';
 import * as ConnectionQualityEvents
     from './service/connectivity/ConnectionQualityEvents';
 import * as E2ePingEvents from './service/e2eping/E2ePingEvents';
@@ -45,38 +44,6 @@ const logger = Logger.getLogger(__filename);
  * {@link JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN} event.
  */
 const USER_MEDIA_PERMISSION_PROMPT_TIMEOUT = 1000;
-
-/**
- * Gets the next lowest desirable resolution to try for a camera. If the given
- * resolution is already the lowest acceptable resolution, returns {@code null}.
- *
- * @param resolution the current resolution
- * @return the next lowest resolution from the given one, or {@code null} if it
- * is already the lowest acceptable resolution.
- */
-function getLowerResolution(resolution) {
-    if (!Resolutions[resolution]) {
-        return null;
-    }
-    const order = Resolutions[resolution].order;
-    let res = null;
-    let resName = null;
-
-    Object.keys(Resolutions).forEach(r => {
-        const value = Resolutions[r];
-
-        if (!res || (res.order < value.order && value.order < order)) {
-            resName = r;
-            res = value;
-        }
-    });
-
-    if (resName === resolution) {
-        resName = null;
-    }
-
-    return resName;
-}
 
 /**
  * Extracts from an 'options' objects with a specific format (TODO what IS the
@@ -321,14 +288,11 @@ export default _mergeNamespaceAndModule({
      *
      * @param {boolean} (firePermissionPromptIsShownEvent) - if event
      * JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN should be fired
-     * @param originalOptions - internal use only, to be able to store the
-     * originally requested options.
      * @returns {Promise.<{Array.<JitsiTrack>}, JitsiConferenceError>} A promise
      * that returns an array of created JitsiTracks if resolved, or a
      * JitsiConferenceError if rejected.
      */
-    createLocalTracks(
-            options = {}, firePermissionPromptIsShownEvent, originalOptions) {
+    createLocalTracks(options = {}, firePermissionPromptIsShownEvent) {
         let promiseFulfilled = false;
 
         if (firePermissionPromptIsShownEvent === true) {
@@ -402,46 +366,6 @@ export default _mergeNamespaceAndModule({
             })
             .catch(error => {
                 promiseFulfilled = true;
-
-                if (error.name === JitsiTrackErrors.UNSUPPORTED_RESOLUTION
-                    && !browser.usesNewGumFlow()) {
-                    const oldResolution = options.resolution || '720';
-                    const newResolution = getLowerResolution(oldResolution);
-
-                    if (newResolution !== null) {
-                        options.resolution = newResolution;
-
-                        logger.debug(
-                            'Retry createLocalTracks with resolution',
-                            newResolution);
-
-                        Statistics.sendAnalytics(createGetUserMediaEvent(
-                            'warning',
-                            {
-                                'old_resolution': oldResolution,
-                                'new_resolution': newResolution,
-                                reason: 'unsupported resolution'
-                            }));
-
-                        return this.createLocalTracks(
-                            options,
-                            undefined,
-                            originalOptions || Object.assign({}, options));
-                    }
-
-                    // We tried everything. If there is a mandatory device id,
-                    // remove it and let gum find a device to use.
-                    if (originalOptions
-                        && error.gum.constraints
-                        && error.gum.constraints.video
-                        && error.gum.constraints.video.mandatory
-                        && error.gum.constraints.video.mandatory.sourceId) {
-                        originalOptions.cameraDeviceId = undefined;
-
-                        return this.createLocalTracks(originalOptions);
-                    }
-                }
-
                 if (error.name
                         === JitsiTrackErrors.SCREENSHARING_USER_CANCELED) {
                     // User cancelled action is not really an error, so only

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -197,39 +197,13 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
-     * Returns whether or not the current browser should be using the new
-     * getUserMedia flow, which utilizes the adapter shim. This method should
-     * be temporary and used while migrating all browsers to use adapter and
-     * the new getUserMedia.
-     *
-     * @returns {boolean}
-     */
-    usesNewGumFlow() {
-        const REQUIRED_CHROME_VERSION = 61;
-
-        if (this.isChrome()) {
-            return !this.isVersionLessThan(REQUIRED_CHROME_VERSION);
-        }
-
-        if (this.isFirefox() || this.isSafari()) {
-            return true;
-        }
-
-        if (this.isChromiumBased()) {
-            return this._getChromiumBasedVersion() >= REQUIRED_CHROME_VERSION;
-        }
-
-        return false;
-    }
-
-    /**
      * Checks if the browser uses webrtc-adapter. All browsers using the new
      * getUserMedia flow and Edge.
      *
      * @returns {boolean}
      */
     usesAdapter() {
-        return this.usesNewGumFlow();
+        return !this.isReactNative();
     }
 
     /**

--- a/modules/proxyconnection/ProxyConnectionService.js
+++ b/modules/proxyconnection/ProxyConnectionService.js
@@ -276,7 +276,7 @@ export default class ProxyConnectionService {
         // Grab the webrtc media stream and pipe it through the same processing
         // that would occur for a locally obtained media stream.
         const mediaStream = jitsiRemoteTrack.getOriginalStream();
-        const jitsiLocalTracks = RTC.newCreateLocalTracks(
+        const jitsiLocalTracks = RTC.createLocalTracks(
             [
                 {
                     deviceId:


### PR DESCRIPTION
- Remove the code related to old GUM flow and force all clients to use the new GUM flow.
- Force all the clients except React Native to use adapter.js.
- Update the unit test for GUM to use the new gum API.
- Take options.resolution into consideration when constructing the constraints for the GUM call. We were ignoring options.resolution in the new GUM flow APIs.