### PR TITLE
fix(XmppConnection): the ATTACHED state equals to CONNECTED with jiconop

### DIFF
--- a/modules/xmpp/XmppConnection.js
+++ b/modules/xmpp/XmppConnection.js
@@ -76,7 +76,7 @@ export default class XmppConnection extends Listenable {
      * @returns {boolean}
      */
     get connected() {
-        return this._status === Strophe.Status.CONNECTED;
+        return this._status === Strophe.Status.CONNECTED || this._status === Strophe.Status.ATTACHED;
     }
 
     /**


### PR DESCRIPTION
When Jiconop is used to attach to a warmed up BOSH session Strophe goes to ATTACHED instead of the CONNECTED state.