### PR TITLE
fix(screenshare): Add google conference flag only when simulcast is on

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2008,11 +2008,13 @@ TraceablePeerConnection.prototype.setRemoteDescription = function(description) {
 
     if (browser.usesPlanB()) {
         // TODO the focus should squeze or explode the remote simulcast
-        // eslint-disable-next-line no-param-reassign
-        description = this.simulcast.mungeRemoteDescription(description);
-        this.trace(
-            'setRemoteDescription::postTransform (simulcast)',
-            dumpSDP(description));
+        if (this.isSimulcastOn()) {
+            // eslint-disable-next-line no-param-reassign
+            description = this.simulcast.mungeRemoteDescription(description);
+            this.trace(
+                'setRemoteDescription::postTransform (simulcast)',
+                dumpSDP(description));
+        }
 
         if (this.options.preferH264) {
             const parsedSdp = transform.parse(description.sdp);


### PR DESCRIPTION
This will make sure we get 30 fps for screenshare on p2p connections