### PR TITLE
Fix: Scale down localVideo which is already smaller than req resulition

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2190,7 +2190,7 @@ TraceablePeerConnection.prototype.setSenderVideoConstraint = function(frameHeigh
                 parameters.encodings[encoding].active = encodingsEnabledState[encoding];
             }
         }
-    } else {
+    } else if (localVideoTrack.resolution > newHeight) {
         parameters.encodings[0].scaleResolutionDownBy = Math.floor(localVideoTrack.resolution / newHeight);
     }
 


### PR DESCRIPTION
When disableSimulcast=true the Lib tries to scale-down the local-video track to match `config.resolution`.
If the local-video track is already slower than config.resolution it results in `scaleResolutionDownBy=0` which ist not a valid scaling value.

---
_CLA already signed, see https://github.com/jitsi/lib-jitsi-meet/pull/1156_