### PR TITLE
fix(callstats): Go back to enabling callstats on % of users rather than % of conferences.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -38,7 +38,6 @@ import SpeakerStatsCollector from './modules/statistics/SpeakerStatsCollector';
 import Statistics from './modules/statistics/statistics';
 import Transcriber from './modules/transcription/transcriber';
 import GlobalOnErrorHandler from './modules/util/GlobalOnErrorHandler';
-import { hashString } from './modules/util/MathUtil';
 import RandomUtil from './modules/util/RandomUtil';
 import ComponentsVersions from './modules/version/ComponentsVersions';
 import VideoSIPGW from './modules/videosipgw/VideoSIPGW';
@@ -375,11 +374,11 @@ JitsiConference.prototype._init = function(options = {}) {
             });
     this.participantConnectionStatus.init();
 
-    // Add the ability to enable callStats only on a percentage of conferences based on config.js settings.
+    // Add the ability to enable callStats only on a percentage of users based on config.js settings.
     let enableCallStats = true;
 
     if (config.testing && config.testing.callStatsThreshold) {
-        enableCallStats = (hashString(this.options.name) % 100) < config.testing.callStatsThreshold;
+        enableCallStats = (Math.random() * 100) <= config.testing.callStatsThreshold;
     }
 
     if (!this.statistics) {


### PR DESCRIPTION
This way we make sure that we don't overshoot the threshold set in config.js