### PR TITLE
rtc: remove default aspect ratio constraint

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -55,7 +55,6 @@ const OLD_GUM_DEFAULT_DEVICES = [ 'audio', 'video' ];
  */
 const DEFAULT_CONSTRAINTS = {
     video: {
-        aspectRatio: 16 / 9,
         height: {
             ideal: 720,
             max: 720,


### PR DESCRIPTION
Some devies may not be able to satisfy it and gUM will fail. Tested with a
crappy old camera which can only do VGA resolution at 4/3 aspect ratio.