### PR TITLE
test: add a test for jingle to sdp conversion

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,6 +14,7 @@ module.exports = function(config) {
 
         // list of files / patterns to load in the browser
         files: [
+            './doc/example/libs/jquery-2.1.1.js',
             'node_modules/core-js/index.js',
             './index.js',
             './modules/**/*.spec.js'

--- a/modules/xmpp/SDP.spec.js
+++ b/modules/xmpp/SDP.spec.js
@@ -1,5 +1,13 @@
+/* globals $ */
 import { $iq } from 'strophe.js';
 import SDP from './SDP';
+
+/**
+ * @param {string} xml - raw xml of the stanza
+ */
+function createStanzaElement(xml) {
+    return new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+}
 
 describe('SDP', () => {
     describe('toJingle', () => {
@@ -90,6 +98,146 @@ describe('SDP', () => {
             }, 0);
 
             expect(count).toBe(2);
+        });
+    });
+
+    describe('fromJingle', () => {
+        /* eslint-disable max-len*/
+        const stanza = `<iq>
+<jingle action='session-initiate' initiator='focus' sid='123' xmlns='urn:xmpp:jingle:1'>
+    <content creator='initiator' name='audio' senders='both'>
+        <description media='audio' maxptime='60' xmlns='urn:xmpp:jingle:apps:rtp:1'>
+            <payload-type channels='2' clockrate='48000' name='opus' id='111'>
+                <parameter name='minptime' value='10'/>
+                <parameter name='useinbandfec' value='1'/>
+                <rtcp-fb type='transport-cc' xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0'/>
+            </payload-type>
+            <payload-type clockrate='16000' name='ISAC' id='103'/>
+            <payload-type clockrate='32000' name='ISAC' id='104'/>
+            <payload-type clockrate='8000' name='telephone-event' id='126'/>
+            <rtp-hdrext uri='urn:ietf:params:rtp-hdrext:ssrc-audio-level' id='1' xmlns='urn:xmpp:jingle:apps:rtp:rtp-hdrext:0'/>
+            <rtp-hdrext uri='http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01' id='5' xmlns='urn:xmpp:jingle:apps:rtp:rtp-hdrext:0'/>
+            <rtcp-mux/>
+            <source ssrc='4039389863' xmlns='urn:xmpp:jingle:apps:rtp:ssma:0'>
+                <parameter name='cname' value='mixed'/>
+                <parameter name='label' value='mixedlabelaudio0'/>
+                <parameter name='msid' value='mixedmslabel mixedlabelaudio0'/>
+                <parameter name='mslabel' value='mixedmslabel'/>
+            </source>
+        </description>
+        <transport ufrag='someufrag' pwd='somepwd' xmlns='urn:xmpp:jingle:transports:ice-udp:1'>
+            <fingerprint hash='sha-256' required='false' setup='actpass' xmlns='urn:xmpp:jingle:apps:dtls:0'>09:B1:51:0F:85:4C:80:19:A1:AF:81:73:47:EE:ED:3D:00:3A:84:C7:76:C1:4E:34:BE:56:F6:42:AD:15:D5:D7</fingerprint>
+            <candidate foundation='1' id='3cbe5aea5bde0c1401a60bbc2' network='0' protocol='udp' generation='0' port='10000' priority='2130706431' type='host' ip='10.0.0.1' component='1'/>
+            <candidate rel-addr='10.0.0.1' network='0' foundation='2' id='dfcfd075bde0c140ffffffff927646ba' port='10000' protocol='udp' generation='0' rel-port='10000' priority='1694498815' type='srflx' ip='10.0.0.2' component='1'/>
+        </transport>
+    </content>
+    <content creator='initiator' name='video' senders='both'>
+        <description media='video' xmlns='urn:xmpp:jingle:apps:rtp:1'>
+            <payload-type clockrate='90000' name='VP8' id='100'>
+                <rtcp-fb subtype='fir' type='ccm' xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0'/>
+                <rtcp-fb type='nack' xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0'/>
+                <rtcp-fb subtype='pli' type='nack' xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0'/>
+                <rtcp-fb type='goog-remb' xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0'/>
+                <rtcp-fb type='transport-cc' xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0'/>
+                <parameter name='x-google-start-bitrate' value='800'/>
+            </payload-type>
+            <payload-type clockrate='90000' name='rtx' id='96'>
+                <rtcp-fb subtype='fir' type='ccm' xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0'/>
+                <rtcp-fb type='nack' xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0'/>
+                <rtcp-fb subtype='pli' type='nack' xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0'/>
+                <parameter name='apt' value='100'/>
+            </payload-type>
+            <rtp-hdrext uri='http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time' id='3' xmlns='urn:xmpp:jingle:apps:rtp:rtp-hdrext:0'/>
+            <rtp-hdrext uri='http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01' id='5' xmlns='urn:xmpp:jingle:apps:rtp:rtp-hdrext:0'/>
+            <rtcp-mux/>
+            <source ssrc='3758540092' xmlns='urn:xmpp:jingle:apps:rtp:ssma:0'>
+                <parameter name='cname' value='mixed'/>
+                <parameter name='label' value='mixedlabelvideo0'/>
+                <parameter name='msid' value='mixedmslabel mixedlabelvideo0'/>
+                <parameter name='mslabel' value='mixedmslabel'/>
+            </source>
+        </description>
+        <transport ufrag='someufrag' pwd='somepwd' xmlns='urn:xmpp:jingle:transports:ice-udp:1'>
+            <fingerprint hash='sha-256' required='false' setup='actpass' xmlns='urn:xmpp:jingle:apps:dtls:0'>09:B1:51:0F:85:4C:80:19:A1:AF:81:73:47:EE:ED:3D:00:3A:84:C7:76:C1:4E:34:BE:56:F6:42:AD:15:D5:D7</fingerprint>
+            <candidate foundation='1' id='3cbe5aea5bde0c1401a60bbc2' network='0' protocol='udp' generation='0' port='10000' priority='2130706431' type='host' ip='10.0.0.1' component='1'/>
+            <candidate rel-addr='10.0.0.1' network='0' foundation='2' id='dfcfd075bde0c140ffffffff927646ba' port='10000' protocol='udp' generation='0' rel-port='10000' priority='1694498815' type='srflx' ip='10.0.0.2' component='1'/>
+        </transport>
+    </content>
+    <group semantics='BUNDLE' xmlns='urn:xmpp:jingle:apps:grouping:0'>
+        <content name='audio'/>
+        <content name='video'/>
+    </group>
+</jingle></iq>`;
+        const expectedSDP = `v=0
+o=- 123 2 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=group:BUNDLE audio video
+m=audio 1 RTP/SAVPF 111 103 104 126
+c=IN IP4 0.0.0.0
+a=rtcp:1 IN IP4 0.0.0.0
+a=ice-ufrag:someufrag
+a=ice-pwd:somepwd
+a=fingerprint:sha-256 09:B1:51:0F:85:4C:80:19:A1:AF:81:73:47:EE:ED:3D:00:3A:84:C7:76:C1:4E:34:BE:56:F6:42:AD:15:D5:D7
+a=setup:actpass
+a=sendrecv
+a=mid:audio
+a=rtcp-mux
+a=rtpmap:111 opus/48000/2
+a=fmtp:111 minptime=10; useinbandfec=1
+a=rtcp-fb:111 transport-cc
+a=rtpmap:103 ISAC/16000
+a=rtpmap:104 ISAC/32000
+a=rtpmap:126 telephone-event/8000
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=candidate:1 1 udp 2130706431 10.0.0.1 10000 typ host generation 0
+a=candidate:2 1 udp 1694498815 10.0.0.2 10000 typ srflx raddr 10.0.0.1 rport 10000 generation 0
+a=ssrc:4039389863 cname:mixed
+a=ssrc:4039389863 label:mixedlabelaudio0
+a=ssrc:4039389863 msid:mixedmslabel mixedlabelaudio0
+a=ssrc:4039389863 mslabel:mixedmslabel
+m=video 1 RTP/SAVPF 100 96
+c=IN IP4 0.0.0.0
+a=rtcp:1 IN IP4 0.0.0.0
+a=ice-ufrag:someufrag
+a=ice-pwd:somepwd
+a=fingerprint:sha-256 09:B1:51:0F:85:4C:80:19:A1:AF:81:73:47:EE:ED:3D:00:3A:84:C7:76:C1:4E:34:BE:56:F6:42:AD:15:D5:D7
+a=setup:actpass
+a=sendrecv
+a=mid:video
+a=rtcp-mux
+a=rtpmap:100 VP8/90000
+a=fmtp:100 x-google-start-bitrate=800
+a=rtcp-fb:100 ccm fir
+a=rtcp-fb:100 nack
+a=rtcp-fb:100 nack pli
+a=rtcp-fb:100 goog-remb
+a=rtcp-fb:100 transport-cc
+a=rtpmap:96 rtx/90000
+a=fmtp:96 apt=100
+a=rtcp-fb:96 ccm fir
+a=rtcp-fb:96 nack
+a=rtcp-fb:96 nack pli
+a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=candidate:1 1 udp 2130706431 10.0.0.1 10000 typ host generation 0
+a=candidate:2 1 udp 1694498815 10.0.0.2 10000 typ srflx raddr 10.0.0.1 rport 10000 generation 0
+a=ssrc:3758540092 cname:mixed
+a=ssrc:3758540092 label:mixedlabelvideo0
+a=ssrc:3758540092 msid:mixedmslabel mixedlabelvideo0
+a=ssrc:3758540092 mslabel:mixedmslabel
+`.split('\n').join('\r\n');
+        /* eslint-enable max-len*/
+
+        it('gets converted to SDP', () => {
+            const offer = createStanzaElement(stanza);
+            const sdp = new SDP('');
+
+            sdp.fromJingle($(offer).find('>jingle'));
+            const rawSDP = sdp.raw.replace(/o=- \d+/, 'o=- 123'); // replace generated o= timestamp.
+
+            expect(rawSDP).toEqual(expectedSDP);
         });
     });
 });


### PR DESCRIPTION
follow-up from #1146. Very high level but this should cover the relevant code paths.

The jingle offer was taken from a current focus offer with a few bits removed:
* ssrc-info element
* web-socket element inside transport
* rtcp-mux element inside transport
* bridge-session element
* bundle element (removed in focus already)