### PR TITLE
fixed incorrect kick() with kickParticipant() in doc/API.md

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -352,7 +352,7 @@ Throws NetworkError or InvalidStateError or Error if the operation fails.
 
     Note: available only for moderator
 
-24. kick(id) - Kick participant from the conference
+24. kickParticipant(id) - Kick participant from the conference
     - id - string participant id
 
 25. setStartMutedPolicy(policy) - make all new participants join with muted audio/video


### PR DESCRIPTION
When `kick()` is used for kicking out a user from the conference, the following runtime error is thrown.
```
TypeError: room.kick() is not a function.
```
The method for kicking out a user is mentioned in the docs as `kick()`, but *it should be `kickParticipant()`*.   
This PR fixes that error in the doc/API.md. 