### PR TITLE
fix: audio issues caused by insertable streams

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -248,9 +248,8 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean} {@code true} if the browser supports insertable streams.
      */
     supportsInsertableStreams() {
-        return Boolean(typeof window.RTCRtpSender !== 'undefined'
-            && (window.RTCRtpSender.prototype.createEncodedStreams
-                || window.RTCRtpSender.prototype.createEncodedVideoStreams));
+        // FIXME insertable streams are causing audio issues when the browser is under load
+        return false;
     }
 
     /**


### PR DESCRIPTION
It's been observed that insertable streams are causing audio issues which sound like robotic voice.
The symptoms are lots of concealed events for the audio stream on the receiver side.
It seems to happen more when the browser or the main JS thread is under load.