### PR TITLE
feat: add granting owner support

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1418,6 +1418,19 @@ JitsiConference.prototype.getParticipantById = function(id) {
 };
 
 /**
+ * Grant owner rights to the participant.
+ * @param {string} id id of the participant to grant owner rights to.
+ */
+JitsiConference.prototype.grantOwner = function(id) {
+    const participant = this.getParticipantById(id);
+
+    if (!participant) {
+        return;
+    }
+    this.room.setAffiliation(participant.getJid(), 'owner');
+};
+
+/**
  * Kick participant from this conference.
  * @param {string} id id of the participant to kick
  */

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1133,6 +1133,30 @@ export default class ChatRoom extends Listenable {
     /**
      *
      * @param jid
+     * @param affiliation
+     */
+    setAffiliation(jid, affiliation) {
+        const grantIQ = $iq({
+            to: this.roomjid,
+            type: 'set'
+        })
+        .c('query', { xmlns: 'http://jabber.org/protocol/muc#admin' })
+        .c('item', {
+            affiliation,
+            nick: Strophe.getResourceFromJid(jid)
+        })
+        .c('reason').t(`Your affiliation has been changed to '${affiliation}'.`)
+        .up().up().up();
+
+        this.connection.sendIQ(
+            grantIQ,
+            result => logger.log('Set affiliation of participant with jid: ', jid, 'to', affiliation, result),
+            error => logger.log('Set affiliation of participant error: ', error));
+    }
+
+    /**
+     *
+     * @param jid
      */
     kick(jid) {
         const kickIQ = $iq({ to: this.roomjid,


### PR DESCRIPTION
Used for extending owner privileges to other participants in the chat room.