### PR TITLE
feat(Safari): Add unified plan support for Safari

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -179,7 +179,7 @@ function getConstraints(um, options = {}) {
     // @see https://github.com/jitsi/lib-jitsi-meet/pull/136
     const isNewStyleConstraintsSupported
         = browser.isFirefox()
-            || browser.isSafariWithVP8()
+            || browser.isSafari()
             || browser.isReactNative();
 
     if (um.indexOf('video') >= 0) {
@@ -1435,7 +1435,7 @@ class RTCUtils extends Listenable {
     isDeviceChangeAvailable(deviceType) {
         return deviceType === 'output' || deviceType === 'audiooutput'
             ? isAudioOutputDeviceChangeAvailable
-            : !browser.isSafariWithVP8();
+            : !browser.isSafari();
     }
 
     /**

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -142,6 +142,8 @@ const ScreenObtainer = {
 
             // Legacy Firefox
             return this.obtainScreenOnFirefox;
+        } else if (browser.isSafari() && browser.supportsGetDisplayMedia()) {
+            return this.obtainScreenFromGetDisplayMedia;
         }
 
         logger.log(

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -193,8 +193,7 @@ export class TPCUtils {
     /**
      * Adds a track on the RTCRtpSender as part of the unmute operation.
      * @param {JitsiLocalTrack} localTrack - track to be unmuted.
-     * @returns {boolean} Returns true if the operation is successful,
-     * false otherwise.
+     * @returns {Promise<void>}
      */
     addTrackUnmute(localTrack) {
         const mediaType = localTrack.getType();
@@ -222,24 +221,17 @@ export class TPCUtils {
 
             return true;
         }
-        transceiver.sender.replaceTrack(track)
+
+        return transceiver.sender.replaceTrack(track)
             .then(() => {
                 this.pc.localTracks.set(localTrack.rtcId, localTrack);
-
-                return true;
-            })
-            .catch(err => {
-                logger.error(`Unmute track failed for ${mediaType} track on ${this.pc}, ${err}`);
-
-                return false;
             });
     }
 
     /**
      * Removes the track from the RTCRtpSender as part of the mute operation.
      * @param {JitsiLocalTrack} localTrack - track to be removed.
-     * @returns {boolean} Returns true if the operation is successful,
-     * false otherwise.
+     * @returns {Promise<void>}
      */
     removeTrackMute(localTrack) {
         const mediaType = localTrack.getType();
@@ -253,17 +245,10 @@ export class TPCUtils {
         }
 
         logger.debug(`Removing ${localTrack} on ${this.pc}`);
-        transceiver.sender.replaceTrack(null)
+
+        return transceiver.sender.replaceTrack(null)
             .then(() => {
                 this.pc.localTracks.delete(localTrack.rtcId);
-                this.pc.localSSRCs.delete(localTrack.rtcId);
-
-                return true;
-            })
-            .catch(err => {
-                logger.error(`Mute track failed for ${mediaType} track on ${this.pc}, ${err}`);
-
-                return false;
             });
     }
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1477,8 +1477,9 @@ TraceablePeerConnection.prototype.addTrack = function(track, isInitiator = false
  * Adds local track as part of the unmute operation.
  * @param {JitsiLocalTrack} track the track to be added as part of the unmute
  * operation
- * @return {boolean} <tt>true</tt> if the state of underlying PC has changed and
- * the renegotiation is required or <tt>false</tt> otherwise.
+ * @return {Promise<boolean>} Promise that resolves to true if the underlying PeerConnection's
+ * state has changed and renegotiation is required, false if no renegotiation is needed or
+ * Promise is rejected when something goes wrong.
  */
 TraceablePeerConnection.prototype.addTrackUnmute = function(track) {
     if (browser.usesUnifiedPlan()) {
@@ -1486,7 +1487,7 @@ TraceablePeerConnection.prototype.addTrackUnmute = function(track) {
     }
     if (!this._assertTrackBelongs('addTrackUnmute', track)) {
         // Abort
-        return false;
+        return Promise.reject('Track not found on the peerconnection');
     }
 
     logger.info(`Adding ${track} as unmute to ${this}`);
@@ -1496,11 +1497,11 @@ TraceablePeerConnection.prototype.addTrackUnmute = function(track) {
         logger.error(
             `Unable to add ${track} as unmute to ${this} - no WebRTC stream`);
 
-        return false;
+        return Promise.reject('Stream not found');
     }
     this._addStream(webRtcStream);
 
-    return true;
+    return Promise.resolve(true);
 };
 
 /**
@@ -1654,8 +1655,9 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
  * Removes local track as part of the mute operation.
  * @param {JitsiLocalTrack} localTrack the local track to be remove as part of
  * the mute operation.
- * @return {boolean} <tt>true</tt> if the underlying PeerConnection's state has
- * changed and the renegotiation is required or <tt>false</tt> otherwise.
+ * @return {Promise<boolean>} Promise that resolves to true if the underlying PeerConnection's
+ * state has changed and renegotiation is required, false if no renegotiation is needed or
+ * Promise is rejected when something goes wrong.
  */
 TraceablePeerConnection.prototype.removeTrackMute = function(localTrack) {
     if (browser.usesUnifiedPlan()) {
@@ -1669,19 +1671,19 @@ TraceablePeerConnection.prototype.removeTrackMute = function(localTrack) {
 
     if (!this._assertTrackBelongs('removeStreamMute', localTrack)) {
         // Abort - nothing to be done here
-        return false;
+        return Promise.reject('Track not found in the peerconnection');
     }
     if (webRtcStream) {
         logger.info(
             `Removing ${localTrack} as mute from ${this}`);
         this._removeStream(webRtcStream);
 
-        return true;
+        return Promise.resolve(true);
     }
 
     logger.error(`removeStreamMute - no WebRTC stream for ${localTrack}`);
 
-    return false;
+    return Promise.reject('Stream not found');
 };
 
 /**

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1481,15 +1481,15 @@ TraceablePeerConnection.prototype.addTrack = function(track, isInitiator = false
  * the renegotiation is required or <tt>false</tt> otherwise.
  */
 TraceablePeerConnection.prototype.addTrackUnmute = function(track) {
+    if (browser.usesUnifiedPlan()) {
+        return this.tpcUtils.addTrackUnmute(track);
+    }
     if (!this._assertTrackBelongs('addTrackUnmute', track)) {
         // Abort
         return false;
     }
 
     logger.info(`Adding ${track} as unmute to ${this}`);
-    if (browser.usesUnifiedPlan()) {
-        return this.tpcUtils.addTrackUnmute(track);
-    }
     const webRtcStream = track.getOriginalStream();
 
     if (!webRtcStream) {
@@ -1658,6 +1658,9 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
  * changed and the renegotiation is required or <tt>false</tt> otherwise.
  */
 TraceablePeerConnection.prototype.removeTrackMute = function(localTrack) {
+    if (browser.usesUnifiedPlan()) {
+        return this.tpcUtils.removeTrackMute(localTrack);
+    }
     const webRtcStream = localTrack.getOriginalStream();
 
     this.trace(
@@ -1667,9 +1670,6 @@ TraceablePeerConnection.prototype.removeTrackMute = function(localTrack) {
     if (!this._assertTrackBelongs('removeStreamMute', localTrack)) {
         // Abort - nothing to be done here
         return false;
-    }
-    if (browser.usesUnifiedPlan()) {
-        return this.tpcUtils.removeTrackMute(localTrack);
     }
     if (webRtcStream) {
         logger.info(
@@ -2458,8 +2458,7 @@ TraceablePeerConnection.prototype.getStats = function(callback, errback) {
     // TODO (brian): After moving all browsers to adapter, check if adapter is
     // accounting for different getStats apis, making the browser-checking-if
     // unnecessary.
-    if (browser.isSafariWithWebrtc() || browser.isFirefox()
-            || browser.isReactNative()) {
+    if (browser.isSafari() || browser.isFirefox() || browser.isReactNative()) {
         // uses the new Promise based getStats
         this.peerconnection.getStats()
             .then(callback)

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -30,7 +30,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * strategy or <tt>false</tt> otherwise.
      */
     doesVideoMuteByStreamRemove() {
-        return this.isChromiumBased();
+        return this.isChromiumBased() || this.isSafari();
     }
 
     /**
@@ -62,28 +62,6 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
-     * Checks if current browser is a Safari and a version of Safari that
-     * supports native webrtc.
-     *
-     * @returns {boolean}
-     */
-    isSafariWithWebrtc() {
-        return this.isSafari()
-            && !this.isVersionLessThan('11');
-    }
-
-    /**
-     * Checks if current browser is a Safari and a version of Safari that
-     * supports VP8.
-     *
-     * @returns {boolean}
-     */
-    isSafariWithVP8() {
-        return this.isSafari()
-            && !this.isVersionLessThan('12.1');
-    }
-
-    /**
      * Checks if the current browser is supported.
      *
      * @returns {boolean} true if the browser is supported, false otherwise.
@@ -92,7 +70,7 @@ export default class BrowserCapabilities extends BrowserDetection {
         return this.isChromiumBased()
             || this.isFirefox()
             || this.isReactNative()
-            || this.isSafariWithWebrtc();
+            || (this.isSafari() && !this.isVersionLessThan('12.1'));
     }
 
     /**
@@ -112,8 +90,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * otherwise.
      */
     supportsVideoMuteOnConnInterrupted() {
-        return this.isChromiumBased() || this.isReactNative()
-            || this.isSafariWithVP8();
+        return this.isChromiumBased() || this.isReactNative() || this.isSafari();
     }
 
     /**
@@ -124,7 +101,7 @@ export default class BrowserCapabilities extends BrowserDetection {
     supportsBandwidthStatistics() {
         // FIXME bandwidth stats are currently not implemented for FF on our
         // side, but not sure if not possible ?
-        return !this.isFirefox() && !this.isSafariWithWebrtc();
+        return !this.isFirefox() && !this.isSafari();
     }
 
     /**
@@ -142,8 +119,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * candidates through the legacy getStats() API.
      */
     supportsLocalCandidateRttStatistics() {
-        return this.isChromiumBased() || this.isReactNative()
-            || this.isSafariWithVP8();
+        return this.isChromiumBased() || this.isReactNative() || this.isSafari();
     }
 
     /**
@@ -169,7 +145,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     supportsRtpSender() {
-        return this.isFirefox() || this.isSafariWithVP8();
+        return this.isFirefox() || this.isSafari();
     }
 
     /**
@@ -178,7 +154,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     supportsRtx() {
-        return !this.isFirefox() && !this.usesUnifiedPlan();
+        return !this.isFirefox();
     }
 
     /**
@@ -188,14 +164,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     supportsVideo() {
-        // FIXME: Check if we can use supportsVideoOut and supportsVideoIn. I
-        // leave the old implementation here in order not to brake something.
-
-        // Older versions of Safari using webrtc/adapter do not support video
-        // due in part to Safari only supporting H264 and the bridge sending VP8
-        // Newer Safari support VP8 and other WebRTC features.
-        return !this.isSafariWithWebrtc()
-            || (this.isSafariWithVP8() && this.usesPlanB());
+        return true;
     }
 
     /**
@@ -213,7 +182,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     usesSdpMungingForSimulcast() {
-        return this.isChromiumBased() || this.isSafariWithVP8();
+        return this.isChromiumBased() || this.isSafari();
     }
 
     /**
@@ -226,7 +195,7 @@ export default class BrowserCapabilities extends BrowserDetection {
             return true;
         }
 
-        if (this.isSafariWithVP8() && typeof window.RTCRtpTransceiver !== 'undefined') {
+        if (this.isSafari() && typeof window.RTCRtpTransceiver !== 'undefined') {
             // eslint-disable-next-line max-len
             // https://trac.webkit.org/changeset/236144/webkit/trunk/LayoutTests/webrtc/video-addLegacyTransceiver.html
             // eslint-disable-next-line no-undef
@@ -252,7 +221,7 @@ export default class BrowserCapabilities extends BrowserDetection {
             return !this.isVersionLessThan(REQUIRED_CHROME_VERSION);
         }
 
-        if (this.isFirefox() || this.isSafariWithWebrtc()) {
+        if (this.isFirefox() || this.isSafari()) {
             return true;
         }
 

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -215,7 +215,7 @@ export default function StatsCollector(
      * @type {boolean}
      */
     this._usesPromiseGetStats
-        = browser.isSafariWithWebrtc() || browser.isFirefox();
+        = browser.isSafari() || browser.isFirefox();
 
     /**
      * The function which is to be used to retrieve the value associated in a


### PR DESCRIPTION
Enabled desktop sharing and discontinued support for Safari versions prior to 12.1, i.e., the ones with no VP8 support.
Get rid of isSafariWithWebrtc() and isSafariWithVP8() checks, only check for Safari >= 12.1