### PR TITLE
fix(XmppConnection): sendUnavailableBeacon

### DIFF
--- a/modules/xmpp/XmppConnection.js
+++ b/modules/xmpp/XmppConnection.js
@@ -399,7 +399,7 @@ export default class XmppConnection extends Listenable {
      * @returns {boolean} - true if the beacon was sent.
      */
     sendUnavailableBeacon() {
-        if (!navigator.sendBeacon || this.connection.disconnecting || !this.connection.connected) {
+        if (!navigator.sendBeacon || this._stropheConn.disconnecting || !this._stropheConn.connected) {
             return false;
         }
 


### PR DESCRIPTION
Copy/paste mistake - there's no such thing as this.connection in the XmppConnection. Hard to track down because no error is logged.