### PR TITLE
fix(last-n): Do not let Jicofo initialize last-n for the whole conference.

### DIFF
--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -177,13 +177,6 @@ Moderator.prototype.createConferenceIq = function() {
                 value: this.options.connection.hosts.call_control
             }).up();
     }
-    if (config.channelLastN !== undefined) {
-        elem.c(
-            'property', {
-                name: 'channelLastN',
-                value: config.channelLastN
-            }).up();
-    }
     elem.c(
         'property', {
             name: 'disableRtx',


### PR DESCRIPTION
The plan is to move the lastNLimits logic to bridge. The clients will be able to override(lower) the bridge limits through the bridge channel only. Also, this lets us configure last-n per receiver and not set the last-n value for the whole conference the way Jicofo sets it currently.