### PR TITLE
fix(xmpp): clear any last strophe errors on reconnect

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -219,7 +219,8 @@ export default class XMPP extends Listenable {
 
             logger.info(`My Jabber ID: ${this.connection.jid}`);
 
-            this.lastErrorMsg = undefined;
+            // XmppConnection emits CONNECTED again on reconnect - a good opportunity to clear any "last error" flags
+            this._resetState();
 
             // Schedule ping ?
             const pingJid = this.connection.domain;


### PR DESCRIPTION
If user experiences any failed reconnect during the entire session, even if followed by a success, then the "connectionFailed" flag will trigger JitsiConnectionEvents.CONNECTION_FAILED on hang up while processing the disconnected transition.