### PR TITLE
fix(RTCUtils): Cannot read property 'find' of undefined

### DIFF
--- a/JitsiMediaDevices.js
+++ b/JitsiMediaDevices.js
@@ -220,7 +220,7 @@ class JitsiMediaDevices {
     setAudioOutputDevice(deviceId) {
         const availableDevices = RTC.getCurrentlyAvailableMediaDevices();
 
-        if (availableDevices && availableDevices.length > 0) {
+        if (availableDevices.length > 0) {
             // if we have devices info report device to stats
             // normally this will not happen on startup as this method is called
             // too early. This will happen only on user selection of new device

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -815,7 +815,7 @@ class RTCUtils extends Listenable {
             logger.info(`Disable HPF: ${disableHPF}`);
         }
 
-        availableDevices = undefined;
+        availableDevices = [];
         window.clearInterval(availableDevicesPollTimer);
         availableDevicesPollTimer = undefined;
 


### PR DESCRIPTION
This error happens in getCurrentlyAvailableMediaDevices. I got this error in my sentry error tracking many times for multiple users. I think this will fix it (reason below).

```console
TypeError: Cannot read property 'find' of undefined
```

in

```javascript
{snip} .a.DESKTOP){const t=y.a.getCurrentlyAvailableMediaDevices().find(t=>t.kind===`${e.getTrack().kind}input`&&t.label===e.getTrack().label);t&&F {snip}
```

I've reverse engineered it and found out that if `this.isDeviceListAvailable()` is not `true` the variable is never set to something else than `undefined`. But the jsdoc description of `getCurrentlyAvailableMediaDevices` says that it will return an empty array which currently seems not to be true:

```javascript
/**
 * Returns list of available media devices if its obtained, otherwise an
 * empty array is returned/
 * @returns {Array} list of available media devices.
 */
getCurrentlyAvailableMediaDevices() {
    return availableDevices;
}
```