### PR TITLE
fix(gum) update permissions prompt detection

### DIFF
--- a/JitsiMediaDevicesEvents.js
+++ b/JitsiMediaDevicesEvents.js
@@ -30,3 +30,5 @@ export const PERMISSIONS_CHANGED = 'rtc.permissions_changed';
  */
 export const PERMISSION_PROMPT_IS_SHOWN
     = 'mediaDevices.permissionPromptIsShown';
+
+export const SLOW_GET_USER_MEDIA = 'mediaDevices.slowGetUserMedia';

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -743,6 +743,14 @@ export default class RTC extends Listenable {
     }
 
     /**
+     * Returns whether available devices have permissions granted
+     * @returns {Boolean}
+     */
+    static arePermissionsGrantedForAvailableDevices() {
+        return RTCUtils.arePermissionsGrantedForAvailableDevices();
+    }
+
+    /**
      * Returns event data for device to be reported to stats.
      * @returns {MediaDeviceInfo} device.
      */

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -120,7 +120,9 @@ function initEnumerateDevicesWithCallback() {
                 .then(devices => {
                     updateKnownDevices(devices);
                     callback(devices);
-                }, () => {
+                })
+                .catch(error => {
+                    logger.warn(`Failed to  enumerate devices. ${error}`);
                     updateKnownDevices([]);
                     callback([]);
                 });
@@ -1498,6 +1500,14 @@ class RTCUtils extends Listenable {
      */
     getCurrentlyAvailableMediaDevices() {
         return availableDevices;
+    }
+
+    /**
+     * Returns whether available devices have permissions granted
+     * @returns {Boolean}
+     */
+    arePermissionsGrantedForAvailableDevices() {
+        return availableDevices.some(device => Boolean(device.label));
     }
 
     /**


### PR DESCRIPTION
Fire PERMISSION_PROMPT_IS_SHOWN when none of the devices have a label
Fire a new SLOW_GET_USER_MEDIA event if the timeout for getUserMedia is exceeded

Update JitsiMeetJS.createLocalTracks to include the options for firing the above events
in the provided options argument. Deprecate the firePermissionPromptIsShownEvent flag in
method's signature