### PR TITLE
feat(video-quality): control the sender resolution based on video quality settings

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -235,6 +235,12 @@ export default function JitsiConference(options) {
     this.recordingManager = new RecordingManager(this.room);
     this._conferenceJoinAnalyticsEventSent = false;
 
+    /**
+     * Max frame height that the user prefers to send to the remote participants.
+     * @type {number}
+     */
+    this.maxFrameHeight = null;
+
     if (browser.supportsInsertableStreams()) {
         this._e2eeCtx = new E2EEContext({ salt: this.options.name });
     }
@@ -1879,6 +1885,13 @@ JitsiConference.prototype._acceptJvbIncomingCall = function(
                 // to be turned off here.
                 if (this.isP2PActive() && this.jvbJingleSession) {
                     this._suspendMediaTransferForJvbConnection();
+                } else if (this.jvbJingleSession && this.maxFrameHeight) {
+                    // Apply user preferred max frame height if it was called before this
+                    // jingle session was created.
+                    this.jvbJingleSession.setSenderVideoConstraint(this.maxFrameHeight)
+                        .catch(err => {
+                            logger.error(`Sender video constraints failed on jvb session - ${err}`);
+                        });
                 }
 
                 // Setup E2EE.
@@ -2644,6 +2657,15 @@ JitsiConference.prototype._acceptP2PIncomingCall = function(
         () => {
             logger.debug('Got RESULT for P2P "session-accept"');
 
+            // Apply user preferred max frame height if it was called before this
+            // jingle session was created.
+            if (this.pendingVideoConstraintsOnP2P) {
+                this.p2pJingleSession.setSenderVideoConstraint(this.maxFrameHeight)
+                    .catch(err => {
+                        logger.error(`Sender video constraints failed on p2p session - ${err}`);
+                    });
+            }
+
             // Setup E2EE.
             for (const track of localTracks) {
                 this._setupSenderE2EEForTrack(jingleSession, track);
@@ -3269,12 +3291,18 @@ JitsiConference.prototype.setReceiverVideoConstraint = function(
  * successful and rejected otherwise.
  */
 JitsiConference.prototype.setSenderVideoConstraint = function(maxFrameHeight) {
+    this.maxFrameHeight = maxFrameHeight;
+    this.pendingVideoConstraintsOnP2P = true;
     const promises = [];
 
+    // We have to always set the sender video constraints on the jvb connection
+    // when we switch from p2p to jvb connection since we need to check if the
+    // tracks constraints have been modified when in p2p.
     if (this.jvbJingleSession) {
         promises.push(this.jvbJingleSession.setSenderVideoConstraint(maxFrameHeight));
     }
     if (this.p2pJingleSession) {
+        this.pendingVideoConstraintsOnP2P = false;
         promises.push(this.p2pJingleSession.setSenderVideoConstraint(maxFrameHeight));
     }
 

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3262,6 +3262,26 @@ JitsiConference.prototype.setReceiverVideoConstraint = function(
 };
 
 /**
+ * Sets the maximum video size the local participant should send to remote
+ * participants.
+ * @param {number} maxFrameHeight - The user preferred max frame height.
+ * @returns {Promise} promise that will be resolved when the operation is
+ * successful and rejected otherwise.
+ */
+JitsiConference.prototype.setSenderVideoConstraint = function(maxFrameHeight) {
+    const promises = [];
+
+    if (this.jvbJingleSession) {
+        promises.push(this.jvbJingleSession.setSenderVideoConstraint(maxFrameHeight));
+    }
+    if (this.p2pJingleSession) {
+        promises.push(this.p2pJingleSession.setSenderVideoConstraint(maxFrameHeight));
+    }
+
+    return Promise.all(promises);
+};
+
+/**
  * Creates a video SIP GW session and returns it if service is enabled. Before
  * creating a session one need to check whether video SIP GW service is
  * available in the system {@link JitsiConference.isVideoSIPGWAvailable}. Even

--- a/doc/API.md
+++ b/doc/API.md
@@ -406,7 +406,9 @@ Throws NetworkError or InvalidStateError or Error if the operation fails.
 34. setReceiverVideoConstraint(resolution) - set the desired resolution to get from JVB (180, 360, 720, 1080, etc).
     You should use that method if you are using simulcast.
 
-35. isHidden - checks if local user has joined as a "hidden" user. This is a specialized role used for integrations.
+35. setSenderVideoConstraint(resolution) - set the desired resolution to send to JVB or the peer (180, 360, 720).
+
+36. isHidden - checks if local user has joined as a "hidden" user. This is a specialized role used for integrations.
 
 JitsiTrack
 ======

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -506,7 +506,6 @@ export default class JitsiLocalTrack extends JitsiTrack {
             if (this.track) {
                 this.track.enabled = !muted;
             }
-            this.emit(TRACK_MUTE_CHANGED, this);
         } else if (muted) {
             promise = new Promise((resolve, reject) => {
                 logMuteInfo();
@@ -522,7 +521,6 @@ export default class JitsiLocalTrack extends JitsiTrack {
                         this._unregisterHandlers();
                         this.stopStream();
                         this._setStream(null);
-                        this.emit(TRACK_MUTE_CHANGED, this);
                         resolve();
                     },
                     reject);
@@ -553,7 +551,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
                     = RTCUtils.obtainAudioAndVideoPermissions(streamOptions);
             }
 
-            promise.then(streamsInfo => {
+            promise = promise.then(streamsInfo => {
                 // The track kind for presenter track is video as well.
                 const mediaType = this.getType() === MediaType.PRESENTER ? MediaType.VIDEO : this.getType();
                 const streamInfo
@@ -586,13 +584,13 @@ export default class JitsiLocalTrack extends JitsiTrack {
                 this.containers.map(
                     cont => RTCUtils.attachMediaStream(cont, this.stream));
 
-                return this._addStreamToConferenceAsUnmute()
-                    .then(() => this.emit(TRACK_MUTE_CHANGED, this));
+                return this._addStreamToConferenceAsUnmute();
             });
         }
 
         return promise
-            .then(() => this._sendMuteStatus(muted));
+            .then(() => this._sendMuteStatus(muted))
+            .then(() => this.emit(TRACK_MUTE_CHANGED, this));
     }
 
     /**

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -506,6 +506,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
             if (this.track) {
                 this.track.enabled = !muted;
             }
+            this.emit(TRACK_MUTE_CHANGED, this);
         } else if (muted) {
             promise = new Promise((resolve, reject) => {
                 logMuteInfo();
@@ -521,6 +522,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
                         this._unregisterHandlers();
                         this.stopStream();
                         this._setStream(null);
+                        this.emit(TRACK_MUTE_CHANGED, this);
                         resolve();
                     },
                     reject);
@@ -584,13 +586,13 @@ export default class JitsiLocalTrack extends JitsiTrack {
                 this.containers.map(
                     cont => RTCUtils.attachMediaStream(cont, this.stream));
 
-                return this._addStreamToConferenceAsUnmute();
+                return this._addStreamToConferenceAsUnmute()
+                    .then(() => this.emit(TRACK_MUTE_CHANGED, this));
             });
         }
 
         return promise
-            .then(() => this._sendMuteStatus(muted))
-            .then(() => this.emit(TRACK_MUTE_CHANGED, this));
+            .then(() => this._sendMuteStatus(muted));
     }
 
     /**

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1329,6 +1329,16 @@ export default class JingleSessionPC extends JingleSession {
     }
 
     /**
+     * Sets the resolution constraint on the local camera track.
+     * @param {number} maxFrameHeight - The user preferred max frame height.
+     * @returns {Promise} promise that will be resolved when the operation is
+     * successful and rejected otherwise.
+     */
+    setSenderVideoConstraint(maxFrameHeight) {
+        return this.peerconnection.setSenderVideoConstraint(maxFrameHeight);
+    }
+
+    /**
      * @inheritDoc
      */
     terminate(success, failure, options) {


### PR DESCRIPTION
For simulcast case, enable the stream encodings that have a resolution <= user setting.
For non-simulcast case, use applyConstraints to change the resolution of the stream.

This currently doesn't work on FF in the simulcast case 
https://bugzilla.mozilla.org/show_bug.cgi?id=1401592 is implementation bug for bringing RTCRtpParameters/setParameters/getParameters up to spec. I will open a new bug for this specific case and update it here.