### PR TITLE
feat: PerformanceObserverStats initial commit

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -375,6 +375,11 @@ JitsiConference.prototype._init = function(options = {}) {
         Statistics.analytics.addPermanentProperties({
             'callstats_name': this._statsCurrentId
         });
+
+        // Start performance observer for monitoring long tasks
+        if (config.performanceStatsInterval) {
+            this.statistics.attachPerformanceStats(this);
+        }
     }
 
     this.eventManager.setupChatRoomListeners();
@@ -717,6 +722,16 @@ JitsiConference.prototype.getLocalAudioTrack = function() {
  */
 JitsiConference.prototype.getLocalVideoTrack = function() {
     return this.rtc ? this.rtc.getLocalVideoTrack() : null;
+};
+
+/**
+ * Obtains the performance statistics.
+ * @returns {Object|null}
+ */
+JitsiConference.prototype.getPerformanceStats = function() {
+    return browser.supportsPerformanceObserver()
+        ? this.statistics.performanceObserverStats.getPerformanceStats()
+        : null;
 };
 
 /**

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -377,8 +377,8 @@ JitsiConference.prototype._init = function(options = {}) {
         });
 
         // Start performance observer for monitoring long tasks
-        if (config.performanceStatsInterval) {
-            this.statistics.attachPerformanceStats(this);
+        if (config.longTasksStatsInterval) {
+            this.statistics.attachLongTasksStats(this);
         }
     }
 
@@ -729,9 +729,9 @@ JitsiConference.prototype.getLocalVideoTrack = function() {
  * @returns {Object|null}
  */
 JitsiConference.prototype.getPerformanceStats = function() {
-    return browser.supportsPerformanceObserver()
-        ? this.statistics.performanceObserverStats.getPerformanceStats()
-        : null;
+    return {
+        longTasksStats: this.statistics.getLongTasksStats()
+    };
 };
 
 /**

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -123,6 +123,16 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
+     * Checks if the current browser supports the Long Tasks API that lets us observe
+     * performance measurement events and be notified of tasks that take longer than
+     * 50ms to execute on the main thread.
+     */
+    supportsPerformanceObserver() {
+        return typeof window.PerformanceObserver !== 'undefined'
+            && PerformanceObserver.supportedEntryTypes.indexOf('longtask') > -1;
+    }
+
+    /**
      * Checks if the current browser supports audio level stats on the receivers.
      */
     supportsReceiverStats() {

--- a/modules/statistics/PerformanceObserverStats.js
+++ b/modules/statistics/PerformanceObserverStats.js
@@ -1,0 +1,97 @@
+
+import { getLogger } from 'jitsi-meet-logger';
+
+import * as StatisticsEvents from '../../service/statistics/Events';
+import { RunningAverage } from '../util/MathUtil';
+
+const logger = getLogger(__filename);
+const MILLI_SECONDS = 1000;
+const SECONDS = 60;
+
+/**
+ * This class creates an observer that monitors browser's performance measurement events
+ * as they are recorded in the browser's performance timeline and computes an average and
+ * a maximum value for the long task events. Tasks are classified as long tasks if they take
+ * longer than 50ms to execute on the main thread.
+ */
+export class PerformanceObserverStats {
+    /**
+     * Creates a new instance of Performance observer statistics.
+     *
+     * @param {*} emitter Event emitter for emitting stats periodically
+     * @param {*} statsInterval interval for calculating the stats
+     */
+    constructor(emitter, statsInterval) {
+        this.eventEmitter = emitter;
+        this.longTasks = 0;
+        this.maxTaskDuration = 0;
+        this.performanceStatsInterval = statsInterval;
+        this.stats = new RunningAverage();
+    }
+
+    /**
+     * Obtains the average rate of long tasks observed per min and the
+     * duration of the longest task recorded by the observer.
+     * @returns {Object}
+     */
+    getPerformanceStats() {
+        return {
+            average: (this.stats.getAverage() * SECONDS).toFixed(2), // calc rate per min
+            maxTaskDuration: this.maxTaskDuration
+        };
+    }
+
+    /**
+     * Starts the performance observer by registering the callback function
+     * that calculates the performance statistics periodically.
+     * @returns {void}
+     */
+    startObserver() {
+        // Create a handler for when the long task event is fired.
+        this.longTaskEventHandler = list => {
+            const entries = list.getEntries();
+
+            for (const task of entries) {
+                this.longTasks++;
+                this.maxTaskDuration = Math.max(this.maxTaskDuration, task.duration).toFixed(3);
+            }
+        };
+
+        // Create an observer for monitoring long tasks.
+        logger.info('Creating a Performance Observer for monitoring Long Tasks');
+        this.observer = new PerformanceObserver(this.longTaskEventHandler);
+        this.observer.observe({ type: 'longtask',
+            buffered: true });
+        const startTime = Date.now();
+
+        // Calculate the average # of events/sec and emit a stats event.
+        this.longTasksIntervalId = setInterval(() => {
+            const now = Date.now();
+            const interval = this._lastTimeStamp
+                ? (now - this._lastTimeStamp) / MILLI_SECONDS
+                : (now - startTime) / MILLI_SECONDS;
+            const rate = this.longTasks / interval;
+
+            this.stats.addNext(rate);
+            this.eventEmitter.emit(
+                StatisticsEvents.LONG_TASKS_STATS, this.getPerformanceStats());
+
+            // Reset the counter and start counting events again.
+            this.longTasks = 0;
+            this._lastTimeStamp = Date.now();
+        }, this.performanceStatsInterval);
+    }
+
+    /**
+     * Stops the performance observer.
+     * @returns {void}
+     */
+    stopObserver() {
+        this.observer && this.observer.disconnect();
+        this.longTaskEventHandler = null;
+        if (this.longTasksIntervalId) {
+            clearInterval(this.longTasksIntervalId);
+            this.longTasksIntervalId = null;
+        }
+    }
+}

--- a/modules/statistics/PerformanceObserverStats.js
+++ b/modules/statistics/PerformanceObserverStats.js
@@ -24,7 +24,7 @@ export class PerformanceObserverStats {
     constructor(emitter, statsInterval) {
         this.eventEmitter = emitter;
         this.longTasks = 0;
-        this.maxTaskDuration = 0;
+        this.maxDuration = 0;
         this.performanceStatsInterval = statsInterval;
         this.stats = new RunningAverage();
     }
@@ -34,10 +34,10 @@ export class PerformanceObserverStats {
      * duration of the longest task recorded by the observer.
      * @returns {Object}
      */
-    getPerformanceStats() {
+    getLongTasksStats() {
         return {
             average: (this.stats.getAverage() * SECONDS).toFixed(2), // calc rate per min
-            maxTaskDuration: this.maxTaskDuration
+            maxDuration: this.maxDuration
         };
     }
 
@@ -53,7 +53,7 @@ export class PerformanceObserverStats {
 
             for (const task of entries) {
                 this.longTasks++;
-                this.maxTaskDuration = Math.max(this.maxTaskDuration, task.duration).toFixed(3);
+                this.maxDuration = Math.max(this.maxDuration, task.duration).toFixed(3);
             }
         };
 
@@ -74,7 +74,7 @@ export class PerformanceObserverStats {
 
             this.stats.addNext(rate);
             this.eventEmitter.emit(
-                StatisticsEvents.LONG_TASKS_STATS, this.getPerformanceStats());
+                StatisticsEvents.LONG_TASKS_STATS, this.getLongTasksStats());
 
             // Reset the counter and start counting events again.
             this.longTasks = 0;

--- a/modules/statistics/PerformanceObserverStats.spec.js
+++ b/modules/statistics/PerformanceObserverStats.spec.js
@@ -27,7 +27,7 @@ describe('PerformanceObserverStats', () => {
         const mockConference = new MockConference();
         const statistics = new Statistics();
 
-        statistics.attachPerformanceStats(mockConference);
+        statistics.attachLongTasksStats(mockConference);
 
         const startObserverSpy = spyOn(statistics.performanceObserverStats, 'startObserver');
         const stopObserverSpy = spyOn(statistics.performanceObserverStats, 'stopObserver');
@@ -35,7 +35,7 @@ describe('PerformanceObserverStats', () => {
 
         mockConference.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_JOINED);
         expect(startObserverSpy).toHaveBeenCalled();
-        expect(statistics.performanceObserverStats.getPerformanceStats()).toBeTruthy();
+        expect(statistics.performanceObserverStats.getLongTasksStats()).toBeTruthy();
 
         setTimeout(() => {
             expect(addNextSpy).toHaveBeenCalled();

--- a/modules/statistics/PerformanceObserverStats.spec.js
+++ b/modules/statistics/PerformanceObserverStats.spec.js
@@ -1,0 +1,47 @@
+import EventEmitter from 'events';
+
+import JitsiConference from '../../JitsiConference';
+import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
+import browser from '../browser';
+
+import Statistics from './statistics';
+
+/**
+ * Mock object to be used in place of a real conference.
+ *
+ * @constructor
+ */
+function MockConference() {
+    this.eventEmitter = new EventEmitter();
+}
+MockConference.prototype = Object.create(JitsiConference.prototype);
+MockConference.prototype.constructor = JitsiConference;
+
+describe('PerformanceObserverStats', () => {
+    beforeEach(() => {
+        // works only on chrome.
+        spyOn(browser, 'isChrome').and.returnValue(true);
+    });
+
+    it('Emits performance stats every sec', () => {
+        const mockConference = new MockConference();
+        const statistics = new Statistics();
+
+        statistics.attachPerformanceStats(mockConference);
+
+        const startObserverSpy = spyOn(statistics.performanceObserverStats, 'startObserver');
+        const stopObserverSpy = spyOn(statistics.performanceObserverStats, 'stopObserver');
+        const addNextSpy = spyOn(statistics.performanceObserverStats.stats, 'addNext');
+
+        mockConference.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_JOINED);
+        expect(startObserverSpy).toHaveBeenCalled();
+        expect(statistics.performanceObserverStats.getPerformanceStats()).toBeTruthy();
+
+        setTimeout(() => {
+            expect(addNextSpy).toHaveBeenCalled();
+        }, 1000);
+
+        mockConference.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_LEFT);
+        expect(stopObserverSpy).toHaveBeenCalled();
+    });
+});

--- a/modules/statistics/PerformanceObserverStats.spec.js
+++ b/modules/statistics/PerformanceObserverStats.spec.js
@@ -1,47 +1,67 @@
-import EventEmitter from 'events';
 
-import JitsiConference from '../../JitsiConference';
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 import browser from '../browser';
+import Listenable from '../util/Listenable';
 
 import Statistics from './statistics';
 
 /**
  * Mock object to be used in place of a real conference.
  *
- * @constructor
  */
-function MockConference() {
-    this.eventEmitter = new EventEmitter();
+class MockConference extends Listenable {
+    /**
+     * constructor
+     */
+    constructor() {
+        super();
+        this.options = {
+            config: {}
+        };
+    }
 }
-MockConference.prototype = Object.create(JitsiConference.prototype);
-MockConference.prototype.constructor = JitsiConference;
 
 describe('PerformanceObserverStats', () => {
+    let mockConference, statistics;
+
     beforeEach(() => {
         // works only on chrome.
         spyOn(browser, 'isChrome').and.returnValue(true);
+        mockConference = new MockConference();
+        Statistics.init({ longTasksStatsInterval: 1000 });
+        statistics = new Statistics();
+        jasmine.clock().install();
     });
 
-    it('Emits performance stats every sec', () => {
-        const mockConference = new MockConference();
-        const statistics = new Statistics();
-
+    it('Conference events start/stop observer', () => {
         statistics.attachLongTasksStats(mockConference);
-
         const startObserverSpy = spyOn(statistics.performanceObserverStats, 'startObserver');
         const stopObserverSpy = spyOn(statistics.performanceObserverStats, 'stopObserver');
-        const addNextSpy = spyOn(statistics.performanceObserverStats.stats, 'addNext');
 
         mockConference.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_JOINED);
         expect(startObserverSpy).toHaveBeenCalled();
-        expect(statistics.performanceObserverStats.getLongTasksStats()).toBeTruthy();
-
-        setTimeout(() => {
-            expect(addNextSpy).toHaveBeenCalled();
-        }, 1000);
 
         mockConference.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_LEFT);
         expect(stopObserverSpy).toHaveBeenCalled();
+    });
+
+    it('Emits long tasks stats every sec', () => {
+        statistics.attachLongTasksStats(mockConference);
+        statistics.performanceObserverStats.eventEmitter = {
+            // eslint-disable-next-line no-empty-function
+            emit: () => {}
+        };
+        statistics.performanceObserverStats.startObserver();
+        const eventEmitSpy = spyOn(statistics.performanceObserverStats.eventEmitter, 'emit');
+
+        expect(statistics.performanceObserverStats.getLongTasksStats()).toBeTruthy();
+        expect(eventEmitSpy).not.toHaveBeenCalled();
+
+        jasmine.clock().tick(1000);
+        expect(eventEmitSpy).toHaveBeenCalled();
+    });
+
+    afterEach(() => {
+        jasmine.clock().uninstall();
     });
 });

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -122,8 +122,8 @@ Statistics.init = function(options) {
         Statistics.audioLevelsInterval = options.audioLevelsInterval;
     }
 
-    if (typeof options.performanceStatsInterval === 'number') {
-        Statistics.performanceStatsInterval = options.performanceStatsInterval;
+    if (typeof options.longTasksStatsInterval === 'number') {
+        Statistics.longTasksStatsInterval = options.longTasksStatsInterval;
     }
 
     Statistics.disableThirdPartyRequests = options.disableThirdPartyRequests;
@@ -194,7 +194,6 @@ export default function Statistics(xmpp, options) {
 Statistics.audioLevelsEnabled = false;
 Statistics.audioLevelsInterval = 200;
 Statistics.pcStatsInterval = 10000;
-Statistics.performanceStatsInterval = 10000;
 Statistics.disableThirdPartyRequests = false;
 Statistics.analytics = analytics;
 
@@ -296,7 +295,7 @@ Statistics.prototype.removeByteSentStatsListener = function(listener) {
  * @param {Function} listener a function that would be called when notified.
  * @returns {void}
  */
-Statistics.prototype.addPerformanceStatsListener = function(listener) {
+Statistics.prototype.addLongTasksStatsListener = function(listener) {
     this.eventEmitter.on(StatisticsEvents.LONG_TASKS_STATS, listener);
 };
 
@@ -306,7 +305,7 @@ Statistics.prototype.addPerformanceStatsListener = function(listener) {
  *
  * @returns {void}
  */
-Statistics.prototype.attachPerformanceStats = function(conference) {
+Statistics.prototype.attachLongTasksStats = function(conference) {
     if (!browser.supportsPerformanceObserver()) {
         logger.warn('Performance observer for long tasks not supported by browser!');
 
@@ -315,7 +314,7 @@ Statistics.prototype.attachPerformanceStats = function(conference) {
 
     this.performanceObserverStats = new PerformanceObserverStats(
         this.eventEmitter,
-        Statistics.performanceStatsInterval);
+        Statistics.longTasksStatsInterval);
 
     conference.on(
         JitsiConferenceEvents.CONFERENCE_JOINED,
@@ -326,14 +325,14 @@ Statistics.prototype.attachPerformanceStats = function(conference) {
 };
 
 /**
- * Obtains the current value of the performance statistics.
+ * Obtains the current value of the LongTasks event statistics.
  *
  * @returns {Object|null} stats object if the observer has been
  * created, null otherwise.
  */
-Statistics.prototype.getPerformanceStats = function() {
+Statistics.prototype.getLongTasksStats = function() {
     return this.performanceObserverStats
-        ? this.performanceObserverStats.getPerformanceStats()
+        ? this.performanceObserverStats.getLongTasksStats()
         : null;
 };
 
@@ -343,7 +342,7 @@ Statistics.prototype.getPerformanceStats = function() {
  * @param {Function} listener the listener we want to remove.
  * @returns {void}
  */
-Statistics.prototype.removePerformanceStatsListener = function(listener) {
+Statistics.prototype.removeLongTasksStatsListener = function(listener) {
     this.eventEmitter.removeListener(StatisticsEvents.LONG_TASKS_STATS, listener);
 };
 

--- a/modules/util/MathUtil.js
+++ b/modules/util/MathUtil.js
@@ -1,5 +1,4 @@
 
-
 /**
  * The method will increase the given number by 1. If the given counter is equal
  * or greater to {@link Number.MAX_SAFE_INTEGER} then it will be rolled back to
@@ -37,4 +36,40 @@ export function calculateAverage(valueArray) {
  */
 export function filterPositiveValues(valueArray) {
     return valueArray.filter(value => value >= 0);
+}
+
+/**
+ * This class calculates a simple running average that continually changes
+ * as more data points are collected and added.
+ */
+export class RunningAverage {
+    /**
+     * Creates an instance of the running average calculator.
+     */
+    constructor() {
+        this.average = 0;
+        this.n = 0;
+    }
+
+    /**
+     * Adds a new data point to the existing set of values and recomputes
+     * the running average.
+     * @param {number} value
+     * @returns {void}
+     */
+    addNext(value) {
+        if (typeof value !== 'number') {
+            return;
+        }
+        this.n += 1;
+        this.average = this.average + ((value - this.average) / this.n);
+    }
+
+    /**
+     * Obtains the average value for the current subset of values.
+     * @returns {number} - computed average.
+     */
+    getAverage() {
+        return this.average;
+    }
 }

--- a/modules/util/MathUtil.spec.js
+++ b/modules/util/MathUtil.spec.js
@@ -1,0 +1,27 @@
+import { RunningAverage } from './MathUtil';
+
+describe('running average', () => {
+    it('should work', () => {
+        const rAvg = new RunningAverage();
+
+        // 1 / 1
+        rAvg.addNext(1);
+        expect(rAvg.getAverage()).toBe(1);
+
+        // 4 / 2
+        rAvg.addNext(3);
+        expect(rAvg.getAverage()).toBe(2);
+
+        // 6 / 3
+        rAvg.addNext(2);
+        expect(rAvg.getAverage()).toBe(2);
+
+        // 12 / 4
+        rAvg.addNext(6);
+        expect(rAvg.getAverage()).toBe(3);
+
+        // 20 / 5
+        rAvg.addNext(8);
+        expect(rAvg.getAverage()).toBe(4);
+    });
+});

--- a/service/statistics/Events.js
+++ b/service/statistics/Events.js
@@ -30,3 +30,8 @@ export const BYTE_SENT_STATS = 'statistics.byte_sent_stats';
  * <tt>resolution</tt>, and <tt>transport</tt>.
  */
 export const CONNECTION_STATS = 'statistics.connectionstats';
+
+/**
+ * An event carrying performance stats.
+ */
+export const LONG_TASKS_STATS = 'statistics.long_tasks_stats';


### PR DESCRIPTION
Add a performance stat around long tasks. Chrome supports PerformanceObserver API that lets us
register for long tasks event. Any task that takes longer than 50ms is considered a long task.