### PR TITLE
fix: IFrame users on Safari start audio/video muted

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -80,7 +80,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     isUserInteractionRequiredForUnmute() {
-        return (this.isFirefox() && this.isVersionLessThan('68')) || this.isSafari();
+        return this.isFirefox() && this.isVersionLessThan('68');
     }
 
     /**


### PR DESCRIPTION
Fix for https://github.com/jitsi/jitsi-meet/issues/7241
User interaction is not needed anymore on Safari for unmuting audio/video. 
This issue manifests only on iframe users on Safari.