### PR TITLE
fix(safari): construct track constraints from getSettings

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -96,6 +96,14 @@ export default class JitsiLocalTrack extends JitsiTrack {
             // Cache the constraints of the track in case of any this track
             // model needs to call getUserMedia again, such as when unmuting.
             this._constraints = track.getConstraints();
+
+            // Safari returns an empty constraints object, construct the constraints using getSettings.
+            if (!Object.keys(this._constraints).length && videoType === VideoType.CAMERA) {
+                this._constraints = {
+                    height: track.getSettings().height,
+                    width: track.getSettings().width
+                };
+            }
         } else {
             // FIXME Currently, Firefox is ignoring our constraints about
             // resolutions so we do not store it, to avoid wrong reporting of

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1435,7 +1435,7 @@ class RTCUtils extends Listenable {
     isDeviceChangeAvailable(deviceType) {
         return deviceType === 'output' || deviceType === 'audiooutput'
             ? isAudioOutputDeviceChangeAvailable
-            : !browser.isSafari();
+            : true;
     }
 
     /**


### PR DESCRIPTION
MediaStreamTrack getConstraints on Safari returns an empty object.
Enable device selection on Safari.