### PR TITLE
deps: update plugin-stream-management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7549,8 +7549,8 @@
       "integrity": "sha512-T9pJFzn1ZUqZ/we9+OvI5pFdrjeb4IBMbEjK+ZWEZV036wEl8l8GOtF8AJ3sIqOMtdIiFLdFu99JiGWd7yapAQ=="
     },
     "strophejs-plugin-stream-management": {
-      "version": "github:jitsi/strophejs-plugin-stream-management#e719a02b4f83856c1530882084a4b048ee622d45",
-      "from": "github:jitsi/strophejs-plugin-stream-management#e719a02b4f83856c1530882084a4b048ee622d45"
+      "version": "github:jitsi/strophejs-plugin-stream-management#001cf02bef2357234e1ac5d163611b4d60bf2b6a",
+      "from": "github:jitsi/strophejs-plugin-stream-management#001cf02bef2357234e1ac5d163611b4d60bf2b6a"
     },
     "supports-color": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sdp-transform": "2.3.0",
     "strophe.js": "1.3.4",
     "strophejs-plugin-disco": "0.0.2",
-    "strophejs-plugin-stream-management": "github:jitsi/strophejs-plugin-stream-management#e719a02b4f83856c1530882084a4b048ee622d45",
+    "strophejs-plugin-stream-management": "github:jitsi/strophejs-plugin-stream-management#001cf02bef2357234e1ac5d163611b4d60bf2b6a",
     "webrtc-adapter": "7.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates strophejs-plugin-stream-management
to 001cf02bef2357234e1ac5d163611b4d60bf2b6a which fixes
few corner cases around XMPP WebSocket reconnect logic.

https://github.com/jitsi/strophejs-plugin-stream-management/pull/8