### PR TITLE
feat: Set degradation preference on video senders

### DIFF
--- a/modules/proxyconnection/ProxyConnectionPC.js
+++ b/modules/proxyconnection/ProxyConnectionPC.js
@@ -233,30 +233,12 @@ export default class ProxyConnectionPC {
         };
 
         /**
-         * A {@code JitsiConference} stub passed to the {@link RTC} module.
-         * @type {Object}
-         */
-        const conferenceStub = {
-            // FIXME: remove once the temporary code below is gone from
-            //  TraceablePeerConnection.
-            // TraceablePeerConnection:359
-            //  this.rtc.conference.on(
-            //         TRACK_ADDED,
-            //         maybeSetSenderVideoConstraints);
-            //     this.rtc.conference.on(
-            //         TRACK_MUTE_CHANGED,
-            //         maybeSetSenderVideoConstraints);
-            // eslint-disable-next-line no-empty-function
-            on: () => {}
-        };
-
-        /**
          * Create an instance of {@code RTC} as it is required for peer
          * connection creation by {@code JingleSessionPC}. An existing instance
          * of {@code RTC} from elsewhere should not be re-used because it is
          * a stateful grouping of utilities.
          */
-        this._rtc = new RTC(conferenceStub, {});
+        this._rtc = new RTC(this, {});
 
         /**
          * Add the remote track listener here as {@code JingleSessionPC} has

--- a/modules/proxyconnection/ProxyConnectionPC.js
+++ b/modules/proxyconnection/ProxyConnectionPC.js
@@ -233,12 +233,18 @@ export default class ProxyConnectionPC {
         };
 
         /**
+         * A {@code JitsiConference} stub passed to the {@link RTC} module.
+         * @type {Object}
+         */
+        const conferenceStub = {};
+
+        /**
          * Create an instance of {@code RTC} as it is required for peer
          * connection creation by {@code JingleSessionPC}. An existing instance
          * of {@code RTC} from elsewhere should not be re-used because it is
          * a stateful grouping of utilities.
          */
-        this._rtc = new RTC(this, {});
+        this._rtc = new RTC(conferenceStub, {});
 
         /**
          * Add the remote track listener here as {@code JingleSessionPC} has

--- a/modules/qualitycontrol/QualityController.js
+++ b/modules/qualitycontrol/QualityController.js
@@ -43,6 +43,9 @@ export class QualityController {
             });
         this.preferredReceiveMaxFrameHeight
             && mediaSession.setReceiverVideoConstraint(this.preferredReceiveMaxFrameHeight);
+
+        // Set the degradation preference on the local video track.
+        mediaSession.setSenderVideoDegradationPreference();
     }
 
     /**


### PR DESCRIPTION
- Use 'maintain-framerate' for camera tracks and 'maintain-resolution' for desktop tracks.
- Apply cached video constraints/preferences on video unmute. Since the sender encodings are available only after the renegotiation is complete (on chrome/safari), constraints/preferences have to be applied after renegotiation is complete