### PR TITLE
fix: Scale remote audio levels reported on receiver to getStats levels

### DIFF
--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -424,6 +424,15 @@ export default class JitsiTrack extends EventEmitter {
      * peerconnection (see /modules/statistics/LocalStatsCollector.js).
      */
     setAudioLevel(audioLevel, tpc) {
+        // The receiver seems to be reporting audio level immediately after the
+        // remote user has muted, so do not set the audio level on the track
+        // if it is muted.
+        if (browser.supportsReceiverStats()
+            && !this.isLocalAudioTrack()
+            && this.isWebRTCTrackMuted()) {
+            return;
+        }
+
         if (this.audioLevel !== audioLevel) {
             this.audioLevel = audioLevel;
             this.emit(

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -303,11 +303,15 @@ StatsCollector.prototype.start = function(startAudioLevelStats) {
 
                     for (const ssrc in audioLevels) {
                         if (audioLevels.hasOwnProperty(ssrc)) {
+                            // Use a scaling factor of 2.5 to report the same
+                            // audio levels that getStats reports.
+                            const audioLevel = audioLevels[ssrc] * 2.5;
+
                             this.eventEmitter.emit(
                                 StatisticsEvents.AUDIO_LEVEL,
                                 this.peerconnection,
                                 Number.parseInt(ssrc, 10),
-                                audioLevels[ssrc],
+                                audioLevel,
                                 false /* isLocal */);
                         }
                     }


### PR DESCRIPTION
The audio levels reported on the audio receivers are lower when compared to the value reported by getStats.
Values reported by getStats on chrome do not follow the the spec and since we have combination of clients using both getStats and getSynchronizationSources, let's stick to one scale to make them look uniform.
Also, the receivers seem to be reporting audio level for a little bit after the remote user has muted. Make sure the track is unmuted before setting the audio level on the track.