### PR TITLE
e2ee: generate silence in case of audio decryption errors

### DIFF
--- a/modules/e2ee/E2EEContext.js
+++ b/modules/e2ee/E2EEContext.js
@@ -314,6 +314,13 @@ export default class E2EEcontext {
                 return controller.enqueue(encodedFrame);
             }, e => {
                 logger.error(e);
+                if (encodedFrameType === undefined) { // audio, replace with silence.
+                    const newData = new ArrayBuffer(3);
+                    const newUint8 = new Uint8Array(newData);
+
+                    newUint8.set([ 0xd8, 0xff, 0xfe ]); // opus silence frame.
+                    encodedFrame.data = newData;
+                }
 
                 // Just feed the (potentially encrypted) frame in case of error.
                 // Worst case it is garbage.


### PR DESCRIPTION
This handles decryption errors for audio differently than the
current version. Instead of forwarding horrible noise to the decoder,
replace the bytes with magic opus bytes for silence:
```
0xd8fffe
```

Those bytes were captured on a modified version of
  https://webrtc.github.io/samples/src/content/peerconnection/endtoend-encryption/
with more dumping and after disabling the track.