### PR TITLE
ref(XMPPEvents): remove PEERCONNECTION_READY

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -549,7 +549,6 @@ export default class JingleSessionPC extends JingleSession {
             const state = this.peerconnection.signalingState;
             const remoteDescription = this.peerconnection.remoteDescription;
 
-            this.room.eventEmitter.emit(XMPPEvents.PEERCONNECTION_READY, this);
             if (browser.usesUnifiedPlan() && state === 'stable'
                 && remoteDescription && typeof remoteDescription.sdp === 'string') {
                 logger.debug(`onnegotiationneeded fired on ${this.peerconnection} in state: ${state}`);

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -175,7 +175,6 @@ const XMPPEvents = {
      */
     PARTCIPANT_FEATURES_CHANGED: 'xmpp.partcipant_features_changed',
     PASSWORD_REQUIRED: 'xmpp.password_required',
-    PEERCONNECTION_READY: 'xmpp.peerconnection_ready',
 
     /**
      * Indicates that phone number changed.


### PR DESCRIPTION
This event is not used anywhere and doesn't make sense with unified.