### PR TITLE
Fix protocol replace for websocket keep-alive

### DIFF
--- a/modules/xmpp/XmppConnection.js
+++ b/modules/xmpp/XmppConnection.js
@@ -325,7 +325,7 @@ export default class XmppConnection extends Listenable {
             logger.debug(`Scheduling next WebSocket keep-alive in ${intervalWithJitter}ms`);
 
             this._wsKeepAlive = setTimeout(() => {
-                const url = this.service.replace('wss', 'https').replace('ws', 'http');
+                const url = this.service.replace('wss://', 'https://').replace('ws://', 'http://');
 
                 fetch(url).catch(
                     error => {


### PR DESCRIPTION
This code fixes a problem we get, when our url of service contains 'ws' symbols inside domain name. Our service url looks like 'wss://vs.myws.com' - In this case keep-alive will fail because of incorrect replace: 'https://vs.myhttp.com'. This pull request should fix this problem.

