### PR TITLE
fix(XmppConnection): use 'search' instead of 'searchParams'

### DIFF
--- a/modules/xmpp/XmppConnection.js
+++ b/modules/xmpp/XmppConnection.js
@@ -454,8 +454,11 @@ export default class XmppConnection extends Listenable {
                 logger.info('Trying to resume the XMPP connection');
 
                 const url = new URL(this._stropheConn.service);
+                let { search } = url;
 
-                url.searchParams.set('previd', resumeToken);
+                search += search.indexOf('?') === -1 ? `?previd=${resumeToken}` : `&previd=${resumeToken}`;
+
+                url.search = search;
 
                 this._stropheConn.service = url.toString();
 


### PR DESCRIPTION
The 'searchParams' are not implemented on react-native.