### PR TITLE
fix(Firefox): Enable simulcast support on Firefox

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -42,8 +42,6 @@ const DESKSTOP_SHARE_RATE = 500000;
  * @param {boolean} options.disableSimulcast if set to 'true' will disable
  * the simulcast.
  * @param {boolean} options.disableRtx if set to 'true' will disable the RTX
- * @param {boolean} options.enableFirefoxSimulcast if set to 'true' will enable
- * experimental simulcast support on Firefox.
  * @param {boolean} options.capScreenshareBitrate if set to 'true' simulcast will
  * be disabled for screenshare and a max bitrate of 500Kbps will applied on the
  * stream.
@@ -434,7 +432,7 @@ TraceablePeerConnection.prototype._getDesiredMediaDirection = function(
  * <tt>false</tt> if it's turned off.
  */
 TraceablePeerConnection.prototype.isSimulcastOn = function() {
-    return !browser.isFirefox() && !this.options.disableSimulcast;
+    return !this.options.disableSimulcast;
 };
 
 /**

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -56,8 +56,6 @@ const DEFAULT_MAX_STATS = 300;
  * @property {boolean} p2p.preferH264 - Described in the config.js[1].
  * @property {boolean} preferH264 - Described in the config.js[1].
  * @property {Object} testing - Testing and/or experimental options.
- * @property {boolean} testing.enableFirefoxSimulcast - Described in the
- * config.js[1].
  * @property {boolean} webrtcIceUdpDisable - Described in the config.js[1].
  * @property {boolean} webrtcIceTcpDisable - Described in the config.js[1].
  *
@@ -316,8 +314,6 @@ export default class JingleSessionPC extends JingleSession {
                 = options.disableSimulcast
                     || (options.preferH264 && !options.disableH264);
             pcOptions.preferH264 = options.preferH264;
-            pcOptions.enableFirefoxSimulcast
-                = options.testing && options.testing.enableFirefoxSimulcast;
             pcOptions.enableLayerSuspension = options.enableLayerSuspension;
 
             // disable simulcast for screenshare and set the max bitrate to

--- a/package-lock.json
+++ b/package-lock.json
@@ -5498,8 +5498,8 @@
       "dev": true
     },
     "js-utils": {
-      "version": "github:jitsi/js-utils#8567f86ec2774ae1d1c47b22e3435928cf5d9771",
-      "from": "github:jitsi/js-utils#8567f86ec2774ae1d1c47b22e3435928cf5d9771",
+      "version": "github:jitsi/js-utils#df68966e3c65b5c57fcd2670da1326a2c77518d1",
+      "from": "github:jitsi/js-utils#df68966e3c65b5c57fcd2670da1326a2c77518d1",
       "requires": {
         "bowser": "2.7.0",
         "js-md5": "0.7.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "async": "0.9.0",
     "current-executing-script": "0.1.3",
     "jitsi-meet-logger": "github:jitsi/jitsi-meet-logger#5ec92357570dc8f0b7ffc1528820721c84c6af8b",
-    "js-utils": "github:jitsi/js-utils#8567f86ec2774ae1d1c47b22e3435928cf5d9771",
+    "js-utils": "github:jitsi/js-utils#df68966e3c65b5c57fcd2670da1326a2c77518d1",
     "lodash.isequal": "4.5.0",
     "sdp-transform": "2.3.0",
     "strophe.js": "1.3.4",


### PR DESCRIPTION
Get rid of the experimental flag for simulcast support, update js-utils for detecting Edge on Android