### PR TITLE
fix(strophe.jingle.js): exception on ICE config modification

### DIFF
--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -149,6 +149,9 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
             logger.info(
                 `Marking session from ${fromJid
                 } as ${isP2P ? '' : '*not*'} P2P`);
+
+            const iceConfig = isP2P ? this.p2pIceConfig : this.jvbIceConfig;
+
             sess
                 = new JingleSessionPC(
                     $(iq).find('jingle').attr('sid'),
@@ -156,7 +159,10 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
                     fromJid,
                     this.connection,
                     this.mediaConstraints,
-                    isP2P ? this.p2pIceConfig : this.jvbIceConfig,
+
+                    // Makes a copy in order to prevent exception thrown on RN when either this.p2pIceConfig or
+                    // this.jvbIceConfig is modified and there's a PeerConnection instance holding a reference
+                    JSON.parse(JSON.stringify(iceConfig)),
                     isP2P,
                     /* initiator */ false);
 


### PR DESCRIPTION
If ICE config object gets modified while there's any native
PeerConnection instance holding a reference, it will cause
an exception about final object being modified.

It happens when trying to reconnect XMPP Websocket on RN and
is caused by the fact that new TURN config is fetched after
the connection is re-established.