### PR TITLE
Added noTurnsOnSafari option to bypass a bug on Safari

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -49,6 +49,7 @@ The `options` parameter is JS object with the following properties:
     - `disableRtx` - (optional) boolean property (default to false).  Enables/disable the use of RTX.
     - `disabledCodec` - the mime type of the code that should not be negotiated on the peerconnection.
     - `preferredCodec` the mime type of the codec that needs to be made the preferred codec for the connection.
+    - `noTurnsOnSafari` - boolean property (default false). Disables use of tls "turns" ice servers on Safari because it has a bug and can't connect when the certificate is from Let's Encrypt (and maybe other CAs) (see: https://b.webkit.org/show_bug.cgi?id=219274)
     - `disableH264` - __DEPRECATED__. Use `disabledCodec` instead.
     - `preferH264` - __DEPRECATED__. Use `preferredCodec` instead.
 

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -382,8 +382,10 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
                 // see: https://b.webkit.org/show_bug.cgi?id=219274
                 if (options.noTurnsOnSafari) {
                     const isSafari = navigator.userAgent.match(/\/([0-9]+).?[0-9]* Safari\//);
-                    if (isSafari/* && parseInt(match[1], 10) < 15*/) { // TODO: add version check when the resolved bug is shipped
-                        filter = s => (s.urls.indexOf('turns:') === -1);
+
+                    if (isSafari/* && parseInt(match[1], 10) < 15*/) {
+                        // TODO: add version check when the resolved bug is shipped
+                        filter = s => s.urls.indexOf('turns:') === -1;
                         iceservers = iceservers.filter(filter);
                     }
                 }


### PR DESCRIPTION
This PR is to provide a way to bypass a bug on current versions of Safari (as of 14): the bug is that Safari can't connect to tls "turns" servers that are using a Let's Encrypt certificate (and maybe other CAs). So this change feature/fix adds an option to disable the use of turns on Safari that can be enabled if one uses LE certificates.

The bug itself is tracked here https://b.webkit.org/show_bug.cgi?id=219274 and has been marked as resolved, but not shipped yet. Anyway, when shipped older versions would still benefit from it.