### PR TITLE
Added the email to JitsiParticipant:getIdentity

### DIFF
--- a/JitsiParticipant.js
+++ b/JitsiParticipant.js
@@ -277,4 +277,13 @@ export default class JitsiParticipant {
     getBotType() {
         return this._botType;
     }
+
+    /**
+     * Returns the identity/email for the participant.
+     *
+     * @returns {string|undefined} - The identity the participant.
+     */
+    getIdentity() {
+        return this._identity;
+    }
 }

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -600,7 +600,7 @@ export default class ChatRoom extends Listenable {
                     member.isHiddenDomain,
                     member.statsID,
                     member.status,
-                    member.identity?member.identity:member.email,
+                    member.identity ? member.identity : member.email,
                     member.botType,
                     member.jid);
 

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -515,6 +515,9 @@ export default class ChatRoom extends Listenable {
             case 'nick':
                 member.nick = node.value;
                 break;
+            case 'email':
+                member.email = node.value;
+                break;
             case 'userId':
                 member.id = node.value;
                 break;
@@ -597,7 +600,7 @@ export default class ChatRoom extends Listenable {
                     member.isHiddenDomain,
                     member.statsID,
                     member.status,
-                    member.identity,
+                    member.identity?member.identity:member.email,
                     member.botType,
                     member.jid);
 


### PR DESCRIPTION
I have the same as issue as the request from https://github.com/jitsi/jitsi-meet/issues/5677.

The following is the simple fix/workaround as currently we don't really use the _identity in JitsiParticipant so just re-use it for the email. 