### PR TITLE
fix(updateDevices): On enumerateDevices.

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -100,6 +100,13 @@ let availableDevices;
 let availableDevicesPollTimer;
 
 /**
+ * An empty function.
+ */
+function emptyFuncton() {
+    // no-op
+}
+
+/**
  * Initialize wrapper function for enumerating devices.
  * TODO: remove this, it should no longer be needed.
  *
@@ -109,7 +116,13 @@ function initEnumerateDevicesWithCallback() {
     if (navigator.mediaDevices && navigator.mediaDevices.enumerateDevices) {
         return callback => {
             navigator.mediaDevices.enumerateDevices()
-                .then(callback, () => callback([]));
+                .then(devices => {
+                    updateKnownDevices(devices);
+                    callback(devices);
+                }, () => {
+                    updateKnownDevices([]);
+                    callback([]);
+                });
         };
     }
 }
@@ -621,6 +634,23 @@ function sendDeviceListToAnalytics(deviceList) {
     });
 }
 
+
+/**
+ * Update known devices.
+ *
+ * @param {Array<Object>} pds - The new devices.
+ * @returns {void}
+ *
+ * NOTE: Use this function as a shared callback to handle both the devicechange event  and the polling implementations.
+ * This prevents duplication and works around a chrome bug (verified to occur on 68) where devicechange fires twice in
+ * a row, which can cause async post devicechange processing to collide.
+ */
+function updateKnownDevices(pds) {
+    if (compareAvailableMediaDevices(pds)) {
+        onMediaDevicesListChanged(pds);
+    }
+}
+
 /**
  * Event handler for the 'devicechange' event.
  *
@@ -895,27 +925,15 @@ class RTCUtils extends Listenable {
                     RTCEvents.DEVICE_LIST_AVAILABLE,
                     availableDevices);
 
-
-                // Use a shared callback to handle both the devicechange event
-                // and the polling implementations. This prevents duplication
-                // and works around a chrome bug (verified to occur on 68) where
-                // devicechange fires twice in a row, which can cause async post
-                // devicechange processing to collide.
-                const updateKnownDevices = () => this.enumerateDevices(pds => {
-                    if (compareAvailableMediaDevices(pds)) {
-                        onMediaDevicesListChanged(pds);
-                    }
-                });
-
                 if (browser.supportsDeviceChangeEvent()) {
                     navigator.mediaDevices.addEventListener(
                         'devicechange',
-                        updateKnownDevices);
+                        () => this.enumerateDevices(emptyFuncton));
                 } else {
                     // Periodically poll enumerateDevices() method to check if
                     // list of media devices has changed.
                     availableDevicesPollTimer = window.setInterval(
-                        updateKnownDevices,
+                        () => this.enumerateDevices(emptyFuncton),
                         AVAILABLE_DEVICES_POLL_INTERVAL_TIME);
                 }
             });


### PR DESCRIPTION

Device IDs can change without triggering any event. In order to sync the
device IDs that  we store with the actual device IDs, we need to update
them every time when we call enumerate devices.