### PR TITLE
fix(JingleSession) log initialization error

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1929,6 +1929,9 @@ JitsiConference.prototype._acceptJvbIncomingCall = function(
         });
     } catch (error) {
         GlobalOnErrorHandler.callErrorHandler(error);
+        logger.error(error);
+
+        return;
     }
 
     // Open a channel with the videobridge.


### PR DESCRIPTION
Also return early to avoid weird errors if the initialization step fails.
Everything is broken at that stage pretty much.