### PR TITLE
sdp: allow removing opus fec via config

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -62,6 +62,7 @@ const DEFAULT_MAX_STATS = 300;
  * @property {Object} testing - Testing and/or experimental options.
  * @property {boolean} webrtcIceUdpDisable - Described in the config.js[1].
  * @property {boolean} webrtcIceTcpDisable - Described in the config.js[1].
+ * @property {boolean} webrtcOpusFecRemove - Described in the config.js[1].
  *
  * [1]: https://github.com/jitsi/jitsi-meet/blob/master/config.js
  */
@@ -322,6 +323,7 @@ export default class JingleSessionPC extends JingleSession {
         this.wasstable = false;
         this.webrtcIceUdpDisable = Boolean(options.webrtcIceUdpDisable);
         this.webrtcIceTcpDisable = Boolean(options.webrtcIceTcpDisable);
+        this.webrtcOpusFecRemove = Boolean(options.webrtcOpusFecRemove);
 
         const pcOptions = { disableRtx: options.disableRtx };
 
@@ -1700,6 +1702,9 @@ export default class JingleSessionPC extends JingleSession {
         }
         if (this.webrtcIceUdpDisable) {
             remoteSdp.removeUdpCandidates = true;
+        }
+        if (this.webrtcOpusFecRemove) {
+            remoteSdp.removeOpusFec = true;
         }
         if (this.failICE) {
             remoteSdp.failICE = true;

--- a/modules/xmpp/SDP.js
+++ b/modules/xmpp/SDP.js
@@ -47,6 +47,12 @@ SDP.prototype.removeTcpCandidates = false;
 SDP.prototype.removeUdpCandidates = false;
 
 /**
+ * Whether or not to remove opus inband FEC when translating from/to jingle.
+ * @type {boolean}
+ */
+SDP.prototype.removeOpusFec = false;
+
+/**
  * Returns map of MediaChannel mapped per channel idx.
  */
 SDP.prototype.getMediaSsrcMap = function() {
@@ -660,6 +666,8 @@ SDP.prototype.jingle2media = function(content) {
             sdp
                 += $(payloadType)
                     .find('>parameter')
+                    .filter((__, parameter) => !(this.removeOpusFec
+                        && parameter.getAttribute('name') === 'useinbandfec'))
                     .map((__, parameter) => {
                         const name = parameter.getAttribute('name');
 


### PR DESCRIPTION
since the fec bitrate is subtracted from the target bitrate, FEC might
decrease the quality / MOS score. See
  https://webrtchacks.com/red-improving-audio-quality-with-redundancy/