### PR TITLE
feat: allow to set the receiver video constraints per endpoint

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3315,6 +3315,24 @@ JitsiConference.prototype.setReceiverVideoConstraint = function(maxFrameHeight) 
 };
 
 /**
+ * Sets the maximum video size the local participant should receive per remote participant.
+ *
+ * This allows the client to specify the ideal resolution height for each of the remote
+ * participants in the conference.
+ *
+ * @param {Array<VideoConstraints>} videoConstraints An array of constraint objects with map of
+ *                                                   participant ID and ideal height, for example:
+ *                                                   [
+ *                                                     { "id": "abcdabcd", "idealHeight": 180 },
+ *                                                     { "id": "12341234", "idealHeight": 360 }
+ *                                                   ]
+ * @returns {void}
+ */
+JitsiConference.prototype.setReceiverVideoConstraints = function(videoConstraints) {
+    this.rtc.setReceiverVideoConstraints(videoConstraints);
+};
+
+/**
  * Sets the maximum video size the local participant should send to remote
  * participants.
  * @param {number} maxFrameHeight - The user preferred max frame height.

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -248,6 +248,30 @@ export default class BridgeChannel {
     }
 
     /**
+     * Sends a "receiver video constraints changed" message via the channel.
+     *
+     * @param {Array<VideoConstraints>} videoConstraints An array of constraint objects with map of
+     *                                                   participant ID and ideal height, for example:
+     *                                                   [
+     *                                                      { "id": "abcdabcd", "idealHeight": 180 },
+     *                                                      { "id": "12341234", "idealHeight": 360 }
+     *                                                   ]
+     * @throws NetworkError or InvalidStateError from RTCDataChannel#send (@see
+     * {@link https://developer.mozilla.org/docs/Web/API/RTCDataChannel/send})
+     * or from WebSocket#send or Error with "No opened channel" message.
+     */
+    sendReceiverVideoConstraintsMessage(videoConstraints) {
+        logger.log(
+            'sending receiver video constraints changed notification to the bridge',
+            JSON.stringify(videoConstraints));
+
+        this._send({
+            colibriClass: 'ReceiverVideoConstraintsChangedEvent',
+            videoConstraints
+        });
+    }
+
+    /**
      * Sends a "receiver video constraint" message via the channel.
      * @param {Number} maxFrameHeightPixels the maximum frame height,
      * in pixels, this receiver is willing to receive

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -172,6 +172,20 @@ export default class RTC extends Listenable {
         this._maxFrameHeight = undefined;
 
         /**
+         * The video constraints that the client specifies to receive from
+         * each remote participant.
+         *
+         * @type {Array<VideoConstraint>|undefined} An array of constraint objects with map of
+         *                                          participant ID and ideal height, for example:
+         *                                          [
+         *                                            { "id": "abcdabcd", "idealHeight": 180 },
+         *                                            { "id": "12341234", "idealHeight": 360 }
+         *                                          ]
+         * @private
+         */
+        this._videoConstraints = undefined;
+
+        /**
          * The endpoint ID of currently pinned participant or <tt>null</tt> if
          * no user is pinned.
          * @type {string|null}
@@ -300,6 +314,10 @@ export default class RTC extends Listenable {
                     this._channel.sendReceiverVideoConstraintMessage(
                         this._maxFrameHeight);
                 }
+                if (typeof this._videoConstraints !== 'undefined') {
+                    this._channel.sendReceiverVideoConstraintsMessage(
+                        this._videoConstraints);
+                }
             } catch (error) {
                 GlobalOnErrorHandler.callErrorHandler(error);
                 logger.error(
@@ -394,6 +412,29 @@ export default class RTC extends Listenable {
             }
 
             this._channel = null;
+        }
+    }
+
+    /**
+     * Sets the maximum video size the local participant should receive per remote participant.
+     *
+     * This allows the client to specify the ideal resolution height for each of the remote
+     * participants in the conference. If there is no channel we store it and send it
+     * through the channel once it is created.
+     *
+     * @param {Array<VideoConstraints>} videoConstraints An array of constraint objects with map of
+     *                                                   participant ID and ideal height, for example:
+     *                                                   [
+     *                                                     { "id": "abcdabcd", "idealHeight": 180 },
+     *                                                     { "id": "12341234", "idealHeight": 360 }
+     *                                                   ]
+     * @returns {void}
+     */
+    setReceiverVideoConstraints(videoConstraints) {
+        this._videoConstraints = videoConstraints;
+
+        if (this._channel && this._channel.isOpen()) {
+            this._channel.sendReceiverVideoConstraintsMessage(videoConstraints);
         }
     }
 


### PR DESCRIPTION
This allows for flexible quality management.

However for this to work, a fix is needed in videobridge too (see jitsi/jitsi-videobridge#1458)

Issue #1175