### PR TITLE
fix(ice-failed): initial ICE failure

### DIFF
--- a/modules/connectivity/IceFailedNotification.js
+++ b/modules/connectivity/IceFailedNotification.js
@@ -35,17 +35,19 @@ export default class IceFailedNotification {
                     return;
                 }
 
-                if (this._conference.isJvbConnectionInterrupted) {
+                const jvbConnection = this._conference.jvbJingleSession;
+                const jvbConnIceState = jvbConnection && jvbConnection.getIceConnectionState();
+
+                if (!jvbConnection) {
+                    logger.warn('Not sending ICE failed - no JVB connection');
+                } else if (jvbConnIceState === 'connected') {
+                    logger.info('ICE connection restored - not sending ICE failed');
+                } else {
                     this._iceFailedTimeout = window.setTimeout(() => {
-                        logger.info(
-                            'Sending ICE failed'
-                            + ' - the connection has not recovered');
+                        logger.info(`Sending ICE failed - the connection has not recovered: ${jvbConnIceState}`);
                         this._iceFailedTimeout = undefined;
                         session.sendIceFailedNotification();
                     }, 2000);
-                } else {
-                    logger.info(
-                        'ICE connection restored - not sending ICE failed');
                 }
             },
             error => {

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -2336,7 +2336,7 @@ export default class JingleSessionPC extends JingleSession {
      * @returns the ice connection state for the peer connection.
      */
     getIceConnectionState() {
-        return this.peerconnection.iceConnectionState;
+        return this.peerconnection.getConnectionState();
     }
 
     /**


### PR DESCRIPTION
Switches from using JitsiConference.isJvbConnectionInterrupted flag to peerconnection's ICE state. The interrupted flag is not set if the connection fails initially.