### PR TITLE
ref: disable ICE restart by default

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -84,6 +84,8 @@ const JINGLE_SI_TIMEOUT = 5000;
  * @param {number} [options.config.avgRtpStatsN=15] how many samples are to be
  * collected by {@link AvgRTPStatsReporter}, before arithmetic mean is
  * calculated and submitted to the analytics module.
+ * @param {boolean} [options.config.enableIceRestart=false] - enables the ICE
+ * restart logic.
  * @param {boolean} [options.config.p2p.enabled] when set to <tt>true</tt>
  * the peer to peer mode will be enabled. It means that when there are only 2
  * participants in the conference an attempt to make direct connection will be
@@ -2613,6 +2615,15 @@ JitsiConference.prototype._onIceConnectionFailed = function(session) {
         }
         this._stopP2PSession('connectivity-error', 'ICE FAILED');
     } else if (session && this.jvbJingleSession === session) {
+        if (!this.options.config.enableIceRestart) {
+            logger.info('ICE Failed and ICE restarts are disabled');
+            this.eventEmitter.emit(
+                JitsiConferenceEvents.CONFERENCE_FAILED,
+                JitsiConferenceErrors.ICE_FAILED);
+
+            return;
+        }
+
         if (this.xmpp.isPingSupported()) {
             this._delayedIceFailed = new IceFailedNotification(this);
             this._delayedIceFailed.start(session);

--- a/JitsiConferenceErrors.js
+++ b/JitsiConferenceErrors.js
@@ -49,6 +49,11 @@ export const FOCUS_LEFT = 'conference.focusLeft';
 export const GRACEFUL_SHUTDOWN = 'conference.gracefulShutdown';
 
 /**
+ * Indicates that the media connection has failed.
+ */
+export const ICE_FAILED = 'conference.iceFailed';
+
+/**
  * Indicates that the versions of the server side components are incompatible
  * with the client side.
  */
@@ -74,11 +79,6 @@ export const PASSWORD_REQUIRED = 'conference.passwordRequired';
  * Indicates that reservation system returned error.
  */
 export const RESERVATION_ERROR = 'conference.reservationError';
-
-/**
- * Indicates that the conference setup failed.
- */
-export const SETUP_FAILED = 'conference.setup_failed';
 
 /**
  * Indicates that there is no available videobridge.


### PR DESCRIPTION
Adds ICE_FAILED event emitted when ICE fails and disables it by default.

The reason for that it's currently causing issues with signaling when
Octo is enabled. Also when we do an "ICE restart"(which is not a real
ICE restart), the client maintains the TCC sequence number counter, but
the bridge resets it. The bridge sends media packets with TCC sequence
numbers starting from 0.

The 'enableIceRestart' config option can be used to force it, but it's
not recommended.