### PR TITLE
Fix of case when findLine returns false

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -806,7 +806,7 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track, tr
             mediaLines = remoteSDP.media.filter(mls => {
                 const msid = SDPUtil.findLine(mls, 'a=msid');
 
-                return typeof msid !== 'undefined' && streamId === msid.substring(7).split(' ')[0];
+                return typeof msid !== 'undefined' && msid !== false && streamId === msid.substring(7).split(' ')[0];
             });
         }
     } else {


### PR DESCRIPTION
Hi,

I stumbled upon a case where `findLine` at this position in the code returns `false` instead of a string (I'm not entirely sure what the case is about regarding the actual feature though, I arrived there through the debugger). The problem is that it makes the .substring(7) fail because the function does not exist on `false`. The proposed change fixes this case.