### PR TITLE
e2ee: sync key ring size and packet format

### DIFF
--- a/doc/e2ee.md
+++ b/doc/e2ee.md
@@ -26,7 +26,7 @@ At a high level the encrypted frame format looks like this:
    +^+-------------------------------------------------------+ +
    | |                 Authentication Tag                    | |
    | +---------------------------------------+-+-+-+-+-+-+-+-+ |
-   | |    CTR... (length=LEN + 1)            |S|LEN  |0| KID | |
+   | |    CTR... (length=LEN + 1)            |S|LEN  |KID    | |
    | +---------------------------------------+-+-+-+-+-+-+-+-+^|
    |                                                           |
    +----+Encrypted Portion            Authenticated Portion+---+


### PR DESCRIPTION
this uses the full four bits in the wire format. The wire format
looses the (currently not implemented) extensibility with variable
length keys.