### PR TITLE
Fix sender constraints for camera started with resolutions > 720p

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -3,6 +3,7 @@
 import { getLogger } from 'jitsi-meet-logger';
 import { $iq, Strophe } from 'strophe.js';
 
+import CodecMimeType from '../../service/RTC/CodecMimeType';
 import RTCEvents from '../../service/RTC/RTCEvents';
 import {
     ICE_DURATION,
@@ -345,7 +346,11 @@ export default class JingleSessionPC extends JingleSession {
 
             // codec preference options for p2p.
             if (options.p2p) {
-                pcOptions.disabledCodec = options.p2p.disabledCodec;
+                // Do not negotiate H246 codec when insertable streams is used because of issues like this -
+                // https://bugs.chromium.org/p/webrtc/issues/detail?id=11886
+                pcOptions.disabledCodec = options.enableInsertableStreams
+                    ? CodecMimeType.H264
+                    : options.p2p.disabledCodec;
                 pcOptions.preferredCodec = options.p2p.preferredCodec;
             }
 


### PR DESCRIPTION
Make sure the LD stream is enabled even when requested resolution is lower.
This should fix the case when camera is started with 1080p and LD simulcast stream's resolution is 270p but the requested resolution is 180.
Do not negotiate H264 for p2p connections when E2EE is enabled.