### PR TITLE
fix(E2EE): Apply E2EE on RTCRtpSender when track is replaced on pc

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -964,6 +964,16 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
         actorParticipant = this.participants[actorId];
     }
 
+    // Setup E2EE on the sender that is created for the unmuted track.
+    if (this._e2eeCtx && !track.isMuted() && browser.doesVideoMuteByStreamRemove()) {
+        if (this.p2pJingleSession) {
+            this._setupSenderE2EEForTrack(this.p2pJingleSession, track);
+        }
+        if (this.jvbJingleSession) {
+            this._setupSenderE2EEForTrack(this.jvbJingleSession, track);
+        }
+    }
+
     this.eventEmitter.emit(JitsiConferenceEvents.TRACK_MUTE_CHANGED, track, actorParticipant);
 };
 
@@ -1107,6 +1117,17 @@ JitsiConference.prototype._setupNewTrack = function(newTrack) {
         this.room.setAudioMute(newTrack.isMuted());
     } else {
         this.room.setVideoMute(newTrack.isMuted());
+    }
+
+    // Setup E2EE on the new track that has been added
+    // to the conference, apply it on all the open peerconnections.
+    if (this._e2eeCtx) {
+        if (this.p2pJingleSession) {
+            this._setupSenderE2EEForTrack(this.p2pJingleSession, newTrack);
+        }
+        if (this.jvbJingleSession) {
+            this._setupSenderE2EEForTrack(this.jvbJingleSession, newTrack);
+        }
     }
 
     newTrack.muteHandler = this._fireMuteChangeEvent.bind(this, newTrack);

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -334,6 +334,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
         this._streamEffect = effect;
         this._originalStream = this.stream;
         this._setStream(this._streamEffect.startEffect(this._originalStream));
+        this.track = this.stream.getTracks()[0];
     }
 
     /**
@@ -346,6 +347,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
         if (this._streamEffect) {
             this._streamEffect.stopEffect();
             this._setStream(this._originalStream);
+            this.track = this.stream.getTracks()[0];
         }
     }
 


### PR DESCRIPTION
Make sure we inject the encoding function on RTCRtpsenders when tracks are replaced on the peerconnection.
Update the MediaStreamTrack on the JitsiLocalTrack when effects are applied or removed so that
we can find the RTCRtpSender using the MediaStreamTrack