### PR TITLE
ref/feat: add QualityController

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -61,6 +61,7 @@ import {
     createJingleEvent,
     createP2PEvent
 } from './service/statistics/AnalyticsEvents';
+import { QualityController } from './modules/qualitycontrol/QualityController';
 import * as XMPPEvents from './service/xmpp/XMPPEvents';
 
 const logger = getLogger(__filename);
@@ -237,12 +238,6 @@ export default function JitsiConference(options) {
     this.recordingManager = new RecordingManager(this.room);
     this._conferenceJoinAnalyticsEventSent = false;
 
-    /**
-     * Max frame height that the user prefers to send to the remote participants.
-     * @type {number}
-     */
-    this.maxFrameHeight = null;
-
     if (browser.supportsInsertableStreams()) {
         this._e2eeCtx = new E2EEContext({ salt: this.options.name });
     }
@@ -355,6 +350,8 @@ JitsiConference.prototype._init = function(options = {}) {
         this.rtc = new RTC(this, options);
         this.eventManager.setupRTCListeners();
     }
+
+    this.qualityController = new QualityController(this);
 
     this.participantConnectionStatus
         = new ParticipantConnectionStatusHandler(
@@ -619,6 +616,31 @@ JitsiConference.prototype.leave = function() {
     // If this.room == null we are calling second time leave().
     return Promise.reject(
         new Error('The conference is has been already left'));
+};
+
+/**
+ * Returns the currently active media session if any.
+ *
+ * @returns {JingleSessionPC|undefined}
+ * @private
+ */
+JitsiConference.prototype._getActiveMediaSession = function() {
+    return this.isP2PActive() ? this.p2pJingleSession : this.jvbJingleSession;
+};
+
+/**
+ * Returns an array containing all media sessions existing in this conference.
+ *
+ * @returns {Array<JingleSessionPC>}
+ * @private
+ */
+JitsiConference.prototype._getMediaSessions = function() {
+    const sessions = [];
+
+    this.jvbJingleSession && sessions.push(this.jvbJingleSession);
+    this.p2pJingleSession && sessions.push(this.p2pJingleSession);
+
+    return sessions;
 };
 
 /**
@@ -1727,14 +1749,6 @@ JitsiConference.prototype.onCallAccepted = function(session, answer) {
     if (this.p2pJingleSession === session) {
         logger.info('P2P setAnswer');
 
-        // Apply pending video constraints.
-        if (this.pendingVideoConstraintsOnP2P) {
-            this.p2pJingleSession.setSenderVideoConstraint(this.maxFrameHeight)
-                .catch(err => {
-                    logger.error(`Sender video constraints failed on p2p session - ${err}`);
-                });
-        }
-
         // Setup E2EE.
         const localTracks = this.getLocalTracks();
 
@@ -1743,6 +1757,7 @@ JitsiConference.prototype.onCallAccepted = function(session, answer) {
         }
 
         this.p2pJingleSession.setAnswer(answer);
+        this.eventEmitter.emit(JitsiConferenceEvents._MEDIA_SESSION_STARTED, this.p2pJingleSession);
     }
 };
 
@@ -1917,13 +1932,15 @@ JitsiConference.prototype._acceptJvbIncomingCall = function(
                 // to be turned off here.
                 if (this.isP2PActive() && this.jvbJingleSession) {
                     this._suspendMediaTransferForJvbConnection();
-                } else if (this.jvbJingleSession && this.maxFrameHeight) {
-                    // Apply user preferred max frame height if it was called before this
-                    // jingle session was created.
-                    this.jvbJingleSession.setSenderVideoConstraint(this.maxFrameHeight)
-                        .catch(err => {
-                            logger.error(`Sender video constraints failed on jvb session - ${err}`);
-                        });
+                }
+
+                this.eventEmitter.emit(
+                    JitsiConferenceEvents._MEDIA_SESSION_STARTED,
+                    jingleSession);
+                if (!this.isP2PActive()) {
+                    this.eventEmitter.emit(
+                        JitsiConferenceEvents._MEDIA_SESSION_ACTIVE_CHANGED,
+                        jingleSession);
                 }
 
                 // Setup E2EE.
@@ -2697,14 +2714,9 @@ JitsiConference.prototype._acceptP2PIncomingCall = function(
         () => {
             logger.debug('Got RESULT for P2P "session-accept"');
 
-            // Apply user preferred max frame height if it was called before this
-            // jingle session was created.
-            if (this.pendingVideoConstraintsOnP2P) {
-                this.p2pJingleSession.setSenderVideoConstraint(this.maxFrameHeight)
-                    .catch(err => {
-                        logger.error(`Sender video constraints failed on p2p session - ${err}`);
-                    });
-            }
+            this.eventEmitter.emit(
+                JitsiConferenceEvents._MEDIA_SESSION_STARTED,
+                this.p2pJingleSession);
 
             // Setup E2EE.
             for (const track of localTracks) {
@@ -3007,6 +3019,9 @@ JitsiConference.prototype._setP2PStatus = function(newStatus) {
         JitsiConferenceEvents.P2P_STATUS,
         this,
         this.p2p);
+    this.eventEmitter.emit(
+        JitsiConferenceEvents._MEDIA_SESSION_ACTIVE_CHANGED,
+        this._getActiveMediaSession());
 
     // Refresh connection interrupted/restored
     this.eventEmitter.emit(
@@ -3314,13 +3329,12 @@ JitsiConference.prototype.getSpeakerStats = function() {
  * Sets the maximum video size the local participant should receive from remote
  * participants.
  *
- * @param {number} maxFrameHeightPixels the maximum frame height, in pixels,
+ * @param {number} maxFrameHeight - the maximum frame height, in pixels,
  * this receiver is willing to receive.
  * @returns {void}
  */
-JitsiConference.prototype.setReceiverVideoConstraint = function(
-        maxFrameHeight) {
-    this.rtc.setReceiverVideoConstraint(maxFrameHeight);
+JitsiConference.prototype.setReceiverVideoConstraint = function(maxFrameHeight) {
+    this.qualityController.setPreferredReceiveMaxFrameHeight(maxFrameHeight);
 };
 
 /**
@@ -3331,22 +3345,7 @@ JitsiConference.prototype.setReceiverVideoConstraint = function(
  * successful and rejected otherwise.
  */
 JitsiConference.prototype.setSenderVideoConstraint = function(maxFrameHeight) {
-    this.maxFrameHeight = maxFrameHeight;
-    this.pendingVideoConstraintsOnP2P = true;
-    const promises = [];
-
-    // We have to always set the sender video constraints on the jvb connection
-    // when we switch from p2p to jvb connection since we need to check if the
-    // tracks constraints have been modified when in p2p.
-    if (this.jvbJingleSession) {
-        promises.push(this.jvbJingleSession.setSenderVideoConstraint(maxFrameHeight));
-    }
-    if (this.p2pJingleSession) {
-        this.pendingVideoConstraintsOnP2P = false;
-        promises.push(this.p2pJingleSession.setSenderVideoConstraint(maxFrameHeight));
-    }
-
-    return Promise.all(promises);
+    return this.qualityController.setPreferredSendMaxFrameHeight(maxFrameHeight);
 };
 
 /**

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -149,6 +149,20 @@ export const LOCK_STATE_CHANGED = 'conference.lock_state_changed';
 export const SERVER_REGION_CHANGED = 'conference.server_region_changed';
 
 /**
+ * An event(library-private) fired when a new media session is added to the conference.
+ * @type {string}
+ * @private
+ */
+export const _MEDIA_SESSION_STARTED = 'conference.media_session.started';
+
+/**
+ * An event(library-private) fired when the conference switches the currently active media session.
+ * @type {string}
+ * @private
+ */
+export const _MEDIA_SESSION_ACTIVE_CHANGED = 'conference.media_session.active_changed';
+
+/**
  * Indicates that the conference had changed to members only enabled/disabled.
  * The first argument of this event is a <tt>boolean</tt> which when set to
  * <tt>true</tt> means that the conference is running in members only mode.

--- a/modules/RTC/MockClasses.js
+++ b/modules/RTC/MockClasses.js
@@ -1,0 +1,86 @@
+/* eslint-disable no-empty-function */
+
+/**
+ * Mock {@link TraceablePeerConnection} - add things as needed, but only things useful for all tests.
+ */
+export class MockPeerConnection {
+    /**
+     * {@link TraceablePeerConnection.localDescription}.
+     *
+     * @returns {Object}
+     */
+    get localDescription() {
+        return {
+            sdp: ''
+        };
+    }
+
+    /**
+     * {@link TraceablePeerConnection.remoteDescription}.
+     *
+     * @returns {Object}
+     */
+    get remoteDescription() {
+        return {
+            sdp: ''
+        };
+    }
+
+    /**
+     * {@link TraceablePeerConnection.createAnswer}.
+     *
+     * @returns {Promise<Object>}
+     */
+    createAnswer() {
+        return Promise.resolve(/* answer */{});
+    }
+
+    /**
+     * {@link TraceablePeerConnection.setLocalDescription}.
+     *
+     * @returns {Promise<void>}
+     */
+    setLocalDescription() {
+        return Promise.resolve();
+    }
+
+    /**
+     * {@link TraceablePeerConnection.setRemoteDescription}.
+     *
+     * @returns {Promise<void>}
+     */
+    setRemoteDescription() {
+        return Promise.resolve();
+    }
+
+    /**
+     * {@link TraceablePeerConnection.setSenderVideoConstraint}.
+     */
+    setSenderVideoConstraint() {
+    }
+
+    /**
+     * {@link TraceablePeerConnection.setVideoTransferActive}.
+     */
+    setVideoTransferActive() {
+        return false;
+    }
+}
+
+/**
+ * Mock {@link RTC} - add things as needed, but only things useful for all tests.
+ */
+export class MockRTC {
+    /**
+     * {@link RTC.createPeerConnection}.
+     *
+     * @returns {MockPeerConnection}
+     */
+    createPeerConnection() {
+        this.pc = new MockPeerConnection();
+
+        return this.pc;
+    }
+}
+
+/* eslint-enable no-empty-function */

--- a/modules/qualitycontrol/QualityController.js
+++ b/modules/qualitycontrol/QualityController.js
@@ -55,6 +55,10 @@ export class QualityController {
         const sendMaxFrameHeight = this.selectSendMaxFrameHeight();
         const promises = [];
 
+        if (!sendMaxFrameHeight) {
+            return Promise.resolve();
+        }
+
         for (const session of this.conference._getMediaSessions()) {
             promises.push(session.setSenderVideoConstraint(sendMaxFrameHeight));
         }

--- a/modules/qualitycontrol/QualityController.js
+++ b/modules/qualitycontrol/QualityController.js
@@ -41,7 +41,8 @@ export class QualityController {
                     this._propagateSendMaxFrameHeight();
                 }
             });
-        mediaSession.setReceiverVideoConstraint(this.preferredReceiveMaxFrameHeight);
+        this.preferredReceiveMaxFrameHeight
+            && mediaSession.setReceiverVideoConstraint(this.preferredReceiveMaxFrameHeight);
     }
 
     /**
@@ -93,7 +94,7 @@ export class QualityController {
         this.preferredReceiveMaxFrameHeight = maxFrameHeight;
 
         for (const session of this.conference._getMediaSessions()) {
-            session.setReceiverVideoConstraint(maxFrameHeight);
+            maxFrameHeight && session.setReceiverVideoConstraint(maxFrameHeight);
         }
     }
 

--- a/modules/qualitycontrol/QualityController.js
+++ b/modules/qualitycontrol/QualityController.js
@@ -1,0 +1,107 @@
+import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
+import MediaSessionEvents from '../xmpp/MediaSessionEvents';
+
+/**
+ * The class manages send and receive video constraints across media sessions({@link JingleSessionPC}) which belong to
+ * {@link JitsiConference}. It finds the lowest common value, between the local user's send preference and
+ * the remote party's receive preference. Also this module will consider only the active session's receive value,
+ * because local tracks are shared and while JVB may have no preference, the remote p2p may have and they may be totally
+ * different.
+ */
+export class QualityController {
+    /**
+     * Creates new instance for a given conference.
+     *
+     * @param {JitsiConference} conference - the conference instance for which the new instance will be managing
+     * the quality constraints.
+     */
+    constructor(conference) {
+        this.conference = conference;
+        this.conference.on(
+            JitsiConferenceEvents._MEDIA_SESSION_STARTED,
+            session => this._onMediaSessionStarted(session));
+        this.conference.on(
+            JitsiConferenceEvents._MEDIA_SESSION_ACTIVE_CHANGED,
+            () => this._propagateSendMaxFrameHeight());
+    }
+
+    /**
+     * Handles the {@link JitsiConferenceEvents.MEDIA_SESSION_STARTED}, that is when the conference creates new media
+     * session. It doesn't mean it's already active though. For example the JVB connection may be created after
+     * the conference has entered the p2p mode already.
+     *
+     * @param {JingleSessionPC} mediaSession - the started media session.
+     * @private
+     */
+    _onMediaSessionStarted(mediaSession) {
+        mediaSession.addListener(
+            MediaSessionEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED,
+            session => {
+                if (session === this.conference._getActiveMediaSession()) {
+                    this._propagateSendMaxFrameHeight();
+                }
+            });
+        mediaSession.setReceiverVideoConstraint(this.preferredReceiveMaxFrameHeight);
+    }
+
+    /**
+     * Figures out the send video constraint as specified by {@link selectSendMaxFrameHeight} and sets it on all media
+     * sessions for the reasons mentioned in this class description.
+     *
+     * @returns {Promise<void[]>}
+     * @private
+     */
+    _propagateSendMaxFrameHeight() {
+        const sendMaxFrameHeight = this.selectSendMaxFrameHeight();
+        const promises = [];
+
+        for (const session of this.conference._getMediaSessions()) {
+            promises.push(session.setSenderVideoConstraint(sendMaxFrameHeight));
+        }
+
+        return Promise.all(promises);
+    }
+
+    /**
+     * Selects the lowest common value for the local video send constraint by looking at local user's preference and
+     * the active media session's receive preference set by the remote party.
+     *
+     * @returns {number|undefined}
+     */
+    selectSendMaxFrameHeight() {
+        const activeMediaSession = this.conference._getActiveMediaSession();
+        const remoteRecvMaxFrameHeight = activeMediaSession && activeMediaSession.getRemoteRecvMaxFrameHeight();
+
+        if (this.preferredSendMaxFrameHeight && remoteRecvMaxFrameHeight) {
+            return Math.min(this.preferredSendMaxFrameHeight, remoteRecvMaxFrameHeight);
+        } else if (remoteRecvMaxFrameHeight) {
+            return remoteRecvMaxFrameHeight;
+        }
+
+        return this.preferredSendMaxFrameHeight;
+    }
+
+    /**
+     * Sets local preference for max receive video frame height.
+     * @param {number|undefined} maxFrameHeight - the new value.
+     */
+    setPreferredReceiveMaxFrameHeight(maxFrameHeight) {
+        this.preferredReceiveMaxFrameHeight = maxFrameHeight;
+
+        for (const session of this.conference._getMediaSessions()) {
+            session.setReceiverVideoConstraint(maxFrameHeight);
+        }
+    }
+
+    /**
+     * Sets local preference for max send video frame height.
+     *
+     * @param {number} maxFrameHeight - the new value to set.
+     * @returns {Promise<void[]>} - resolved when the operation is complete.
+     */
+    setPreferredSendMaxFrameHeight(maxFrameHeight) {
+        this.preferredSendMaxFrameHeight = maxFrameHeight;
+
+        return this._propagateSendMaxFrameHeight();
+    }
+}

--- a/modules/xmpp/JingleSession.js
+++ b/modules/xmpp/JingleSession.js
@@ -1,6 +1,7 @@
 /* global __filename */
 import { getLogger } from 'jitsi-meet-logger';
 import * as JingleSessionState from './JingleSessionState';
+import Listenable from '../util/Listenable';
 
 const logger = getLogger(__filename);
 
@@ -9,7 +10,7 @@ const logger = getLogger(__filename);
  * have different implementations depending on the underlying interface used
  * (i.e. WebRTC and ORTC) and here we hold the code common to all of them.
  */
-export default class JingleSession {
+export default class JingleSession extends Listenable {
 
     /* eslint-disable max-params */
 
@@ -34,6 +35,7 @@ export default class JingleSession {
             mediaConstraints,
             iceConfig,
             isInitiator) {
+        super();
         this.sid = sid;
         this.localJid = localJid;
         this.remoteJid = remoteJid;

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -11,6 +11,7 @@ import { integerHash } from '../util/StringUtils';
 import browser from './../browser';
 import JingleSession from './JingleSession';
 import * as JingleSessionState from './JingleSessionState';
+import MediaSessionEvents from './MediaSessionEvents';
 import SDP from './SDP';
 import SDPDiffer from './SDPDiffer';
 import SDPUtil from './SDPUtil';
@@ -88,6 +89,18 @@ export default class JingleSessionPC extends JingleSession {
         }
 
         return null;
+    }
+
+    /**
+     * Parses the video max frame height value out of the 'content-modify' IQ.
+     *
+     * @param {jQuery} jingleContents - A jQuery selector pointing to the '>jingle' element.
+     * @returns {Number|null}
+     */
+    static parseMaxFrameHeight(jingleContents) {
+        const maxFrameHeightSel = jingleContents.find('>content[name="video"]>max-frame-height');
+
+        return maxFrameHeightSel.length ? Number(maxFrameHeightSel.text()) : null;
     }
 
     /* eslint-disable max-params */
@@ -174,6 +187,13 @@ export default class JingleSessionPC extends JingleSession {
         this._gatheringStartedTimestamp = null;
 
         /**
+         * Local preference for the receive video max frame height.
+         *
+         * @type {Number|undefined}
+         */
+        this.localRecvMaxFrameHeight = undefined;
+
+        /**
          * Indicates whether or not this session is willing to send/receive
          * video media. When set to <tt>false</tt> the underlying peer
          * connection will disable local video transfer and the remote peer will
@@ -220,6 +240,13 @@ export default class JingleSessionPC extends JingleSession {
          * session or <tt>false</tt> if it's a JVB session
          */
         this.isP2P = isP2P;
+
+        /**
+         * Remote preference for the receive video max frame height.
+         *
+         * @type {Number|undefined}
+         */
+        this.remoteRecvMaxFrameHeight = undefined;
 
         /**
          * The signaling layer implementation.
@@ -564,6 +591,17 @@ export default class JingleSessionPC extends JingleSession {
                 }
             );
         }
+    }
+
+    /**
+     * Remote preference for receive video max frame height.
+     *
+     * @returns {Number|undefined}
+     */
+    getRemoteRecvMaxFrameHeight() {
+        return this.isP2P
+            ? this.remoteRecvMaxFrameHeight
+            : undefined; // FIXME George: put a getter for the JVB's preference here
     }
 
     /**
@@ -1028,7 +1066,7 @@ export default class JingleSessionPC extends JingleSession {
                     if (this.state === JingleSessionState.PENDING) {
                         this.state = JingleSessionState.ACTIVE;
 
-                        // Sync up video transfer active/inactive only after
+                        // #1 Sync up video transfer active/inactive only after
                         // the initial O/A cycle. We want to adjust the video
                         // media direction only in the local SDP and the Jingle
                         // contents direction included in the initial
@@ -1039,8 +1077,11 @@ export default class JingleSessionPC extends JingleSession {
                         // Changing media direction in the remote SDP will mess
                         // up our SDP translation chain (simulcast, video mute,
                         // RTX etc.)
-                        if (this.isP2P && !this._localVideoActive) {
-                            this.sendContentModify(this._localVideoActive);
+                        //
+                        // #2 Sends the max frame height if it was set, before the session-initiate/accept
+                        if (this.isP2P
+                            && (!this._localVideoActive || this.localRecvMaxFrameHeight)) {
+                            this.sendContentModify();
                         }
                     }
 
@@ -1215,17 +1256,14 @@ export default class JingleSessionPC extends JingleSession {
 
     /**
      * Will send 'content-modify' IQ in order to ask the remote peer to
-     * either stop or resume sending video media.
-     * @param {boolean} videoTransferActive <tt>false</tt> to let the other peer
-     * know that we're not sending nor interested in receiving video contents.
-     * When set to <tt>true</tt> remote peer will be asked to resume video
-     * transfer.
+     * either stop or resume sending video media or to adjust sender's video constraints.
      * @private
      */
-    sendContentModify(videoTransferActive) {
-        const newSendersValue = videoTransferActive ? 'both' : 'none';
+    sendContentModify() {
+        const maxFrameHeight = this.localRecvMaxFrameHeight;
+        const senders = this._localVideoActive ? 'both' : 'none';
 
-        const sessionModify
+        let sessionModify
             = $iq({
                 to: this.remoteJid,
                 type: 'set'
@@ -1238,17 +1276,42 @@ export default class JingleSessionPC extends JingleSession {
                 })
                 .c('content', {
                     name: 'video',
-                    senders: newSendersValue
+                    senders
                 });
 
-        logger.info(
-            `Sending content-modify, video senders: ${newSendersValue}`);
+        if (typeof maxFrameHeight !== 'undefined') {
+            sessionModify = sessionModify
+                .c('max-frame-height', { xmlns: 'http://jitsi.org/jitmeet/video' })
+                .t(maxFrameHeight);
+        }
+
+        logger.info(`${this} sending content-modify, video senders: ${senders}, max frame height: ${maxFrameHeight}`);
 
         this.connection.sendIQ(
             sessionModify,
             null,
             this.newJingleErrorHandler(sessionModify),
             IQ_TIMEOUT);
+    }
+
+    /**
+     * Adjust the preference for max video frame height that the local party is willing to receive. Signals
+     * the remote party.
+     *
+     * @param {Number} maxFrameHeight - the new value to set.
+     */
+    setReceiverVideoConstraint(maxFrameHeight) {
+        this.localRecvMaxFrameHeight = maxFrameHeight;
+
+        if (this.isP2P) {
+            // Tell the remote peer about our receive constraint. If Jingle session is not yet active the state will
+            // be synced after offer/answer.
+            if (this.state === JingleSessionState.ACTIVE) {
+                this.sendContentModify();
+            }
+        } else {
+            this.rtc.setReceiverVideoConstraint(maxFrameHeight);
+        }
     }
 
     /**
@@ -1336,7 +1399,13 @@ export default class JingleSessionPC extends JingleSession {
      * successful and rejected otherwise.
      */
     setSenderVideoConstraint(maxFrameHeight) {
-        return this.peerconnection.setSenderVideoConstraint(maxFrameHeight);
+        if (this._assertNotEnded()) {
+            logger.info(`${this} accepted setSenderVideoConstraint: ${maxFrameHeight}`);
+
+            return this.peerconnection.setSenderVideoConstraint(maxFrameHeight);
+        }
+
+        return Promise.resolve();
     }
 
     /**
@@ -2087,7 +2156,7 @@ export default class JingleSessionPC extends JingleSession {
                 // 'inactive' on video media in remote SDP will mess up our SDP
                 // translation chain (simulcast, RTX, video mute etc.).
                 if (this.isP2P && isSessionActive) {
-                    this.sendContentModify(videoActive);
+                    this.sendContentModify();
                 }
             }
 
@@ -2134,6 +2203,17 @@ export default class JingleSessionPC extends JingleSession {
     modifyContents(jingleContents) {
         const newVideoSenders
             = JingleSessionPC.parseVideoSenders(jingleContents);
+        const newMaxFrameHeight
+            = JingleSessionPC.parseMaxFrameHeight(jingleContents);
+
+        // frame height is optional in our content-modify protocol
+        if (newMaxFrameHeight) {
+            this.remoteRecvMaxFrameHeight = newMaxFrameHeight;
+            this.eventEmitter.emit(
+                MediaSessionEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED,
+                this,
+                newMaxFrameHeight);
+        }
 
         if (newVideoSenders === null) {
             logger.error(

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1301,6 +1301,8 @@ export default class JingleSessionPC extends JingleSession {
      * @param {Number} maxFrameHeight - the new value to set.
      */
     setReceiverVideoConstraint(maxFrameHeight) {
+        logger.info(`${this} setReceiverVideoConstraint - max frame height: ${maxFrameHeight}`);
+
         this.localRecvMaxFrameHeight = maxFrameHeight;
 
         if (this.isP2P) {
@@ -1400,7 +1402,7 @@ export default class JingleSessionPC extends JingleSession {
      */
     setSenderVideoConstraint(maxFrameHeight) {
         if (this._assertNotEnded()) {
-            logger.info(`${this} accepted setSenderVideoConstraint: ${maxFrameHeight}`);
+            logger.info(`${this} setSenderVideoConstraint: ${maxFrameHeight}`);
 
             return this.peerconnection.setSenderVideoConstraint(maxFrameHeight);
         }
@@ -2208,6 +2210,7 @@ export default class JingleSessionPC extends JingleSession {
 
         // frame height is optional in our content-modify protocol
         if (newMaxFrameHeight) {
+            logger.info(`${this} received remote max frame height: ${newMaxFrameHeight}`);
             this.remoteRecvMaxFrameHeight = newMaxFrameHeight;
             this.eventEmitter.emit(
                 MediaSessionEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED,

--- a/modules/xmpp/JingleSessionPC.spec.js
+++ b/modules/xmpp/JingleSessionPC.spec.js
@@ -1,0 +1,122 @@
+/* global $, jQuery */
+import { MockRTC } from '../RTC/MockClasses';
+
+import JingleSessionPC from './JingleSessionPC';
+import * as JingleSessionState from './JingleSessionState';
+import MediaSessionEvents from './MediaSessionEvents';
+import { MockChatRoom, MockStropheConnection } from './MockClasses';
+
+/**
+ * Creates 'content-modify' Jingle IQ.
+ * @param {string} senders - 'both' or 'none'.
+ * @param {number|undefined} maxFrameHeight - the receive max video frame height.
+ * @returns {jQuery}
+ */
+function createContentModify(senders = 'both', maxFrameHeight) {
+    const modifyContentsIq = jQuery.parseXML(
+        '<jingle action="content-modify" initiator="peer2" sid="sid12345" xmlns="urn:xmpp:jingle:1">'
+        + `<content name="video" senders="${senders}">`
+        + `<max-frame-height xmlns="http://jitsi.org/jitmeet/video">${maxFrameHeight}</max-frame-height>`
+        + '</content>'
+        + '</jingle>');
+
+    return $(modifyContentsIq).find('>jingle');
+}
+
+describe('JingleSessionPC', () => {
+    let jingleSession;
+    let connection;
+    let rtc;
+    const offerIQ = {
+        find: () => {
+            return {
+                // eslint-disable-next-line no-empty-function
+                each: () => { }
+            };
+        }
+    };
+
+    const SID = 'sid12345';
+
+    beforeEach(() => {
+        connection = new MockStropheConnection();
+        jingleSession = new JingleSessionPC(
+            SID,
+            'peer1',
+            'peer2',
+            connection,
+            { },
+            { },
+            true,
+            false);
+
+        rtc = new MockRTC();
+
+        jingleSession.initialize(
+            /* ChatRoom */ new MockChatRoom(),
+            /* RTC */ rtc,
+            /* options */ { });
+
+        // eslint-disable-next-line no-empty-function
+        // connection.connect('jid', undefined, () => { }); */
+    });
+
+    describe('send/receive video constraints', () => {
+        it('sends content-modify with recv frame size', () => {
+            const sendIQSpy = spyOn(connection, 'sendIQ').and.callThrough();
+
+            jingleSession.setReceiverVideoConstraint(180);
+
+            expect(jingleSession.getState()).toBe(JingleSessionState.PENDING);
+
+            return new Promise((resolve, reject) => {
+                jingleSession.acceptOffer(
+                    offerIQ,
+                    resolve,
+                    reject,
+                    /* local tracks */ []);
+            }).then(() => {
+                expect(jingleSession.getState()).toBe(JingleSessionState.ACTIVE);
+
+                // FIXME content-modify is sent before session-accept
+                expect(sendIQSpy.calls.count()).toBe(2);
+
+                expect(sendIQSpy.calls.first().args[0].toString()).toBe(
+                    '<iq to="peer2" type="set" xmlns="jabber:client">'
+                    + '<jingle action="content-modify" initiator="peer2" sid="sid12345" xmlns="urn:xmpp:jingle:1">'
+                    + '<content name="video" senders="both">'
+                    + '<max-frame-height xmlns="http://jitsi.org/jitmeet/video">180</max-frame-height>'
+                    + '</content>'
+                    + '</jingle>'
+                    + '</iq>');
+            });
+        });
+        it('fires an event when remote peer sends content-modify', () => {
+            let remoteRecvMaxFrameHeight;
+            const remoteVideoConstraintsListener = (session, maxFrameHeight) => {
+                remoteRecvMaxFrameHeight = maxFrameHeight;
+            };
+
+            jingleSession.addListener(
+                MediaSessionEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED,
+                remoteVideoConstraintsListener);
+
+            return new Promise((resolve, reject) => {
+                jingleSession.acceptOffer(
+                    offerIQ,
+                    resolve,
+                    reject,
+                    /* local tracks */ []);
+            }).then(() => {
+                jingleSession.modifyContents(createContentModify('both', 180));
+                expect(remoteRecvMaxFrameHeight).toBe(180);
+
+                jingleSession.modifyContents(createContentModify('both', 360));
+                expect(remoteRecvMaxFrameHeight).toBe(360);
+
+                jingleSession.modifyContents(createContentModify('both', 180));
+                expect(remoteRecvMaxFrameHeight).toBe(180);
+            });
+        });
+    });
+});

--- a/modules/xmpp/MediaSessionEvents.js
+++ b/modules/xmpp/MediaSessionEvents.js
@@ -1,0 +1,6 @@
+export default {
+    /**
+     * Event triggered when the remote party signals it's receive video max frame height.
+     */
+    REMOTE_VIDEO_CONSTRAINTS_CHANGED: 'media_session.REMOTE_VIDEO_CONSTRAINTS_CHANGED'
+};

--- a/modules/xmpp/MockClasses.js
+++ b/modules/xmpp/MockClasses.js
@@ -1,0 +1,71 @@
+import { Strophe } from 'strophe.js';
+import Listenable from '../util/Listenable';
+
+/* eslint-disable no-empty-function */
+
+/**
+ * Mock {@link ChatRoom}.
+ */
+export class MockChatRoom {
+    /**
+     * {@link ChatRoom.addPresenceListener}.
+     */
+    addPresenceListener() {
+    }
+}
+
+/**
+ * Mock Strophe connection.
+ */
+export class MockStropheConnection extends Listenable {
+    /**
+     * A constructor...
+     */
+    constructor() {
+        super();
+        this.sentIQs = [];
+    }
+
+    /**
+     * XMPP service URL.
+     *
+     * @returns {string}
+     */
+    get service() {
+        return 'wss://localhost/xmpp-websocket';
+    }
+
+    /**
+     * {@see Strophe.Connection.connect}
+     */
+    connect(jid, pass, callback) {
+        this._connectCb = callback;
+    }
+
+    /**
+     * {@see Strophe.Connection.disconnect}
+     */
+    disconnect() {
+        this.simulateConnectionState(Strophe.Status.DISCONNECTING);
+        this.simulateConnectionState(Strophe.Status.DISCONNECTED);
+    }
+
+    /**
+     * Simulates transition to the new connection status.
+     *
+     * @param {Strophe.Status} newState - The new connection status to set.
+     * @returns {void}
+     */
+    simulateConnectionState(newState) {
+        this._connectCb(newState);
+    }
+
+    /**
+     * {@see Strophe.Connection.sendIQ}.
+     */
+    sendIQ(iq, resultCb) {
+        this.sentIQs.push(iq);
+        resultCb && resultCb();
+    }
+}
+/* eslint-enable no-empty-function */

--- a/modules/xmpp/XmppConnection.spec.js
+++ b/modules/xmpp/XmppConnection.spec.js
@@ -1,52 +1,9 @@
-import { default as XmppConnection } from './XmppConnection';
 import { $iq, Strophe } from 'strophe.js';
+
 import { nextTick } from '../util/TestUtils';
 
-/**
- * Mock Strophe connection.
- */
-class MockStropheConnection {
-    /**
-     * XMPP service URL.
-     *
-     * @returns {string}
-     */
-    get service() {
-        return 'wss://localhost/xmpp-websocket';
-    }
-
-    /**
-     * {@see Strophe.Connection.connect}
-     */
-    connect(jid, pass, callback) {
-        this._connectCb = callback;
-    }
-
-    /**
-     * {@see Strophe.Connection.disconnect}
-     */
-    disconnect() {
-        this.simulateConnectionState(Strophe.Status.DISCONNECTING);
-        this.simulateConnectionState(Strophe.Status.DISCONNECTED);
-    }
-
-    /**
-     * Simulates transition to the new connection status.
-     *
-     * @param {Strophe.Status} newState - The new connection status to set.
-     * @returns {void}
-     */
-    simulateConnectionState(newState) {
-        this._connectCb(newState);
-    }
-
-    /**
-     * {@see Strophe.Connection.sendIQ}.
-     */
-    sendIQ(iq, resultCb) {
-        resultCb();
-    }
-}
+import { default as XmppConnection } from './XmppConnection';
+import { MockStropheConnection } from './MockClasses';
 
 /**
  * Creates any IQ.


### PR DESCRIPTION
Refactors the way send/receive video constraints are managed and puts the high level
logic in a separate module. See QualityController.js for high level overview on how
the constraints are managed now.

Adds events to JitsiConference fired whenever it starts new jvb/p2p session.

Adds event to JingleSessionPC.js when remote party signals receive max frame height.
Also adds signaling of the local recv preference for the p2p mode(only existed for JVB).