### PR TITLE
fix: Maybe start p2p only when we have received all presences.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1528,11 +1528,26 @@ JitsiConference.prototype.onMemberJoined = function(
 
     this._updateFeatures(participant);
 
-    this._maybeStartOrStopP2P();
+    // maybeStart only if we had finished joining as then we will have information for the number of participants
+    if (this.isJoined()) {
+        this._maybeStartOrStopP2P();
+    }
+
     this._maybeSetSITimeout();
 };
 
 /* eslint-enable max-params */
+
+/**
+ * Get notified when we joined the room.
+ *
+ * FIXME This should NOT be exposed!
+ *
+ * @private
+ */
+JitsiConference.prototype._onMucJoined = function() {
+    this._maybeStartOrStopP2P();
+};
 
 /**
  * Updates features for a participant.

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -120,6 +120,8 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
     // send some analytics events
     chatRoom.addListener(XMPPEvents.MUC_JOINED,
         () => {
+            this.conference._onMucJoined();
+
             this.conference.isJvbConnectionInterrupted = false;
 
             // TODO: Move all of the 'connectionTimes' logic to its own module.


### PR DESCRIPTION
There are cases where we start p2p on the first participant received presence, where there are more presences coming. This starts the process of p2p resulting and few iq errors while terminating it quickly after starting it.
On a normal joining as third participant we see around 38 send or received iq messages, in the problem scenario we see 60.