### PR TITLE
WIP: Generate TypeScript definitions

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -74,6 +74,7 @@ const JINGLE_SI_TIMEOUT = 5000;
  * Creates a JitsiConference object with the given name and properties.
  * Note: this constructor is not a part of the public API (objects should be
  * created using JitsiConnection.createConference).
+ * @constructor
  * @param options.config properties / settings related to the conference that
  * will be created.
  * @param options.name the name of the conference
@@ -101,7 +102,6 @@ const JINGLE_SI_TIMEOUT = 5000;
  * open with the videobridge. Values can be "datachannel", "websocket", true
  * (treat it as "datachannel"), undefined (treat it as "datachannel") and false
  * (don't open any channel).
- * @constructor
  *
  * FIXME Make all methods which are called from lib-internal classes
  *       to non-public (use _). To name a few:
@@ -2212,7 +2212,7 @@ JitsiConference.prototype.getMeetingUniqueId = function() {
  *
  * @return {TraceablePeerConnection|null} null if there isn't any active
  * <tt>TraceablePeerConnection</tt> currently available.
- * @public (FIXME how to make package local ?)
+ * FIXME how to make package local?
  */
 JitsiConference.prototype.getActivePeerConnection = function() {
     if (this.isP2PActive()) {

--- a/JitsiConferenceErrors.js
+++ b/JitsiConferenceErrors.js
@@ -4,83 +4,115 @@
 
 /**
  * Indicates that client must be authenticated to create the conference.
+ * @type {string}
+ * @const
  */
 export const AUTHENTICATION_REQUIRED = 'conference.authenticationRequired';
 
 /**
  * Indicates that chat error occurred.
+ * @type {string}
+ * @const
  */
 export const CHAT_ERROR = 'conference.chatError';
 
 /**
  * Indicates that conference has been destroyed.
+ * @type {string}
+ * @const
  */
 export const CONFERENCE_DESTROYED = 'conference.destroyed';
 
 /**
  * Indicates that max users limit has been reached.
+ * @type {string}
+ * @const
  */
 export const CONFERENCE_MAX_USERS = 'conference.max_users';
 
 /**
  * Indicates that a connection error occurred when trying to join a conference.
+ * @type {string}
+ * @const
  */
 export const CONNECTION_ERROR = 'conference.connectionError';
 
 /**
  * Indicates that a connection error is due to not allowed,
  * occurred when trying to join a conference.
+ * @type {string}
+ * @const
  */
 export const NOT_ALLOWED_ERROR = 'conference.connectionError.notAllowed';
 
 /**
  * Indicates that focus error happened.
+ * @type {string}
+ * @const
  */
 export const FOCUS_DISCONNECTED = 'conference.focusDisconnected';
 
 /**
  * Indicates that focus left the conference.
+ * @type {string}
+ * @const
  */
 export const FOCUS_LEFT = 'conference.focusLeft';
 
 /**
  * Indicates that graceful shutdown happened.
+ * @type {string}
+ * @const
  */
 export const GRACEFUL_SHUTDOWN = 'conference.gracefulShutdown';
 
 /**
  * Indicates that the versions of the server side components are incompatible
  * with the client side.
+ * @type {string}
+ * @const
  */
 export const INCOMPATIBLE_SERVER_VERSIONS
     = 'conference.incompatible_server_versions';
 
 /**
  * Indicates that offer/answer had failed.
+ * @type {string}
+ * @const
  */
 export const OFFER_ANSWER_FAILED = 'conference.offerAnswerFailed';
 
 /**
  * Indicates that password cannot be set for this conference.
+ * @type {string}
+ * @const
  */
 export const PASSWORD_NOT_SUPPORTED = 'conference.passwordNotSupported';
 
 /**
  * Indicates that a password is required in order to join the conference.
+ * @type {string}
+ * @const
  */
 export const PASSWORD_REQUIRED = 'conference.passwordRequired';
 
 /**
  * Indicates that reservation system returned error.
+ * @type {string}
+ * @const
  */
 export const RESERVATION_ERROR = 'conference.reservationError';
 
 /**
  * Indicates that the conference setup failed.
+ * @type {string}
+ * @const
  */
 export const SETUP_FAILED = 'conference.setup_failed';
 
 /**
  * Indicates that there is no available videobridge.
+ * @type {string}
+ * @const
  */
 export const VIDEOBRIDGE_NOT_AVAILABLE = 'conference.videobridgeNotAvailable';

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -5,16 +5,22 @@
 /**
  * Event indicates that the current conference audio input switched between audio
  * input states,i.e. with or without audio input.
+ * @type {string}
+ * @const
  */
 export const AUDIO_INPUT_STATE_CHANGE = 'conference.audio_input_state_changed';
 
 /**
  * Indicates that authentication status changed.
+ * @type {string}
+ * @const
  */
 export const AUTH_STATUS_CHANGED = 'conference.auth_status_changed';
 
 /**
  * A participant avatar has changed.
+ * @type {string}
+ * @const
  */
 export const AVATAR_CHANGED = 'conference.avatarChanged';
 
@@ -22,27 +28,37 @@ export const AVATAR_CHANGED = 'conference.avatarChanged';
  * Fired just before the statistics module is disposed and it's the last chance
  * to submit some logs to the statistics service (ex. CallStats if enabled),
  * before it's disconnected.
+ * @type {string}
+ * @const
  */
 export const BEFORE_STATISTICS_DISPOSED = 'conference.beforeStatisticsDisposed';
 
 /**
  * Indicates that an error occured.
+ * @type {string}
+ * @const
  */
 export const CONFERENCE_ERROR = 'conference.error';
 
 /**
  * Indicates that conference failed.
+ * @type {string}
+ * @const
  */
 export const CONFERENCE_FAILED = 'conference.failed';
 
 /**
  * Indicates that conference has been joined. The event does NOT provide any
  * parameters to its listeners.
+ * @type {string}
+ * @const
  */
 export const CONFERENCE_JOINED = 'conference.joined';
 
 /**
  * Indicates that conference has been left.
+ * @type {string}
+ * @const
  */
 export const CONFERENCE_LEFT = 'conference.left';
 
@@ -50,6 +66,8 @@ export const CONFERENCE_LEFT = 'conference.left';
  * Indicates that the connection to the conference has been established
  * XXX This is currently fired whenVthe *ICE* connection enters 'connected'
  * state for the first time.
+ * @type {string}
+ * @const
  */
 export const CONNECTION_ESTABLISHED = 'conference.connectionEstablished';
 
@@ -57,43 +75,59 @@ export const CONNECTION_ESTABLISHED = 'conference.connectionEstablished';
  * Indicates that the connection to the conference has been interrupted for some
  * reason.
  * XXX This is currently fired when the *ICE* connection is interrupted.
+ * @type {string}
+ * @const
  */
 export const CONNECTION_INTERRUPTED = 'conference.connectionInterrupted';
 
 /**
  * Indicates that the connection to the conference has been restored.
  * XXX This is currently fired when the *ICE* connection is restored.
+ * @type {string}
+ * @const
  */
 export const CONNECTION_RESTORED = 'conference.connectionRestored';
 
 /**
  * A connection to the video bridge's data channel has been established.
+ * @type {string}
+ * @const
  */
 export const DATA_CHANNEL_OPENED = 'conference.dataChannelOpened';
 
 /**
  * A user has changed it display name
+ * @type {string}
+ * @const
  */
 export const DISPLAY_NAME_CHANGED = 'conference.displayNameChanged';
 
 /**
  * The dominant speaker was changed.
+ * @type {string}
+ * @const
  */
 export const DOMINANT_SPEAKER_CHANGED = 'conference.dominantSpeaker';
 
 /**
  * UTC conference timestamp when first participant joined.
+ * @type {string}
+ * @const
  */
 export const CONFERENCE_CREATED_TIMESTAMP = 'conference.createdTimestamp';
 
 /**
  * Indicates that DTMF support changed.
+ * @type {string}
+ * @const
  */
 export const DTMF_SUPPORT_CHANGED = 'conference.dtmfSupportChanged';
 
 /**
  * Indicates that a message from another participant is received on data
  * channel.
+ * @type {string}
+ * @const
  */
 export const ENDPOINT_MESSAGE_RECEIVED = 'conference.endpoint_message_received';
 
@@ -108,19 +142,23 @@ export const ENDPOINT_MESSAGE_RECEIVED = 'conference.endpoint_message_received';
  * The first argument is a boolean which carries the previous value and
  * the seconds argument is a boolean with the new status. The event is emitted
  * only if the previous and the new values are different.
- *
  * @type {string}
+ * @const
  */
 export const JVB121_STATUS = 'conference.jvb121Status';
 
 /**
  * You are kicked from the conference.
+ * @type {string}
+ * @const
  * @param {JitsiParticipant} the participant that initiated the kick.
  */
 export const KICKED = 'conference.kicked';
 
 /**
  * Participant was kicked from the conference.
+ * @type {string}
+ * @const
  * @param {JitsiParticipant} the participant that initiated the kick.
  * @param {JitsiParticipant} the participant that was kicked.
  */
@@ -128,6 +166,8 @@ export const PARTICIPANT_KICKED = 'conference.participant_kicked';
 
 /**
  * The Last N set is changed.
+ * @type {string}
+ * @const
  *
  * @param {Array<string>|null} leavingEndpointIds the ids of all the endpoints
  * which are leaving Last N
@@ -138,6 +178,8 @@ export const LAST_N_ENDPOINTS_CHANGED = 'conference.lastNEndpointsChanged';
 
 /**
  * Indicates that the room has been locked or unlocked.
+ * @type {string}
+ * @const
  */
 export const LOCK_STATE_CHANGED = 'conference.lock_state_changed';
 
@@ -145,26 +187,35 @@ export const LOCK_STATE_CHANGED = 'conference.lock_state_changed';
  * Indicates that the region of the media server (jitsi-videobridge) that we
  * are connected to changed (or was initially set).
  * @type {string} the region.
+ * @const
  */
 export const SERVER_REGION_CHANGED = 'conference.server_region_changed';
 
 /**
  * New text message was received.
+ * @type {string}
+ * @const
  */
 export const MESSAGE_RECEIVED = 'conference.messageReceived';
 
 /**
  * Event indicates that the current selected input device has no signal
+ * @type {string}
+ * @const
  */
 export const NO_AUDIO_INPUT = 'conference.no_audio_input';
 
 /**
  * Event indicates that the current microphone used by the conference is noisy.
+ * @type {string}
+ * @const
  */
 export const NOISY_MIC = 'conference.noisy_mic';
 
 /**
  * New private text message was received.
+ * @type {string}
+ * @const
  */
 export const PRIVATE_MESSAGE_RECEIVED = 'conference.privateMessageReceived';
 
@@ -181,12 +232,16 @@ export const PRIVATE_MESSAGE_RECEIVED = 'conference.privateMessageReceived';
  *
  * The current status value can be obtained by calling
  * JitsiParticipant.getConnectionStatus().
+ * @type {string}
+ * @const
  */
 export const PARTICIPANT_CONN_STATUS_CHANGED
     = 'conference.participant_conn_status_changed';
 
 /**
  * Indicates that the features of the participant has been changed.
+ * @type {string}
+ * @const
  */
 export const PARTCIPANT_FEATURES_CHANGED
     = 'conference.partcipant_features_changed';
@@ -194,6 +249,8 @@ export const PARTCIPANT_FEATURES_CHANGED
 /**
  * Indicates that a the value of a specific property of a specific participant
  * has changed.
+ * @type {string}
+ * @const
  */
 export const PARTICIPANT_PROPERTY_CHANGED
     = 'conference.participant_property_changed';
@@ -202,27 +259,36 @@ export const PARTICIPANT_PROPERTY_CHANGED
  * Indicates that the conference has switched between JVB and P2P connections.
  * The first argument of this event is a <tt>boolean</tt> which when set to
  * <tt>true</tt> means that the conference is running on the P2P connection.
+ * @type {string}
+ * @const
  */
 export const P2P_STATUS = 'conference.p2pStatus';
 
 /**
  * Indicates that phone number changed.
+ * @type {string}
+ * @const
  */
 export const PHONE_NUMBER_CHANGED = 'conference.phoneNumberChanged';
 
 /**
  * The conference properties changed.
  * @type {string}
+ * @const
  */
 export const PROPERTIES_CHANGED = 'conference.propertiesChanged';
 
 /**
  * Indicates that recording state changed.
+ * @type {string}
+ * @const
  */
 export const RECORDER_STATE_CHANGED = 'conference.recorderStateChanged';
 
 /**
  * Indicates that video SIP GW state changed.
+ * @type {string}
+ * @const
  * @param {VideoSIPGWConstants} status.
  */
 export const VIDEO_SIP_GW_AVAILABILITY_CHANGED
@@ -230,6 +296,8 @@ export const VIDEO_SIP_GW_AVAILABILITY_CHANGED
 
 /**
  * Indicates that video SIP GW Session state changed.
+ * @type {string}
+ * @const
  * @param {options} event - {
  *     {string} address,
  *     {VideoSIPGWConstants} oldState,
@@ -242,33 +310,45 @@ export const VIDEO_SIP_GW_SESSION_STATE_CHANGED
 
 /**
  * Indicates that start muted settings changed.
+ * @type {string}
+ * @const
  */
 export const START_MUTED_POLICY_CHANGED
     = 'conference.start_muted_policy_changed';
 
 /**
  * Indicates that the local user has started muted.
+ * @type {string}
+ * @const
  */
 export const STARTED_MUTED = 'conference.started_muted';
 
 /**
  * Indicates that subject of the conference has changed.
+ * @type {string}
+ * @const
  */
 export const SUBJECT_CHANGED = 'conference.subjectChanged';
 
 /**
  * Indicates that DTMF support changed.
+ * @type {string}
+ * @const
  */
 export const SUSPEND_DETECTED = 'conference.suspendDetected';
 
 /**
  * Event indicates that local user is talking while he muted himself
+ * @type {string}
+ * @const
  */
 export const TALK_WHILE_MUTED = 'conference.talk_while_muted';
 
 /**
  * A new media track was added to the conference. The event provides the
  * following parameters to its listeners:
+ * @type {string}
+ * @const
  *
  * @param {JitsiTrack} track the added JitsiTrack
  */
@@ -276,11 +356,15 @@ export const TRACK_ADDED = 'conference.trackAdded';
 
 /**
  * Audio levels of a media track ( attached to the conference) was changed.
+ * @type {string}
+ * @const
  */
 export const TRACK_AUDIO_LEVEL_CHANGED = 'conference.audioLevelsChanged';
 
 /**
  * A media track ( attached to the conference) mute status was changed.
+ * @type {string}
+ * @const
  * @param {JitsiParticipant|null} the participant that initiated the mute
  * if it is a remote mute.
  */
@@ -289,6 +373,8 @@ export const TRACK_MUTE_CHANGED = 'conference.trackMuteChanged';
 /**
  * The media track was removed from the conference. The event provides the
  * following parameters to its listeners:
+ * @type {string}
+ * @const
  *
  * @param {JitsiTrack} track the removed JitsiTrack
  */
@@ -297,7 +383,8 @@ export const TRACK_REMOVED = 'conference.trackRemoved';
 /**
  * Notifies for transcription status changes. The event provides the
  * following parameters to its listeners:
- *
+ * @type {string}
+ * @const
  * @param {String} status - The new status.
  */
 export const TRANSCRIPTION_STATUS_CHANGED
@@ -306,25 +393,35 @@ export const TRANSCRIPTION_STATUS_CHANGED
 
 /**
  * A new user joined the conference.
+ * @type {string}
+ * @const
  */
 export const USER_JOINED = 'conference.userJoined';
 
 /**
  * A user has left the conference.
+ * @type {string}
+ * @const
  */
 export const USER_LEFT = 'conference.userLeft';
 
 /**
  * User role changed.
+ * @type {string}
+ * @const
  */
 export const USER_ROLE_CHANGED = 'conference.roleChanged';
 
 /**
  * User status changed.
+ * @type {string}
+ * @const
  */
 export const USER_STATUS_CHANGED = 'conference.statusChanged';
 
 /**
  * Event indicates that the bot participant type changed.
+ * @type {string}
+ * @const
  */
 export const BOT_TYPE_CHANGED = 'conference.bot_type_changed';

--- a/JitsiConnectionErrors.js
+++ b/JitsiConnectionErrors.js
@@ -12,21 +12,29 @@
  * could also happen when BOSH request is sent to the server with the session-id
  * that is not know to the server. But this should not happen in lib-jitsi-meet
  * case as long as the service is configured correctly (there is no bug).
+ * @type {string}
+ * @const
  */
 export const CONNECTION_DROPPED_ERROR = 'connection.droppedError';
 
 /**
  * Not specified errors.
+ * @type {string}
+ * @const
  */
 export const OTHER_ERROR = 'connection.otherError';
 
 /**
  * Indicates that a password is required in order to join the conference.
+ * @type {string}
+ * @const
  */
 export const PASSWORD_REQUIRED = 'connection.passwordRequired';
 
 /**
  * Indicates that the connection was dropped, because of too many 5xx HTTP
  * errors on BOSH requests.
+ * @type {string}
+ * @const
  */
 export const SERVER_ERROR = 'connection.serverError';

--- a/JitsiConnectionEvents.js
+++ b/JitsiConnectionEvents.js
@@ -5,6 +5,8 @@
 /**
  * Indicates that the connection has been disconnected. The event provides
  * the following parameters to its listeners:
+ * @type {string}
+ * @const
  *
  * @param msg {string} a message associated with the disconnect such as the
  * last (known) error message
@@ -14,6 +16,8 @@ export const CONNECTION_DISCONNECTED = 'connection.connectionDisconnected';
 /**
  * Indicates that the connection has been established. The event provides
  * the following parameters to its listeners:
+ * @type {string}
+ * @const
  *
  * @param id {string} the ID of the local endpoint/participant/peer (within
  * the context of the established connection)
@@ -23,6 +27,8 @@ export const CONNECTION_ESTABLISHED = 'connection.connectionEstablished';
 /**
  * Indicates that the connection has been failed for some reason. The event
  * provides the following parameters to its listeners:
+ * @type {string}
+ * @const
  *
  * @param errType {JitsiConnectionErrors} the type of error associated with
  * the failure
@@ -36,5 +42,7 @@ export const CONNECTION_FAILED = 'connection.connectionFailed';
 /**
  * Indicates that the performed action cannot be executed because the
  * connection is not in the correct state(connected, disconnected, etc.)
+ * @type {string}
+ * @const
  */
 export const WRONG_STATE = 'connection.wrongState';

--- a/JitsiMediaDevicesEvents.js
+++ b/JitsiMediaDevicesEvents.js
@@ -5,6 +5,8 @@
 /**
  * Indicates that the list of available media devices has been changed. The
  * event provides the following parameters to its listeners:
+ * @type {string}
+ * @const
  *
  * @param {MediaDeviceInfo[]} devices - array of MediaDeviceInfo or
  *  MediaDeviceInfo-like objects that are currently connected.
@@ -16,6 +18,8 @@ export const DEVICE_LIST_CHANGED = 'mediaDevices.devicechange';
  * Indicates that the environment is currently showing permission prompt to
  * access camera and/or microphone. The event provides the following
  * parameters to its listeners:
+ * @type {string}
+ * @const
  *
  * @param {'chrome'|'opera'|'firefox'|'safari'|'nwjs'
  *  |'react-native'|'android'} environmentType - type of browser or

--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -44,9 +44,9 @@ TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.TRACK_NO_STREAM_FOUND]
  *
  * @constructor
  * @param {Object|string} error - error object or error name
- * @param {Object|string} (options) - getUserMedia constraints object or
+ * @param {Object|string} [options] - getUserMedia constraints object or
  * error message
- * @param {('audio'|'video'|'desktop'|'screen'|'audiooutput')[]} (devices) -
+ * @param {Array.<('audio'|'video'|'desktop'|'screen'|'audiooutput')>} [devices] -
  * list of getUserMedia requested devices
  */
 function JitsiTrackError(error, options, devices) {

--- a/JitsiTrackErrors.js
+++ b/JitsiTrackErrors.js
@@ -4,6 +4,8 @@
 
 /**
  * Generic error for jidesha extension for Chrome.
+ * @type {string}
+ * @const
  */
 export const CHROME_EXTENSION_GENERIC_ERROR
     = 'gum.chrome_extension_generic_error';
@@ -11,6 +13,8 @@ export const CHROME_EXTENSION_GENERIC_ERROR
 /**
  * An error which indicates that the jidesha extension for Chrome is
  * failed to install.
+ * @type {string}
+ * @const
  */
 export const CHROME_EXTENSION_INSTALLATION_ERROR
     = 'gum.chrome_extension_installation_error';
@@ -21,6 +25,7 @@ export const CHROME_EXTENSION_INSTALLATION_ERROR
  * you should to trigger the action again in response to a button click for
  * example.
  * @type {string}
+ * @const
  */
 export const CHROME_EXTENSION_USER_GESTURE_REQUIRED
     = 'gum.chrome_extension_user_gesture_required';
@@ -28,6 +33,8 @@ export const CHROME_EXTENSION_USER_GESTURE_REQUIRED
 /**
  * An error which indicates that user canceled screen sharing window
  * selection dialog in jidesha extension for Chrome.
+ * @type {string}
+ * @const
  */
 export const CHROME_EXTENSION_USER_CANCELED
     = 'gum.chrome_extension_user_canceled';
@@ -35,12 +42,16 @@ export const CHROME_EXTENSION_USER_CANCELED
 /**
  * An error which indicates that some of requested constraints in
  * getUserMedia call were not satisfied.
+ * @type {string}
+ * @const
  */
 export const CONSTRAINT_FAILED = 'gum.constraint_failed';
 
 /**
  * A generic error which indicates an error occurred while selecting
  * a DesktopCapturerSource from the electron app.
+ * @type {string}
+ * @const
  */
 export const ELECTRON_DESKTOP_PICKER_ERROR
     = 'gum.electron_desktop_picker_error';
@@ -48,6 +59,8 @@ export const ELECTRON_DESKTOP_PICKER_ERROR
 /**
  * An error which indicates a custom desktop picker could not be detected
  * for the electron app.
+ * @type {string}
+ * @const
  */
 export const ELECTRON_DESKTOP_PICKER_NOT_FOUND
     = 'gum.electron_desktop_picker_not_found';
@@ -55,38 +68,52 @@ export const ELECTRON_DESKTOP_PICKER_NOT_FOUND
 /**
  * An error which indicates that the jidesha extension for Firefox is
  * needed to proceed with screen sharing, and that it is not installed.
+ * @type {string}
+ * @const
  */
 export const FIREFOX_EXTENSION_NEEDED = 'gum.firefox_extension_needed';
 
 /**
  * Generic getUserMedia error.
+ * @type {string}
+ * @const
  */
 export const GENERAL = 'gum.general';
 
 /**
  * An error which indicates that requested device was not found.
+ * @type {string}
+ * @const
  */
 export const NOT_FOUND = 'gum.not_found';
 
 /**
  * An error which indicates that user denied permission to share requested
  * device.
+ * @type {string}
+ * @const
  */
 export const PERMISSION_DENIED = 'gum.permission_denied';
 
 /**
  * An error which indicates that track has been already disposed and cannot
  * be longer used.
+ * @type {string}
+ * @const
  */
 export const TRACK_IS_DISPOSED = 'track.track_is_disposed';
 
 /**
  * An error which indicates that track has no MediaStream associated.
+ * @type {string}
+ * @const
  */
 export const TRACK_NO_STREAM_FOUND = 'track.no_stream_found';
 
 /**
  * An error which indicates that requested video resolution is not supported
  * by a webcam.
+ * @type {string}
+ * @const
  */
 export const UNSUPPORTED_RESOLUTION = 'gum.unsupported_resolution';

--- a/JitsiTrackEvents.js
+++ b/JitsiTrackEvents.js
@@ -1,5 +1,7 @@
 /**
  * The media track was removed to the conference.
+ * @type {string}
+ * @const
  */
 export const LOCAL_TRACK_STOPPED = 'track.stopped';
 
@@ -14,26 +16,36 @@ export const LOCAL_TRACK_STOPPED = 'track.stopped';
  *
  * NOTE The second argument should be treated as library internal and can be
  * removed at any time.
+ * @type {string}
+ * @const
  */
 export const TRACK_AUDIO_LEVEL_CHANGED = 'track.audioLevelsChanged';
 
 /**
  * The audio output of the track was changed.
+ * @type {string}
+ * @const
  */
 export const TRACK_AUDIO_OUTPUT_CHANGED = 'track.audioOutputChanged';
 
 /**
  * A media track mute status was changed.
+ * @type {string}
+ * @const
  */
 export const TRACK_MUTE_CHANGED = 'track.trackMuteChanged';
 
 /**
  * The video type("camera" or "desktop") of the track was changed.
+ * @type {string}
+ * @const
  */
 export const TRACK_VIDEOTYPE_CHANGED = 'track.videoTypeChanged';
 
 /**
  * Indicates that the track is not receiving any data even though we expect it
  * to receive data (i.e. the stream is not stopped).
+ * @type {string}
+ * @const
  */
 export const NO_DATA_FROM_SOURCE = 'track.no_data_from_source';

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -1,0 +1,11 @@
+{
+  "source": {
+    "include": ["."],
+    "includePattern": ".+\\.js(doc|x)?$",
+    "excludePattern": "node_modules",
+    "plugins": ["./node_modules/jsdoc-export-default-interop/dist/index"]
+  },
+  "opts": {
+    "template": "./node_modules/tsd-jsdoc/dist"
+  }
+}

--- a/jsdoc.log
+++ b/jsdoc.log
@@ -1,0 +1,154 @@
+WARNING: The @type tag does not permit a description; the description will be ignored. File: JitsiConferenceEvents.js, line: 186
+WARNING: The @type tag does not permit a description; the description will be ignored. File: JitsiConferenceEvents.js, line: 192
+[TSD-JSDoc] JitsiConference.js:113:0 Failed to find parent of doclet 'module.exports' using memberof 'module', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:251:0 Failed to find parent of doclet 'JitsiConference.resourceCreator' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:281:0 Failed to find parent of doclet 'JitsiConference#_init' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:457:0 Failed to find parent of doclet 'JitsiConference#join' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:471:0 Failed to find parent of doclet 'JitsiConference#authenticateAndUpgradeRole' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:481:0 Failed to find parent of doclet 'JitsiConference#isJoined' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:489:0 Failed to find parent of doclet 'JitsiConference#isP2PEnabled' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:501:0 Failed to find parent of doclet 'JitsiConference#isP2PTestModeEnabled' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:510:0 Failed to find parent of doclet 'JitsiConference#leave' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:602:0 Failed to find parent of doclet 'JitsiConference#getName' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:609:0 Failed to find parent of doclet 'JitsiConference#getConnection' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:616:0 Failed to find parent of doclet 'JitsiConference#isAuthEnabled' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:623:0 Failed to find parent of doclet 'JitsiConference#isLoggedIn' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:630:0 Failed to find parent of doclet 'JitsiConference#getAuthLogin' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:637:0 Failed to find parent of doclet 'JitsiConference#isExternalAuthEnabled' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:647:0 Failed to find parent of doclet 'JitsiConference#getExternalAuthUrl' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:667:0 Failed to find parent of doclet 'JitsiConference#getLocalTracks' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:681:0 Failed to find parent of doclet 'JitsiConference#getLocalAudioTrack' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:689:0 Failed to find parent of doclet 'JitsiConference#getLocalVideoTrack' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:702:0 Failed to find parent of doclet 'JitsiConference#on' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:716:0 Failed to find parent of doclet 'JitsiConference#off' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:732:0 Failed to find parent of doclet 'JitsiConference#addCommandListener' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:743:0 Failed to find parent of doclet 'JitsiConference#removeCommandListener' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:755:0 Failed to find parent of doclet 'JitsiConference#sendTextMessage' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:771:0 Failed to find parent of doclet 'JitsiConference#sendPrivateTextMessage' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:783:0 Failed to find parent of doclet 'JitsiConference#sendCommand' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:798:0 Failed to find parent of doclet 'JitsiConference#sendCommandOnce' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:807:0 Failed to find parent of doclet 'JitsiConference#removeCommand' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:817:0 Failed to find parent of doclet 'JitsiConference#setDisplayName' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:834:0 Failed to find parent of doclet 'JitsiConference#setSubject' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:844:0 Failed to find parent of doclet 'JitsiConference#getTranscriber' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:871:0 Failed to find parent of doclet 'JitsiConference#getTranscriptionStatus' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:882:0 Failed to find parent of doclet 'JitsiConference#addTrack' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:908:0 Failed to find parent of doclet 'JitsiConference#_fireAudioLevelChangeEvent' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:929:0 Failed to find parent of doclet 'JitsiConference#_fireMuteChangeEvent' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:953:0 Failed to find parent of doclet 'JitsiConference#onLocalTrackRemoved' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:977:0 Failed to find parent of doclet 'JitsiConference#removeTrack' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:990:0 Failed to find parent of doclet 'JitsiConference#replaceTrack' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1028:0 Failed to find parent of doclet 'JitsiConference#replaceTrackWithoutOfferAnswer' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1083:0 Failed to find parent of doclet 'JitsiConference#_setupNewTrack' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1140:0 Failed to find parent of doclet 'JitsiConference#_addLocalTrackAsUnmute' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1169:0 Failed to find parent of doclet 'JitsiConference#_removeLocalTrackAsMute' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1194:0 Failed to find parent of doclet 'JitsiConference#getRole' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1205:0 Failed to find parent of doclet 'JitsiConference#isHidden' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1219:0 Failed to find parent of doclet 'JitsiConference#isModerator' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1228:0 Failed to find parent of doclet 'JitsiConference#lock' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1246:0 Failed to find parent of doclet 'JitsiConference#unlock' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1258:0 Failed to find parent of doclet 'JitsiConference#selectParticipant' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1289:0 Failed to find parent of doclet 'JitsiConference#pinParticipant' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1297:0 Failed to find parent of doclet 'JitsiConference#getLastN' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1309:0 Failed to find parent of doclet 'JitsiConference#setLastN' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1345:0 Failed to find parent of doclet 'JitsiConference#isInLastN' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1353:0 Failed to find parent of doclet 'JitsiConference#getParticipants' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1365:0 Failed to find parent of doclet 'JitsiConference#getParticipantCount' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1383:0 Failed to find parent of doclet 'JitsiConference#getParticipantById' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1391:0 Failed to find parent of doclet 'JitsiConference#kickParticipant' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1439:0 Failed to find parent of doclet 'JitsiConference#muteParticipant' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1465:0 Failed to find parent of doclet 'JitsiConference#onMemberJoined' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1579:0 Failed to find parent of doclet 'JitsiConference#onMemberKicked' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1601:0 Failed to find parent of doclet 'JitsiConference#onLocalRoleChanged' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1644:0 Failed to find parent of doclet 'JitsiConference#onRemoteTrackAdded' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1702:0 Failed to find parent of doclet 'JitsiConference#onCallAccepted' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1717:0 Failed to find parent of doclet 'JitsiConference#onTransportInfo' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1730:0 Failed to find parent of doclet 'JitsiConference#onRemoteTrackRemoved' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1756:0 Failed to find parent of doclet 'JitsiConference#_onIncomingCallP2P' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1800:0 Failed to find parent of doclet 'JitsiConference#onIncomingCall' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1827:0 Failed to find parent of doclet 'JitsiConference#_acceptJvbIncomingCall' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1910:0 Failed to find parent of doclet 'JitsiConference#_setBridgeChannel' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:1984:0 Failed to find parent of doclet 'JitsiConference#onCallEnded' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2039:0 Failed to find parent of doclet 'JitsiConference#onSuspendDetected' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2070:0 Failed to find parent of doclet 'JitsiConference#isDTMFSupported' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2078:0 Failed to find parent of doclet 'JitsiConference#myUserId' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2102:0 Failed to find parent of doclet 'JitsiConference#startRecording' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2117:0 Failed to find parent of doclet 'JitsiConference#stopRecording' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2128:0 Failed to find parent of doclet 'JitsiConference#isSIPCallingSupported' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2140:0 Failed to find parent of doclet 'JitsiConference#dial' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2153:0 Failed to find parent of doclet 'JitsiConference#hangup' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2166:0 Failed to find parent of doclet 'JitsiConference#startTranscriber' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2174:0 Failed to find parent of doclet 'JitsiConference#stopTranscriber' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2179:0 Failed to find parent of doclet 'JitsiConference#getPhoneNumber' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2190:0 Failed to find parent of doclet 'JitsiConference#getPhonePin' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2203:0 Failed to find parent of doclet 'JitsiConference#getMeetingUniqueId' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2217:0 Failed to find parent of doclet 'JitsiConference#getActivePeerConnection' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2233:0 Failed to find parent of doclet 'JitsiConference#getConnectionState' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2245:0 Failed to find parent of doclet 'JitsiConference#setStartMutedPolicy' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2265:0 Failed to find parent of doclet 'JitsiConference#getStartMutedPolicy' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2272:0 Failed to find parent of doclet 'JitsiConference#isStartAudioMuted' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2279:0 Failed to find parent of doclet 'JitsiConference#isStartVideoMuted' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2286:0 Failed to find parent of doclet 'JitsiConference#getLogs' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2309:0 Failed to find parent of doclet 'JitsiConference#getConnectionTimes' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2316:0 Failed to find parent of doclet 'JitsiConference#setLocalParticipantProperty' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2323:0 Failed to find parent of doclet 'JitsiConference#removeLocalParticipantProperty' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2334:0 Failed to find parent of doclet 'JitsiConference#getLocalParticipantProperty' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2350:0 Failed to find parent of doclet 'JitsiConference#sendFeedback' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2363:0 Failed to find parent of doclet 'JitsiConference#isCallstatsEnabled' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2374:0 Failed to find parent of doclet 'JitsiConference#_onTrackAttach' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2412:0 Failed to find parent of doclet 'JitsiConference#sendApplicationLog' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2424:0 Failed to find parent of doclet 'JitsiConference#_isFocus' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2431:0 Failed to find parent of doclet 'JitsiConference#_fireIncompatibleVersionsEvent' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2444:0 Failed to find parent of doclet 'JitsiConference#sendEndpointMessage' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2454:0 Failed to find parent of doclet 'JitsiConference#broadcastEndpointMessage' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2472:0 Failed to find parent of doclet 'JitsiConference#sendMessage' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:2809:0 Failed to find parent of doclet 'JitsiConference#getProperty' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:3182:0 Failed to find parent of doclet 'JitsiConference#isP2PActive' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:3192:0 Failed to find parent of doclet 'JitsiConference#getP2PConnectionState' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:3204:0 Failed to find parent of doclet 'JitsiConference#startP2PSession' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:3221:0 Failed to find parent of doclet 'JitsiConference#stopP2PSession' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:3229:0 Failed to find parent of doclet 'JitsiConference#getSpeakerStats' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:3241:0 Failed to find parent of doclet 'JitsiConference#setReceiverVideoConstraint' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:3259:0 Failed to find parent of doclet 'JitsiConference#createVideoSIPGWSession' using memberof 'JitsiConference', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConferenceEventManager.js:30:0 Failed to find parent of doclet 'module.exports' using memberof 'module', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConferenceEventManager.js:58:0 Failed to find parent of doclet 'JitsiConferenceEventManager#setupChatRoomListeners' using memberof 'JitsiConferenceEventManager', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConferenceEventManager.js:430:0 Failed to find parent of doclet 'JitsiConferenceEventManager#setupRTCListeners' using memberof 'JitsiConferenceEventManager', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConferenceEventManager.js:558:0 Failed to find parent of doclet 'JitsiConferenceEventManager#removeXMPPListeners' using memberof 'JitsiConferenceEventManager', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConferenceEventManager.js:578:0 Failed to find parent of doclet 'JitsiConferenceEventManager#setupXMPPListeners' using memberof 'JitsiConferenceEventManager', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConferenceEventManager.js:646:0 Failed to find parent of doclet 'JitsiConferenceEventManager#_addConferenceXMPPListener' using memberof 'JitsiConferenceEventManager', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConferenceEventManager.js:655:0 Failed to find parent of doclet 'JitsiConferenceEventManager#setupStatisticsListeners' using memberof 'JitsiConferenceEventManager', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConnection.js:20:0 Failed to find parent of doclet 'module.exports' using memberof 'module', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConnection.js:60:0 Failed to find parent of doclet 'JitsiConnection#connect' using memberof 'JitsiConnection', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConnection.js:71:0 Failed to find parent of doclet 'JitsiConnection#attach' using memberof 'JitsiConnection', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConnection.js:79:0 Failed to find parent of doclet 'JitsiConnection#disconnect' using memberof 'JitsiConnection', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConnection.js:92:0 Failed to find parent of doclet 'JitsiConnection#getJid' using memberof 'JitsiConnection', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConnection.js:100:0 Failed to find parent of doclet 'JitsiConnection#setToken' using memberof 'JitsiConnection', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConnection.js:112:0 Failed to find parent of doclet 'JitsiConnection#initJitsiConference' using memberof 'JitsiConnection', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConnection.js:125:0 Failed to find parent of doclet 'JitsiConnection#addEventListener' using memberof 'JitsiConnection', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConnection.js:134:0 Failed to find parent of doclet 'JitsiConnection#removeEventListener' using memberof 'JitsiConnection', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConnection.js:141:0 Failed to find parent of doclet 'JitsiConnection#getConnectionTimes' using memberof 'JitsiConnection', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConnection.js:152:0 Failed to find parent of doclet 'JitsiConnection#addFeature' using memberof 'JitsiConnection', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConnection.js:163:0 Failed to find parent of doclet 'JitsiConnection#removeFeature' using memberof 'JitsiConnection', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiMeetJS.js:132:0 Failed to find parent of doclet 'module.exports' using memberof 'module', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiParticipant.js:33:4 Failed to find parent of doclet 'module.exports' using memberof 'module', this is likely due to invalid JSDoc.
+[TSD-JSDoc] authenticateAndUpgradeRole.js:60:0 Failed to find parent of doclet 'module.exports' using memberof 'module', this is likely due to invalid JSDoc.
+[TSD-JSDoc] authenticateAndUpgradeRole.js:151:4 Failed to find parent of doclet 'authenticateAndUpgradeRole~process.cancel' using memberof 'authenticateAndUpgradeRole~process', this is likely due to invalid JSDoc.
+[TSD-JSDoc] lib-jitsi-meet.min.js:6:4 Failed to find parent of doclet '<anonymous>~r~t' using memberof '<anonymous>~r', this is likely due to invalid JSDoc.
+[TSD-JSDoc] JitsiConference.js:163:4 Unable to resolve type for connectionQuality, none specified in JSDoc. Defaulting to `any`.
+[TSD-JSDoc] JitsiConference.js:182:4 Unable to resolve type for isJvbConnectionInterrupted, none specified in JSDoc. Defaulting to `any`.
+[TSD-JSDoc] JitsiConference.js:187:4 Unable to resolve type for speakerStatsCollector, none specified in JSDoc. Defaulting to `any`.
+[TSD-JSDoc] Unable to resolve type for an unnamed item, this is likely due to invalid JSDoc. Often this is caused by invalid JSDoc on a parameter. Defaulting to `any`.
+[TSD-JSDoc] Unable to resolve type for an unnamed item, this is likely due to invalid JSDoc. Often this is caused by invalid JSDoc on a parameter. Defaulting to `any`.
+[TSD-JSDoc] Unable to resolve type for an unnamed item, this is likely due to invalid JSDoc. Often this is caused by invalid JSDoc on a parameter. Defaulting to `any`.
+[TSD-JSDoc] JitsiMeetJS.js:54:0 Unable to resolve type for getLowerResolution, none specified in JSDoc. Defaulting to `any`.
+[TSD-JSDoc] Unable to resolve type for an unnamed item, this is likely due to invalid JSDoc. Often this is caused by invalid JSDoc on a parameter. Defaulting to `any`.
+[TSD-JSDoc] JitsiMeetJS.js:145:4 Unable to resolve type for ProxyConnectionService, none specified in JSDoc. Defaulting to `any`.
+[TSD-JSDoc] Unable to resolve type for an unnamed item, this is likely due to invalid JSDoc. Often this is caused by invalid JSDoc on a parameter. Defaulting to `any`.
+[TSD-JSDoc] Unable to resolve type for an unnamed item, this is likely due to invalid JSDoc. Often this is caused by invalid JSDoc on a parameter. Defaulting to `any`.
+[TSD-JSDoc] Unable to resolve type for an unnamed item, this is likely due to invalid JSDoc. Often this is caused by invalid JSDoc on a parameter. Defaulting to `any`.
+[TSD-JSDoc] Unable to resolve type for an unnamed item, this is likely due to invalid JSDoc. Often this is caused by invalid JSDoc on a parameter. Defaulting to `any`.
+[TSD-JSDoc] Unable to resolve object value type, this is likely due to invalid JSDoc. Defaulting to `any`.
+[TSD-JSDoc] JitsiMeetJS.js:524:4 Unable to resolve type for getActiveAudioDevice, none specified in JSDoc. Defaulting to `any`.
+[TSD-JSDoc] JitsiMeetJS.js:600:4 Unable to resolve type for getGlobalOnErrorHandler, none specified in JSDoc. Defaulting to `any`.
+[TSD-JSDoc] JitsiMeetJS.js:634:4 Unable to resolve type for util, none specified in JSDoc. Defaulting to `any`.
+[TSD-JSDoc] JitsiParticipant.js:103:4 Unable to resolve type for the name of the property., none specified in JSDoc. Defaulting to `any`.

--- a/out/types.d.ts
+++ b/out/types.d.ts
@@ -1,0 +1,1123 @@
+/**
+ * How long since Jicofo is supposed to send a session-initiate, before
+ * {@link ACTION_JINGLE_SI_TIMEOUT} analytics event is sent (in ms).
+ */
+declare const JINGLE_SI_TIMEOUT = 5000;
+
+/**
+ * Jingle session instance for the JVB connection.
+ */
+declare var jvbJingleSession: JingleSessionPC;
+
+/**
+ * The object which monitors local and remote connection statistics (e.g.
+ * sending bitrate) and calculates a number which represents the connection
+ * quality.
+ */
+declare var connectionQuality: any;
+
+/**
+ * Reports average RTP statistics to the analytics module.
+ */
+declare var avgRtpStatsReporter: AvgRTPStatsReporter;
+
+/**
+ * Detects issues with the audio of remote participants.
+ */
+declare var _audioOutputProblemDetector: AudioOutputProblemDetector;
+
+/**
+ * Indicates whether the connection is interrupted or not.
+ */
+declare var isJvbConnectionInterrupted: any;
+
+/**
+ * The object which tracks active speaker times
+ */
+declare var speakerStatsCollector: any;
+
+/**
+ * Stores reference to deferred start P2P task. It's created when 3rd
+ * participant leaves the room in order to avoid ping pong effect (it
+ * could be just a page reload).
+ */
+declare var deferredStartP2PTask: number | null;
+
+/**
+ * A delay given in seconds, before the conference switches back to P2P
+ * after the 3rd participant has left.
+ */
+declare var backToP2PDelay: number;
+
+/**
+ * If set to <tt>true</tt> it means the P2P ICE is no longer connected.
+ * When <tt>false</tt> it means that P2P ICE (media) connection is up
+ * and running.
+ */
+declare var isP2PConnectionInterrupted: boolean;
+
+/**
+ * Flag set to <tt>true</tt> when P2P session has been established
+ * (ICE has been connected) and this conference is currently in the peer to
+ * peer mode (P2P connection is the active one).
+ */
+declare var p2p: boolean;
+
+/**
+ * A JingleSession for the direct peer to peer connection.
+ */
+declare var p2pJingleSession: JingleSessionPC;
+
+/**
+ * Indicates that client must be authenticated to create the conference.
+ */
+declare const AUTHENTICATION_REQUIRED: string;
+
+/**
+ * Indicates that chat error occurred.
+ */
+declare const CHAT_ERROR: string;
+
+/**
+ * Indicates that conference has been destroyed.
+ */
+declare const CONFERENCE_DESTROYED: string;
+
+/**
+ * Indicates that max users limit has been reached.
+ */
+declare const CONFERENCE_MAX_USERS: string;
+
+/**
+ * Indicates that a connection error occurred when trying to join a conference.
+ */
+declare const CONNECTION_ERROR: string;
+
+/**
+ * Indicates that a connection error is due to not allowed,
+ * occurred when trying to join a conference.
+ */
+declare const NOT_ALLOWED_ERROR: string;
+
+/**
+ * Indicates that focus error happened.
+ */
+declare const FOCUS_DISCONNECTED: string;
+
+/**
+ * Indicates that focus left the conference.
+ */
+declare const FOCUS_LEFT: string;
+
+/**
+ * Indicates that graceful shutdown happened.
+ */
+declare const GRACEFUL_SHUTDOWN: string;
+
+/**
+ * Indicates that the versions of the server side components are incompatible
+ * with the client side.
+ */
+declare const INCOMPATIBLE_SERVER_VERSIONS: string;
+
+/**
+ * Indicates that offer/answer had failed.
+ */
+declare const OFFER_ANSWER_FAILED: string;
+
+/**
+ * Indicates that password cannot be set for this conference.
+ */
+declare const PASSWORD_NOT_SUPPORTED: string;
+
+/**
+ * Indicates that a password is required in order to join the conference.
+ */
+declare const PASSWORD_REQUIRED: string;
+
+/**
+ * Indicates that reservation system returned error.
+ */
+declare const RESERVATION_ERROR: string;
+
+/**
+ * Indicates that the conference setup failed.
+ */
+declare const SETUP_FAILED: string;
+
+/**
+ * Indicates that there is no available videobridge.
+ */
+declare const VIDEOBRIDGE_NOT_AVAILABLE: string;
+
+/**
+ * Event indicates that the current conference audio input switched between audio
+ * input states,i.e. with or without audio input.
+ */
+declare const AUDIO_INPUT_STATE_CHANGE: string;
+
+/**
+ * Indicates that authentication status changed.
+ */
+declare const AUTH_STATUS_CHANGED: string;
+
+/**
+ * A participant avatar has changed.
+ */
+declare const AVATAR_CHANGED: string;
+
+/**
+ * Fired just before the statistics module is disposed and it's the last chance
+ * to submit some logs to the statistics service (ex. CallStats if enabled),
+ * before it's disconnected.
+ */
+declare const BEFORE_STATISTICS_DISPOSED: string;
+
+/**
+ * Indicates that an error occured.
+ */
+declare const CONFERENCE_ERROR: string;
+
+/**
+ * Indicates that conference failed.
+ */
+declare const CONFERENCE_FAILED: string;
+
+/**
+ * Indicates that conference has been joined. The event does NOT provide any
+ * parameters to its listeners.
+ */
+declare const CONFERENCE_JOINED: string;
+
+/**
+ * Indicates that conference has been left.
+ */
+declare const CONFERENCE_LEFT: string;
+
+/**
+ * Indicates that the connection to the conference has been established
+ * XXX This is currently fired whenVthe *ICE* connection enters 'connected'
+ * state for the first time.
+ */
+declare const CONNECTION_ESTABLISHED: string;
+
+/**
+ * Indicates that the connection to the conference has been interrupted for some
+ * reason.
+ * XXX This is currently fired when the *ICE* connection is interrupted.
+ */
+declare const CONNECTION_INTERRUPTED: string;
+
+/**
+ * Indicates that the connection to the conference has been restored.
+ * XXX This is currently fired when the *ICE* connection is restored.
+ */
+declare const CONNECTION_RESTORED: string;
+
+/**
+ * A connection to the video bridge's data channel has been established.
+ */
+declare const DATA_CHANNEL_OPENED: string;
+
+/**
+ * A user has changed it display name
+ */
+declare const DISPLAY_NAME_CHANGED: string;
+
+/**
+ * The dominant speaker was changed.
+ */
+declare const DOMINANT_SPEAKER_CHANGED: string;
+
+/**
+ * UTC conference timestamp when first participant joined.
+ */
+declare const CONFERENCE_CREATED_TIMESTAMP: string;
+
+/**
+ * Indicates that DTMF support changed.
+ */
+declare const DTMF_SUPPORT_CHANGED: string;
+
+/**
+ * Indicates that a message from another participant is received on data
+ * channel.
+ */
+declare const ENDPOINT_MESSAGE_RECEIVED: string;
+
+/**
+ * NOTE This is lib-jitsi-meet internal event and can be removed at any time !
+ *
+ * Event emitted when conference transits, between one to one and multiparty JVB
+ * conference. If the conference switches to P2P it's neither one to one nor
+ * a multiparty JVB conference, but P2P (the status argument of this event will
+ * be <tt>false</tt>).
+ *
+ * The first argument is a boolean which carries the previous value and
+ * the seconds argument is a boolean with the new status. The event is emitted
+ * only if the previous and the new values are different.
+ */
+declare const JVB121_STATUS: string;
+
+/**
+ * You are kicked from the conference.
+ * @param the - participant that initiated the kick.
+ */
+declare const KICKED: string;
+
+/**
+ * Participant was kicked from the conference.
+ * @param the - participant that initiated the kick.
+ * @param the - participant that was kicked.
+ */
+declare const PARTICIPANT_KICKED: string;
+
+/**
+ * The Last N set is changed.
+ * @param leavingEndpointIds - the ids of all the endpoints
+ * which are leaving Last N
+ * @param enteringEndpointIds - the ids of all the endpoints
+ * which are entering Last N
+ */
+declare const LAST_N_ENDPOINTS_CHANGED: string;
+
+/**
+ * Indicates that the room has been locked or unlocked.
+ */
+declare const LOCK_STATE_CHANGED: string;
+
+/**
+ * Indicates that the region of the media server (jitsi-videobridge) that we
+ * are connected to changed (or was initially set).
+ */
+declare const SERVER_REGION_CHANGED: string;
+
+/**
+ * New text message was received.
+ */
+declare const MESSAGE_RECEIVED: string;
+
+/**
+ * Event indicates that the current selected input device has no signal
+ */
+declare const NO_AUDIO_INPUT: string;
+
+/**
+ * Event indicates that the current microphone used by the conference is noisy.
+ */
+declare const NOISY_MIC: string;
+
+/**
+ * New private text message was received.
+ */
+declare const PRIVATE_MESSAGE_RECEIVED: string;
+
+/**
+ * Event fired when JVB sends notification about interrupted/restored user's
+ * ICE connection status or we detect local problem with the video track.
+ * First argument is the ID of the participant and
+ * the seconds is a string indicating if the connection is currently
+ * - active - the connection is active
+ * - inactive - the connection is inactive, was intentionally interrupted by
+ * the bridge
+ * - interrupted - a network problem occurred
+ * - restoring - the connection was inactive and is restoring now
+ *
+ * The current status value can be obtained by calling
+ * JitsiParticipant.getConnectionStatus().
+ */
+declare const PARTICIPANT_CONN_STATUS_CHANGED: string;
+
+/**
+ * Indicates that the features of the participant has been changed.
+ */
+declare const PARTCIPANT_FEATURES_CHANGED: string;
+
+/**
+ * Indicates that a the value of a specific property of a specific participant
+ * has changed.
+ */
+declare const PARTICIPANT_PROPERTY_CHANGED: string;
+
+/**
+ * Indicates that the conference has switched between JVB and P2P connections.
+ * The first argument of this event is a <tt>boolean</tt> which when set to
+ * <tt>true</tt> means that the conference is running on the P2P connection.
+ */
+declare const P2P_STATUS: string;
+
+/**
+ * Indicates that phone number changed.
+ */
+declare const PHONE_NUMBER_CHANGED: string;
+
+/**
+ * The conference properties changed.
+ */
+declare const PROPERTIES_CHANGED: string;
+
+/**
+ * Indicates that recording state changed.
+ */
+declare const RECORDER_STATE_CHANGED: string;
+
+/**
+ * Indicates that video SIP GW state changed.
+ */
+declare const VIDEO_SIP_GW_AVAILABILITY_CHANGED: string;
+
+/**
+ * Indicates that video SIP GW Session state changed.
+ * @param event - {
+ *     {string} address,
+ *     {VideoSIPGWConstants} oldState,
+ *     {VideoSIPGWConstants} newState,
+ *     {string} displayName}
+ * }.
+ */
+declare const VIDEO_SIP_GW_SESSION_STATE_CHANGED: string;
+
+/**
+ * Indicates that start muted settings changed.
+ */
+declare const START_MUTED_POLICY_CHANGED: string;
+
+/**
+ * Indicates that the local user has started muted.
+ */
+declare const STARTED_MUTED: string;
+
+/**
+ * Indicates that subject of the conference has changed.
+ */
+declare const SUBJECT_CHANGED: string;
+
+/**
+ * Indicates that DTMF support changed.
+ */
+declare const SUSPEND_DETECTED: string;
+
+/**
+ * Event indicates that local user is talking while he muted himself
+ */
+declare const TALK_WHILE_MUTED: string;
+
+/**
+ * A new media track was added to the conference. The event provides the
+ * following parameters to its listeners:
+ * @param track - the added JitsiTrack
+ */
+declare const TRACK_ADDED: string;
+
+/**
+ * Audio levels of a media track ( attached to the conference) was changed.
+ */
+declare const TRACK_AUDIO_LEVEL_CHANGED: string;
+
+/**
+ * A media track ( attached to the conference) mute status was changed.
+ * @param the - participant that initiated the mute
+ * if it is a remote mute.
+ */
+declare const TRACK_MUTE_CHANGED: string;
+
+/**
+ * The media track was removed from the conference. The event provides the
+ * following parameters to its listeners:
+ * @param track - the removed JitsiTrack
+ */
+declare const TRACK_REMOVED: string;
+
+/**
+ * Notifies for transcription status changes. The event provides the
+ * following parameters to its listeners:
+ * @param status - The new status.
+ */
+declare const TRANSCRIPTION_STATUS_CHANGED: string;
+
+/**
+ * A new user joined the conference.
+ */
+declare const USER_JOINED: string;
+
+/**
+ * A user has left the conference.
+ */
+declare const USER_LEFT: string;
+
+/**
+ * User role changed.
+ */
+declare const USER_ROLE_CHANGED: string;
+
+/**
+ * User status changed.
+ */
+declare const USER_STATUS_CHANGED: string;
+
+/**
+ * Event indicates that the bot participant type changed.
+ */
+declare const BOT_TYPE_CHANGED: string;
+
+/**
+ * Indicates that the connection was dropped with an error which was most likely
+ * caused by some networking issues. The dropped term in this context means that
+ * the connection was closed unexpectedly (not on user's request).
+ *
+ * One example is 'item-not-found' error thrown by Prosody when the BOSH session
+ * times out after 60 seconds of inactivity. On the other hand 'item-not-found'
+ * could also happen when BOSH request is sent to the server with the session-id
+ * that is not know to the server. But this should not happen in lib-jitsi-meet
+ * case as long as the service is configured correctly (there is no bug).
+ */
+declare const CONNECTION_DROPPED_ERROR: string;
+
+/**
+ * Not specified errors.
+ */
+declare const OTHER_ERROR: string;
+
+/**
+ * Indicates that a password is required in order to join the conference.
+ */
+declare const PASSWORD_REQUIRED: string;
+
+/**
+ * Indicates that the connection was dropped, because of too many 5xx HTTP
+ * errors on BOSH requests.
+ */
+declare const SERVER_ERROR: string;
+
+/**
+ * Indicates that the connection has been disconnected. The event provides
+ * the following parameters to its listeners:
+ * @param msg - a message associated with the disconnect such as the
+ * last (known) error message
+ */
+declare const CONNECTION_DISCONNECTED: string;
+
+/**
+ * Indicates that the connection to the conference has been established
+ * XXX This is currently fired whenVthe *ICE* connection enters 'connected'
+ * state for the first time.
+ */
+declare const CONNECTION_ESTABLISHED: string;
+
+/**
+ * Indicates that the connection has been failed for some reason. The event
+ * provides the following parameters to its listeners:
+ * @param errType - the type of error associated with
+ * the failure
+ * @param errReason - the error (message) associated with the failure
+ * @param credentials - the credentials used to connect (if any)
+ * @param errReasonDetails - an optional object with details about
+ * the error, like shard moving, suspending. Used for analytics purposes.
+ */
+declare const CONNECTION_FAILED: string;
+
+/**
+ * Indicates that the performed action cannot be executed because the
+ * connection is not in the correct state(connected, disconnected, etc.)
+ */
+declare const WRONG_STATE: string;
+
+/**
+ * Initializes a {@code JitsiMediaDevices} object. There will be a single
+ * instance of this class.
+ */
+declare class JitsiMediaDevices {
+    /**
+     * Updated the local granted permissions cache. A permissions might be
+     * granted, denied, or undefined. This is represented by having its media
+     * type key set to {@code true} or {@code false} respectively.
+     * @param grantedPermissions - Array with the permissions
+     * which were granted.
+     */
+    _handleGrantedPermissions(grantedPermissions: any): void;
+    /**
+     * Gathers data and sends it to statistics.
+     * @param deviceID - the device id to log
+     * @param devices - list of devices
+     */
+    _logOutputDevice(deviceID: any, devices: any): void;
+    /**
+     * Executes callback with list of media devices connected.
+     */
+    enumerateDevices(callback: (...params: any[]) => any): void;
+    /**
+     * Checks if its possible to enumerate available cameras/micropones.
+     * @returns a Promise which will be resolved only once
+     * the WebRTC stack is ready, either with true if the device listing is
+     * available available or with false otherwise.
+     */
+    isDeviceListAvailable(): Promise<boolean>;
+    /**
+     * Returns true if changing the input (camera / microphone) or output
+     * (audio) device is supported and false if not.
+     * @param [deviceType] - type of device to change. Default is
+     *      undefined or 'input', 'output' - for audio output device change.
+     * @returns true if available, false otherwise.
+     */
+    isDeviceChangeAvailable(deviceType?: string): boolean;
+    /**
+     * Checks if the permission for the given device was granted.
+     * @param [type] - type of devices to check,
+     *      undefined stands for both 'audio' and 'video' together
+     */
+    isDevicePermissionGranted(type?: 'audio' | 'video'): Promise<boolean>;
+    /**
+     * Returns true if it is possible to be simultaneously capturing audio
+     * from more than one device.
+     */
+    isMultipleAudioInputSupported(): boolean;
+    /**
+     * Returns currently used audio output device id, 'default' stands
+     * for default device
+     */
+    getAudioOutputDevice(): string;
+    /**
+     * Sets current audio output device.
+     * @param deviceId - id of 'audiooutput' device from
+     *      navigator.mediaDevices.enumerateDevices(), 'default' is for
+     *      default device
+     * @returns - resolves when audio output is changed, is rejected
+     *      otherwise
+     */
+    setAudioOutputDevice(deviceId: string): Promise;
+    /**
+     * Adds an event handler.
+     * @param event - event name
+     * @param handler - event handler
+     */
+    addEventListener(event: string, handler: (...params: any[]) => any): void;
+    /**
+     * Removes event handler.
+     * @param event - event name
+     * @param handler - event handler
+     */
+    removeEventListener(event: string, handler: (...params: any[]) => any): void;
+    /**
+     * Emits an event.
+     * @param event - event name
+     */
+    emitEvent(event: string): void;
+    /**
+     * Returns whether or not the current browser can support capturing video,
+     * be it camera or desktop, and displaying received video.
+     */
+    supportsVideo(): boolean;
+}
+
+/**
+ * Indicates that the list of available media devices has been changed. The
+ * event provides the following parameters to its listeners:
+ * @param devices - array of MediaDeviceInfo or
+ *  MediaDeviceInfo-like objects that are currently connected.
+ */
+declare const DEVICE_LIST_CHANGED: string;
+
+/**
+ * Indicates that the environment is currently showing permission prompt to
+ * access camera and/or microphone. The event provides the following
+ * parameters to its listeners:
+ * @param environmentType - type of browser or
+ *  other execution environment.
+ */
+declare const PERMISSION_PROMPT_IS_SHOWN: string;
+
+/**
+ * The amount of time to wait until firing
+ * {@link JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN} event.
+ */
+declare const USER_MEDIA_PERMISSION_PROMPT_TIMEOUT = 1000;
+
+/**
+ * Gets the next lowest desirable resolution to try for a camera. If the given
+ * resolution is already the lowest acceptable resolution, returns {@code null}.
+ * @param resolution - the current resolution
+ * @returns the next lowest resolution from the given one, or {@code null} if it
+ * is already the lowest acceptable resolution.
+ */
+declare function getLowerResolution(resolution: any): any;
+
+/**
+ * Extracts from an 'options' objects with a specific format (TODO what IS the
+ * format?) the attributes which are to be logged in analytics events.
+ * @param options - gum options (???)
+ * @returns the attributes to attach to analytics events.
+ */
+declare function getAnalyticsAttributesFromOptions(options: any): any;
+
+/**
+ * {@code ProxyConnectionService} is used to connect a remote peer to a
+ * local Jitsi participant without going through a Jitsi conference. It is
+ * currently used for room integration development, specifically wireless
+ * screensharing. Its API is experimental and will likely change; usage of
+ * it is advised against.
+ */
+declare var ProxyConnectionService: any;
+
+/**
+ * Returns whether the desktop sharing is enabled or not.
+ */
+declare function isDesktopSharingEnabled(): boolean;
+
+/**
+ * Returns whether the current execution environment supports WebRTC (for
+ * use within this library).
+ * @returns {@code true} if WebRTC is supported in the current
+ * execution environment (for use within this library); {@code false},
+ * otherwise.
+ */
+declare function isWebRtcSupported(): boolean;
+
+/**
+ * Sets the log level to the <tt>Logger</tt> instance with given id.
+ * @param level - the logging level to be set
+ * @param id - the logger id to which new logging level will be set.
+ * Usually it's the name of the JavaScript source file including the path
+ * ex. "modules/xmpp/ChatRoom.js"
+ */
+declare function setLogLevelById(level: Logger.levels, id: string): void;
+
+/**
+ * Registers new global logger transport to the library logging framework.
+ */
+declare function addGlobalLogTransport(globalTransport: any): void;
+
+/**
+ * Removes global logging transport from the library logging framework.
+ */
+declare function removeGlobalLogTransport(globalTransport: any): void;
+
+/**
+ * Sets global options which will be used by all loggers. Changing these
+ * works even after other loggers are created.
+ */
+declare function setGlobalLogOptions(options: any): void;
+
+/**
+ * Creates the media tracks and returns them trough the callback.
+ * @param options - Object with properties / settings specifying the tracks
+ * which should be created. should be created or some additional
+ * configurations about resolution for example.
+ * @param options.effects - optional effects array for the track
+ * @param options.devices - the devices that will be requested
+ * @param options.resolution - resolution constraints
+ * @param options.desktopSharingExtensionExternalInstallation - enables external installation process for desktop sharing extension if
+ * the inline installation is not posible. The following properties should
+ * be provided:
+ * @param interval - the interval (in ms) for
+ * checking whether the desktop sharing extension is installed or not
+ * @param checkAgain - returns boolean. While checkAgain()==true
+ * createLocalTracks will wait and check on every "interval" ms for the
+ * extension. If the desktop extension is not install and checkAgain()==true
+ * createLocalTracks will finish with rejected Promise.
+ * @param listener - The listener will be called to notify the
+ * user of lib-jitsi-meet that createLocalTracks is starting external
+ * extension installation process.
+ * NOTE: If the inline installation process is not possible and external
+ * installation is enabled the listener property will be called to notify
+ * the start of external installation process. After that createLocalTracks
+ * will start to check for the extension on every interval ms until the
+ * plugin is installed or until checkAgain return false. If the extension
+ * is found createLocalTracks will try to get the desktop sharing track and
+ * will finish the execution. If checkAgain returns false, createLocalTracks
+ * will finish the execution with rejected Promise.
+ * @param (firePermissionPromptIsShownEvent) - if event
+ * JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN should be fired
+ * @param originalOptions - internal use only, to be able to store the
+ * originally requested options.
+ * @returns A promise
+ * that returns an array of created JitsiTracks if resolved, or a
+ * JitsiConferenceError if rejected.
+ */
+declare function createLocalTracks(options: {
+    effects: any[];
+    devices: any[];
+    resolution: string;
+    cameraDeviceId: string;
+    micDeviceId: string;
+    desktopSharingExtensionExternalInstallation: any;
+}, interval: intiger, checkAgain: (...params: any[]) => any, listener: (...params: any[]) => any, (firePermissionPromptIsShownEvent): boolean, originalOptions: any): Promise<{ Array: any; }>;
+
+/**
+ * Create a TrackVADEmitter service that connects an audio track to an VAD (voice activity detection) processor in
+ * order to obtain VAD scores for individual PCM audio samples.
+ * @param localAudioDeviceId - The target local audio device.
+ * @param sampleRate - Sample rate at which the emitter will operate. Possible values  256, 512, 1024,
+ * 4096, 8192, 16384. Passing other values will default to closes neighbor.
+ * I.e. Providing a value of 4096 means that the emitter will process 4096 PCM samples at a time, higher values mean
+ * longer calls, lowers values mean more calls but shorter.
+ * @param vadProcessor - VAD Processors that does the actual compute on a PCM sample.The processor needs
+ * to implement the following functions:
+ * - <tt>getSampleLength()</tt> - Returns the sample size accepted by calculateAudioFrameVAD.
+ * - <tt>getRequiredPCMFrequency()</tt> - Returns the PCM frequency at which the processor operates.
+ * i.e. (16KHz, 44.1 KHz etc.)
+ * - <tt>calculateAudioFrameVAD(pcmSample)</tt> - Process a 32 float pcm sample of getSampleLength size.
+ */
+declare function createTrackVADEmitter(localAudioDeviceId: string, sampleRate: number, vadProcessor: any): Promise<TrackVADEmitter>;
+
+/**
+ * Go through all audio devices on the system and return one that is active, i.e. has audio signal.
+ * @returns Promise<Object> - Object containing information about the found device.
+ */
+declare function getActiveAudioDevice(): any;
+
+/**
+ * Checks if its possible to enumerate available cameras/microphones.
+ * @returns a Promise which will be resolved only once
+ * the WebRTC stack is ready, either with true if the device listing is
+ * available available or with false otherwise.
+ */
+declare function isDeviceListAvailable(): Promise<boolean>;
+
+/**
+ * Returns true if changing the input (camera / microphone) or output
+ * (audio) device is supported and false if not.
+ * @param [deviceType] - type of device to change. Default is
+ * {@code undefined} or 'input', 'output' - for audio output device change.
+ * @returns {@code true} if available; {@code false}, otherwise.
+ */
+declare function isDeviceChangeAvailable(deviceType?: string): boolean;
+
+/**
+ * Checks if the current environment supports having multiple audio
+ * input devices in use simultaneously.
+ * @returns True if multiple audio input devices can be used.
+ */
+declare function isMultipleAudioInputSupported(): boolean;
+
+/**
+ * Checks if local tracks can collect stats and collection is enabled.
+ * @param True - if stats are being collected for local tracks.
+ */
+declare function isCollectingLocalStats(True: boolean): void;
+
+/**
+ * Executes callback with list of media devices connected.
+ */
+declare function enumerateDevices(callback: (...params: any[]) => any): void;
+
+/**
+ * @returns function that can be used to be attached to window.onerror and
+ * if options.enableWindowOnErrorHandler is enabled returns
+ * the function used by the lib.
+ * (function(message, source, lineno, colno, error)).
+ */
+declare function getGlobalOnErrorHandler(): any;
+
+/**
+ * Set the contentHint on the transmitted stream track to indicate
+ * charaterstics in the video stream, which informs PeerConnection
+ * on how to encode the track (to prefer motion or individual frame detail)
+ * @param track - the track that is transmitted
+ * @param hint - contentHint value that needs to be set on the track
+ */
+declare function setVideoTrackContentHints(track: MediaStreamTrack, hint: string): void;
+
+/**
+ * Represents a hub/namespace for utility functionality which may be of
+ * interest to lib-jitsi-meet clients.
+ */
+declare var util: any;
+
+/**
+ * @returns The conference that this participant belongs
+ * to.
+ */
+declare function getConference(): JitsiConference;
+
+/**
+ * Gets the value of a property of this participant.
+ */
+declare function getProperty(): void;
+
+/**
+ * Checks whether this <tt>JitsiParticipant</tt> has any video tracks which
+ * are muted according to their underlying WebRTC <tt>MediaStreamTrack</tt>
+ * muted status.
+ * @returns <tt>true</tt> if this <tt>participant</tt> contains any
+ * video <tt>JitsiTrack</tt>s which are muted as defined in
+ * {@link JitsiTrack.isWebRTCTrackMuted}.
+ */
+declare function hasAnyVideoTrackWebRTCMuted(): boolean;
+
+/**
+ * Return participant's connectivity status.
+ * @returns the connection status
+ * <tt>ParticipantConnectionStatus</tt> of the user.
+ * {@link ParticipantConnectionStatus}.
+ */
+declare function getConnectionStatus(): string;
+
+/**
+ * Sets the value of a property of this participant, and fires an event if
+ * the value has changed.
+ */
+declare var the name of the property.: any;
+
+/**
+ * @returns The list of media tracks for this
+ * participant.
+ */
+declare function getTracks(): JitsiTrack[];
+
+/**
+ * @returns an array of media tracks for this
+ * participant, for given media type.
+ */
+declare function getTracksByMediaType(mediaType: MediaType): JitsiTrack[];
+
+/**
+ * @returns The ID of this participant.
+ */
+declare function getId(): string;
+
+/**
+ * @returns The JID of this participant.
+ */
+declare function getJid(): string;
+
+/**
+ * @returns The human-readable display name of this participant.
+ */
+declare function getDisplayName(): string;
+
+/**
+ * @returns The stats ID of this participant.
+ */
+declare function getStatsID(): string;
+
+/**
+ * @returns The status of the participant.
+ */
+declare function getStatus(): string;
+
+/**
+ * @returns Whether this participant is a moderator or not.
+ */
+declare function isModerator(): boolean;
+
+/**
+ * @returns Whether this participant is a hidden participant. Some
+ * special system participants may want to join hidden (like for example the
+ * recorder).
+ */
+declare function isHidden(): boolean;
+
+/**
+ * @returns Whether this participant has muted their audio.
+ */
+declare function isAudioMuted(): boolean;
+
+/**
+ * @returns Whether this participant has muted their video.
+ */
+declare function isVideoMuted(): boolean;
+
+/**
+ * @returns The role of this participant.
+ */
+declare function getRole(): string;
+
+declare function supportsDTMF(): void;
+
+/**
+ * Returns a set with the features for the participant.
+ * @param timeout - the timeout in ms for reply from the participant.
+ */
+declare function getFeatures(timeout?: int): Promise<Set<String>>;
+
+/**
+ * Returns the bot type for the participant.
+ * @returns - The bot type of the participant.
+ */
+declare function getBotType(): string | undefined;
+
+/**
+ * Represents an error that occurred to a JitsiTrack. Can represent various
+ * types of errors. For error descriptions (@see JitsiTrackErrors).
+ * @param error - error object or error name
+ * @param [options] - getUserMedia constraints object or
+ * error message
+ * @param [devices] - list of getUserMedia requested devices
+ */
+declare class JitsiTrackError extends Error {
+    constructor(error: any | string, options?: any | string, devices?: ('audio' | 'video' | 'desktop' | 'screen' | 'audiooutput')[]);
+    /**
+     * Additional information about original getUserMedia error
+     * and constraints.
+     */
+    gum: any;
+}
+
+/**
+ * Gets failed resolution constraint from corresponding object.
+ */
+declare function getResolutionFromFailedConstraint(failedConstraintName: string, constraints: any): string | number;
+
+/**
+ * Generic error for jidesha extension for Chrome.
+ */
+declare const CHROME_EXTENSION_GENERIC_ERROR: string;
+
+/**
+ * An error which indicates that the jidesha extension for Chrome is
+ * failed to install.
+ */
+declare const CHROME_EXTENSION_INSTALLATION_ERROR: string;
+
+/**
+ * This error indicates that the attempt to start screensharing was initiated by
+ * a script which did not originate in user gesture handler. It means that
+ * you should to trigger the action again in response to a button click for
+ * example.
+ */
+declare const CHROME_EXTENSION_USER_GESTURE_REQUIRED: string;
+
+/**
+ * An error which indicates that user canceled screen sharing window
+ * selection dialog in jidesha extension for Chrome.
+ */
+declare const CHROME_EXTENSION_USER_CANCELED: string;
+
+/**
+ * An error which indicates that some of requested constraints in
+ * getUserMedia call were not satisfied.
+ */
+declare const CONSTRAINT_FAILED: string;
+
+/**
+ * A generic error which indicates an error occurred while selecting
+ * a DesktopCapturerSource from the electron app.
+ */
+declare const ELECTRON_DESKTOP_PICKER_ERROR: string;
+
+/**
+ * An error which indicates a custom desktop picker could not be detected
+ * for the electron app.
+ */
+declare const ELECTRON_DESKTOP_PICKER_NOT_FOUND: string;
+
+/**
+ * An error which indicates that the jidesha extension for Firefox is
+ * needed to proceed with screen sharing, and that it is not installed.
+ */
+declare const FIREFOX_EXTENSION_NEEDED: string;
+
+/**
+ * Generic getUserMedia error.
+ */
+declare const GENERAL: string;
+
+/**
+ * An error which indicates that requested device was not found.
+ */
+declare const NOT_FOUND: string;
+
+/**
+ * An error which indicates that user denied permission to share requested
+ * device.
+ */
+declare const PERMISSION_DENIED: string;
+
+/**
+ * An error which indicates that track has been already disposed and cannot
+ * be longer used.
+ */
+declare const TRACK_IS_DISPOSED: string;
+
+/**
+ * An error which indicates that track has no MediaStream associated.
+ */
+declare const TRACK_NO_STREAM_FOUND: string;
+
+/**
+ * An error which indicates that requested video resolution is not supported
+ * by a webcam.
+ */
+declare const UNSUPPORTED_RESOLUTION: string;
+
+/**
+ * The media track was removed to the conference.
+ */
+declare const LOCAL_TRACK_STOPPED: string;
+
+/**
+ * Audio levels of a media track ( attached to the conference) was changed.
+ */
+declare const TRACK_AUDIO_LEVEL_CHANGED: string;
+
+/**
+ * The audio output of the track was changed.
+ */
+declare const TRACK_AUDIO_OUTPUT_CHANGED: string;
+
+/**
+ * A media track ( attached to the conference) mute status was changed.
+ * @param the - participant that initiated the mute
+ * if it is a remote mute.
+ */
+declare const TRACK_MUTE_CHANGED: string;
+
+/**
+ * The video type("camera" or "desktop") of the track was changed.
+ */
+declare const TRACK_VIDEOTYPE_CHANGED: string;
+
+/**
+ * Indicates that the track is not receiving any data even though we expect it
+ * to receive data (i.e. the stream is not stopped).
+ */
+declare const NO_DATA_FROM_SOURCE: string;
+
+/**
+ * The transciption is on.
+ */
+declare const ON: string;
+
+/**
+ * The transciption is off.
+ */
+declare const OFF: string;
+
+/**
+ * @property [connectionError] - One of
+ * {@link JitsiConnectionErrors} which occurred when trying to connect to the
+ * XMPP server.
+ * @property [authenticationError] - One of XMPP error conditions
+ * returned by Jicofo on authentication attempt. See
+ * {@link https://xmpp.org/rfcs/rfc3920.html#streams-error}.
+ * @property [message] - More details about the error.
+ * @property [credentials] - The credentials that failed the
+ * authentication.
+ * @property [credentials.jid] - The XMPP ID part of the credentials
+ * that failed the authentication.
+ * @property [credentials.password] - The password part of the
+ * credentials that failed the authentication.
+ *
+ * NOTE If neither one of the errors is present, then the operation has been
+ * canceled.
+ */
+declare type UpgradeRoleError = {
+    connectionError?: JitsiConnectionErrors;
+    authenticationError?: string;
+    message?: string;
+    credentials?: {
+        jid?: string;
+        password?: string;
+    };
+};
+
+/**
+ * [js-md5]{@link https://github.com/emn178/js-md5}
+ */
+declare namespace md5 { }
+
+/**
+ * [js-md5]{@link https://github.com/emn178/js-md5}
+ */
+declare namespace md5 { }
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -2259,6 +2259,23 @@
       "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
       "dev": true
     },
+    "catharsis": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
+      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -5127,6 +5144,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "in-publish": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+      "dev": true
+    },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
@@ -5513,6 +5536,73 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      }
+    },
+    "js2xmlparser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.0.tgz",
+      "integrity": "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==",
+      "dev": true,
+      "requires": {
+        "xmlcreate": "^2.0.0"
+      }
+    },
+    "jsdoc": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.3.tgz",
+      "integrity": "sha512-Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.4.4",
+        "bluebird": "^3.5.4",
+        "catharsis": "^0.8.11",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.0",
+        "klaw": "^3.0.0",
+        "markdown-it": "^8.4.2",
+        "markdown-it-anchor": "^5.0.2",
+        "marked": "^0.7.0",
+        "mkdirp": "^0.5.1",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.0.1",
+        "taffydb": "2.6.2",
+        "underscore": "~1.9.1"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+          "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+          "dev": true
+        }
+      }
+    },
+    "jsdoc-export-default-interop": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-export-default-interop/-/jsdoc-export-default-interop-0.3.1.tgz",
+      "integrity": "sha1-Ri+p+bSiqwag9NBiQUPQLlui0F8=",
+      "dev": true,
+      "requires": {
+        "in-publish": "^2.0.0",
+        "lodash": "^4.0.1"
       }
     },
     "jsesc": {
@@ -6532,7 +6622,7 @@
     },
     "karma-webpack": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/karma-webpack/-/karma-webpack-3.0.0.tgz",
       "integrity": "sha512-Ja1o9LLoqWaJyUNhTKaXjWiEH9y7a9H3mzP8pYB30SBsgoF5KBS/65NeHFd+QPuT9ITrym8xFt8BZeGbcOfujA==",
       "dev": true,
       "requires": {
@@ -6572,6 +6662,15 @@
         "is-buffer": "^1.1.5"
       }
     },
