### PR TITLE
API.md - Important Mention of Add Local Track to Conference

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -511,7 +511,9 @@ room.on(JitsiMeetJS.events.conference.CONFERENCE_JOINED, onConferenceJoined);
 
 5. You also may want to get your local tracks from the camera and microphone:
 ```javascript
-JitsiMeetJS.createLocalTracks().then(onLocalTracks);
+JitsiMeetJS.createLocalTracks().then(localTracks => {
+  room.addTrack(localTracks[0]);
+});
 ```
 
 NOTE: Adding listeners and creating local streams are not mandatory steps.

--- a/doc/API.md
+++ b/doc/API.md
@@ -512,6 +512,7 @@ room.on(JitsiMeetJS.events.conference.CONFERENCE_JOINED, onConferenceJoined);
 5. You also may want to get your local tracks from the camera and microphone:
 ```javascript
 JitsiMeetJS.createLocalTracks().then(localTracks => {
+  // You can share the local track with other participants by adding it to the room:
   room.addTrack(localTracks[0]);
 });
 ```


### PR DESCRIPTION
In most use cases, the developer will want to add the newly acquired local track to the room.

As this is extremely common and required to actually share the track with others I would like to recommend that step 5 quickly mentions this.

This furthermore makes it clear that createLocalTracks() does not automatically do anything like this.

With this added, these steps now produce a visible result (excellent for a "hello world" demonstration)