### PR TITLE
Add google conference flag for screensharing

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -349,7 +349,7 @@ export default class RTC extends Listenable {
      * @private
      */
     _senderVideoConstraintsChanged(senderVideoConstraints) {
-        logger.info(`Received remote max frame height of ${senderVideoConstraints} on the bridge channel`);
+        logger.info('Remote max frame height received on bridge channel: ', JSON.stringify(senderVideoConstraints));
         this._senderVideoConstraints = senderVideoConstraints;
         this.eventEmitter.emit(RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED);
     }

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -659,9 +659,7 @@ function updateKnownDevices(pds) {
  */
 function onMediaDevicesListChanged(devicesReceived) {
     availableDevices = devicesReceived.slice(0);
-    logger.info(
-        'list of media devices has changed:',
-        availableDevices);
+    logger.info('list of media devices has changed:', availableDevices);
 
     sendDeviceListToAnalytics(availableDevices);
 
@@ -987,7 +985,7 @@ class RTCUtils extends Listenable {
     getUserMediaWithConstraints(um, options = {}) {
         const constraints = getConstraints(um, options);
 
-        logger.info('Get media constraints', constraints);
+        logger.info('Get media constraints', JSON.stringify(constraints));
 
         return new Promise((resolve, reject) => {
             navigator.mediaDevices.getUserMedia(constraints)
@@ -997,8 +995,7 @@ class RTCUtils extends Listenable {
                 resolve(stream);
             })
             .catch(error => {
-                logger.warn('Failed to get access to local media. '
-                    + ` ${error} ${constraints} `);
+                logger.warn(`Failed to get access to local media. ${error} ${JSON.stringify(constraints)}`);
                 updateGrantedPermissions(um, undefined);
                 reject(new JitsiTrackError(error, constraints, um));
             });
@@ -1022,8 +1019,7 @@ class RTCUtils extends Listenable {
                     resolve(stream);
                 })
                 .catch(error => {
-                    logger.warn('Failed to get access to local media. '
-                        + ` ${error} ${constraints} `);
+                    logger.warn(`Failed to get access to local media. ${error} ${JSON.stringify(constraints)}`);
                     updateGrantedPermissions(umDevices, undefined);
                     reject(new JitsiTrackError(error, constraints, umDevices));
                 });
@@ -1382,7 +1378,7 @@ class RTCUtils extends Listenable {
             const constraints = newGetConstraints(
                 requestedCaptureDevices, options);
 
-            logger.info('Got media constraints: ', constraints);
+            logger.info('Got media constraints: ', JSON.stringify(constraints));
 
             return this._newGetUserMediaWithConstraints(
                 requestedCaptureDevices, constraints);

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2278,6 +2278,13 @@ TraceablePeerConnection.prototype.setSenderVideoConstraint = function(frameHeigh
 
     this.senderVideoMaxHeight = newHeight;
 
+    // If layer suspension is disabled and sender constraint is not configured for the conference,
+    // resolve here so that the encodings stay enabled. This can happen in custom apps built using
+    // lib-jitsi-meet.
+    if (newHeight === null) {
+        return Promise.resolve();
+    }
+
     logger.log(`${this} senderVideoMaxHeight: ${newHeight}`);
 
     const localVideoTrack = this.getLocalVideoTrack();

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2197,13 +2197,8 @@ TraceablePeerConnection.prototype.setRemoteDescription = function(description) {
     if (browser.usesPlanB()) {
         // TODO the focus should squeze or explode the remote simulcast
         if (this.isSimulcastOn()) {
-            // Determine if "x-google-conference" needs to be added to the remote description.
-            // We need to add that flag for camera tracks always and for desktop tracks only when
-            // capScreenshareBitrate is disabled.
-            const enableConferenceFlag = !(this.options.capScreenshareBitrate && !hasCameraTrack(this));
-
             // eslint-disable-next-line no-param-reassign
-            description = this.simulcast.mungeRemoteDescription(description, enableConferenceFlag);
+            description = this.simulcast.mungeRemoteDescription(description, true /* add x-google-conference flag */);
             this.trace(
                 'setRemoteDescription::postTransform (simulcast)',
                 dumpSDP(description));


### PR DESCRIPTION
Add the conference flag back since the bridge is now able to handle the case where more than 1 temporal layers are received even when only 1 SSRC is signaled.
Do not disable encodings when sender constraints are not configured for the conference. Fixes #1333 in applications that use lib-jitsi-meet and do not have layer suspension enabled.