+    "klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -6589,6 +6688,15 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
       }
     },
     "load-json-file": {
@@ -6809,6 +6917,39 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-it": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+          "dev": true
+        }
+      }
+    },
+    "markdown-it-anchor": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.5.tgz",
+      "integrity": "sha512-xLIjLQmtym3QpoY9llBgApknl7pxAcN3WDRc2d3rwpl+/YvDZHPmKscGs+L6E05xf2KrCXPBvosWt7MZukwSpQ==",
+      "dev": true
+    },
+    "marked": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+      "dev": true
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -6827,6 +6968,12 @@
           "dev": true
         }
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -7918,6 +8065,23 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "requizzle": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
@@ -8829,6 +8993,12 @@
         }
       }
     },
+    "taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
+    },
     "tapable": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
@@ -9175,6 +9345,14 @@
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
       "dev": true
     },
+    "tsd-jsdoc": {
+      "version": "github:englercj/tsd-jsdoc#a8a4c63930cf08fbd14b930a68b53cfdf8f4eabd",
+      "from": "github:englercj/tsd-jsdoc",
+      "dev": true,
+      "requires": {
+        "typescript": "^3.2.1"
+      }
+    },
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
@@ -9229,10 +9407,28 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "dev": true
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -9938,6 +10134,12 @@
         "safe-buffer": "~5.1.0",
         "ultron": "~1.1.0"
       }
