### PR TITLE
dep(js-utils): do not use window.chrome to identify webOS 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5497,8 +5497,8 @@
       "dev": true
     },
     "js-utils": {
-      "version": "github:jitsi/js-utils#abc73a98a61124aa12c87c72dd0d86985a1a4d41",
-      "from": "github:jitsi/js-utils#abc73a98a61124aa12c87c72dd0d86985a1a4d41",
+      "version": "github:jitsi/js-utils#0a8ea63983863e38d062f91fc42883270ccdb38c",
+      "from": "github:jitsi/js-utils#0a8ea63983863e38d062f91fc42883270ccdb38c",
       "requires": {
         "bowser": "2.7.0",
         "js-md5": "0.7.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "async": "0.9.0",
     "current-executing-script": "0.1.3",
     "jitsi-meet-logger": "github:jitsi/jitsi-meet-logger#5ec92357570dc8f0b7ffc1528820721c84c6af8b",
-    "js-utils": "github:jitsi/js-utils#abc73a98a61124aa12c87c72dd0d86985a1a4d41",
+    "js-utils": "github:jitsi/js-utils#0a8ea63983863e38d062f91fc42883270ccdb38c",
     "lodash.isequal": "4.5.0",
     "sdp-transform": "2.3.0",
     "strophe.js": "1.2.16",


### PR DESCRIPTION
and other chromium-like browsers.
The PR for js-utils - https://github.com/jitsi/js-utils/pull/21
