### PR TITLE
fix(TPC): Ensure encodings resolutions match configured values.

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -436,4 +436,22 @@ export class TPCUtils {
     setVideoTransferActive(active) {
         this.setMediaTransferActive(MediaType.VIDEO, active);
     }
+
+    /**
+     * Ensures that the resolution of the stream encodings are consistent with the values
+     * that were configured on the RTCRtpSender when the source was added to the peerconnection.
+     * This should prevent us from overriding the default values if the browser returns
+     * erroneous values when RTCRtpSender.getParameters is used for getting the encodings info.
+     * @param {Object} parameters - the RTCRtpEncodingParameters obtained from the browser.
+     * @returns {void}
+     */
+    updateEncodingsResolution(parameters) {
+        if (!(parameters && parameters.encodings && Array.isArray(parameters.encodings))) {
+            return;
+        }
+
+        parameters.encodings.forEach((encoding, idx) => {
+            encoding.scaleResolutionDownBy = this.localStreamEncodingsConfig[idx].scaleResolutionDownBy;
+        });
+    }
 }

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2086,6 +2086,7 @@ TraceablePeerConnection.prototype.setSenderVideoDegradationPreference = function
             parameters.encodings[encoding].degradationPreference = preference;
         }
     }
+    this.tpcUtils.updateEncodingsResolution(parameters);
 
     return videoSender.setParameters(parameters);
 };
@@ -2183,6 +2184,7 @@ TraceablePeerConnection.prototype.setMaxBitRate = function() {
         }
         parameters.encodings[0].maxBitrate = bitrate;
     }
+    this.tpcUtils.updateEncodingsResolution(parameters);
 
     return videoSender.setParameters(parameters);
 };
@@ -2323,6 +2325,7 @@ TraceablePeerConnection.prototype.setSenderVideoConstraint = function(frameHeigh
                 parameters.encodings[encoding].active = encodingsEnabledState[encoding];
             }
         }
+        this.tpcUtils.updateEncodingsResolution(parameters);
     } else if (newHeight > 0) {
         parameters.encodings[0].scaleResolutionDownBy = localVideoTrack.resolution >= newHeight
             ? Math.floor(localVideoTrack.resolution / newHeight)


### PR DESCRIPTION
On every call to RTCRtpSender.setParameters(), ensure that the resolution configured for the encoding matches that of the value configured on the RTCRtpSender when the source was added to the peerconnection. This should prevent us from overriding the default values if the browser returns erroneous values when RTCRtpSender.getParameters is used for getting the encodings info. 

This fixes the issue on recent versions of Safari where the 'scaleResolutionDownBy' value comes back as 1 for all encodings even though the encoding resolution is different from the stream capture resolution.
Fixes https://github.com/jitsi/jitsi-meet/issues/7953.

Here is a snapshot of the encodings when simulcast is enabled, the scaleResolutionDownBy value should be 4, 2 and 1  for LD, SD and HD streams respectively.
<img width="1621" alt="Screen Shot 2020-11-09 at 2 57 32 PM" src="https://user-images.githubusercontent.com/54324652/98600925-4b6bb000-22ac-11eb-971f-43ee12cafdd2.png">
