### PR TITLE
Initial implementation of lobby rooms.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3436,12 +3436,11 @@ JitsiConference.prototype.isMembersOnly = function() {
 /**
  * Enables lobby by moderators
  *
- * @param {string} password shared password that can be used to skip lobby waiting.
  * @returns {Promise} resolves when lobby room is joined or rejects with the error.
  */
-JitsiConference.prototype.enableLobby = function(password) {
+JitsiConference.prototype.enableLobby = function() {
     if (this.room && this.isModerator()) {
-        return this.room.getLobby().enable(password);
+        return this.room.getLobby().enable();
     }
 
     return Promise.reject(
@@ -3464,12 +3463,11 @@ JitsiConference.prototype.disableLobby = function() {
  *
  * @param {string} displayName Display name should be set to show it to moderators.
  * @param {string} email Optional email is used to present avatar to the moderator.
- * @param {string} password Shared password can be used to skip waiting in the lobby room.
  * @returns {Promise<never>}
  */
-JitsiConference.prototype.joinLobby = function(displayName, email, password) {
+JitsiConference.prototype.joinLobby = function(displayName, email) {
     if (this.room) {
-        return this.room.getLobby().join(displayName, email, password);
+        return this.room.getLobby().join(displayName, email);
     }
 
     return Promise.reject(new Error('The conference not started'));

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3412,6 +3412,78 @@ JitsiConference.prototype.setE2EEKey = function(key) {
 };
 
 /**
+ * Returns <tt>true</tt> if lobby support is enabled in the backend.
+ *
+ * @returns {boolean} whether lobby is supported in the backend.
+ */
+JitsiConference.prototype.isLobbySupported = function() {
+    return Boolean(this.room && this.room.getLobby().isLobbySupported());
+};
+
+/**
+ * Enables lobby by moderators
+ *
+ * @param {string} password shared password that can be used to skip lobby waiting.
+ * @returns {Promise} resolves when lobby room is joined or rejects with the error.
+ */
+JitsiConference.prototype.enableLobby = function(password) {
+    if (this.room && this.isModerator()) {
+        return this.room.getLobby().enableLobby(password);
+    }
+
+    return Promise.reject(
+        new Error('The conference not started or user is not moderator'));
+};
+
+/**
+ * Disabled lobby by moderators
+ *
+ * @returns {void}
+ */
+JitsiConference.prototype.disableLobby = function() {
+    if (this.room && this.isModerator()) {
+        this.room.getLobby().disableLobby();
+    }
+};
+
+/**
+ * Joins the lobby room with display name and optional email or with a shared password to skip waiting.
+ *
+ * @param {string} displayName Display name should be set to show it to moderators.
+ * @param {string} email Optional email is used to present avatar to the moderator.
+ * @param {string} password Shared password can be used to skip waiting in the lobby room.
+ * @returns {Promise<never>}
+ */
+JitsiConference.prototype.joinLobby = function(displayName, email, password) {
+    if (this.room) {
+        return this.room.getLobby().joinLobbyRoom(displayName, email, password);
+    }
+
+    return Promise.reject(new Error('The conference not started'));
+};
+
+/**
+ * Denies access to the conference in a participant waiting in the lobby.
+ * @param {string} id The participant id.
+ */
+JitsiConference.prototype.lobbyDenyAccess = function(id) {
+    if (this.room) {
+        this.room.getLobby().denyAccess(id);
+    }
+};
+
+/**
+ * Approves the request to join the conference to a participant waiting in the lobby.
+ *
+ * @param {string} id The participant id.
+ */
+JitsiConference.prototype.lobbyApproveAccess = function(id) {
+    if (this.room) {
+        this.room.getLobby().approveAccess(id);
+    }
+};
+
+/**
  * Setup E2EE for the sending side, if supported.
  * Note that this is only done for the JVB Peer Connecction.
  *

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3463,7 +3463,7 @@ JitsiConference.prototype.joinLobby = function(displayName, email, password) {
 };
 
 /**
- * Denies access to the conference in a participant waiting in the lobby.
+ * Denies an occupant in the lobby room access to the conference.
  * @param {string} id The participant id.
  */
 JitsiConference.prototype.lobbyDenyAccess = function(id) {

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3421,6 +3421,15 @@ JitsiConference.prototype.isLobbySupported = function() {
 };
 
 /**
+ * Returns <tt>true</tt> if the room has members only enabled.
+ *
+ * @returns {boolean} whether conference room is members only.
+ */
+JitsiConference.prototype.isMembersOnly = function() {
+    return Boolean(this.room && this.room.membersOnlyEnabled);
+};
+
+/**
  * Enables lobby by moderators
  *
  * @param {string} password shared password that can be used to skip lobby waiting.

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3417,7 +3417,7 @@ JitsiConference.prototype.setE2EEKey = function(key) {
  * @returns {boolean} whether lobby is supported in the backend.
  */
 JitsiConference.prototype.isLobbySupported = function() {
-    return Boolean(this.room && this.room.getLobby().isLobbySupported());
+    return Boolean(this.room && this.room.getLobby().isSupported());
 };
 
 /**
@@ -3428,7 +3428,7 @@ JitsiConference.prototype.isLobbySupported = function() {
  */
 JitsiConference.prototype.enableLobby = function(password) {
     if (this.room && this.isModerator()) {
-        return this.room.getLobby().enableLobby(password);
+        return this.room.getLobby().enable(password);
     }
 
     return Promise.reject(
@@ -3442,7 +3442,7 @@ JitsiConference.prototype.enableLobby = function(password) {
  */
 JitsiConference.prototype.disableLobby = function() {
     if (this.room && this.isModerator()) {
-        this.room.getLobby().disableLobby();
+        this.room.getLobby().disable();
     }
 };
 
@@ -3456,7 +3456,7 @@ JitsiConference.prototype.disableLobby = function() {
  */
 JitsiConference.prototype.joinLobby = function(displayName, email, password) {
     if (this.room) {
-        return this.room.getLobby().joinLobbyRoom(displayName, email, password);
+        return this.room.getLobby().join(displayName, email, password);
     }
 
     return Promise.reject(new Error('The conference not started'));

--- a/JitsiConferenceErrors.js
+++ b/JitsiConferenceErrors.js
@@ -34,6 +34,18 @@ export const CONNECTION_ERROR = 'conference.connectionError';
 export const NOT_ALLOWED_ERROR = 'conference.connectionError.notAllowed';
 
 /**
+ * Indicates that a connection error is due to not allowed,
+ * occurred when trying to join a conference, only approved members are allowed to join.
+ */
+export const MEMBERS_ONLY_ERROR = 'conference.connectionError.membersOnly';
+
+/**
+ * Indicates that a connection error is due to denied access to the room,
+ * occurred after joining a lobby room and access is denied by the room moderators.
+ */
+export const CONFERENCE_ACCESS_DENIED = 'conference.connectionError.accessDenied';
+
+/**
  * Indicates that focus error happened.
  */
 export const FOCUS_DISCONNECTED = 'conference.focusDisconnected';

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -159,6 +159,9 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
     this.chatRoomForwarder.forward(XMPPEvents.ROOM_CONNECT_NOT_ALLOWED_ERROR,
         JitsiConferenceEvents.CONFERENCE_FAILED,
         JitsiConferenceErrors.NOT_ALLOWED_ERROR);
+    this.chatRoomForwarder.forward(XMPPEvents.ROOM_CONNECT_MEMBERS_ONLY_ERROR,
+        JitsiConferenceEvents.CONFERENCE_FAILED,
+        JitsiConferenceErrors.MEMBERS_ONLY_ERROR);
 
     this.chatRoomForwarder.forward(XMPPEvents.ROOM_MAX_USERS_ERROR,
         JitsiConferenceEvents.CONFERENCE_FAILED,
@@ -274,12 +277,21 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
 
     chatRoom.addListener(XMPPEvents.MUC_MEMBER_JOINED,
         conference.onMemberJoined.bind(conference));
+    this.chatRoomForwarder.forward(XMPPEvents.MUC_LOBBY_MEMBER_JOINED,
+        JitsiConferenceEvents.LOBBY_USER_JOINED);
+    this.chatRoomForwarder.forward(XMPPEvents.MUC_LOBBY_MEMBER_UPDATED,
+        JitsiConferenceEvents.LOBBY_USER_UPDATED);
+    this.chatRoomForwarder.forward(XMPPEvents.MUC_LOBBY_MEMBER_LEFT,
+        JitsiConferenceEvents.LOBBY_USER_LEFT);
     chatRoom.addListener(XMPPEvents.MUC_MEMBER_BOT_TYPE_CHANGED,
         conference._onMemberBotTypeChanged.bind(conference));
     chatRoom.addListener(XMPPEvents.MUC_MEMBER_LEFT,
         conference.onMemberLeft.bind(conference));
     this.chatRoomForwarder.forward(XMPPEvents.MUC_LEFT,
         JitsiConferenceEvents.CONFERENCE_LEFT);
+    this.chatRoomForwarder.forward(XMPPEvents.MUC_DENIED_ACCESS,
+        JitsiConferenceEvents.CONFERENCE_FAILED,
+        JitsiConferenceErrors.CONFERENCE_ACCESS_DENIED);
 
     chatRoom.addListener(XMPPEvents.DISPLAY_NAME_CHANGED,
         conference.onDisplayNameChanged.bind(conference));

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -275,6 +275,9 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
     this.chatRoomForwarder.forward(XMPPEvents.MUC_LOCK_CHANGED,
         JitsiConferenceEvents.LOCK_STATE_CHANGED);
 
+    this.chatRoomForwarder.forward(XMPPEvents.MUC_MEMBERS_ONLY_CHANGED,
+        JitsiConferenceEvents.MEMBERS_ONLY_CHANGED);
+
     chatRoom.addListener(XMPPEvents.MUC_MEMBER_JOINED,
         conference.onMemberJoined.bind(conference));
     this.chatRoomForwarder.forward(XMPPEvents.MUC_LOBBY_MEMBER_JOINED,

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -328,3 +328,18 @@ export const USER_STATUS_CHANGED = 'conference.statusChanged';
  * Event indicates that the bot participant type changed.
  */
 export const BOT_TYPE_CHANGED = 'conference.bot_type_changed';
+
+/**
+ * A new user joined the lobby room.
+ */
+export const LOBBY_USER_JOINED = 'conference.lobby.userJoined';
+
+/**
+ * A user from the lobby room has been update.
+ */
+export const LOBBY_USER_UPDATED = 'conference.lobby.userUpdated';
+
+/**
+ * A user left the lobby room.
+ */
+export const LOBBY_USER_LEFT = 'conference.lobby.userLeft';

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -149,6 +149,14 @@ export const LOCK_STATE_CHANGED = 'conference.lock_state_changed';
 export const SERVER_REGION_CHANGED = 'conference.server_region_changed';
 
 /**
+ * Indicates that the conference had changed to members only enabled/disabled.
+ * The first argument of this event is a <tt>boolean</tt> which when set to
+ * <tt>true</tt> means that the conference is running in members only mode.
+ * You may need to use Lobby if supported to ask for permissions to enter the conference.
+ */
+export const MEMBERS_ONLY_CHANGED = 'conference.membersOnly';
+
+/**
  * New text message was received.
  */
 export const MESSAGE_RECEIVED = 'conference.messageReceived';

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -154,7 +154,7 @@ export const SERVER_REGION_CHANGED = 'conference.server_region_changed';
  * <tt>true</tt> means that the conference is running in members only mode.
  * You may need to use Lobby if supported to ask for permissions to enter the conference.
  */
-export const MEMBERS_ONLY_CHANGED = 'conference.membersOnly';
+export const MEMBERS_ONLY_CHANGED = 'conference.membersOnlyChanged';
 
 /**
  * New text message was received.

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -96,10 +96,10 @@ export default class ChatRoom extends Listenable {
      * @param XMPP
      * @param options
      * @param {boolean} options.disableFocus - when set to {@code false} will
-     * not invite Jicofo into the room. This is intended to be used only by
+     * not invite Jicofo into the room.
      * @param {boolean} options.disableDiscoInfo - when set to {@code false} will skip disco info.
      * This is intended to be used only for lobby rooms.
-     * @param {boolean} options.disableLobby - when set to {@code true} will skip creating lobby room.
+     * @param {boolean} options.disable - when set to {@code true} will skip creating lobby room.
      */
     constructor(connection, jid, password, XMPP, options) {
         super();

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -99,7 +99,7 @@ export default class ChatRoom extends Listenable {
      * not invite Jicofo into the room.
      * @param {boolean} options.disableDiscoInfo - when set to {@code false} will skip disco info.
      * This is intended to be used only for lobby rooms.
-     * @param {boolean} options.disable - when set to {@code true} will skip creating lobby room.
+     * @param {boolean} options.enableLobby - when set to {@code false} will skip creating lobby room.
      */
     constructor(connection, jid, password, XMPP, options) {
         super();
@@ -123,7 +123,7 @@ export default class ChatRoom extends Listenable {
                 connection: this.xmpp.options,
                 conference: this.options
             });
-        if (!this.options.disableLobby) {
+        if (typeof this.options.enableLobby === 'undefined' || this.options.enableLobby) {
             this.lobby = new Lobby(this);
         }
         this.initPresenceMap(options);

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -895,8 +895,9 @@ export default class ChatRoom extends Listenable {
         }
 
         // room destroyed ?
-        if ($(pres).find('>x[xmlns="http://jabber.org/protocol/muc#user"]'
-            + '>destroy').length) {
+        const destroySelect = $(pres).find('>x[xmlns="http://jabber.org/protocol/muc#user"]>destroy');
+
+        if (destroySelect.length) {
             let reason;
             const reasonSelect
                 = $(pres).find(
@@ -907,7 +908,7 @@ export default class ChatRoom extends Listenable {
                 reason = reasonSelect.text();
             }
 
-            this.eventEmitter.emit(XMPPEvents.MUC_DESTROYED, reason);
+            this.eventEmitter.emit(XMPPEvents.MUC_DESTROYED, reason, destroySelect.attr('jid'));
             this.connection.emuc.doLeave(this.roomjid);
 
             return true;

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1204,6 +1204,16 @@ export default class ChatRoom extends Listenable {
                         .up()
                         .up();
 
+                    // if members only enabled
+                    if (this.membersOnlyEnabled) {
+                        formsubmit
+                            .c('field', { 'var': 'muc#roomconfig_membersonly' })
+                            .c('value')
+                            .t('true')
+                            .up()
+                            .up();
+                    }
+
                     // Fixes a bug in prosody 0.9.+
                     // https://prosody.im/issues/issue/373
                     formsubmit

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1028,8 +1028,15 @@ export default class ChatRoom extends Listenable {
                 this.discoRoomInfo();
             } else if ((invite = $(msg).find('>x[xmlns="http://jabber.org/protocol/muc#user"]>invite'))
                         && invite.length) {
+                const passwordSelect = $(msg).find('>x[xmlns="http://jabber.org/protocol/muc#user"]>password');
+                let password;
+
+                if (passwordSelect && passwordSelect.length) {
+                    password = passwordSelect.text();
+                }
+
                 this.eventEmitter.emit(XMPPEvents.INVITE_MESSAGE_RECEIVED,
-                    from, invite.attr('from'), txt);
+                    from, invite.attr('from'), txt, password);
             }
         }
         const jsonMessage = $(msg).find('>json-message').text();
@@ -1264,15 +1271,19 @@ export default class ChatRoom extends Listenable {
                         .t(enabled ? 'true' : 'false')
                         .up()
                         .up();
-
-                    if (password) {
-                        formToSubmit
-                            .c('field', { 'var': 'muc#roomconfig_lobbypassword' })
-                            .c('value')
-                            .t(password)
-                            .up()
-                            .up();
-                    }
+                    formToSubmit
+                        .c('field', { 'var': 'muc#roomconfig_roomsecret' })
+                        .c('value')
+                        .t(password || '')
+                        .up()
+                        .up();
+                    formToSubmit
+                        .c('field',
+                            { 'var': 'muc#roomconfig_passwordprotectedroom' })
+                        .c('value')
+                        .t(!password || password.length === 0 ? '0' : '1')
+                        .up()
+                        .up();
 
                     this.xmpp.connection.sendIQ(formToSubmit, onSuccess, e => {
                         onError(e);

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1281,19 +1281,27 @@ export default class ChatRoom extends Listenable {
                         .t(enabled ? 'true' : 'false')
                         .up()
                         .up();
-                    formToSubmit
-                        .c('field', { 'var': 'muc#roomconfig_roomsecret' })
-                        .c('value')
-                        .t(password || '')
-                        .up()
-                        .up();
-                    formToSubmit
-                        .c('field',
-                            { 'var': 'muc#roomconfig_passwordprotectedroom' })
-                        .c('value')
-                        .t(!password || password.length === 0 ? '0' : '1')
-                        .up()
-                        .up();
+
+                    let isRoomLocked = this.locked;
+
+                    // if room is locked from other participant or we are locking it
+                    if (isRoomLocked || (password && password.length > 0)) {
+                        formToSubmit
+                            .c('field',
+                                { 'var': 'muc#roomconfig_passwordprotectedroom' })
+                            .c('value')
+                            .t('1')
+                            .up()
+                            .up();
+                        if (password) {
+                            formToSubmit
+                                .c('field', { 'var': 'muc#roomconfig_roomsecret' })
+                                .c('value')
+                                .t(password)
+                                .up()
+                                .up();
+                        }
+                    }
 
                     this.xmpp.connection.sendIQ(formToSubmit, onSuccess, errorCB);
                 } else {

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1292,10 +1292,8 @@ export default class ChatRoom extends Listenable {
                         .up()
                         .up();
 
-                    let isRoomLocked = this.locked;
-
                     // if room is locked from other participant or we are locking it
-                    if (isRoomLocked || (password && password.length > 0)) {
+                    if (this.locked || (password && password.length > 0)) {
                         formToSubmit
                             .c('field',
                                 { 'var': 'muc#roomconfig_passwordprotectedroom' })

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1237,11 +1237,10 @@ export default class ChatRoom extends Listenable {
      * Turns of or on the members only config for the main room.
      *
      * @param {boolean} enabled - Whether to turn it on or off.
-     * @param {string} password - Shared password if any.
      * @param onSuccess - optional callback.
      * @param onError - optional callback.
      */
-    setMembersOnly(enabled, password, onSuccess, onError) {
+    setMembersOnly(enabled, onSuccess, onError) {
         if (enabled && Object.values(this.members).filter(m => !m.isFocus).length) {
             // first grant membership to all that are in the room
             if (Object.keys(this.members).length > 0) {
@@ -1293,7 +1292,7 @@ export default class ChatRoom extends Listenable {
                         .up();
 
                     // if room is locked from other participant or we are locking it
-                    if (this.locked || (password && password.length > 0)) {
+                    if (this.locked) {
                         formToSubmit
                             .c('field',
                                 { 'var': 'muc#roomconfig_passwordprotectedroom' })
@@ -1301,14 +1300,6 @@ export default class ChatRoom extends Listenable {
                             .t('1')
                             .up()
                             .up();
-                        if (password) {
-                            formToSubmit
-                                .c('field', { 'var': 'muc#roomconfig_roomsecret' })
-                                .c('value')
-                                .t(password)
-                                .up()
-                                .up();
-                        }
                     }
 
                     this.xmpp.connection.sendIQ(formToSubmit, onSuccess, errorCB);

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1216,7 +1216,7 @@ export default class ChatRoom extends Listenable {
      * @param onError
      */
     setMembersOnly(enabled, password, onSuccess, onError) {
-        if (enabled) {
+        if (enabled && Object.values(this.members).filter(m => !m.isFocus).length) {
             // first grant membership to all that are in the room
             if (Object.keys(this.members).length > 0) {
                 const grantMembership = $iq({ to: this.roomjid,

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -318,17 +318,18 @@ export default class ChatRoom extends Listenable {
 
             const membersOnly = $(result).find('>query>feature[var="muc_membersonly"]').length === 1;
 
-            if (membersOnly !== this.membersOnlyEnabled) {
-                this.membersOnlyEnabled = membersOnly;
-                this.eventEmitter.emit(XMPPEvents.MUC_MEMBERS_ONLY_CHANGED, membersOnly);
-            }
-
             const lobbyRoomField
                 = $(result).find('>query>x[type="result"]>field[var="muc#roominfo_lobbyroom"]>value');
 
             if (lobbyRoomField.length && this.lobby) {
                 this.lobby.setLobbyRoomJid(lobbyRoomField.text());
             }
+
+            if (membersOnly !== this.membersOnlyEnabled) {
+                this.membersOnlyEnabled = membersOnly;
+                this.eventEmitter.emit(XMPPEvents.MUC_MEMBERS_ONLY_CHANGED, membersOnly);
+            }
+
         }, error => {
             GlobalOnErrorHandler.callErrorHandler(error);
             logger.error('Error getting room info: ', error);

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -321,8 +321,8 @@ export default class ChatRoom extends Listenable {
             const lobbyRoomField
                 = $(result).find('>query>x[type="result"]>field[var="muc#roominfo_lobbyroom"]>value');
 
-            if (lobbyRoomField.length && this.lobby) {
-                this.lobby.setLobbyRoomJid(lobbyRoomField.text());
+            if (this.lobby) {
+                this.lobby.setLobbyRoomJid(lobbyRoomField && lobbyRoomField.length ? lobbyRoomField.text() : undefined);
             }
 
             if (membersOnly !== this.membersOnlyEnabled) {
@@ -1220,8 +1220,8 @@ export default class ChatRoom extends Listenable {
      *
      * @param {boolean} enabled - Whether to turn it on or off.
      * @param {string} password - Shared password if any.
-     * @param onSuccess
-     * @param onError
+     * @param onSuccess - optional callback.
+     * @param onError - optional callback.
      */
     setMembersOnly(enabled, password, onSuccess, onError) {
         if (enabled && Object.values(this.members).filter(m => !m.isFocus).length) {
@@ -1241,6 +1241,8 @@ export default class ChatRoom extends Listenable {
                 this.xmpp.connection.sendIQ(grantMembership.up());
             }
         }
+
+        const errorCB = onError ? onError : () => {}; // eslint-disable-line no-empty-function
 
         this.xmpp.connection.sendIQ(
             $iq({
@@ -1285,16 +1287,12 @@ export default class ChatRoom extends Listenable {
                         .up()
                         .up();
 
-                    this.xmpp.connection.sendIQ(formToSubmit, onSuccess, e => {
-                        onError(e);
-                    });
+                    this.xmpp.connection.sendIQ(formToSubmit, onSuccess, errorCB);
                 } else {
-                    onError(new Error('Setting members only room not supported!'));
+                    errorCB(new Error('Setting members only room not supported!'));
                 }
             },
-            e => {
-                onError(e);
-            });
+            errorCB);
     }
 
     /**

--- a/modules/xmpp/ChatRoom.spec.js
+++ b/modules/xmpp/ChatRoom.spec.js
@@ -172,7 +172,8 @@ describe('ChatRoom', () => {
                 undefined, // statsID
                 'status-text',
                 undefined,
-                undefined
+                undefined,
+                'fulljid'
             ]);
         });
 
@@ -200,7 +201,8 @@ describe('ChatRoom', () => {
                 undefined, // statsID
                 undefined,
                 undefined,
-                undefined);
+                undefined,
+                'jid=attr');
         });
 
         it('parses identity correctly', () => {
@@ -245,7 +247,8 @@ describe('ChatRoom', () => {
                 undefined, // statsID
                 'status-text',
                 expectedIdentity,
-                undefined
+                undefined,
+                'fulljid'
             ]);
         });
 
@@ -276,7 +279,8 @@ describe('ChatRoom', () => {
                 undefined, // statsID
                 'status-text',
                 undefined,
-                expectedBotType
+                expectedBotType,
+                'fulljid'
             ]);
         });
 

--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -254,7 +254,7 @@ export default class Lobby {
                 customDomain,
                 disableDiscoInfo: true,
                 disableFocus: true,
-                disableLobby: true
+                enableLobby: false
             }
         );
 

--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -1,0 +1,396 @@
+/* global $ */
+
+import { $iq, $msg, Strophe } from 'strophe.js';
+import { getLogger } from 'jitsi-meet-logger';
+import XMPPEvents from '../../service/xmpp/XMPPEvents';
+
+const logger = getLogger(__filename);
+
+/**
+ * The command type for updating a lobby participant's e-mail address.
+ *
+ * @type {string}
+ */
+const EMAIL_COMMAND = 'email';
+
+/**
+ * Array of affiliations that are allowed in members only room.
+ * @type {string[]}
+ */
+const MEMBERS_AFFILIATIONS = [ 'owner', 'admin', 'member' ];
+
+/**
+ * The Lobby room implementation. Setting a room to members only, joining the lobby room
+ * approving or denying access to participants from the lobby room.
+ */
+export default class Lobby {
+
+    /**
+     * Constructs lobby room.
+     *
+     * @param {ChatRoom} room the main room.
+     */
+    constructor(room) {
+        this.xmpp = room.xmpp;
+        this.mainRoom = room;
+
+        const maybeEnableDisableLobby = this._maybeEnableDisableLobby.bind(this);
+
+        this.mainRoom.addEventListener(
+            XMPPEvents.LOCAL_ROLE_CHANGED,
+            maybeEnableDisableLobby);
+
+        this.mainRoom.addEventListener(
+            XMPPEvents.MUC_MEMBERS_ONLY_CHANGED,
+            maybeEnableDisableLobby);
+
+        this.mainRoom.addEventListener(
+            XMPPEvents.ROOM_CONNECT_MEMBERS_ONLY_ERROR,
+            jid => {
+                this.lobbyRoomJid = jid;
+            });
+    }
+
+    /**
+     * Whether lobby is supported on backend.
+     *
+     * @returns {boolean} whether lobby is supported on backend.
+     */
+    isLobbySupported() {
+        return this.xmpp.lobbySupported;
+    }
+
+    /**
+     * Enables lobby by setting the main room to be members only and joins the lobby chat room.
+     *
+     * @param {string} password shared password that can be used to skip lobby room.
+     * @returns {Promise}
+     */
+    enableLobby(password) {
+        if (!this.isLobbySupported()) {
+            return Promise.reject(new Error('Lobby not supported!'));
+        }
+
+        return new Promise((resolve, reject) => {
+
+            // first grant membership to all that are in the room
+            if (Object.keys(this.mainRoom.members).length > 0) {
+                const grantMembership = $iq({ to: this.mainRoom.roomjid,
+                    type: 'set' })
+                    .c('query', { xmlns: 'http://jabber.org/protocol/muc#admin' });
+
+                Object.values(this.mainRoom.members).forEach(m => {
+                    if (m.jid && !MEMBERS_AFFILIATIONS.includes(m.affiliation)) {
+                        grantMembership.c('item', {
+                            'affiliation': 'member',
+                            'jid': m.jid }).up();
+                    }
+                });
+                this.xmpp.connection.sendIQ(grantMembership.up());
+            }
+
+            this._setMembersOnly(true, password, resolve, reject);
+        });
+    }
+
+    /**
+     * Disable lobby by setting the main room to be non members only and levaes the lobby chat room if joined.
+     *
+     * @returns {void}
+     */
+    disableLobby() {
+        if (!this.isLobbySupported() || !this.mainRoom.isModerator()
+                || !this.lobbyRoom || !this.mainRoom.membersOnlyEnabled) {
+            return;
+        }
+
+        this._setMembersOnly(false, undefined, () => {
+            this._leaveLobbyRoom();
+        }, () => {}); // eslint-disable-line no-empty-function
+    }
+
+    /**
+     * Leaves the lobby room.
+     * @private
+     */
+    _leaveLobbyRoom() {
+        this.lobbyRoom.leave()
+            .then(() => {
+                this.lobbyRoom = undefined;
+                logger.info('Lobby room left!');
+            })
+            .catch(() => {}); // eslint-disable-line no-empty-function
+    }
+
+    /**
+     * Turns of or on the members only config for the main room.
+     *
+     * @param {boolean} enabled - Whether to turn it on or off.
+     * @param {string} password - Shared password if any.
+     * @param resolve
+     * @param reject
+     * @private
+     */
+    _setMembersOnly(enabled, password, resolve, reject) {
+        this.xmpp.connection.sendIQ(
+            $iq({
+                to: this.mainRoom.roomjid,
+                type: 'get'
+            }).c('query', { xmlns: 'http://jabber.org/protocol/muc#owner' }),
+            res => {
+                if ($(res)
+                    .find('>query>x[xmlns="jabber:x:data"]>field[var="muc#roomconfig_membersonly"]').length) {
+                    const formToSubmit
+                        = $iq({
+                            to: this.mainRoom.roomjid,
+                            type: 'set'
+                        }).c('query', { xmlns: 'http://jabber.org/protocol/muc#owner' });
+
+                    formToSubmit.c('x', {
+                        xmlns: 'jabber:x:data',
+                        type: 'submit'
+                    });
+                    formToSubmit
+                        .c('field', { 'var': 'FORM_TYPE' })
+                        .c('value')
+                        .t('http://jabber.org/protocol/muc#roomconfig')
+                        .up()
+                        .up();
+                    formToSubmit
+                        .c('field', { 'var': 'muc#roomconfig_membersonly' })
+                        .c('value')
+                        .t(enabled ? 'true' : false)
+                        .up()
+                        .up();
+
+                    if (password) {
+                        // TODO make sure this is filtered and removed from form in the prosody module
+                        formToSubmit
+                            .c('field', { 'var': 'muc#roomconfig_lobbypassword' })
+                            .c('value')
+                            .t(password)
+                            .up()
+                            .up();
+                    }
+
+                    this.xmpp.connection.sendIQ(formToSubmit, resolve, e => {
+                        reject(e);
+                    });
+                } else {
+                    reject(new Error('Setting members only room not supported!'));
+                }
+            },
+            e => {
+                reject(e);
+            });
+    }
+
+    /**
+     * We had received a jid for the lobby room.
+     *
+     * @param jid the lobby room jid to join.
+     */
+    setLobbyRoomJid(jid) {
+        if (!this.isLobbySupported() || !this.mainRoom.isModerator()
+            || this.lobbyRoom || !this.mainRoom.membersOnlyEnabled) {
+            return;
+        }
+
+        this.lobbyRoomJid = jid;
+
+        this.joinLobbyRoom()
+            .then(() => {}) // eslint-disable-line no-empty-function
+            .catch(e => logger.error('Failed joining lobby room', e));
+    }
+
+    /**
+     * Checks the state of mainRoom, lobbyRoom and current user role to decide whether to join/leave lobby room.
+     * @private
+     */
+    _maybeEnableDisableLobby() {
+        if (!this.isLobbySupported()) {
+            return;
+        }
+
+        const isModerator = this.mainRoom.joined && this.mainRoom.isModerator();
+
+        if (isModerator && this.mainRoom.membersOnlyEnabled && !this.lobbyRoom) {
+            // join the lobby
+            this.enableLobby()
+                .then(() => logger.info('Joined lobby room'))
+                .catch(e => logger.error('Failed joining lobby', e));
+        } else if (isModerator && !this.mainRoom.membersOnlyEnabled && this.lobbyRoom) {
+            // leave lobby room
+            this._leaveLobbyRoom();
+        }
+    }
+
+    /**
+     * Joins a lobby room setting display name and eventually avatar(using the email provided).
+     *
+     * @param {string} username is required.
+     * @param {string} email is optional.
+     * @param {string} password is optional for non moderators and should not be passed when moderator.
+     * @returns {Promise} resolves once we join the room.
+     */
+    joinLobbyRoom(displayName, email, password) {
+        const isModerator = this.mainRoom.joined && this.mainRoom.isModerator();
+
+        // shared password let's try it
+        if (password && !isModerator) {
+            return this.mainRoom.join(undefined, { 'lobbySharedPassword': password });
+        }
+
+        if (!this.lobbyRoomJid) {
+            return Promise.reject(new Error('Missing lobbyRoomJid, cannot join lobby room.'));
+        }
+
+        const roomName = Strophe.getNodeFromJid(this.lobbyRoomJid);
+        const customDomain = Strophe.getDomainFromJid(this.lobbyRoomJid);
+
+        this.lobbyRoom = this.xmpp.createRoom(
+            roomName, {
+                customDomain,
+                disableDiscoInfo: true,
+                disableFocus: true,
+                disableLobby: true
+            }
+        );
+
+        if (displayName) {
+            // remove previously set nickname
+            this.lobbyRoom.removeFromPresence('nick');
+            this.lobbyRoom.addToPresence('nick', {
+                attributes: { xmlns: 'http://jabber.org/protocol/nick' },
+                value: displayName
+            });
+        }
+
+        if (isModerator) {
+            this.lobbyRoom.addPresenceListener(EMAIL_COMMAND, (node, from) => {
+                this.mainRoom.eventEmitter.emit(XMPPEvents.MUC_LOBBY_MEMBER_UPDATED, from, { email: node.value });
+            });
+            this.lobbyRoom.addEventListener(
+                XMPPEvents.MUC_MEMBER_JOINED,
+                // eslint-disable-next-line max-params
+                (from, nick, role, isHiddenDomain, statsID, status, identity, botType, jid) => {
+                    // we need to ignore joins on lobby for participants that are already in the main room
+                    if (Object.values(this.mainRoom.members).find(m => m.jid === jid)) {
+                        return;
+                    }
+
+                    // we emit the new event on the main room so we can propagate
+                    // events to the conference
+                    this.mainRoom.eventEmitter.emit(
+                        XMPPEvents.MUC_LOBBY_MEMBER_JOINED,
+                        Strophe.getResourceFromJid(from),
+                        nick,
+                        identity ? identity.avatar : undefined
+                    );
+                });
+            this.lobbyRoom.addEventListener(
+                XMPPEvents.MUC_MEMBER_LEFT, from => {
+                    // we emit the new event on the main room so we can propagate
+                    // events to the conference
+                    this.mainRoom.eventEmitter.emit(
+                        XMPPEvents.MUC_LOBBY_MEMBER_LEFT,
+                        Strophe.getResourceFromJid(from)
+                    );
+                });
+
+        } else {
+            // this should only be handled by those waiting in lobby
+            this.lobbyRoom.addEventListener(XMPPEvents.KICKED, isSelfPresence => {
+                if (isSelfPresence) {
+                    this.mainRoom.eventEmitter.emit(XMPPEvents.MUC_DENIED_ACCESS);
+
+                    this.lobbyRoom.clean();
+
+                    return;
+                }
+            });
+
+            // As there is still reference of the main room
+            // the invite will be detected and addressed to its eventEmitter, even though we are not in it
+            // the invite message should be received directly to the xmpp conn in general
+            this.mainRoom.addEventListener(
+                XMPPEvents.INVITE_MESSAGE_RECEIVED,
+                (roomJid, from, txt) => {
+                    logger.debug(`Received approval to join ${roomJid} ${from} ${txt}`);
+                    if (roomJid === this.mainRoom.roomjid) {
+                        // we are now allowed let's join and leave lobby
+                        this.mainRoom.join();
+
+                        this._leaveLobbyRoom();
+                    }
+                });
+        }
+
+        return new Promise((resolve, reject) => {
+            this.lobbyRoom.addEventListener(XMPPEvents.MUC_JOINED, () => {
+                resolve();
+
+                // send our email, as we do not handle this on initial presence we need a second one
+                if (email && !isModerator) {
+                    this.lobbyRoom.removeFromPresence(EMAIL_COMMAND);
+                    this.lobbyRoom.addToPresence(EMAIL_COMMAND, { value: email });
+                    this.lobbyRoom.sendPresence();
+                }
+            });
+            this.lobbyRoom.addEventListener(XMPPEvents.ROOM_JOIN_ERROR, reject);
+            this.lobbyRoom.addEventListener(XMPPEvents.ROOM_CONNECT_NOT_ALLOWED_ERROR, reject);
+            this.lobbyRoom.addEventListener(XMPPEvents.ROOM_CONNECT_ERROR, reject);
+
+            this.lobbyRoom.join();
+        });
+
+    }
+
+    /**
+     * Should be possible only for moderators.
+     * @param id
+     */
+    denyAccess(id) {
+        if (!this.isLobbySupported() || !this.mainRoom.isModerator()) {
+            return;
+        }
+
+        const jid = Object.keys(this.lobbyRoom.members)
+            .find(j => Strophe.getResourceFromJid(j) === id);
+
+        if (jid) {
+            this.lobbyRoom.kick(jid);
+        } else {
+            logger.error(`Not found member for ${jid} in lobby room.`);
+        }
+    }
+
+    /**
+     * Should be possible only for moderators.
+     * @param id
+     */
+    approveAccess(id) {
+        if (!this.isLobbySupported() || !this.mainRoom.isModerator()) {
+            return;
+        }
+
+        const roomJid = Object.keys(this.lobbyRoom.members)
+            .find(j => Strophe.getResourceFromJid(j) === id);
+
+        if (roomJid) {
+            const jid = this.lobbyRoom.members[roomJid].jid;
+            const msgToSend
+                = $msg({ to: this.mainRoom.roomjid })
+                    .c('x', { xmlns: 'http://jabber.org/protocol/muc#user' })
+                    .c('invite', { to: jid });
+
+            this.xmpp.connection.sendIQ(msgToSend,
+                () => { }, // eslint-disable-line no-empty-function
+                e => {
+                    logger.error(`Error sending invite for ${jid}`, e);
+                });
+        } else {
+            logger.error(`Not found member for ${roomJid} in lobby room.`);
+        }
+    }
+}

--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -26,15 +26,15 @@ export default class Lobby {
         this.xmpp = room.xmpp;
         this.mainRoom = room;
 
-        const maybeEnableDisable = this._maybeEnableDisable.bind(this);
+        const maybeJoinLeaveLobbyRoom = this._maybeJoinLeaveLobbyRoom.bind(this);
 
         this.mainRoom.addEventListener(
             XMPPEvents.LOCAL_ROLE_CHANGED,
-            maybeEnableDisable);
+            maybeJoinLeaveLobbyRoom);
 
         this.mainRoom.addEventListener(
             XMPPEvents.MUC_MEMBERS_ONLY_CHANGED,
-            maybeEnableDisable);
+            maybeJoinLeaveLobbyRoom);
 
         this.mainRoom.addEventListener(
             XMPPEvents.ROOM_CONNECT_MEMBERS_ONLY_ERROR,
@@ -105,23 +105,14 @@ export default class Lobby {
      * @param jid the lobby room jid to join.
      */
     setLobbyRoomJid(jid) {
-        if (!this.isSupported() || !this.mainRoom.isModerator()
-            || this.lobbyRoom || !this.mainRoom.membersOnlyEnabled) {
-            return;
-        }
-
         this.lobbyRoomJid = jid;
-
-        this.join()
-            .then(() => {}) // eslint-disable-line no-empty-function
-            .catch(e => logger.error('Failed joining lobby room', e));
     }
 
     /**
      * Checks the state of mainRoom, lobbyRoom and current user role to decide whether to join/leave lobby room.
      * @private
      */
-    _maybeEnableDisable() {
+    _maybeJoinLeaveLobbyRoom() {
         if (!this.isSupported()) {
             return;
         }
@@ -130,7 +121,7 @@ export default class Lobby {
 
         if (isModerator && this.mainRoom.membersOnlyEnabled && !this.lobbyRoom) {
             // join the lobby
-            this.enable()
+            this.join()
                 .then(() => logger.info('Joined lobby room'))
                 .catch(e => logger.error('Failed joining lobby', e));
         } else if (isModerator && !this.mainRoom.membersOnlyEnabled && this.lobbyRoom) {

--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -247,6 +247,14 @@ export default class Lobby {
 
                     this.mainRoom.eventEmitter.emit(XMPPEvents.MUC_DESTROYED, reason);
                 });
+
+            // If participant retries joining shared password while waiting in the lobby
+            // and succeeds make sure we leave lobby
+            this.mainRoom.addEventListener(
+                XMPPEvents.MUC_JOINED,
+                () => {
+                    this._leaveLobbyRoom();
+                });
         }
 
         return new Promise((resolve, reject) => {

--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -225,7 +225,7 @@ export default class Lobby {
             // the invite message should be received directly to the xmpp conn in general
             this.mainRoom.addEventListener(
                 XMPPEvents.INVITE_MESSAGE_RECEIVED,
-                (roomJid, from, invitePassword, txt) => {
+                (roomJid, from, txt, invitePassword) => {
                     logger.debug(`Received approval to join ${roomJid} ${from} ${txt}`);
                     if (roomJid === this.mainRoom.roomjid) {
                         // we are now allowed let's join and leave lobby

--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -55,16 +55,15 @@ export default class Lobby {
     /**
      * Enables lobby by setting the main room to be members only and joins the lobby chat room.
      *
-     * @param {string} password shared password that can be used to skip lobby room.
      * @returns {Promise}
      */
-    enable(password) {
+    enable() {
         if (!this.isSupported()) {
             return Promise.reject(new Error('Lobby not supported!'));
         }
 
         return new Promise((resolve, reject) => {
-            this.mainRoom.setMembersOnly(true, password, resolve, reject);
+            this.mainRoom.setMembersOnly(true, resolve, reject);
         });
     }
 
@@ -130,16 +129,10 @@ export default class Lobby {
      *
      * @param {string} username is required.
      * @param {string} email is optional.
-     * @param {string} password is optional for non moderators and should not be passed when moderator.
      * @returns {Promise} resolves once we join the room.
      */
-    join(displayName, email, password) {
+    join(displayName, email) {
         const isModerator = this.mainRoom.joined && this.mainRoom.isModerator();
-
-        // lobby password let's try it
-        if (password && !isModerator) {
-            return this.mainRoom.join(password);
-        }
 
         if (!this.lobbyRoomJid) {
             return Promise.reject(new Error('Missing lobbyRoomJid, cannot join lobby room.'));

--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -298,11 +298,11 @@ export default class Lobby {
             return;
         }
 
-        const roomJid = Object.keys(this.lobbyRoom.members)
+        const memberRoomJid = Object.keys(this.lobbyRoom.members)
             .find(j => Strophe.getResourceFromJid(j) === id);
 
-        if (roomJid) {
-            const jid = this.lobbyRoom.members[roomJid].jid;
+        if (memberRoomJid) {
+            const jid = this.lobbyRoom.members[memberRoomJid].jid;
             const msgToSend
                 = $msg({ to: this.mainRoom.roomjid })
                     .c('x', { xmlns: 'http://jabber.org/protocol/muc#user' })
@@ -314,7 +314,7 @@ export default class Lobby {
                     logger.error(`Error sending invite for ${jid}`, e);
                 });
         } else {
-            logger.error(`Not found member for ${roomJid} in lobby room.`);
+            logger.error(`Not found member for ${memberRoomJid} in lobby room.`);
         }
     }
 }

--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -143,7 +143,7 @@ export default class Lobby {
 
         // lobby password let's try it
         if (password && !isModerator) {
-            return this.mainRoom.join(undefined, { 'lobbySharedPassword': password });
+            return this.mainRoom.join(password);
         }
 
         if (!this.lobbyRoomJid) {
@@ -220,11 +220,11 @@ export default class Lobby {
             // the invite message should be received directly to the xmpp conn in general
             this.mainRoom.addEventListener(
                 XMPPEvents.INVITE_MESSAGE_RECEIVED,
-                (roomJid, from, txt) => {
+                (roomJid, from, invitePassword, txt) => {
                     logger.debug(`Received approval to join ${roomJid} ${from} ${txt}`);
                     if (roomJid === this.mainRoom.roomjid) {
                         // we are now allowed let's join and leave lobby
-                        this.mainRoom.join();
+                        this.mainRoom.join(invitePassword);
 
                         this._leaveLobbyRoom();
                     }

--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -229,6 +229,11 @@ export default class Lobby {
                         this._leaveLobbyRoom();
                     }
                 });
+            this.lobbyRoom.addEventListener(
+                XMPPEvents.MUC_DESTROYED,
+                reason => {
+                    this.mainRoom.eventEmitter.emit(XMPPEvents.MUC_DESTROYED, reason);
+                });
         }
 
         return new Promise((resolve, reject) => {

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -248,6 +248,10 @@ export default class XMPP extends Listenable {
                         if (identity.type === 'conference_duration') {
                             this.conferenceDurationComponentAddress = identity.name;
                         }
+
+                        if (identity.type === 'lobbyrooms') {
+                            this.lobbySupported = true;
+                        }
                     });
 
                     if (this.speakerStatsComponentAddress
@@ -469,7 +473,8 @@ export default class XMPP extends Listenable {
      * @returns {Promise} Resolves with an instance of a strophe muc.
      */
     createRoom(roomName, options, onCreateResource) {
-        let roomjid = `${roomName}@${this.options.hosts.muc}/`;
+        let roomjid = `${roomName}@${options.customDomain
+            ? options.customDomain : this.options.hosts.muc}/`;
 
         const mucNickname = onCreateResource
             ? onCreateResource(this.connection.jid, this.authenticatedUser)

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -108,6 +108,10 @@ const XMPPEvents = {
     // received.
     MESSAGE_RECEIVED: 'xmpp.message_received',
 
+    // Designates an event indicating that an invite XMPP message in the MUC was
+    // received.
+    INVITE_MESSAGE_RECEIVED: 'xmpp.invite_message_received',
+
     // Designates an event indicating that a private XMPP message in the MUC was
     // received.
     PRIVATE_MESSAGE_RECEIVED: 'xmpp.private_message_received',
@@ -127,6 +131,18 @@ const XMPPEvents = {
     // Designates an event indicating that a participant left the XMPP MUC.
     MUC_MEMBER_LEFT: 'xmpp.muc_member_left',
 
+    // Designates an event indicating that a participant joined the lobby XMPP MUC.
+    MUC_LOBBY_MEMBER_JOINED: 'xmpp.muc_lobby_member_joined',
+
+    // Designates an event indicating that a participant in the lobby XMPP MUC has been updated
+    MUC_LOBBY_MEMBER_UPDATED: 'xmpp.muc_lobby_member_updated',
+
+    // Designates an event indicating that a participant left the XMPP MUC.
+    MUC_LOBBY_MEMBER_LEFT: 'xmpp.muc_lobby_member_left',
+
+    // Designates an event indicating that a participant was denied access to a conference from the lobby XMPP MUC.
+    MUC_DENIED_ACCESS: 'xmpp.muc_denied access',
+
     // Designates an event indicating that local participant left the muc
     MUC_LEFT: 'xmpp.muc_left',
 
@@ -136,6 +152,9 @@ const XMPPEvents = {
 
     // Designates an event indicating that the MUC has been locked or unlocked.
     MUC_LOCK_CHANGED: 'xmpp.muc_lock_changed',
+
+    // Designates an event indicating that the MUC members only config has changed.
+    MUC_MEMBERS_ONLY_CHANGED: 'xmpp.muc_members_only_changed',
 
     // Designates an event indicating that a participant in the XMPP MUC has
     // advertised that they have audio muted (or unmuted).
@@ -186,6 +205,7 @@ const XMPPEvents = {
     ROOM_CONNECT_ERROR: 'xmpp.room_connect_error',
     ROOM_CONNECT_NOT_ALLOWED_ERROR: 'xmpp.room_connect_error.not_allowed',
     ROOM_JOIN_ERROR: 'xmpp.room_join_error',
+    ROOM_CONNECT_MEMBERS_ONLY_ERROR: 'xmpp.room_connect_error.members_only',
 
     /**
      * Indicates that max users limit has been reached.


### PR DESCRIPTION
Overview:

1. Let's start with how is backend activated/configured:
```
VirtualHost "jitmeet.example.com"
    modules_enabled = {
     "muc_lobby_rooms"
    }
    lobby_muc = "lobby.jitmeet.example.com"
    main_muc = "conference.jitmeet.example.com"

Component "lobbyrooms.jitmeet.example.com" "muc"
    storage = "memory"
    muc_room_cache_size = 1000
    restrict_room_creation = true
    muc_room_locking = false
    muc_room_default_public_jids = true
```
The lobby rooms muc component is a separate one, on which rooms can be created only by admins.

2. When a moderator enables lobby feature, just changes the muc config to be set to members_only https://xmpp.org/extensions/xep-0045.html#enter-members
Also a shared password can be used by adding it as `muc#roomconfig_lobbypassword`.
What happens in the prosody module is that when this members_only setting is detected a corresponding lobby room is created in the custom component, and if there is a shared password it is stored in the main room object, so we can compare it later.
The jid of the created lobby room is set in the room object and is distributed through the muc config so other moderators can join it (`muc#roominfo_lobbyroom`).

3. When a user tries to join the standard error for joining a members_only room is detected: https://xmpp.org/extensions/xep-0045.html#enter-members (we slightly modify that adding the lobby room jid to it) and the participant can join the lobby room by providing display name, and email which is optional or can provide a shared password to try to skip the lobby.

4. The moderators see people joining the lobby room and can approve/deny. Approving is by inviting them to the room, using https://xmpp.org/extensions/xep-0045.html#invite-mediated
Deny is just kicking the user from the lobby room.

5. Another part which is in the backend is that the lobby room is filtering presences between participants and only moderators can see those.

I think this is all ... 
