### PR TITLE
 e2ee: ratchet the key forward on authentication tag errors

### DIFF
--- a/doc/e2ee.md
+++ b/doc/e2ee.md
@@ -39,6 +39,14 @@ We do not encrypt the first few bytes of the packet that form the VP8 payload
 This allows the decoder to understand the frame a bit more and makes it decode the fun looking garbage we see in the video.
 This also means the SFU does not know (ideally) that the content is end-to-end encrypted and there are no changes in the SFU required at all.
 
+## Key Ratcheting
+Unlike described in
+  https://tools.ietf.org/html/draft-omara-sframe-00#section-4.3.5.1
+we attempt to ratchet the key forward when we do not find a valid
+authentication tag. Note that we only update the set of keys when
+we find a valid signature which avoids a denial of service attack with invalid signatures.
+
+TODO: if a frame ratchets the key forward it should be signed with the senders private key.
 
 ## Using workers
 

--- a/modules/e2ee/E2EEContext.js
+++ b/modules/e2ee/E2EEContext.js
@@ -23,17 +23,8 @@ const kJitsiE2EE = Symbol('kJitsiE2EE');
 export default class E2EEcontext {
     /**
      * Build a new E2EE context instance, which will be used in a given conference.
-     *
-     * @param {string} options.salt - Salt to be used for key deviation.
-     * FIXME: We currently use the MUC room name for this which has the same lifetime
-     * as this context. While not (pseudo)random as recommended in
-     * https://developer.mozilla.org/en-US/docs/Web/API/Pbkdf2Params
-     * this is easily available and the same for all participants.
-     * We currently do not enforce a minimum length of 16 bytes either.
      */
-    constructor(options) {
-        this._options = options;
-
+    constructor() {
         // Determine the URL for the worker script. Relative URLs are relative to
         // the entry point, not the script that launches the worker.
         let baseUrl = '';

--- a/modules/e2ee/E2EEContext.js
+++ b/modules/e2ee/E2EEContext.js
@@ -139,15 +139,4 @@ export default class E2EEcontext {
             keyIndex
         });
     }
-
-    /**
-     * Ratchet our own key.
-     * @param {string} participantId - the ID of the participant who's key we should ratchet.
-     */
-    ratchet(participantId) {
-        this._worker.postMessage({
-            operation: 'ratchet',
-            participantId
-        });
-    }
 }

--- a/modules/e2ee/E2EEContext.js
+++ b/modules/e2ee/E2EEContext.js
@@ -148,4 +148,15 @@ export default class E2EEcontext {
             keyIndex
         });
     }
+
+    /**
+     * Ratchet our own key.
+     * @param {string} participantId - the ID of the participant who's key we should ratchet.
+     */
+    ratchet(participantId) {
+        this._worker.postMessage({
+            operation: 'ratchet',
+            participantId
+        });
+    }
 }

--- a/modules/e2ee/E2EEncryption.js
+++ b/modules/e2ee/E2EEncryption.js
@@ -31,7 +31,7 @@ export class E2EEncryption {
         this._enabled = false;
         this._initialized = false;
 
-        this._e2eeCtx = new E2EEContext({ salt: conference.getName() });
+        this._e2eeCtx = new E2EEContext();
         this._olmAdapter = new OlmAdapter(conference);
 
         // Debounce key rotation / ratcheting to avoid a storm of messages.

--- a/modules/e2ee/E2EEncryption.js
+++ b/modules/e2ee/E2EEncryption.js
@@ -169,7 +169,7 @@ export class E2EEncryption {
     }
 
     /**
-     * Advances (using ratcheting) the current key whern a new participant joins the conference.
+     * Advances (using ratcheting) the current key when a new participant joins the conference.
      * @private
      */
     _onParticipantJoined(id) {
@@ -195,7 +195,7 @@ export class E2EEncryption {
     }
 
     /**
-     * Event posted when the E2EE signalling channel has been establioshed with the given participant.
+     * Event posted when the E2EE signalling channel has been established with the given participant.
      * @private
      */
     _onParticipantE2EEChannelReady(id) {
@@ -218,15 +218,16 @@ export class E2EEncryption {
 
     /**
      * Advances the current key by using ratcheting.
-     * TODO: not yet implemented, we are just rotating the key at the moment,
-     * which is a heavier operation.
      *
      * @private
      */
     async _ratchetKeyImpl() {
         logger.debug('Ratchetting key');
 
-        return this._rotateKey();
+        this._e2eeCtx.ratchet(this.conference.myUserId());
+
+        // TODO: how do we tell the olm adapter which might need to send the current ratchet key
+        //      to the other side?
     }
 
     /**

--- a/modules/e2ee/OlmAdapter.js
+++ b/modules/e2ee/OlmAdapter.js
@@ -88,6 +88,19 @@ export class OlmAdapter extends Listenable {
      * by sending a key-info message.
      *
      * @param {Uint8Array|boolean} key - The new key.
+     * @returns {number}
+     */
+    async updateCurrentKey(key) {
+        this._key = key;
+
+        return this._keyIndex;
+    }
+
+    /**
+     * Updates the current participant key and distributes it to all participants in the conference
+     * by sending a key-info message.
+     *
+     * @param {Uint8Array|boolean} key - The new key.
      * @retrns {Promise<Number>}
      */
     async updateKey(key) {
@@ -95,9 +108,9 @@ export class OlmAdapter extends Listenable {
         this._key = key;
         this._keyIndex++;
 
+        // Broadcast it.
         const promises = [];
 
-        // Broadcast it.
         for (const participant of this._conf.getParticipants()) {
             const pId = participant.getId();
             const olmData = this._getParticipantOlmData(participant);

--- a/modules/e2ee/Worker.js
+++ b/modules/e2ee/Worker.js
@@ -193,16 +193,6 @@ class Context {
     }
 
     /**
-     * Ratchets a key forward one step.
-     */
-    async ratchet() {
-        const keys = this._cryptoKeyRing[this._currentKeyIndex];
-        const material = await ratchet(keys.material);
-
-        this.setKey(material, this._currentKeyIndex);
-    }
-
-    /**
      * Function that will be injected in a stream and will encrypt the given encoded frames.
      *
      * @param {RTCEncodedVideoFrame|RTCEncodedAudioFrame} encodedFrame - Encoded video frame.
@@ -484,19 +474,6 @@ onmessage = async event => {
         } else {
             context.setKey(false, keyIndex);
         }
-    } else if (operation === 'ratchet') {
-        const { participantId } = event.data;
-
-        // TODO: can we ensure this is for our own sender key?
-
-        if (!contexts.has(participantId)) {
-            console.error('Could not find context for', participantId);
-
-            return;
-        }
-        const context = contexts.get(participantId);
-
-        context.ratchet();
     } else if (operation === 'cleanup') {
         const { participantId } = event.data;
 


### PR DESCRIPTION
similar to what is explained here:
  https://tools.ietf.org/html/draft-omara-sframe-00#section-4.3.5.1
but we do it on authentication tag failures since it is not possible
to tell whether decrypt.