### PR TITLE
fix(video-quality): Fix p2p desktop share quality.

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -273,7 +273,9 @@ export class TPCUtils {
         }
 
         const localVideoHeightConstraints = [];
-        const height = localTrack.getSettings().height;
+
+        // Firefox doesn't return the height of the desktop track, assume a min. height of 720.
+        const { height = 720 } = localTrack.getSettings();
 
         for (const encoding of this.localStreamEncodingsConfig) {
             localVideoHeightConstraints.push(height / encoding.scaleResolutionDownBy);

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2289,7 +2289,7 @@ TraceablePeerConnection.prototype.setSenderVideoConstraint = function(frameHeigh
 
     const localVideoTrack = this.getLocalVideoTrack();
 
-    if (!localVideoTrack || localVideoTrack.isMuted() || localVideoTrack.videoType !== VideoType.CAMERA) {
+    if (!localVideoTrack || localVideoTrack.isMuted()) {
         return Promise.resolve();
     }
     const videoSender = this.findSenderByKind(MediaType.VIDEO);


### PR DESCRIPTION
In p2p mode, 'scaleResolutionDownBy' is used for downscaling a stream when needed, i.e. when the user receives a receive constraint of 360p because the other participant is in tile view. When desktop share is started, the encoding config has to be scaled back up so that the other participant starts receiving HD resolution for the share as desktop shares are autopinned.
Therefore, encodings have to be enabled/disabled for desktop shares as well. Earlier it was done only for camera tracks.