### PR TITLE
e2ee: don't pass plain frames to decoder if we are encrypting

### DIFF
--- a/modules/e2ee/E2EEContext.js
+++ b/modules/e2ee/E2EEContext.js
@@ -341,6 +341,13 @@ export default class E2EEcontext {
                     controller.enqueue(encodedFrame);
                 }
             });
+        } else if (keyIndex >= this._cryptoKeyRing.length
+                && this._cryptoKeyRing[this._currentKeyIndex % this._cryptoKeyRing.length]) {
+            // If we are encrypting but don't have a key for the remote drop the frame.
+            // This is a heuristic since we don't know whether a packet is encrypted,
+            // do not have a checksum and do not have signaling for whether a remote participant does
+            // encrypt or not.
+            return;
         }
 
         // TODO: this just passes through to the decoder. Is that ok? If we don't know the key yet


### PR DESCRIPTION
If we are encrypting and the key index from a (potentially unencrypted)
frame exceeds our key ring size (1 currently) drop the frame.

This is a heuristic. We currently don't have the signaling for whether a
remote end does encrypt its frames or not.