### PR TITLE
ref: Moves xmpp logs to be accessed from connection.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2337,13 +2337,6 @@ JitsiConference.prototype.isStartVideoMuted = function() {
 };
 
 /**
- * Get object with internal logs.
- */
-JitsiConference.prototype.getLogs = function() {
-    return this.connection.getLogs();
-};
-
-/**
  * Returns measured connectionTimes.
  */
 JitsiConference.prototype.getConnectionTimes = function() {

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2340,23 +2340,7 @@ JitsiConference.prototype.isStartVideoMuted = function() {
  * Get object with internal logs.
  */
 JitsiConference.prototype.getLogs = function() {
-    const data = this.xmpp.getJingleLog();
-
-    const metadata = {};
-
-    metadata.time = new Date();
-    metadata.url = window.location.href;
-    metadata.ua = navigator.userAgent;
-
-    const log = this.xmpp.getXmppLog();
-
-    if (log) {
-        metadata.xmpp = log;
-    }
-
-    data.metadata = metadata;
-
-    return data;
+    return this.connection.getLogs();
 };
 
 /**

--- a/JitsiConnection.js
+++ b/JitsiConnection.js
@@ -163,3 +163,26 @@ JitsiConnection.prototype.addFeature = function(feature, submit = false) {
 JitsiConnection.prototype.removeFeature = function(feature, submit = false) {
     return this.xmpp.caps.removeFeature(feature, submit);
 };
+
+/**
+ * Get object with internal logs.
+ */
+JitsiConnection.prototype.getLogs = function() {
+    const data = this.xmpp.getJingleLog();
+
+    const metadata = {};
+
+    metadata.time = new Date();
+    metadata.url = window.location.href;
+    metadata.ua = navigator.userAgent;
+
+    const log = this.xmpp.getXmppLog();
+
+    if (log) {
+        metadata.xmpp = log;
+    }
+
+    data.metadata = metadata;
+
+    return data;
+};

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -261,7 +261,7 @@ export default class XMPP extends Listenable {
                                         }
                                     });
                                 })
-                                .catch(logger.warn('Error getting features from lobby.'));
+                                .catch(() => logger.warn('Error getting features from lobby.'));
                         }
                     });
 

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -261,7 +261,7 @@ export default class XMPP extends Listenable {
                                         }
                                     });
                                 })
-                                .catch(() => logger.warn('Error getting features from lobby.'));
+                                .catch(e => logger.warn('Error getting features from lobby.', e && e.message));
                         }
                     });
 


### PR DESCRIPTION
In cases where there is no room like pre-join and lobby screen we still want to be able to debug xmpp messages.