### PR TITLE
use 720 for height constraint on Safari to get video working

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -55,7 +55,7 @@ const OLD_GUM_DEFAULT_DEVICES = [ 'audio', 'video' ];
  */
 const DEFAULT_CONSTRAINTS = {
     video: {
-        height: {
+        height: browser.isSafari() ? OLD_GUM_DEFAULT_RESOLUTION : {
             ideal: 720,
             max: 720,
             min: 240


### PR DESCRIPTION
Without this change, the example at `doc/examples/index.html` wasn't showing video on Safari 13.1 (14609.1.20.111.8). That was because the height constraint was being set to `{ ideal: 720, max: 720, min: 240 }`, but Safari doesn't allow that, at least not on version 13.1.