### PR TITLE
feat: make focusUserJid configurable

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1518,8 +1518,10 @@ JitsiConference.prototype.muteParticipant = function(id) {
 JitsiConference.prototype.onMemberJoined = function(
         jid, nick, role, isHidden, statsID, status, identity, botType) {
     const id = Strophe.getResourceFromJid(jid);
+    const focusid
+        = this.options.config.focusUserJid ? Strophe.getNodeFromJid(this.options.config.focusUserJid) : 'focus';
 
-    if (id === 'focus' || this.myUserId() === id) {
+    if (id === focusid || this.myUserId() === id) {
         return;
     }
 
@@ -1599,8 +1601,10 @@ JitsiConference.prototype._onMemberBotTypeChanged = function(jid, botType) {
 
 JitsiConference.prototype.onMemberLeft = function(jid) {
     const id = Strophe.getResourceFromJid(jid);
+    const focusid
+        = this.options.config.focusUserJid ? Strophe.getNodeFromJid(this.options.config.focusUserJid) : 'focus';
 
-    if (id === 'focus' || this.myUserId() === id) {
+    if (id === focusid || this.myUserId() === id) {
         return;
     }
 

--- a/modules/recording/recordingXMLUtils.js
+++ b/modules/recording/recordingXMLUtils.js
@@ -1,3 +1,4 @@
+/* global config */
 /**
  * A collection of utility functions for taking in XML and parsing it to return
  * certain values.

--- a/modules/recording/recordingXMLUtils.js
+++ b/modules/recording/recordingXMLUtils.js
@@ -89,6 +89,6 @@ export default {
      * @returns {boolean} True if the presence is from the focus.
      */
     isFromFocus(presence) {
-        return presence.getAttribute('from').includes('focus');
+        return presence.getAttribute('from').includes(config.focusUserJid || 'focus');
     }
 };

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -107,8 +107,9 @@ Moderator.prototype.isSipGatewayEnabled = function() {
 Moderator.prototype.onMucMemberLeft = function(jid) {
     logger.info(`Someone left is it focus ? ${jid}`);
     const resource = Strophe.getResourceFromJid(jid);
+    const focus = Strophe.getNodeFromJid(this.getFocusUserJid());
 
-    if (resource === 'focus') {
+    if (resource === focus) {
         logger.info(
             'Focus has left the room - leaving conference');
         this.eventEmitter.emit(XMPPEvents.FOCUS_LEFT);

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -1,4 +1,4 @@
-/* global $, __filename */
+/* global $, __filename, config */
 
 import { getLogger } from 'jitsi-meet-logger';
 import { $iq, Strophe } from 'strophe.js';

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -36,6 +36,7 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
     constructor(xmpp, eventEmitter, iceConfig) {
         super();
         this.xmpp = xmpp;
+        this.focus = config.focusUserJid ? Strophe.getNodeFromJid(config.focusUserJid) : 'focus';
         this.eventEmitter = eventEmitter;
         this.sessions = {};
         this.jvbIceConfig = iceConfig.jvb;
@@ -127,7 +128,7 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
         // FIXME that should work most of the time, but we'd have to
         // think how secure it is to assume that user with "focus"
         // nickname is Jicofo.
-        const isP2P = Strophe.getResourceFromJid(fromJid) !== 'focus';
+        const isP2P = Strophe.getResourceFromJid(fromJid) !== this.focus;
 
         // see http://xmpp.org/extensions/xep-0166.html#concepts-session
 


### PR DESCRIPTION
These changes use configuration values instead of every occurrence of the string 'focus' in order to make the focus user jid configurable as requested in #7376 and https://github.com/jitsi/jitsi-meet/blob/master/config.js#L37
This patch runs on my jitsi instance with a configured focus user name focusUserJid: 'testfocus@example.com' without any issues.