### PR TITLE
Support the urn:xmpp:extdisco:2 namespace specified by XEP-0215

### DIFF
--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -306,92 +306,104 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
         this.connection.sendIQ(
             $iq({ type: 'get',
                 to: this.xmpp.options.hosts.domain })
-                .c('services', { xmlns: 'urn:xmpp:extdisco:1' }),
-            res => {
-                const iceservers = [];
-
-                $(res).find('>services>service').each((idx, el) => {
-                    // eslint-disable-next-line no-param-reassign
-                    el = $(el);
-                    const dict = {};
-                    const type = el.attr('type');
-
-                    switch (type) {
-                    case 'stun':
-                        dict.urls = `stun:${el.attr('host')}`;
-                        if (el.attr('port')) {
-                            dict.urls += `:${el.attr('port')}`;
-                        }
-                        iceservers.push(dict);
-                        break;
-                    case 'turn':
-                    case 'turns': {
-                        dict.urls = `${type}:`;
-                        const username = el.attr('username');
-
-                        // https://code.google.com/p/webrtc/issues/detail
-                        // ?id=1508
-
-                        if (username) {
-                            const match
-                                = navigator.userAgent.match(
-                                    /Chrom(e|ium)\/([0-9]+)\./);
-
-                            if (match && parseInt(match[2], 10) < 28) {
-                                dict.urls += `${username}@`;
-                            } else {
-                                // only works in M28
-                                dict.username = username;
-                            }
-                        }
-                        dict.urls += el.attr('host');
-                        const port = el.attr('port');
-
-                        if (port) {
-                            dict.urls += `:${el.attr('port')}`;
-                        }
-                        const transport = el.attr('transport');
-
-                        if (transport && transport !== 'udp') {
-                            dict.urls += `?transport=${transport}`;
-                        }
-
-                        dict.credential = el.attr('password')
-                                || dict.credential;
-                        iceservers.push(dict);
-                        break;
+                .c('services', { xmlns: 'urn:xmpp:extdisco:2' }),
+            v2Res => this.onReceiveStunAndTurnCredentials(v2Res),
+            v2Err => {
+                logger.info('getting turn credentials with extdisco:2 failed, trying extdisco:1', v2Err);
+                this.connection.sendIQ(
+                    $iq({ type: 'get',
+                        to: this.xmpp.options.hosts.domain })
+                        .c('services', { xmlns: 'urn:xmpp:extdisco:1' }),
+                    v1Res => this.onReceiveStunAndTurnCredentials(v1Res),
+                    v1Err => {
+                        logger.warn('getting turn credentials failed', v1Err);
+                        logger.warn('is mod_turncredentials or similar installed?');
                     }
-                    }
-                });
-
-                const options = this.xmpp.options;
-
-                // Shuffle ICEServers for loadbalancing
-                for (let i = iceservers.length - 1; i > 0; i--) {
-                    const j = Math.floor(Math.random() * (i + 1));
-                    const temp = iceservers[i];
-
-                    iceservers[i] = iceservers[j];
-                    iceservers[j] = temp;
-                }
-
-                let filter;
-
-                if (options.useTurnUdp) {
-                    filter = s => s.urls.startsWith('turn');
-                } else {
-                    // By default we filter out STUN and TURN/UDP and leave only TURN/TCP.
-                    filter = s => s.urls.startsWith('turn') && (s.urls.indexOf('transport=tcp') >= 0);
-                }
-
-                this.jvbIceConfig.iceServers = iceservers.filter(filter);
-                this.p2pIceConfig.iceServers = iceservers;
-            }, err => {
-                logger.warn('getting turn credentials failed', err);
-                logger.warn('is mod_turncredentials or similar installed?');
+                );
             });
 
         // implement push?
+    }
+
+    onReceiveStunAndTurnCredentials(res) {
+        const iceservers = [];
+
+        $(res).find('>services>service').each((idx, el) => {
+            // eslint-disable-next-line no-param-reassign
+            el = $(el);
+            const dict = {};
+            const type = el.attr('type');
+
+            switch (type) {
+            case 'stun':
+                dict.urls = `stun:${el.attr('host')}`;
+                if (el.attr('port')) {
+                    dict.urls += `:${el.attr('port')}`;
+                }
+                iceservers.push(dict);
+                break;
+            case 'turn':
+            case 'turns': {
+                dict.urls = `${type}:`;
+                const username = el.attr('username');
+
+                // https://code.google.com/p/webrtc/issues/detail
+                // ?id=1508
+
+                if (username) {
+                    const match
+                        = navigator.userAgent.match(
+                            /Chrom(e|ium)\/([0-9]+)\./);
+
+                    if (match && parseInt(match[2], 10) < 28) {
+                        dict.urls += `${username}@`;
+                    } else {
+                        // only works in M28
+                        dict.username = username;
+                    }
+                }
+                dict.urls += el.attr('host');
+                const port = el.attr('port');
+
+                if (port) {
+                    dict.urls += `:${el.attr('port')}`;
+                }
+                const transport = el.attr('transport');
+
+                if (transport && transport !== 'udp') {
+                    dict.urls += `?transport=${transport}`;
+                }
+
+                dict.credential = el.attr('password')
+                        || dict.credential;
+                iceservers.push(dict);
+                break;
+            }
+            }
+        });
+
+        const options = this.xmpp.options;
+
+        // Shuffle ICEServers for loadbalancing
+        for (let i = iceservers.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            const temp = iceservers[i];
+
+            iceservers[i] = iceservers[j];
+            iceservers[j] = temp;
+        }
+
+        let filter;
+
+        if (options.useTurnUdp) {
+            filter = s => s.urls.startsWith('turn');
+        } else {
+            // By default we filter out STUN and TURN/UDP and leave only TURN/TCP.
+            filter = s => s.urls.startsWith('turn') && (s.urls.indexOf('transport=tcp') >= 0);
+        }
+
+        this.jvbIceConfig.iceServers = iceservers.filter(filter);
+        this.p2pIceConfig.iceServers = iceservers;
     }
 
     /**


### PR DESCRIPTION
XEP-0215 specifies the use of the namespace `urn:xmpp:extdisco:2` for discovery of external services, but Jitsi only looks them up using the older `urn:xmpp:extdisco:1`. One some XMPP servers this means discovery fails entirely, and with Prosody's `mod_turncredentials` (rather than Jitsi's patched one) this means that some information (e.g. transport) is not provided in the response.

This patch adds support for `urn:xmpp:extdisco:2` whilst still supporting `urn:xmpp:extdisco:1`.