### PR TITLE
fix: let camera pick the best aspect ratio when applying sender video contraints

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2137,15 +2137,12 @@ TraceablePeerConnection.prototype.setSenderVideoConstraint = function(frameHeigh
                 });
             });
     }
-
-    // Apply the height constraint on the local camera track
-    const aspectRatio = (track.getSettings().width / track.getSettings().height).toPrecision(4);
-
     logger.debug(`Setting max height of ${newHeight} on local video`);
 
+    // Do not specify the aspect ratio, let camera pick
+    // the best aspect ratio for the given height.
     return track.applyConstraints(
         {
-            aspectRatio,
             height: {
                 ideal: newHeight
             }


### PR DESCRIPTION
When the sender resolution is changed on a p2p connection as a result of the receiver constraint change, do not specify the aspect ratio while restarting the video track with the new resolution. We are leaving it to the camera to pick up the best aspect ratio for a given resolution.