### PR TITLE
feat(video-quality): fix for mobile

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -182,6 +182,10 @@ export class TPCUtils {
      * @returns {void}
      */
     _setSimulcastStreamConstraints(track) {
+        if (browser.isReactNative()) {
+            return;
+        }
+
         const height = track.getSettings().height;
 
         for (const encoding in this.simulcastEncodings) {

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1494,6 +1494,7 @@ TraceablePeerConnection.prototype.addTrack = function(track, isInitiator = false
             this.rtxModifier.setSsrcCache(rtxSsrcMapping);
         }
     }
+
     if (browser.usesUnifiedPlan() && !browser.usesSdpMungingForSimulcast()) {
         this.tpcUtils.setEncodings(track);
     }


### PR DESCRIPTION
MediaStreamTrack.getSettings is not implemented.