### PR TITLE
Fix unified p2p

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -256,10 +256,7 @@ export class TPCUtils {
             return Promise.resolve();
         }
 
-        return transceiver.sender.replaceTrack(track)
-            .then(() => {
-                this.pc.localTracks.set(localTrack.rtcId, localTrack);
-            });
+        return transceiver.sender.replaceTrack(track);
     }
 
     /**
@@ -289,8 +286,7 @@ export class TPCUtils {
     /**
      * Removes the track from the RTCRtpSender as part of the mute operation.
      * @param {JitsiLocalTrack} localTrack - track to be removed.
-     * @returns {Promise<boolean>} - Promise that resolves to false if unmute
-     * operation is successful, a reject otherwise.
+     * @returns {Promise<void>} - resolved when done.
      */
     removeTrackMute(localTrack) {
         const mediaType = localTrack.getType();
@@ -303,12 +299,7 @@ export class TPCUtils {
 
         logger.debug(`Removing ${localTrack} on ${this.pc}`);
 
-        return transceiver.sender.replaceTrack(null)
-            .then(() => {
-                this.pc.localTracks.delete(localTrack.rtcId);
-
-                return Promise.resolve(false);
-            });
+        return transceiver.sender.replaceTrack(null);
     }
 
     /**
@@ -408,8 +399,8 @@ export class TPCUtils {
         const transceivers = this.pc.peerconnection.getTransceivers()
             .filter(t => t.receiver && t.receiver.track && t.receiver.track.kind === mediaType);
         const localTracks = this.pc.getLocalTracks(mediaType);
-        logger.info(`${active ? 'Enabling' : 'Suspending'} ${mediaType} media transfer on ${this.pc}`);
 
+        logger.info(`${active ? 'Enabling' : 'Suspending'} ${mediaType} media transfer on ${this.pc}`);
         transceivers.forEach((transceiver, idx) => {
             if (active) {
                 // The first transceiver is for the local track and only this one can be set to 'sendrecv'

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -192,9 +192,11 @@ export class TPCUtils {
     /**
     * Adds {@link JitsiLocalTrack} to the WebRTC peerconnection for the first time.
     * @param {JitsiLocalTrack} track - track to be added to the peerconnection.
+    * @param {boolean} isInitiator - boolean that indicates if the endpoint is offerer
+    * in a p2p connection.
     * @returns {void}
     */
-    addTrack(localTrack, isInitiator = true) {
+    addTrack(localTrack, isInitiator) {
         const track = localTrack.getTrack();
 
         if (isInitiator) {
@@ -375,7 +377,7 @@ export class TPCUtils {
     * @returns {void}
     */
     setAudioTransferActive(active) {
-        this.setMediaTransferActive('audio', active);
+        this.setMediaTransferActive(MediaType.AUDIO, active);
     }
 
     /**
@@ -406,6 +408,7 @@ export class TPCUtils {
         const transceivers = this.pc.peerconnection.getTransceivers()
             .filter(t => t.receiver && t.receiver.track && t.receiver.track.kind === mediaType);
         const localTracks = this.pc.getLocalTracks(mediaType);
+        logger.info(`${active ? 'Enabling' : 'Suspending'} ${mediaType} media transfer on ${this.pc}`);
 
         transceivers.forEach((transceiver, idx) => {
             if (active) {
@@ -431,6 +434,6 @@ export class TPCUtils {
     * @returns {void}
     */
     setVideoTransferActive(active) {
-        this.setMediaTransferActive('video', active);
+        this.setMediaTransferActive(MediaType.VIDEO, active);
     }
 }

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2109,12 +2109,12 @@ TraceablePeerConnection.prototype.setMaxBitRate = function() {
     const videoSender = this.findSenderByKind(MediaType.VIDEO);
 
     if (!videoSender) {
-        return Promise.reject(new Error('RTCRtpSender not found for local video'));
+        return Promise.resolve();
     }
     const parameters = videoSender.getParameters();
 
     if (!(parameters.encodings && parameters.encodings.length)) {
-        return Promise.reject(new Error('RTCRtpEncodingParameters not found for local video'));
+        return Promise.resolve();
     }
 
     if (this.isSimulcastOn()) {
@@ -2258,12 +2258,12 @@ TraceablePeerConnection.prototype.setSenderVideoConstraint = function(frameHeigh
     const videoSender = this.findSenderByKind(MediaType.VIDEO);
 
     if (!videoSender) {
-        return Promise.reject(new Error('RTCRtpSender not found for local video'));
+        return Promise.resolve();
     }
     const parameters = videoSender.getParameters();
 
     if (!parameters || !parameters.encodings || !parameters.encodings.length) {
-        return Promise.reject(new Error('RTCRtpSendParameters not found for local video track'));
+        return Promise.resolve();
     }
 
     if (this.isSimulcastOn()) {

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1657,9 +1657,6 @@ TraceablePeerConnection.prototype.addTrack = function(track, isInitiator = false
  * Promise is rejected when something goes wrong.
  */
 TraceablePeerConnection.prototype.addTrackUnmute = function(track) {
-    if (browser.usesUnifiedPlan()) {
-        return this.tpcUtils.addTrackUnmute(track);
-    }
     if (!this._assertTrackBelongs('addTrackUnmute', track)) {
         // Abort
         return Promise.reject('Track not found on the peerconnection');
@@ -1674,6 +1671,11 @@ TraceablePeerConnection.prototype.addTrackUnmute = function(track) {
 
         return Promise.reject('Stream not found');
     }
+
+    if (browser.usesUnifiedPlan()) {
+        return this.tpcUtils.addTrackUnmute(track);
+    }
+
     this._addStream(webRtcStream);
 
     return Promise.resolve(true);
@@ -1832,9 +1834,6 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
  * Promise is rejected when something goes wrong.
  */
 TraceablePeerConnection.prototype.removeTrackMute = function(localTrack) {
-    if (browser.usesUnifiedPlan()) {
-        return this.tpcUtils.removeTrackMute(localTrack);
-    }
     const webRtcStream = localTrack.getOriginalStream();
 
     this.trace(
@@ -1845,6 +1844,11 @@ TraceablePeerConnection.prototype.removeTrackMute = function(localTrack) {
         // Abort - nothing to be done here
         return Promise.reject('Track not found in the peerconnection');
     }
+
+    if (browser.usesUnifiedPlan()) {
+        return this.tpcUtils.removeTrackMute(localTrack);
+    }
+
     if (webRtcStream) {
         logger.info(
             `Removing ${localTrack} as mute from ${this}`);

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -945,7 +945,7 @@ export default class JingleSessionPC extends JingleSession {
             const addTracks = [];
 
             for (const localTrack of localTracks) {
-                addTracks.push(this.peerconnection.addTrack(localTrack, true /* isInitiator */));
+                addTracks.push(this.peerconnection.addTrack(localTrack, this.isInitiator));
             }
 
             Promise.all(addTracks)
@@ -1044,7 +1044,7 @@ export default class JingleSessionPC extends JingleSession {
             const addTracks = [];
 
             for (const track of localTracks) {
-                addTracks.push(this.peerconnection.addTrack(track));
+                addTracks.push(this.peerconnection.addTrack(track, this.isInitiator));
             }
 
             const newRemoteSdp


### PR DESCRIPTION
Configure the encodings on FF after the track is added in the p2p case.
Do not add/remove video tracks from TPC for unmute/mute case on Safari.
Only add/remove the tracks from the peerconnection so that the camera led turns off on mute