### PR TITLE
Remove screenshare extension support

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -299,10 +299,6 @@ export default _mergeNamespaceAndModule({
      * @param {string} options.resolution resolution constraints
      * @param {string} options.cameraDeviceId
      * @param {string} options.micDeviceId
-     * @param {object} options.desktopSharingExtensionExternalInstallation -
-     * enables external installation process for desktop sharing extension if
-     * the inline installation is not posible. The following properties should
-     * be provided:
      * @param {intiger} interval - the interval (in ms) for
      * checking whether the desktop sharing extension is installed or not
      * @param {Function} checkAgain - returns boolean. While checkAgain()==true

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -445,12 +445,12 @@ export default _mergeNamespaceAndModule({
                 }
 
                 if (error.name
-                        === JitsiTrackErrors.CHROME_EXTENSION_USER_CANCELED) {
+                        === JitsiTrackErrors.SCREENSHARING_USER_CANCELED) {
                     // User cancelled action is not really an error, so only
                     // log it as an event to avoid having conference classified
                     // as partially failed
                     const logObject = {
-                        id: 'chrome_extension_user_canceled',
+                        id: 'screensharing_user_canceled',
                         message: error.message
                     };
 

--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -4,16 +4,10 @@ const TRACK_ERROR_TO_MESSAGE_MAP = {};
 
 TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.UNSUPPORTED_RESOLUTION]
     = 'Video resolution is not supported: ';
-TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.CHROME_EXTENSION_INSTALLATION_ERROR]
-    = 'Failed to install Chrome extension';
-TRACK_ERROR_TO_MESSAGE_MAP[
-    JitsiTrackErrors.CHROME_EXTENSION_USER_GESTURE_REQUIRED]
-    = 'Failed to install Chrome extension - installations can only be initiated'
-        + ' by a user gesture.';
-TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.CHROME_EXTENSION_USER_CANCELED]
-    = 'User canceled Chrome\'s screen sharing prompt';
-TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.CHROME_EXTENSION_GENERIC_ERROR]
-    = 'Unknown error from Chrome extension';
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.SCREENSHARING_USER_CANCELED]
+    = 'User canceled screen sharing prompt';
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.SCREENSHARING_GENERIC_ERROR]
+    = 'Unknown error from screensharing';
 TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_ERROR]
     = 'Unkown error from desktop picker';
 TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_NOT_FOUND]

--- a/JitsiTrackErrors.js
+++ b/JitsiTrackErrors.js
@@ -3,36 +3,6 @@
  */
 
 /**
- * Generic error for jidesha extension for Chrome.
- */
-export const CHROME_EXTENSION_GENERIC_ERROR
-    = 'gum.chrome_extension_generic_error';
-
-/**
- * An error which indicates that the jidesha extension for Chrome is
- * failed to install.
- */
-export const CHROME_EXTENSION_INSTALLATION_ERROR
-    = 'gum.chrome_extension_installation_error';
-
-/**
- * This error indicates that the attempt to start screensharing was initiated by
- * a script which did not originate in user gesture handler. It means that
- * you should to trigger the action again in response to a button click for
- * example.
- * @type {string}
- */
-export const CHROME_EXTENSION_USER_GESTURE_REQUIRED
-    = 'gum.chrome_extension_user_gesture_required';
-
-/**
- * An error which indicates that user canceled screen sharing window
- * selection dialog in jidesha extension for Chrome.
- */
-export const CHROME_EXTENSION_USER_CANCELED
-    = 'gum.chrome_extension_user_canceled';
-
-/**
  * An error which indicates that some of requested constraints in
  * getUserMedia call were not satisfied.
  */
@@ -53,12 +23,6 @@ export const ELECTRON_DESKTOP_PICKER_NOT_FOUND
     = 'gum.electron_desktop_picker_not_found';
 
 /**
- * An error which indicates that the jidesha extension for Firefox is
- * needed to proceed with screen sharing, and that it is not installed.
- */
-export const FIREFOX_EXTENSION_NEEDED = 'gum.firefox_extension_needed';
-
-/**
  * Generic getUserMedia error.
  */
 export const GENERAL = 'gum.general';
@@ -73,6 +37,19 @@ export const NOT_FOUND = 'gum.not_found';
  * device.
  */
 export const PERMISSION_DENIED = 'gum.permission_denied';
