### PR TITLE
fix(screenshare): stop using exact for specified device sharing

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1241,8 +1241,7 @@ class RTCUtils extends Listenable {
                 const constraints = {
                     video: {
                         ...gumOptions,
-                        deviceId: (matchingDevice && matchingDevice.deviceId)
-                            || desktopSharingSourceDevice
+                        deviceId: matchingDevice.deviceId
                     }
                 };
 

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1222,6 +1222,15 @@ class RTCUtils extends Listenable {
                         device.kind === 'videoinput'
                             && (device.deviceId === desktopSharingSourceDevice
                             || device.label === desktopSharingSourceDevice));
+
+                if (!matchingDevice) {
+                    return Promise.reject(new JitsiTrackError(
+                        { name: 'ConstraintNotSatisfiedError' },
+                        {},
+                        [ desktopSharingSourceDevice ]
+                    ));
+                }
+
                 const requestedDevices = [ 'video' ];
 
                 // Leverage the helper used by {@link _newGetDesktopMedia} to
@@ -1229,17 +1238,11 @@ class RTCUtils extends Listenable {
                 const { gumOptions, trackOptions }
                     = this._parseDesktopSharingOptions(options);
 
-                // Create a custom constraints object to use exact device
-                // matching to make sure there is no fallthrough to another
-                // camera device. If a matching device could not be found, try
-                // anyways and let the caller handle errors.
                 const constraints = {
                     video: {
                         ...gumOptions,
-                        deviceId: {
-                            exact: (matchingDevice && matchingDevice.deviceId)
-                                || desktopSharingSourceDevice
-                        }
+                        deviceId: (matchingDevice && matchingDevice.deviceId)
+                            || desktopSharingSourceDevice
                     }
                 };
 


### PR DESCRIPTION
Overconstrainederror occurs when calling gum with "exact"
when on URLs with a hash. To get around this, remove
"exact". Add handling for specified device not being
found, as we can no longer rely on "exact". This
still leaves open the possibility of the wrong
camera being accessed.