### PR TITLE
Feat: stop sending video

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
         preprocessors: {
             'node_modules/core-js/**': [ 'webpack' ],
             './index.js': [ 'webpack' ],
-            './**/*.spec.js': [ 'webpack' ]
+            './**/*.spec.js': [ 'webpack', 'sourcemap' ]
         },
 
         // test results reporter to use

--- a/modules/qualitycontrol/QualityController.js
+++ b/modules/qualitycontrol/QualityController.js
@@ -62,12 +62,10 @@ export class QualityController {
         const sendMaxFrameHeight = this.selectSendMaxFrameHeight();
         const promises = [];
 
-        if (!sendMaxFrameHeight) {
-            return Promise.resolve();
-        }
-
-        for (const session of this.conference._getMediaSessions()) {
-            promises.push(session.setSenderVideoConstraint(sendMaxFrameHeight));
+        if (sendMaxFrameHeight >= 0) {
+            for (const session of this.conference._getMediaSessions()) {
+                promises.push(session.setSenderVideoConstraint(sendMaxFrameHeight));
+            }
         }
 
         return Promise.all(promises);
@@ -83,9 +81,9 @@ export class QualityController {
         const activeMediaSession = this.conference._getActiveMediaSession();
         const remoteRecvMaxFrameHeight = activeMediaSession && activeMediaSession.getRemoteRecvMaxFrameHeight();
 
-        if (this.preferredSendMaxFrameHeight && remoteRecvMaxFrameHeight) {
+        if (this.preferredSendMaxFrameHeight >= 0 && remoteRecvMaxFrameHeight >= 0) {
             return Math.min(this.preferredSendMaxFrameHeight, remoteRecvMaxFrameHeight);
-        } else if (remoteRecvMaxFrameHeight) {
+        } else if (remoteRecvMaxFrameHeight >= 0) {
             return remoteRecvMaxFrameHeight;
         }
 

--- a/modules/qualitycontrol/QualityController.spec.js
+++ b/modules/qualitycontrol/QualityController.spec.js
@@ -1,0 +1,134 @@
+import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
+import Listenable from '../util/Listenable';
+import MediaSessionEvents from '../xmpp/MediaSessionEvents';
+
+import { QualityController } from './QualityController';
+
+// JSDocs disabled for Mock classes to avoid duplication - check on the original classes for info.
+/* eslint-disable require-jsdoc */
+/**
+ * A mock JingleSessionPC impl that fit the needs of the QualityController module.
+ * Should a generic, shared one exist in the future this test file should switch to use it too.
+ */
+class MockJingleSessionPC extends Listenable {
+    constructor() {
+        super();
+        this._remoteRecvMaxFrameHeight = undefined;
+        this.senderVideoConstraint = undefined;
+    }
+
+    getRemoteRecvMaxFrameHeight() {
+        return this._remoteRecvMaxFrameHeight;
+    }
+
+    // eslint-disable-next-line no-empty-function
+    setSenderVideoDegradationPreference() {
+
+    }
+
+    // eslint-disable-next-line no-empty-function
+    setSenderMaxBitrates() {
+
+    }
+
+    setSenderVideoConstraint(senderVideoConstraint) {
+        this.senderVideoConstraint = senderVideoConstraint;
+    }
+
+    setRemoteRecvMaxFrameHeight(remoteRecvMaxFrameHeight) {
+        this._remoteRecvMaxFrameHeight = remoteRecvMaxFrameHeight;
+        this.eventEmitter.emit(
+            MediaSessionEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED,
+            this);
+    }
+}
+
+/**
+ * Mock conference for the purpose of this test file.
+ */
+class MockConference extends Listenable {
+    /**
+     * A constructor...
+     */
+    constructor() {
+        super();
+        this.options = {
+            config: { }
+        };
+        this.activeMediaSession = undefined;
+        this.mediaSessions = [];
+    }
+
+    addMediaSession(mediaSession) {
+        this.mediaSessions.push(mediaSession);
+
+        this.eventEmitter.emit(JitsiConferenceEvents._MEDIA_SESSION_STARTED, mediaSession);
+    }
+
+    setActiveMediaSession(mediaSession) {
+        if (this.mediaSessions.indexOf(mediaSession) === -1) {
+            throw new Error('Given session is not part of this conference');
+        }
+
+        this.activeMediaSession = mediaSession;
+
+        this.eventEmitter.emit(JitsiConferenceEvents._MEDIA_SESSION_ACTIVE_CHANGED, this.activeMediaSession);
+    }
+
+    _getActiveMediaSession() {
+        return this.activeMediaSession;
+    }
+
+    _getMediaSessions() {
+        return this.mediaSessions;
+    }
+}
+/* eslint-enable require-jsdoc */
+
+describe('QualityController', () => {
+    let conference;
+    let qualityController;
+    let jvbConnection;
+    let p2pConnection;
+
+    beforeEach(() => {
+        conference = new MockConference();
+        qualityController = new QualityController(conference);
+        jvbConnection = new MockJingleSessionPC();
+        p2pConnection = new MockJingleSessionPC();
+
+        conference.addMediaSession(jvbConnection);
+        conference.addMediaSession(p2pConnection);
+    });
+    describe('handles 0 as receiver/sender video constraint', () => {
+        it('0 if it\'s the active sessions\'s remote recv constraint', () => {
+            jvbConnection.setRemoteRecvMaxFrameHeight(0);
+            p2pConnection.setRemoteRecvMaxFrameHeight(720);
+
+            conference.setActiveMediaSession(jvbConnection);
+
+            expect(jvbConnection.senderVideoConstraint).toBe(0);
+            expect(p2pConnection.senderVideoConstraint).toBe(0);
+        });
+        it('720 if 0 is set on the non-active session', () => {
+            jvbConnection.setRemoteRecvMaxFrameHeight(0);
+            p2pConnection.setRemoteRecvMaxFrameHeight(720);
+
+            conference.setActiveMediaSession(p2pConnection);
+
+            expect(jvbConnection.senderVideoConstraint).toBe(720);
+            expect(p2pConnection.senderVideoConstraint).toBe(720);
+        });
+        it('0 if it\'s the local send preference while remote are 720', () => {
+            conference.setActiveMediaSession(p2pConnection);
+
+            jvbConnection.setRemoteRecvMaxFrameHeight(720);
+            p2pConnection.setRemoteRecvMaxFrameHeight(720);
+
+            qualityController.setPreferredSendMaxFrameHeight(0);
+
+            expect(jvbConnection.senderVideoConstraint).toBe(0);
+            expect(p2pConnection.senderVideoConstraint).toBe(0);
+        });
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5392,6 +5392,15 @@
         "jasmine-core": "^3.5.0"
       }
     },
+    "karma-sourcemap-loader": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz",
+      "integrity": "sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
     "karma-webpack": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "karma": "5.1.1",
     "karma-chrome-launcher": "3.1.0",
     "karma-jasmine": "3.1.1",
+    "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "4.0.2",
     "string-replace-loader": "2.1.1",
     "webpack": "4.43.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,8 @@ const minimize
         || process.argv.indexOf('--optimize-minimize') !== -1;
 
 const config = {
-    devtool: 'source-map',
+    // The inline-source-map is used to allow debugging the unit tests with Karma
+    devtool: minimize ? 'source-map' : 'inline-source-map',
     mode: minimize ? 'production' : 'development',
     module: {
         rules: [ {


### PR DESCRIPTION
Will stop sending video when `setSenderVideoConstraint` is called with `0`. The bridge is supposed to signal this value when participant's video is not displayed.

This PR depends on the functionality added in https://github.com/jitsi/jitsi-videobridge/pull/1381 but can land independently.