### PR TITLE
fix(safari): Do not reuse inactive m-lines

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -419,7 +419,9 @@ JitsiConference.prototype._init = function(options = {}) {
         }
     }
 
-    if (config.enableNoisyMicDetection) {
+    // Disable noisy mic detection on safari since it causes the audio input to
+    // fail on Safari on iPadOS.
+    if (config.enableNoisyMicDetection && !browser.isSafari()) {
         if (config.createVADProcessor) {
             if (!this._audioAnalyser) {
                 this._audioAnalyser = new VADAudioAnalyser(this, config.createVADProcessor);

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1624,8 +1624,13 @@ export default class JingleSessionPC extends JingleSession {
                     if (mid > -1) {
                         remoteSdp.media[mid] = remoteSdp.media[mid].replace(`${line}\r\n`, '');
 
-                        // Change the direction to "inactive".
-                        remoteSdp.media[mid] = remoteSdp.media[mid].replace('a=sendonly', 'a=inactive');
+                        // Change the direction to "inactive" only on Firefox. Audio fails on
+                        // Safari (possibly Chrome in unified plan mode) when we try to re-use inactive
+                        // m-lines due to a webkit bug.
+                        // https://bugs.webkit.org/show_bug.cgi?id=211181
+                        if (browser.isFirefox()) {
+                            remoteSdp.media[mid] = remoteSdp.media[mid].replace('a=sendonly', 'a=inactive');
+                        }
                     }
                 });
             }


### PR DESCRIPTION
Audio fails on Safari when we try to re-use audio m-lines whose direction has been set to 'inactive'
when the remote source left the conference.
Disable noisy mic detection on Safari as this causes audio input to fail on Safari on iPadOS