### PR TITLE
fix(video-quality): check max constraints before applying HD

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -109,6 +109,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
             // resolutions so we do not store it, to avoid wrong reporting of
             // local track resolution.
             this.resolution = browser.isFirefox() ? null : resolution;
+            this._constraints = null;
         }
 
         this.deviceId = deviceId;
@@ -198,6 +199,15 @@ export default class JitsiLocalTrack extends JitsiTrack {
         RTCUtils.addListener(RTCEvents.DEVICE_LIST_WILL_CHANGE, this._onDeviceListWillChange);
 
         this._initNoDataFromSourceHandlers();
+    }
+
+    /**
+     * Returns the original constraints used for creating the track.
+     *
+     * @returns {Object}
+     */
+    getOriginalConstraints() {
+        return this._constraints;
     }
 
     /**

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2146,13 +2146,20 @@ TraceablePeerConnection.prototype.setSenderVideoConstraint = function(frameHeigh
     // Apply the height constraint on the local camera track
     const aspectRatio = (track.getSettings().width / track.getSettings().height).toPrecision(4);
 
+    // Make sure the new frame height is not greater than the value specified in the
+    // original constraints used for creating the camera track.
+    const constraints = localVideoTrack.getOriginalConstraints();
+    const height = constraints
+        ? Math.min(frameHeight, constraints.height.ideal)
+        : frameHeight;
+
     logger.debug(`Setting max height of ${frameHeight} on local video`);
 
     return track.applyConstraints(
         {
             aspectRatio,
             height: {
-                ideal: frameHeight
+                ideal: height
             }
         });
 };


### PR DESCRIPTION
Make sure that the max frame height applied on the track doesn't exceed the value from the constraints used for creating the original camera track