+    },
+    "xmlcreate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz",
+      "integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -44,12 +44,15 @@
     "eslint-plugin-import": "2.8.0",
     "flow-bin": "0.104.0",
     "jasmine-core": "2.5.2",
+    "jsdoc": "3.6.3",
+    "jsdoc-export-default-interop": "0.3.1",
     "karma": "3.0.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-jasmine": "1.1.2",
     "karma-webpack": "3.0.0",
     "precommit-hook": "3.0.0",
     "string-replace-loader": "2.1.1",
+    "tsd-jsdoc": "github:englercj/tsd-jsdoc",
     "webpack": "4.26.1",
     "webpack-bundle-analyzer": "3.4.1",
     "webpack-cli": "3.1.2"
@@ -59,7 +62,8 @@
     "postinstall": "webpack -p",
     "test": "karma start karma.conf.js",
     "test-watch": "karma start karma.conf.js --no-single-run",
-    "validate": "npm ls"
+    "validate": "npm ls",
+    "generate": "jsdoc -c ./jsdoc.conf.json"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
This is the starting point for generating typescript definitions for lib-jitsi-meet using the jsdoc types already used in this project. I also had to add some missing ones and also fix a few of them.

There are still some problems which can be found in the `jsdoc.log`. I was not able to solve most of them.

TODO:
- [ ] Fix errors and add missing types
- [ ] Generate types using [webpack plugin](https://github.com/Jaid/jsdoc-tsd-webpack-plugin)
- [ ] Add types.d.ts to package

Closes #1025