### PR TITLE
feat: revoke owner from a participant

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1438,6 +1438,19 @@ JitsiConference.prototype.grantOwner = function(id) {
 };
 
 /**
+ * Revoke owner rights from a participant.
+ * @param {string} id id of the participant to revoke owner rights from.
+ */
+JitsiConference.prototype.revokeOwner = function(id) {
+    const participant = this.getParticipantById(id);
+
+    if (!participant) {
+        return;
+    }
+    this.room.setAffiliation(participant.getJid(), 'none');
+};
+
+/**
  * Kick participant from this conference.
  * @param {string} id id of the participant to kick
  */


### PR DESCRIPTION
Proposing a MR with a new feature of revoking ownership from a participant. The added method is a counterpart of `grantOwner` and is helpful when the affiliation is being changed while participants are already in the conference.