### PR TITLE
sdp: add missing colon to findLines calls

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -804,7 +804,7 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track, tr
             mediaLines = remoteSDP.media.filter(mls => SDPUtil.findLine(mls, `a=mid:${mid}`));
         } else {
             mediaLines = remoteSDP.media.filter(mls => {
-                const msid = SDPUtil.findLine(mls, 'a=msid');
+                const msid = SDPUtil.findLine(mls, 'a=msid:');
 
                 return typeof msid !== 'undefined' && streamId === msid.substring(7).split(' ')[0];
             });

--- a/modules/xmpp/SDP.js
+++ b/modules/xmpp/SDP.js
@@ -249,7 +249,7 @@ SDP.prototype.toJingle = function(elem, thecreator) {
                 });
             }
 
-            const ridLines = SDPUtil.findLines(this.media[i], 'a=rid');
+            const ridLines = SDPUtil.findLines(this.media[i], 'a=rid:');
 
             if (ridLines.length && browser.usesRidsForSimulcast()) {
                 // Map a line which looks like "a=rid:2 send" to just


### PR DESCRIPTION
in order to not match a=msid-somethingelse, a=ridiculous and similar