### PR TITLE
feat: send conference.left analytics event

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -233,7 +233,14 @@ export default function JitsiConference(options) {
 
     this.videoSIPGWHandler = new VideoSIPGW(this.room);
     this.recordingManager = new RecordingManager(this.room);
-    this._conferenceJoinAnalyticsEventSent = false;
+
+    /**
+     * If the conference.joined event has been sent this will store the timestamp when it happened.
+     *
+     * @type {undefined|number}
+     * @private
+     */
+    this._conferenceJoinAnalyticsEventSent = undefined;
 }
 
 // FIXME convert JitsiConference to ES6 - ASAP !
@@ -542,6 +549,9 @@ JitsiConference.prototype.leave = function() {
     this.getLocalTracks().forEach(track => this.onLocalTrackRemoved(track));
 
     this.rtc.closeBridgeChannel();
+
+    this._sendConferenceLeftAnalyticsEvent();
+
     if (this.statistics) {
         this.statistics.dispose();
     }
@@ -3338,7 +3348,29 @@ JitsiConference.prototype._sendConferenceJoinAnalyticsEvent = function() {
         meetingId,
         participantId: `${meetingId}.${this._statsCurrentId}`
     }));
-    this._conferenceJoinAnalyticsEventSent = true;
+    this._conferenceJoinAnalyticsEventSent = Date.now();
+};
+
+/**
+ * Sends conference.left analytics event.
+ * @private
+ */
+JitsiConference.prototype._sendConferenceLeftAnalyticsEvent = function() {
+    const meetingId = this.getMeetingUniqueId();
+
+    if (!meetingId || !this._conferenceJoinAnalyticsEventSent) {
+
+        return;
+    }
+
+    Statistics.sendAnalytics(createConferenceEvent('left', {
+        meetingId,
+        participantId: `${meetingId}.${this._statsCurrentId}`,
+        stats: {
+            duration: Math.floor((Date.now() - this._conferenceJoinAnalyticsEventSent) / 1000),
+            perf: this.getPerformanceStats()
+        }
+    }));
 };
 
 /**

--- a/modules/statistics/PerformanceObserverStats.js
+++ b/modules/statistics/PerformanceObserverStats.js
@@ -36,8 +36,8 @@ export class PerformanceObserverStats {
      */
     getLongTasksStats() {
         return {
-            average: (this.stats.getAverage() * SECONDS).toFixed(2), // calc rate per min
-            maxDuration: this.maxDuration
+            avgRatePerMinute: (this.stats.getAverage() * SECONDS).toFixed(2), // calc rate per min
+            maxDurationMs: this.maxDuration
         };
     }
 


### PR DESCRIPTION
...which contains conference duration in seconds and performance stats (currently long tasks).