### PR TITLE
sdp: improve sdp matching for simulcast lines

### DIFF
--- a/modules/xmpp/SDP.js
+++ b/modules/xmpp/SDP.js
@@ -266,7 +266,7 @@ SDP.prototype.toJingle = function(elem, thecreator) {
                     elem.up();
                 });
                 const unifiedSimulcast
-                    = SDPUtil.findLine(this.media[i], 'a=simulcast');
+                    = SDPUtil.findLine(this.media[i], 'a=simulcast:');
 
                 if (unifiedSimulcast) {
                     elem.c('rid-group', {


### PR DESCRIPTION
which should include the colon in order not to match something like
  a=simulcast-is-cool