### PR TITLE
fix(StropheLastSuccess): refresh the timestamp in connected

### DIFF
--- a/modules/xmpp/StropheLastSuccess.js
+++ b/modules/xmpp/StropheLastSuccess.js
@@ -12,13 +12,18 @@ export default class LastRequestTracker {
     /**
      * Starts tracking requests on the given connection.
      *
+     * @param {XmppConnection} xmppConnection - The XMPP connection which manages the given {@code stropheConnection}.
      * @param {Object} stropheConnection - Strophe connection instance.
      */
-    startTracking(stropheConnection) {
+    startTracking(xmppConnection, stropheConnection) {
         const originalRawInput = stropheConnection.rawInput;
 
-        stropheConnection.rawInput = function(...args) {
-            this._lastSuccess = Date.now();
+        stropheConnection.rawInput = (...args) => {
+            // It's okay to use rawInput callback only once the connection has been established, otherwise it will
+            // treat 'item-not-found' or other connection error on websocket reconnect as successful stanza received.
+            if (xmppConnection.connected) {
+                this._lastSuccess = Date.now();
+            }
             originalRawInput.apply(stropheConnection, args);
         };
     }

--- a/modules/xmpp/XmppConnection.js
+++ b/modules/xmpp/XmppConnection.js
@@ -65,7 +65,7 @@ export default class XmppConnection extends Listenable {
         this._stropheConn.maxRetries = 3;
 
         this._lastSuccessTracker = new LastSuccessTracker();
-        this._lastSuccessTracker.startTracking(this._stropheConn);
+        this._lastSuccessTracker.startTracking(this, this._stropheConn);
 
         /**
          * @typedef DeferredSendIQ Object


### PR DESCRIPTION
An 'item-not-found' or other error on Websocket reconnect will refresh the timestamp which will give misleading information about when the last stanza was received.