### PR TITLE
fix: Disabling lobby when using tenant.

### DIFF
--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -235,7 +235,7 @@ export default class Lobby {
                 (reason, jid) => {
                     // we are receiving the jid of the main room
                     // means we are invited to join, maybe lobby was disabled
-                    if (jid && jid === this.mainRoom.roomjid) {
+                    if (jid) {
                         this.mainRoom.join();
 
                         return;


### PR DESCRIPTION
The jid received is the main jid in internal representation with [tenant]roomname@domain.com and we cannot compare it directly to roomname@conference.tenant.domain.com.