### PR TITLE
fix(safari): override min/max video constraints on safari

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -382,6 +382,26 @@ function newGetConstraints(um = [], options = {}) {
             constraints.video = {};
         }
 
+        // Override the constraints on Safari because of the following webkit bug.
+        // https://bugs.webkit.org/show_bug.cgi?id=210932
+        // Camera doesn't start on older macOS versions if min/max constraints are specified.
+        // TODO: remove this hack when the bug fix is available on Mojave, Sierra and High Sierra.
+        if (browser.isSafari()) {
+            if (constraints.video.height && constraints.video.height.ideal) {
+                const ideal = JSON.parse(JSON.stringify(constraints.video.height.ideal));
+
+                constraints.video.height = { ideal };
+            } else {
+                logger.warn('Ideal camera height missing, camera may not start properly');
+            }
+            if (constraints.video.width && constraints.video.width.ideal) {
+                const ideal = JSON.parse(JSON.stringify(constraints.video.width.ideal));
+
+                constraints.video.width = { ideal };
+            } else {
+                logger.warn('Ideal camera width missing, camera may not start properly');
+            }
+        }
         if (options.cameraDeviceId) {
             constraints.video.deviceId = options.cameraDeviceId;
         } else {

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -10,6 +10,7 @@ import { AVAILABLE_DEVICE } from '../../service/statistics/AnalyticsEvents';
 import CameraFacingMode from '../../service/RTC/CameraFacingMode';
 import EventEmitter from 'events';
 import { getLogger } from 'jitsi-meet-logger';
+import clonedeep from 'lodash.clonedeep';
 import GlobalOnErrorHandler from '../util/GlobalOnErrorHandler';
 import JitsiTrackError from '../../JitsiTrackError';
 import Listenable from '../util/Listenable';
@@ -374,8 +375,7 @@ function getConstraints(um, options = {}) {
 function newGetConstraints(um = [], options = {}) {
     // Create a deep copy of the constraints to avoid any modification of
     // the passed in constraints object.
-    const constraints = JSON.parse(JSON.stringify(
-        options.constraints || DEFAULT_CONSTRAINTS));
+    const constraints = clonedeep(options.constraints || DEFAULT_CONSTRAINTS);
 
     if (um.indexOf('video') >= 0) {
         if (!constraints.video) {
@@ -388,16 +388,12 @@ function newGetConstraints(um = [], options = {}) {
         // TODO: remove this hack when the bug fix is available on Mojave, Sierra and High Sierra.
         if (browser.isSafari()) {
             if (constraints.video.height && constraints.video.height.ideal) {
-                const ideal = JSON.parse(JSON.stringify(constraints.video.height.ideal));
-
-                constraints.video.height = { ideal };
+                constraints.video.height = { ideal: clonedeep(constraints.video.height.ideal) };
             } else {
                 logger.warn('Ideal camera height missing, camera may not start properly');
             }
             if (constraints.video.width && constraints.video.width.ideal) {
-                const ideal = JSON.parse(JSON.stringify(constraints.video.width.ideal));
-
-                constraints.video.width = { ideal };
+                constraints.video.width = { ideal: clonedeep(constraints.video.width.ideal) };
             } else {
                 logger.warn('Ideal camera width missing, camera may not start properly');
             }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "current-executing-script": "0.1.3",
     "jitsi-meet-logger": "github:jitsi/jitsi-meet-logger#5ec92357570dc8f0b7ffc1528820721c84c6af8b",
     "js-utils": "github:jitsi/js-utils#cf11996bd866fdb47326c59a5d3bc24be17282d4",
+    "lodash.clonedeep": "4.5.0",
     "lodash.isequal": "4.5.0",
     "sdp-transform": "2.3.0",
     "strophe.js": "1.3.4",


### PR DESCRIPTION
Override the constraints on Safari because of the following webkit bug.
https://bugs.webkit.org/show_bug.cgi?id=210932
Camera doesn't start on older macOS versions if min/max constraints are specified.