### PR TITLE
fix(video-quality): add missing simulcast stream constraints

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -269,6 +269,13 @@ export class TPCUtils {
                 this.setEncodings(localTrack);
                 this.pc.localTracks.set(localTrack.rtcId, localTrack);
                 transceiver.direction = 'sendrecv';
+
+                // Construct the simulcast stream constraints for the newly added track.
+                if (localTrack.isVideoTrack()
+                    && localTrack.videoType === VideoType.CAMERA
+                    && this.pc.isSimulcastOn()) {
+                    this.setSimulcastStreamConstraints(localTrack.getTrack());
+                }
             }
 
             return Promise.resolve(false);


### PR DESCRIPTION
When the client starts video muted and the track is later added, make sure we construct the simulcast stream constraints then.