### PR TITLE
e2ee: sign multiple frames

### DIFF
--- a/doc/e2ee.md
+++ b/doc/e2ee.md
@@ -87,6 +87,8 @@ between the counter and the trailing bit:
    +^+-------------------------------------------------------+ +
    | |                 Authentication Tag                    | |
    | +---------------------------------------+-+-+-+-+-+-+-+-+ |
+   | | additional authentication tags        |number of tags | |
+   | +---------------------------------------+-+-+-+-+-+-+-+-+ |
    | |    CTR... (length=LEN + 1)            |  SIGNATURE    | |
    | +---------------------------------------+-+-+-+-+-+-+-+-+ |
    | |    SIGNATURE (fixed length)           |1|LEN  |KID    | |

--- a/doc/e2ee.md
+++ b/doc/e2ee.md
@@ -70,7 +70,7 @@ video. This also means the SFU does not know (ideally) that the content is end-t
 changes in the SFU required at all.
 
 If the signature bit is set on the frame trailer, there is an additional fixed-length signature that is located
-between the counter and the trailing bit:
+before the counter and the trailing byte:
 ```
      +------------+------------------------------------------+^+
      |unencrypted payload header (variable length)           | |
@@ -89,9 +89,9 @@ between the counter and the trailing bit:
    | +---------------------------------------+-+-+-+-+-+-+-+-+ |
    | | additional authentication tags        |number of tags | |
    | +---------------------------------------+-+-+-+-+-+-+-+-+ |
-   | |    CTR... (length=LEN + 1)            |  SIGNATURE    | |
+   | |    SIGNATURE (fixed length)                           | |
    | +---------------------------------------+-+-+-+-+-+-+-+-+ |
-   | |    SIGNATURE (fixed length)           |1|LEN  |KID    | |
+   | |    CTR... (length=LEN + 1))           |1|LEN  |KID    | |
    | +---------------------------------------+-+-+-+-+-+-+-+-+^|
    |                                                           |
    +----+Encrypted Portion            Authenticated Portion+---+

--- a/modules/e2ee/Context.spec.js
+++ b/modules/e2ee/Context.spec.js
@@ -83,7 +83,7 @@ describe('E2EE Context', () => {
                     const data = new Uint8Array(encodedFrame.data);
 
                     // An audio frame will have an overhead of 6 bytes with this counter and key size:
-                    //   4 bytes truncated signature, counter (1 byte) and 1 byte trailer.
+                    //   4 bytes truncated auth tag, counter (1 byte) and 1 byte trailer.
                     expect(data.byteLength).toEqual(audioBytes.length + 6);
 
                     // TODO: provide test vector.
@@ -100,7 +100,7 @@ describe('E2EE Context', () => {
                     const data = new Uint8Array(encodedFrame.data);
 
                     // A video frame will have an overhead of 12 bytes with this counter and key size:
-                    //   10 bytes signature, counter (1 byte) and 1 byte trailer.
+                    //   10 bytes truncated auth tag, counter (1 byte) and 1 byte trailer.
 
                     expect(data.byteLength).toEqual(videoBytes.length + 12);
 
@@ -224,7 +224,7 @@ describe('E2EE Context', () => {
                     expect(data[data.byteLength - 1] & 0x80).toEqual(0x80);
 
                     // An audio frame will have an overhead of 6 bytes with this counter and key size:
-                    //   4 bytes truncated signature, counter (1 byte) and 1 byte trailer.
+                    //   4 bytes truncated auth tag, counter (1 byte) and 1 byte trailer.
                     // In addition to that we have the 132 bytes signature and a one byte counter field.
                     expect(data.byteLength).toEqual(audioBytes.length + 6 + 1 + 132);
 


### PR DESCRIPTION
signs multiple frames instead of every single frame. All key frames are signed,
so are the first frames with a new ssrc as well as every frame on which we ratcheted
forward