### PR TITLE
Include bridge session ID in session-terminate

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2735,7 +2735,7 @@ JitsiConference.prototype._addRemoteP2PTracks = function() {
 JitsiConference.prototype._addRemoteTracks = function(logName, remoteTracks) {
     for (const track of remoteTracks) {
         logger.info(`Adding remote ${logName} track: ${track}`);
-        this.rtc.eventEmitter.emit(RTCEvents.REMOTE_TRACK_ADDED, track);
+        this.onRemoteTrackAdded(track);
     }
 };
 
@@ -2922,7 +2922,7 @@ JitsiConference.prototype._removeRemoteTracks = function(
         remoteTracks) {
     for (const track of remoteTracks) {
         logger.info(`Removing remote ${sessionNickname} track: ${track}`);
-        this.rtc.eventEmitter.emit(RTCEvents.REMOTE_TRACK_REMOVED, track);
+        this.onRemoteTrackRemoved(track);
     }
 };
 

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -523,7 +523,7 @@ export default class RTC extends Listenable {
         // FIXME: We should rename iceConfig to pcConfig.
 
         if (browser.supportsInsertableStreams()) {
-            logger.debug('E2EE - setting insertable streams constraints');
+            logger.debug(`E2EE - setting insertable streams constraints on ${this}`);
             iceConfig.encodedInsertableStreams = true;
             iceConfig.forceEncodedAudioInsertableStreams = true; // legacy, to be removed in M85.
             iceConfig.forceEncodedVideoInsertableStreams = true; // legacy, to be removed in M85.

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -499,6 +499,8 @@ export default class RTC extends Listenable {
      * @param {boolean} isP2P Indicates whether or not the new TPC will be used
      *      in a peer to peer type of session.
      * @param {object} options The config options.
+     * @param {boolean} options.enableInsertableStreams - Set to true when the insertable streams constraints is to be
+     * enabled on the PeerConnection.
      * @param {boolean} options.disableSimulcast If set to 'true' will disable
      *      the simulcast.
      * @param {boolean} options.disableRtx If set to 'true' will disable the
@@ -522,7 +524,7 @@ export default class RTC extends Listenable {
 
         // FIXME: We should rename iceConfig to pcConfig.
 
-        if (browser.supportsInsertableStreams()) {
+        if (options.enableInsertableStreams) {
             logger.debug(`E2EE - setting insertable streams constraints on ${this}`);
             iceConfig.encodedInsertableStreams = true;
             iceConfig.forceEncodedAudioInsertableStreams = true; // legacy, to be removed in M85.

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -831,7 +831,7 @@ TraceablePeerConnection.prototype._createRemoteTrack = function(
 
     remoteTracksMap.set(mediaType, remoteTrack);
 
-    this.eventEmitter.emit(RTCEvents.REMOTE_TRACK_ADDED, remoteTrack);
+    this.eventEmitter.emit(RTCEvents.REMOTE_TRACK_ADDED, remoteTrack, this);
 };
 
 /* eslint-enable max-params */
@@ -1412,6 +1412,23 @@ Object.keys(getters).forEach(prop => {
 
 TraceablePeerConnection.prototype._getSSRC = function(rtcId) {
     return this.localSSRCs.get(rtcId);
+};
+
+/**
+ * Checks if given track belongs to this peerconnection instance.
+ *
+ * @param {JitsiLocalTrack|JitsiRemoteTrack} track - The track to be checked.
+ * @returns {boolean}
+ */
+TraceablePeerConnection.prototype.containsTrack = function(track) {
+    if (track.isLocal()) {
+        return this.localTracks.has(track.rtcId);
+    }
+
+    const participantId = track.getParticipantId();
+    const remoteTracksMap = this.remoteTracks.get(participantId);
+
+    return Boolean(remoteTracksMap && remoteTracksMap.get(track.getType()) === track);
 };
 
 /**

--- a/modules/e2ee/E2EEncryption.js
+++ b/modules/e2ee/E2EEncryption.js
@@ -1,0 +1,121 @@
+/* global __filename */
+import { getLogger } from 'jitsi-meet-logger';
+
+import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
+import browser from '../browser';
+import RTCEvents from '../../service/RTC/RTCEvents';
+
+import E2EEContext from './E2EEContext';
+
+const logger = getLogger(__filename);
+
+/**
+ * This module integrates {@link E2EEContext} with {@link JitsiConference} in order to enable E2E encryption.
+ */
+export class E2EEncryption {
+    /**
+     * A constructor.
+     * @param {JitsiConference} conference - The conference instance for which E2E encryption is to be enabled.
+     * @param {Object} options
+     * @param {string} options.salt - Salt to be used for key deviation. Check {@link E2EEContext} for more details.
+     */
+    constructor(conference, { salt }) {
+        this.conference = conference;
+        this._e2eeCtx = new E2EEContext({ salt });
+        this.conference.on(
+            JitsiConferenceEvents._MEDIA_SESSION_STARTED,
+            this._onMediaSessionStarted.bind(this));
+
+        // FIXME add events to TraceablePeerConnection which will allow to see when there's new receiver or sender
+        //  added instead of shenanigans around conference track events and track muted.
+        this.conference.on(
+            JitsiConferenceEvents.TRACK_ADDED,
+            track => track.isLocal() && this._onLocalTrackAdded(track));
+        this.conference.rtc.on(
+            RTCEvents.REMOTE_TRACK_ADDED,
+            (track, tpc) => this._setupReceiverE2EEForTrack(tpc, track));
+        this.conference.on(
+            JitsiConferenceEvents.TRACK_MUTE_CHANGED,
+            this._trackMuteChanged.bind(this));
+    }
+
+    /**
+     * Setups E2E encryption for the new session.
+     * @param {JingleSessionPC} session - the new media session.
+     * @private
+     */
+    _onMediaSessionStarted(session) {
+        const localTracks = this.conference.getLocalTracks();
+
+        for (const track of localTracks) {
+            this._setupSenderE2EEForTrack(session, track);
+        }
+    }
+
+    /**
+     * Setup E2EE on the new track that has been added to the conference, apply it on all the open peerconnections.
+     * @param {JitsiLocalTrack} track - the new track that's being added to the conference.
+     * @private
+     */
+    _onLocalTrackAdded(track) {
+        for (const session of this.conference._getMediaSessions()) {
+            this._setupSenderE2EEForTrack(session, track);
+        }
+    }
+
+    /**
+     * Sets the key to be used for End-To-End encryption.
+     *
+     * @param {string} key - the key to be used.
+     * @returns {void}
+     */
+    setKey(key) {
+        this._e2eeCtx.setKey(key);
+    }
+
+    /**
+     * Setup E2EE for the receiving side.
+     *
+     * @returns {void}
+     */
+    _setupReceiverE2EEForTrack(tpc, track) {
+        const receiver = tpc.findReceiverForTrack(track.track);
+
+        if (receiver) {
+            this._e2eeCtx.handleReceiver(receiver, track.getType(), track.getParticipantId());
+        } else {
+            logger.warn(`Could not handle E2EE for ${track}: receiver not found in: ${tpc}`);
+        }
+    }
+
+    /**
+     * Setup E2EE for the sending side.
+     *
+     * @param {JingleSessionPC} session - the session which sends the media produced by the track.
+     * @param {JitsiLocalTrack} track - the local track for which e2e encoder will be configured.
+     * @returns {void}
+     */
+    _setupSenderE2EEForTrack(session, track) {
+        const pc = session.peerconnection;
+        const sender = pc && pc.findSenderForTrack(track.track);
+
+        if (sender) {
+            this._e2eeCtx.handleSender(sender, track.getType(), track.getParticipantId());
+        } else {
+            logger.warn(`Could not handle E2EE for ${track}: sender not found in ${pc}`);
+        }
+    }
+
+    /**
+     * Setup E2EE on the sender that is created for the unmuted local video track.
+     * @param {JitsiLocalTrack} track - the track for which muted status has changed.
+     * @private
+     */
+    _trackMuteChanged(track) {
+        if (browser.doesVideoMuteByStreamRemove() && track.isLocal() && track.isVideoTrack() && !track.isMuted()) {
+            for (const session of this.conference._getMediaSessions()) {
+                this._setupSenderE2EEForTrack(session, track);
+            }
+        }
+    }
+}

--- a/modules/xmpp/JingleSession.js
+++ b/modules/xmpp/JingleSession.js
@@ -175,6 +175,8 @@ export default class JingleSession extends Listenable {
      * @param {Object} options
      * @param {string} [options.reason] XMPP Jingle error condition
      * @param {string} [options.reasonDescription] some meaningful error message
+     * @param {boolean} [options.requestRestart=false] set to true to ask Jicofo to start a new session one this once is
+     * terminated.
      * @param {boolean} [options.sendSessionTerminate=true] set to false to skip
      * sending session-terminate. It may not make sense to send it if the XMPP
      * connection has been closed already or if the remote peer has disconnected

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -47,6 +47,8 @@ const DEFAULT_MAX_STATS = 300;
  * @property {boolean} disableH264 - Described in the config.js[1].
  * @property {boolean} disableRtx - Described in the config.js[1].
  * @property {boolean} disableSimulcast - Described in the config.js[1].
+ * @property {boolean} enableInsertableStreams - Set to true when the insertable streams constraints is to be enabled
+ * on the PeerConnection.
  * @property {boolean} enableLayerSuspension - Described in the config.js[1].
  * @property {boolean} failICE - it's an option used in the tests. Set to
  * <tt>true</tt> to block any real candidates and make the ICE fail.
@@ -326,6 +328,8 @@ export default class JingleSessionPC extends JingleSession {
             pcOptions.maxstats = DEFAULT_MAX_STATS;
         }
         pcOptions.capScreenshareBitrate = false;
+        pcOptions.enableInsertableStreams = options.enableInsertableStreams;
+
         if (this.isP2P) {
             // simulcast needs to be disabled for P2P (121) calls
             pcOptions.disableSimulcast = true;
@@ -1455,7 +1459,8 @@ export default class JingleSessionPC extends JingleSession {
                 && sessionTerminate.c(
                     'bridge-session', {
                         xmlns: 'http://jitsi.org/protocol/focus',
-                        id: this._bridgeSessionId
+                        id: this._bridgeSessionId,
+                        restart: options && options.requestRestart === true
                     }).up();
 
             // Calling tree() to print something useful

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1438,13 +1438,25 @@ export default class JingleSessionPC extends JingleSession {
                         sid: this.sid
                     })
                     .c('reason')
-                    .c((options && options.reason) || 'success');
+                    .c((options && options.reason) || 'success')
+                    .up();
 
             if (options && options.reasonDescription) {
-                sessionTerminate.up()
+                sessionTerminate
                     .c('text')
-                    .t(options.reasonDescription);
+                    .t(options.reasonDescription)
+                    .up()
+                    .up();
+            } else {
+                sessionTerminate.up();
             }
+
+            this._bridgeSessionId
+                && sessionTerminate.c(
+                    'bridge-session', {
+                        xmlns: 'http://jitsi.org/protocol/focus',
+                        id: this._bridgeSessionId
+                    }).up();
 
             // Calling tree() to print something useful
             sessionTerminate = sessionTerminate.tree();


### PR DESCRIPTION
Call this from JS console in Jitsi Meet to try it out:
 `APP.conference._room.jvbJingleSession.terminate(function(){console.info('OK');}, function(error){console.error('ERROR', error);},{sendSessionTerminate:true})`

Depends on https://github.com/jitsi/jicofo/pull/562/files