### PR TITLE
Refactor around unified media transfer active logic

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -375,10 +375,10 @@ export class TPCUtils {
     * the connection should be kept alive.
     * @param {boolean} active - true to enable audio media transmission or
     * false to disable.
-    * @returns {Promise<void>} - resolved when done.
+    * @returns {void}
     */
     setAudioTransferActive(active) {
-        return this.setMediaTransferActive('audio', active);
+        this.setMediaTransferActive('audio', active);
     }
 
     /**
@@ -403,38 +403,25 @@ export class TPCUtils {
      * @param {String} mediaType - 'audio' or 'video'
      * @param {boolean} active - true to enable media transmission or false
      * to disable.
-     * @returns {Promise<void>} - resolved when done.
+     * @returns {void}
      */
     setMediaTransferActive(mediaType, active) {
         const transceivers = this.pc.peerconnection.getTransceivers()
             .filter(t => t.receiver && t.receiver.track && t.receiver.track.kind === mediaType);
         const localTracks = this.pc.getLocalTracks(mediaType);
 
-        const setParamPromises = [];
-
-        if (active) {
-            transceivers.forEach(transceiver => {
+        transceivers.forEach(transceiver => {
+            if (active) {
                 if (localTracks.length) {
+                    // FIXME should adjust only the direction of the local sender or FF will fall into renegotiate loop
                     transceiver.direction = 'sendrecv';
-                    const parameters = transceiver.sender.getParameters();
-
-                    if (parameters && parameters.encodings && parameters.encodings.length) {
-                        parameters.encodings.forEach(encoding => {
-                            encoding.active = true;
-                        });
-                        setParamPromises.push(transceiver.sender.setParameters(parameters));
-                    }
                 } else {
                     transceiver.direction = 'recvonly';
                 }
-            });
-        } else {
-            transceivers.forEach(transceiver => {
+            } else {
                 transceiver.direction = 'inactive';
-            });
-        }
-
-        return Promise.all(setParamPromises);
+            }
+        });
     }
 
     /**
@@ -444,9 +431,9 @@ export class TPCUtils {
     * the connection should be kept alive.
     * @param {boolean} active - true to enable video media transmission or
     * false to disable.
-    * @returns {Promise<void>} - resolved when done.
+    * @returns {void}
     */
     setVideoTransferActive(active) {
-        return this.setMediaTransferActive('video', active);
+        this.setMediaTransferActive('video', active);
     }
 }

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -410,10 +410,10 @@ export class TPCUtils {
             .filter(t => t.receiver && t.receiver.track && t.receiver.track.kind === mediaType);
         const localTracks = this.pc.getLocalTracks(mediaType);
 
-        transceivers.forEach(transceiver => {
+        transceivers.forEach((transceiver, idx) => {
             if (active) {
-                if (localTracks.length) {
-                    // FIXME should adjust only the direction of the local sender or FF will fall into renegotiate loop
+                // The first transceiver is for the local track and only this one can be set to 'sendrecv'
+                if (idx === 0 && localTracks.length) {
                     transceiver.direction = 'sendrecv';
                 } else {
                     transceiver.direction = 'recvonly';

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1946,13 +1946,16 @@ TraceablePeerConnection.prototype.setLocalDescription = function(description) {
  */
 TraceablePeerConnection.prototype.setAudioTransferActive = function(active) {
     logger.debug(`${this} audio transfer active: ${active}`);
-    if (browser.usesUnifiedPlan()) {
-        return this.tpcUtils.setAudioTransferActive(active)
-            .then(() => false);
-    }
     const changed = this.audioTransferActive !== active;
 
     this.audioTransferActive = active;
+
+    if (browser.usesUnifiedPlan()) {
+        this.tpcUtils.setAudioTransferActive(active);
+
+        // false means no renegotiation up the chain which is not needed in the Unified mode
+        return false;
+    }
 
     return changed;
 };
@@ -2224,13 +2227,16 @@ TraceablePeerConnection.prototype.setSenderVideoConstraint = function(frameHeigh
  */
 TraceablePeerConnection.prototype.setVideoTransferActive = function(active) {
     logger.debug(`${this} video transfer active: ${active}`);
-    if (browser.usesUnifiedPlan()) {
-        return this.tpcUtils.setVideoTransferActive(active)
-            .then(() => false);
-    }
     const changed = this.videoTransferActive !== active;
 
     this.videoTransferActive = active;
+
+    if (browser.usesUnifiedPlan()) {
+        this.tpcUtils.setVideoTransferActive(active);
+
+        // false means no renegotiation up the chain which is not needed in the Unified mode
+        return false;
+    }
 
     return changed;
 };


### PR DESCRIPTION
The first commit removes the logic which was setting 'encoding.active' flag without taking current sender video constraints into consideration. This leaves p2p in unified (not currently enabled) possibly in a broken state in some corner cases, but it makes other changes needed now easier to be done.

The second commit fixes an issue where setting 'sendrecv' on the 'recvonly' transceivers for remote video would cause endless renegotiate loop.