### PR TITLE
docs for setLocalParticipantProperty, PARTICIPANT_PROPERTY_CHANGED added.

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -450,6 +450,10 @@ Throws NetworkError or InvalidStateError or Error if the operation fails.
 
 36. `isHidden` - checks if local user has joined as a "hidden" user. This is a specialized role used for integrations.
 
+37. `setLocalParticipantProperty(key, value)` - used to set a custom propery to the local participant("fullName": "Full Name", favoriteColor: "red", "userId": 234).
+    - `key` - custom property name
+    - `value` - custom property value
+
 JitsiTrack
 ======
 The object represents single track - video or audio. They can be remote tracks ( from the other participants in the call) or local tracks (from the devices of the local participant).

--- a/doc/API.md
+++ b/doc/API.md
@@ -139,6 +139,7 @@ JitsiMeetJS.setLogLevel(JitsiMeetJS.logLevels.ERROR);
         - `NO_AUDIO_INPUT` - notifies that the current selected input device has no signal.
         - `AUDIO_INPUT_STATE_CHANGE` - notifies that the current conference audio input switched between audio input states i.e. with or without audio input.
         - `NOISY_MIC` - notifies that the current microphone used by the conference is noisy.
+        - `PARTICIPANT_PROPERTY_CHANGED` - notifies that user has changed his custom participant property. (parameters - user(JitsiParticipant), propertyKey(string), oldPropertyValue(string), propertyValue(string))
 
     2. `connection`
         - `CONNECTION_FAILED` - indicates that the server connection failed.
@@ -450,9 +451,9 @@ Throws NetworkError or InvalidStateError or Error if the operation fails.
 
 36. `isHidden` - checks if local user has joined as a "hidden" user. This is a specialized role used for integrations.
 
-37. `setLocalParticipantProperty(key, value)` - used to set a custom propery to the local participant("fullName": "Full Name", favoriteColor: "red", "userId": 234).
-    - `key` - custom property name
-    - `value` - custom property value
+37. `setLocalParticipantProperty(propertyKey, propertyValue)` - used to set a custom propery to the local participant("fullName": "Full Name", favoriteColor: "red", "userId": 234). Also this can be used to modify an already set custom property.
+    - `propertyKey` - string - custom property name
+    - `propertyValue` - string - custom property value
 
 JitsiTrack
 ======


### PR DESCRIPTION
After using lib-jitsi-meet fairly well, I realized there is no way for us to set a custom property on the local user other than the display name. So, I went on a search and found on the jitsi community that we have `setLocalParticipantProperty` and `PARTICIPANT_PROPERTY_CHANGED` that are not given in the official documentation at [API.md](https://github.com/jitsi/lib-jitsi-meet/blob/master/doc/API.md). Knowing that these options are there helped me a lot in writing new features and I think there are others like me who might be using lib-jitsi-meet and don't know about these. So, I decided to add them in the docs.