### PR TITLE
feat: Disable JVB via configuration

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -540,6 +540,16 @@ JitsiConference.prototype.isJoined = function() {
 };
 
 /**
+ * Tells whether or not the JVB mode is enabled in the configuration.
+ * @return {boolean}
+ */
+JitsiConference.prototype.isJVBEnabled = function() {
+    // FIXME: remove once we have a default config template.
+    return typeof this.options.config.jvbEnabled === 'undefined'
+        || Boolean(this.options.config.jvbEnabled);
+};
+
+/**
  * Tells whether or not the P2P mode is enabled in the configuration.
  * @return {boolean}
  */
@@ -1907,6 +1917,16 @@ JitsiConference.prototype.onIncomingCall = function(
     if (jingleSession.isP2P) {
         this._onIncomingCallP2P(jingleSession, jingleOffer);
     } else {
+        if (!this.isJVBEnabled()) {
+            this._rejectIncomingCall(
+                jingleSession, {
+                    reason: 'decline',
+                    reasonDescription: 'JVB disabled',
+                    errorMsg: 'JVB mode disabled in the configuration'
+                });
+
+            return;
+        }
         if (!this.room.isFocus(jingleSession.remoteJid)) {
             const description = 'Rejecting session-initiate from non-focus.';
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -269,6 +269,7 @@ This objects represents the server connection. You can create new `JitsiConnecti
         - `deploymentInfo`
             - `shard`
             - `userRegion`
+        - `jvbEnabled` - if disabled no media will be routed through the Jitsi Videobridge.
         - `p2p` - Peer to peer related options
             - `enabled` - enables or disable peer-to-peer connection, if disabled all media will be routed through the Jitsi Videobridge.
             - `stunServers` - list of STUN servers e.g. `{ urls: 'stun:meet-jit-si-turnrelay.jitsi.net:443' }`


### PR DESCRIPTION
In a context of strong data protection policy, disabling the JVB and forcing the P2P mode would ensure that the hosting provider is not able to access the conference traffic.

This would be an alternative to E2EE, which is not fully ready yet (esp. on native mobile SDKs).