### PR TITLE
feat(stats): Add the ability to enable callStats only on a certain % of users

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -38,6 +38,7 @@ import SpeakerStatsCollector from './modules/statistics/SpeakerStatsCollector';
 import Statistics from './modules/statistics/statistics';
 import Transcriber from './modules/transcription/transcriber';
 import GlobalOnErrorHandler from './modules/util/GlobalOnErrorHandler';
+import { hashString } from './modules/util/MathUtil';
 import RandomUtil from './modules/util/RandomUtil';
 import ComponentsVersions from './modules/version/ComponentsVersions';
 import VideoSIPGW from './modules/videosipgw/VideoSIPGW';
@@ -374,12 +375,11 @@ JitsiConference.prototype._init = function(options = {}) {
             });
     this.participantConnectionStatus.init();
 
-    // Add the ability to enable callStats only on a certain percentage of users based
-    // on config.js setting.
-    let disableCallStats = false;
+    // Add the ability to enable callStats only on a percentage of conferences based on config.js settings.
+    let enableCallStats = true;
 
-    if (config.testing && config.testing.callStatsUserThreshold) {
-        disableCallStats = Math.random() > config.testing.callStatsUserThreshold;
+    if (config.testing && config.testing.callStatsThreshold) {
+        enableCallStats = (hashString(this.options.name) % 100) < config.testing.callStatsThreshold;
     }
 
     if (!this.statistics) {
@@ -392,7 +392,7 @@ JitsiConference.prototype._init = function(options = {}) {
             callStatsID: config.callStatsID,
             callStatsSecret: config.callStatsSecret,
             callStatsApplicationLogsDisabled: config.callStatsApplicationLogsDisabled,
-            disableCallStats,
+            enableCallStats,
             roomName: this.options.name,
             applicationName: config.applicationName,
             getWiFiStatsMethod: config.getWiFiStatsMethod

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -374,6 +374,14 @@ JitsiConference.prototype._init = function(options = {}) {
             });
     this.participantConnectionStatus.init();
 
+    // Add the ability to enable callStats only on a certain percentage of users based
+    // on config.js setting.
+    let disableCallStats = false;
+
+    if (config.testing && config.testing.callStatsUserThreshold) {
+        disableCallStats = Math.random() > config.testing.callStatsUserThreshold;
+    }
+
     if (!this.statistics) {
         this.statistics = new Statistics(this.xmpp, {
             aliasName: this._statsCurrentId,
@@ -384,6 +392,7 @@ JitsiConference.prototype._init = function(options = {}) {
             callStatsID: config.callStatsID,
             callStatsSecret: config.callStatsSecret,
             callStatsApplicationLogsDisabled: config.callStatsApplicationLogsDisabled,
+            disableCallStats,
             roomName: this.options.name,
             applicationName: config.applicationName,
             getWiFiStatsMethod: config.getWiFiStatsMethod

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -160,7 +160,7 @@ export default function Statistics(xmpp, options) {
     this.options = options || {};
 
     this.callStatsIntegrationEnabled
-        = this.options.callStatsID && this.options.callStatsSecret && !this.options.disableCallStats
+        = this.options.callStatsID && this.options.callStatsSecret && this.options.enableCallStats
 
             // Even though AppID and AppSecret may be specified, the integration
             // of callstats.io may be disabled because of globally-disallowed

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -160,7 +160,7 @@ export default function Statistics(xmpp, options) {
     this.options = options || {};
 
     this.callStatsIntegrationEnabled
-        = this.options.callStatsID && this.options.callStatsSecret
+        = this.options.callStatsID && this.options.callStatsSecret && !this.options.disableCallStats
 
             // Even though AppID and AppSecret may be specified, the integration
             // of callstats.io may be disabled because of globally-disallowed

--- a/modules/util/MathUtil.js
+++ b/modules/util/MathUtil.js
@@ -27,6 +27,25 @@ export function calculateAverage(valueArray) {
     return valueArray.length > 0 ? valueArray.reduce((a, b) => a + b) / valueArray.length : 0;
 }
 
+/**
+ * Calculates a unique hash for a given string similar to Java's
+ * implementation of String.hashCode()
+ *
+ * @param {String} string - String whose hash has to be calculated.
+ * @returns {number} - Unique hash code calculated.
+ */
+export function hashString(string) {
+    let hash = 0;
+
+    for (let i = 0; i < string.length; i++) {
+        hash += Math.pow(string.charCodeAt(i) * 31, string.length - i);
+
+        /* eslint-disable no-bitwise */
+        hash = hash & hash; // Convert to 32bit integer
+    }
+
+    return Math.abs(hash);
+}
 
 /**
  * Returns only the positive values from an array of numbers.


### PR DESCRIPTION
A new config.js setting `testing->callStatsThreshold` is introduced that determines the % of conferences on which callStats will be enabled. It takes a value between 0 and 100.