### PR TITLE
ref(JitsiConference): allow only 1 track per media type

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -942,27 +942,23 @@ JitsiConference.prototype.getTranscriptionStatus = function() {
 
 /**
  * Adds JitsiLocalTrack object to the conference.
- * @param track the JitsiLocalTrack object.
+ * @param {JitsiLocalTrack} track the JitsiLocalTrack object.
  * @returns {Promise<JitsiLocalTrack>}
  * @throws {Error} if the specified track is a video track and there is already
  * another video track in the conference.
  */
 JitsiConference.prototype.addTrack = function(track) {
-    if (track.isVideoTrack()) {
-        // Ensure there's exactly 1 local video track in the conference.
-        const localVideoTrack = this.rtc.getLocalVideoTrack();
+    const mediaType = track.getType();
+    const localTracks = this.rtc.getLocalTracks(mediaType);
 
-        if (localVideoTrack) {
-            // Don't be excessively harsh and severe if the API client happens
-            // to attempt to add the same local video track twice.
-            if (track === localVideoTrack) {
-                return Promise.resolve(track);
-            }
-
-            return Promise.reject(new Error(
-                'cannot add second video track to the conference'));
-
+    // Ensure there's exactly 1 local track of each media type in the conference.
+    if (localTracks.length > 0) {
+        // Don't be excessively harsh and severe if the API client happens to attempt to add the same local track twice.
+        if (track === localTracks[0]) {
+            return Promise.resolve(track);
         }
+
+        return Promise.reject(new Error(`Cannot add second ${mediaType} track to the conference`));
     }
 
     return this.replaceTrack(null, track);


### PR DESCRIPTION
Only one audio or video track is correctly supported by lib-jitsi-meet. This is an attempt to mitigate an issue reported by the community where the user's audio is played in the conference even though the UI shows the user as muted.

Can be reproduced by executing this script in the command line:

`JitsiMeetJS.createLocalTracks({ devices: ['audio']}).then(track => { APP.conference._room.addTrack(track[0])});`