### PR TITLE
fix(analytics): delay conference.join event

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -7,9 +7,7 @@ import GlobalOnErrorHandler from '../util/GlobalOnErrorHandler';
 import * as JitsiTranscriptionStatus from '../../JitsiTranscriptionStatus';
 import Listenable from '../util/Listenable';
 import * as MediaType from '../../service/RTC/MediaType';
-import { createConferenceEvent } from '../../service/statistics/AnalyticsEvents';
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
-import Statistics from '../statistics/statistics';
 
 import Moderator from './moderator';
 import XmppConnection from './XmppConnection';
@@ -314,10 +312,7 @@ export default class ChatRoom extends Listenable {
                 logger.warn(`Meeting Id changed from:${this.meetingId} to:${meetingId}`);
             }
             this.meetingId = meetingId;
-
-            // The name of the action is a little bit confusing but it seems this is the preferred name by the consumers
-            // of the analytics events.
-            Statistics.sendAnalytics(createConferenceEvent('joined', { meetingId }));
+            this.eventEmitter.emit(XMPPEvents.MEETING_ID_SET, meetingId);
         }
     }
 

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -99,6 +99,11 @@ const XMPPEvents = {
     // Designates an event indicating that our role in the XMPP MUC has changed.
     LOCAL_ROLE_CHANGED: 'xmpp.localrole_changed',
 
+    /**
+     * Event fired when the unique meeting id is set.
+     */
+    MEETING_ID_SET: 'xmpp.meeting_id_set',
+
     // Designates an event indicating that an XMPP message in the MUC was
     // received.
     MESSAGE_RECEIVED: 'xmpp.message_received',


### PR DESCRIPTION

Send conference.join event only after the peer connection is created.
This way we won't send events for lonely calls.