### PR TITLE
Add preferred audio bitrate to createConferenceIq

### DIFF
--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -267,6 +267,13 @@ Moderator.prototype.createConferenceIq = function() {
             value: openSctp
         }).up();
 
+    if (config.opusMaxAverageBitrate) {
+        elem.c(
+            'property', {
+                name: 'opusMaxAverageBitrate',
+                value: config.opusMaxAverageBitrate
+            }).up();
+    }
     if (this.options.conference.startAudioMuted !== undefined) {
         elem.c(
             'property', {


### PR DESCRIPTION
Pass a value for Opus' maxaveragebitrate parameter to Jicofo iff opusMaxAvgBitrate is set as configuration option.

Depends on https://github.com/jitsi/jicofo/pull/551