+
+/**
+ * Generic error for screensharing failure.
+ */
+export const SCREENSHARING_GENERIC_ERROR
+    = 'gum.screensharing_generic_error';
+
+/**
+ * An error which indicates that user canceled screen sharing window
+ * selection dialog.
+ */
+export const SCREENSHARING_USER_CANCELED
+    = 'gum.screensharing_user_canceled';
 
 /**
  * An error which indicates that track has been already disposed and cannot

--- a/doc/API.md
+++ b/doc/API.md
@@ -192,10 +192,8 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
         - CONSTRAINT_FAILED - getUserMedia-related error, indicates that some of requested constraints in getUserMedia call were not satisfied.
         - TRACK_IS_DISPOSED - an error which indicates that track has been already disposed and cannot be longer used.
         - TRACK_NO_STREAM_FOUND - an error which indicates that track has no MediaStream associated.
-        - CHROME_EXTENSION_GENERIC_ERROR - generic error for jidesha extension for Chrome.
-        - CHROME_EXTENSION_USER_CANCELED - an error which indicates that user canceled screen sharing window selection dialog in jidesha extension for Chrome.
-        - CHROME_EXTENSION_INSTALLATION_ERROR - an error which indicates that the jidesha extension for Chrome is failed to install.
-        - FIREFOX_EXTENSION_NEEDED - An error which indicates that the jidesha extension for Firefox is needed to proceed with screen sharing, and that it is not installed.
+        - SCREENSHARING_GENERIC_ERROR - generic error for screensharing.
+        - SCREENSHARING_USER_CANCELED - an error which indicates that user canceled screen sharing window selection dialog.
 
 * ```JitsiMeetJS.errorTypes``` - constructors for Error instances that can be produced by library. Are useful for checks like ```error instanceof JitsiMeetJS.errorTypes.JitsiTrackError```. Following Errors are available:
     1. ```JitsiTrackError``` - Error that happened to a JitsiTrack.

--- a/doc/API.md
+++ b/doc/API.md
@@ -39,11 +39,6 @@ You can access the following methods and objects trough ```JitsiMeetJS``` object
 *  ```JitsiMeetJS.init(options)``` - this method initialized Jitsi Meet API.
 The ```options``` parameter is JS object with the following properties:
     - `useIPv6` - boolean property
-    - `desktopSharingChromeExtId` - The ID of the jidesha extension for Chrome. Example: 'mbocklcggfhnbahlnepmldehdhpjfcjp'
-    - `desktopSharingChromeDisabled` - Boolean. Whether desktop sharing should be disabled on Chrome. Example: false.
-    - `desktopSharingChromeSources` - Array of strings with the media sources to use when using screen sharing with the Chrome extension. Example: ['screen', 'window']
-    - `desktopSharingChromeMinExtVersion` - Required version of Chrome extension. Example: '0.1'
-    - `desktopSharingFirefoxDisabled` - Boolean. Whether desktop sharing should be disabled on Firefox. Example: false.
     - `disableAudioLevels` - boolean property. Enables/disables audio levels.
     - `disableSimulcast` - boolean property. Enables/disables simulcast.
     - `enableWindowOnErrorHandler` - boolean property (default false). Enables/disables attaching global onerror handler (window.onerror).

--- a/doc/example/example.js
+++ b/doc/example/example.js
@@ -238,23 +238,7 @@ $(window).bind('unload', unload);
 
 // JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
 const initOptions = {
-    disableAudioLevels: true,
-
-    // The ID of the jidesha extension for Chrome.
-    desktopSharingChromeExtId: 'mbocklcggfhnbahlnepmldehdhpjfcjp',
-
-    // Whether desktop sharing should be disabled on Chrome.
-    desktopSharingChromeDisabled: false,
-
-    // The media sources to use when using screen sharing with the Chrome
-    // extension.
-    desktopSharingChromeSources: [ 'screen', 'window' ],
-
-    // Required version of Chrome extension
-    desktopSharingChromeMinExtVersion: '0.1',
-
-    // Whether desktop sharing should be disabled on Firefox.
-    desktopSharingFirefoxDisabled: true
+    disableAudioLevels: true
 };
 
 JitsiMeetJS.init(initOptions);

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -998,7 +998,6 @@ class RTCUtils extends Listenable {
      * in RTCUtils#_newGetUserMediaWithConstraints.
      *
      * @param {Object} options
-     * @param {Object} options.desktopSharingExtensionExternalInstallation
      * @param {string[]} options.desktopSharingSources
      * @param {Object} options.desktopSharingFrameRate
      * @param {Object} options.desktopSharingFrameRate.min - Minimum fps
@@ -1169,7 +1168,6 @@ class RTCUtils extends Listenable {
      */
     _parseDesktopSharingOptions(options) {
         return {
-            ...options.desktopSharingExtensionExternalInstallation,
             desktopSharingSources: options.desktopSharingSources,
             gumOptions: {
                 frameRate: options.desktopSharingFrameRate
@@ -1221,7 +1219,6 @@ class RTCUtils extends Listenable {
             }
 
             const {
-                desktopSharingExtensionExternalInstallation,
                 desktopSharingSourceDevice,
                 desktopSharingSources,
                 desktopSharingFrameRate
@@ -1278,7 +1275,6 @@ class RTCUtils extends Listenable {
             }
 
             return this._newGetDesktopMedia({
-                desktopSharingExtensionExternalInstallation,
                 desktopSharingSources,
                 desktopSharingFrameRate
             });

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -117,8 +117,7 @@ const ScreenObtainer = {
 
             window.JitsiMeetScreenObtainer.openDesktopPicker(
                 {
-                    desktopSharingSources: desktopSharingSources
-                        || this.options.desktopSharingChromeSources
+                    desktopSharingSources
                 },
                 (streamId, streamType, screenShareAudio = false) =>
                     onGetStreamResponse(

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -1,32 +1,11 @@
-/* global chrome, $, alert */
 
 import JitsiTrackError from '../../JitsiTrackError';
 import * as JitsiTrackErrors from '../../JitsiTrackErrors';
 import browser from '../browser';
 
 const logger = require('jitsi-meet-logger').getLogger(__filename);
-const GlobalOnErrorHandler = require('../util/GlobalOnErrorHandler');
-
-/**
- * Indicates whether the Chrome desktop sharing extension is installed.
- * @type {boolean}
- */
-let chromeExtInstalled = false;
-
-/**
- * Indicates whether an update of the Chrome desktop sharing extension is
- * required.
- * @type {boolean}
- */
-let chromeExtUpdateRequired = false;
 
 let gumFunction = null;
-
-/**
- * The error message returned by chrome when the extension is installed.
- */
-const CHROME_NO_EXTENSION_ERROR_MSG // eslint-disable-line no-unused-vars
-    = 'Could not establish connection. Receiving end does not exist.';
 
 /**
  * Handles obtaining a stream from a screen capture on different browsers.
@@ -38,7 +17,6 @@ const ScreenObtainer = {
      * after it's done.
      * {@type Promise|null}
      */
-    intChromeExtPromise: null,
 
     obtainStream: null,
 
@@ -47,20 +25,13 @@ const ScreenObtainer = {
      * (this.obtainStream).
      *
      * @param {object} options
-     * @param {boolean} [options.desktopSharingChromeDisabled]
-     * @param {boolean} [options.desktopSharingChromeExtId]
-     * @param {boolean} [options.desktopSharingFirefoxDisabled]
      * @param {Function} gum GUM method
      */
-    init(options = {
-        desktopSharingChromeDisabled: false,
-        desktopSharingChromeExtId: null,
-        desktopSharingFirefoxDisabled: false
-    }, gum) {
+    init(options = {}, gum) {
         this.options = options;
         gumFunction = gum;
 
-        this.obtainStream = this._createObtainStreamMethod(options);
+        this.obtainStream = this._createObtainStreamMethod();
 
         if (!this.obtainStream) {
             logger.info('Desktop sharing disabled');
@@ -71,12 +42,10 @@ const ScreenObtainer = {
      * Returns a method which will be used to obtain the screen sharing stream
      * (based on the browser type).
      *
-     * @param {object} options passed from {@link init} - check description
-     * there
      * @returns {Function}
      * @private
      */
-    _createObtainStreamMethod(options) {
+    _createObtainStreamMethod() {
         if (browser.isNWJS()) {
             return (_, onSuccess, onFailure) => {
                 window.JitsiMeetNW.obtainDesktopStream(
@@ -102,7 +71,7 @@ const ScreenObtainer = {
 
                         if (error && error.name === 'InvalidStateError') {
                             jitsiError = new JitsiTrackError(
-                                JitsiTrackErrors.CHROME_EXTENSION_USER_CANCELED
+                                JitsiTrackErrors.SCREENSHARING_USER_CANCELED
                             );
                         } else {
                             jitsiError = new JitsiTrackError(
@@ -114,41 +83,10 @@ const ScreenObtainer = {
             };
         } else if (browser.isElectron()) {
             return this.obtainScreenOnElectron;
-        } else if (browser.isChrome() || browser.isOpera()) {
-            if (browser.supportsGetDisplayMedia()
-                    && !options.desktopSharingChromeDisabled) {
-
-                return this.obtainScreenFromGetDisplayMedia;
-            } else if (options.desktopSharingChromeDisabled
-                || !options.desktopSharingChromeExtId) {
-
-                return null;
-            }
-
-            logger.info('Using Chrome extension for desktop sharing');
-            this.intChromeExtPromise
-                = initChromeExtension(options).then(() => {
-                    this.intChromeExtPromise = null;
-                });
-
-            return this.obtainScreenFromExtension;
-        } else if (browser.isFirefox()) {
-            if (options.desktopSharingFirefoxDisabled) {
-                return null;
-            } else if (browser.supportsGetDisplayMedia()) {
-                // Firefox 66 support getDisplayMedia
-                return this.obtainScreenFromGetDisplayMedia;
-            }
-
-            // Legacy Firefox
-            return this.obtainScreenOnFirefox;
-        } else if (browser.isSafari() && browser.supportsGetDisplayMedia()) {
+        } else if (browser.supportsGetDisplayMedia()) {
             return this.obtainScreenFromGetDisplayMedia;
         }
-
-        logger.log(
-            'Screen sharing not supported by the current browser: ',
-            browser.getName());
+        logger.log('Screen sharing not supported on ', browser.getName());
 
         return null;
     },
@@ -160,15 +98,6 @@ const ScreenObtainer = {
      */
     isSupported() {
         return this.obtainStream !== null;
-    },
-
-    /**
-     * Obtains a screen capture stream on Firefox.
-     * @param callback
-     * @param errorCallback
-     */
-    obtainScreenOnFirefox(options, callback, errorCallback) {
-        obtainWebRTCScreen(options.gumOptions, callback, errorCallback);
     },
 
     /**
@@ -216,88 +145,6 @@ const ScreenObtainer = {
     },
 
     /**
-     * Asks Chrome extension to call chooseDesktopMedia and gets chrome
-     * 'desktop' stream for returned stream token.
-     */
-    obtainScreenFromExtension(options, streamCallback, failCallback) {
-        if (this.intChromeExtPromise !== null) {
-            this.intChromeExtPromise.then(() => {
-                this.obtainScreenFromExtension(
-                    options, streamCallback, failCallback);
-            });
-
-            return;
-        }
-
-        const {
-            desktopSharingChromeExtId,
-            desktopSharingChromeSources
-        } = this.options;
-
-        const {
-            gumOptions
-        } = options;
-
-        const doGetStreamFromExtensionOptions = {
-            desktopSharingChromeExtId,
-            desktopSharingChromeSources:
-                options.desktopSharingSources || desktopSharingChromeSources,
-            gumOptions
-        };
-
-        if (chromeExtInstalled) {
-            doGetStreamFromExtension(
-                doGetStreamFromExtensionOptions,
-                streamCallback,
-                failCallback);
-        } else {
-            if (chromeExtUpdateRequired) {
-                /* eslint-disable no-alert */
-                alert(
-                    'Jitsi Desktop Streamer requires update. '
-                    + 'Changes will take effect after next Chrome restart.');
-
-                /* eslint-enable no-alert */
-            }
-
-            this.handleExternalInstall(options, streamCallback,
-                failCallback);
-        }
-    },
-
-    /* eslint-disable max-params */
-
-    handleExternalInstall(options, streamCallback, failCallback, e) {
-        const webStoreInstallUrl = getWebStoreInstallUrl(this.options);
-
-        options.listener('waitingForExtension', webStoreInstallUrl);
-        this.checkForChromeExtensionOnInterval(options, streamCallback,
-            failCallback, e);
-    },
-
-    /* eslint-enable max-params */
-
-    checkForChromeExtensionOnInterval(options, streamCallback, failCallback) {
-        if (options.checkAgain() === false) {
-            failCallback(new JitsiTrackError(
-                JitsiTrackErrors.CHROME_EXTENSION_INSTALLATION_ERROR));
-
-            return;
-        }
-        waitForExtensionAfterInstall(this.options, options.interval, 1)
-            .then(() => {
-                chromeExtInstalled = true;
-                options.listener('extensionFound');
-                this.obtainScreenFromExtension(options,
-                    streamCallback, failCallback);
-            })
-            .catch(() => {
-                this.checkForChromeExtensionOnInterval(options,
-                    streamCallback, failCallback);
-            });
-    },
-
-    /**
      * Obtains a screen capture stream using getDisplayMedia.
      *
      * @param callback - The success callback.
@@ -341,235 +188,9 @@ const ScreenObtainer = {
             })
             .catch(() =>
                 errorCallback(new JitsiTrackError(JitsiTrackErrors
-                    .CHROME_EXTENSION_USER_CANCELED)));
+                    .SCREENSHARING_USER_CANCELED)));
     }
 };
-
-/**
- * Obtains a desktop stream using getUserMedia.
- * For this to work on Chrome, the
- * 'chrome://flags/#enable-usermedia-screen-capture' flag must be enabled.
- *
- * On firefox, the document's domain must be white-listed in the
- * 'media.getusermedia.screensharing.allowed_domains' preference in
- * 'about:config'.
- */
-function obtainWebRTCScreen(options, streamCallback, failCallback) {
-    gumFunction([ 'screen' ], options)
-        .then(stream => streamCallback({ stream }), failCallback);
-}
-
-/**
- * Constructs inline install URL for Chrome desktop streaming extension.
- * The 'chromeExtensionId' must be defined in options parameter.
- * @param options supports "desktopSharingChromeExtId"
- * @returns {string}
- */
-function getWebStoreInstallUrl(options) {
-    return (
-        `https://chrome.google.com/webstore/detail/${
-            options.desktopSharingChromeExtId}`);
-}
-
-/**
- * Checks whether an update of the Chrome extension is required.
- * @param minVersion minimal required version
- * @param extVersion current extension version
- * @returns {boolean}
- */
-function isUpdateRequired(minVersion, extVersion) {
-    try {
-        const s1 = minVersion.split('.');
-        const s2 = extVersion.split('.');
-
-        const len = Math.max(s1.length, s2.length);
-
-        for (let i = 0; i < len; i++) {
-            let n1 = 0,
-                n2 = 0;
-
-            if (i < s1.length) {
-                n1 = parseInt(s1[i], 10);
-            }
-            if (i < s2.length) {
-                n2 = parseInt(s2[i], 10);
-            }
-
-            if (isNaN(n1) || isNaN(n2)) {
-                return true;
-            } else if (n1 !== n2) {
-                return n1 > n2;
-            }
-        }
-
-        // will happen if both versions have identical numbers in
-        // their components (even if one of them is longer, has more components)
-        return false;
-    } catch (e) {
-        GlobalOnErrorHandler.callErrorHandler(e);
-        logger.error('Failed to parse extension version', e);
-
-        return true;
-    }
-}
-
-/**
- *
- * @param callback
- * @param options
- */
-function checkChromeExtInstalled(callback, options) {
-    if (typeof chrome === 'undefined' || !chrome || !chrome.runtime) {
-        // No API, so no extension for sure
-        callback(false, false);
-
-        return;
-    }
-    chrome.runtime.sendMessage(
-        options.desktopSharingChromeExtId,
-        { getVersion: true },
-        response => {
-            if (!response || !response.version) {
-                // Communication failure - assume that no endpoint exists
-                logger.warn(
-                    'Extension not installed?: ', chrome.runtime.lastError);
-                callback(false, false);
-
-                return;
-            }
-
-            // Check installed extension version
-            const extVersion = response.version;
-
-            logger.log(`Extension version is: ${extVersion}`);
-            const updateRequired
-                = isUpdateRequired(
-                    options.desktopSharingChromeMinExtVersion,
-                    extVersion);
-
-            callback(!updateRequired, updateRequired);
-        }
-    );
-}
-
-/**
- *
- * @param options
- * @param streamCallback
- * @param failCallback
- */
-function doGetStreamFromExtension(options, streamCallback, failCallback) {
-    const {
-        desktopSharingChromeSources,
-        desktopSharingChromeExtId,
-        gumOptions
-    } = options;
-
-    // Sends 'getStream' msg to the extension.
-    // Extension id must be defined in the config.
-    chrome.runtime.sendMessage(
-        desktopSharingChromeExtId,
-        {
-            getStream: true,
-            sources: desktopSharingChromeSources
-        },
-        response => {
-            if (!response) {
-                // possibly re-wraping error message to make code consistent
-                const lastError = chrome.runtime.lastError;
-
-                failCallback(lastError instanceof Error
-                    ? lastError
-                    : new JitsiTrackError(
-                        JitsiTrackErrors.CHROME_EXTENSION_GENERIC_ERROR,
-                        lastError));
-
-                return;
-            }
-            logger.log('Response from extension: ', response);
-            onGetStreamResponse(
-                {
-                    response,
-                    gumOptions
-                },
-                streamCallback,
-                failCallback
-            );
-        }
-    );
-}
-
-/**
- * Initializes <link rel=chrome-webstore-item /> with extension id set in
- * config.js to support inline installs. Host site must be selected as main
- * website of published extension.
- * @param options supports "desktopSharingChromeExtId"
- */
-function initInlineInstalls(options) {
-    if ($('link[rel=chrome-webstore-item]').length === 0) {
-        $('head').append('<link rel="chrome-webstore-item">');
-    }
-    $('link[rel=chrome-webstore-item]').attr('href',
-        getWebStoreInstallUrl(options));
-}
-
-/**
- *
- * @param options
- *
- * @return {Promise} - a Promise resolved once the initialization process is
- * finished.
- */
-function initChromeExtension(options) {
-    // Initialize Chrome extension inline installs
-    initInlineInstalls(options);
-
-    return new Promise(resolve => {
-        // Check if extension is installed
-        checkChromeExtInstalled((installed, updateRequired) => {
-            chromeExtInstalled = installed;
-            chromeExtUpdateRequired = updateRequired;
-            logger.info(
-                `Chrome extension installed: ${
-                    chromeExtInstalled} updateRequired: ${
-                    chromeExtUpdateRequired}`);
-            resolve();
-        }, options);
-    });
-}
-
-/**
- * Checks "retries" times on every "waitInterval"ms whether the ext is alive.
- * @param {Object} options the options passed to ScreanObtainer.obtainStream
- * @param {int} waitInterval the number of ms between retries
- * @param {int} retries the number of retries
- * @returns {Promise} returns promise that will be resolved when the extension
- * is alive and rejected if the extension is not alive even after "retries"
- * checks
- */
-function waitForExtensionAfterInstall(options, waitInterval, retries) {
-    if (retries === 0) {
-        return Promise.reject();
-    }
-
-    return new Promise((resolve, reject) => {
-        let currentRetries = retries;
-        const interval = window.setInterval(() => {
-            checkChromeExtInstalled(installed => {
-                if (installed) {
-                    window.clearInterval(interval);
-                    resolve();
-                } else {
-                    currentRetries--;
-                    if (currentRetries === 0) {
-                        reject();
-                        window.clearInterval(interval);
-                    }
-                }
-            }, options);
-        }, waitInterval);
-    });
-}
 
 /**
  * Handles response from external application / extension and calls GUM to
@@ -614,13 +235,13 @@ function onGetStreamResponse(
         // then the callback is called with an empty streamId.
         if (streamId === '') {
             onFailure(new JitsiTrackError(
-                JitsiTrackErrors.CHROME_EXTENSION_USER_CANCELED));
+                JitsiTrackErrors.SCREENSHARING_USER_CANCELED));
 
             return;
         }
 
         onFailure(new JitsiTrackError(
-            JitsiTrackErrors.CHROME_EXTENSION_GENERIC_ERROR,
+            JitsiTrackErrors.SCREENSHARING_GENERIC_ERROR,
             error));
     }
 }


### PR DESCRIPTION
- Use getDisplayMedia on browsers where it is supported.
- desktopSharingChromeDisabled and desktopSharingFirefoxDisabled will no longer be supported.