### PR TITLE
fix: Uncaught TypeError: CreateListFromArrayLike called on non-object

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sdp-transform": "2.3.0",
     "strophe.js": "1.3.4",
     "strophejs-plugin-disco": "0.0.2",
-    "strophejs-plugin-stream-management": "github:jitsi/strophejs-plugin-stream-management#cec7608601c1bc098543823fc658e3ddf758c009",
+    "strophejs-plugin-stream-management": "github:jitsi/strophejs-plugin-stream-management#e719a02b4f83856c1530882084a4b048ee622d45",
     "webrtc-adapter": "7.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
         at o._interceptDoDisconnect (strophe.stream-management.js:207)
         at P.Connection._dataRecv (strophe.umd.js:3140)
         at I.Bosh._onRequestStateChange (strophe.umd.js:5012)

Update strophejs-plugin-stream-management to fix the crash for
the stacktrace above. It happens only with BOSH.

<img width="1626" alt="Screenshot 2020-04-06 20 29 06" src="https://user-images.githubusercontent.com/2965063/78620565-f6fbe000-7845-11ea-97cb-5ddcc50c9ff4.png">
