### PR TITLE
Adds support for sending tenantID to callstats

### DIFF
--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -362,7 +362,7 @@ export default class CallStats {
             CallStats.callStatsSecret = options.callStatsSecret;
 
             let configParams;
-
+            configParams.additionalIDs = {};
             if (options.applicationName) {
                 configParams = {
                     applicationVersion:
@@ -377,6 +377,7 @@ export default class CallStats {
 
                 // if there is no tenant, we will just set '/'
                 configParams.siteID = options.siteID || (match && match[1]) || '/';
+                configParams.additionalIDs.tenantID = (match && match[1]) || '/';
             }
 
             // userID is generated or given by the origin server

--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -362,6 +362,7 @@ export default class CallStats {
             CallStats.callStatsSecret = options.callStatsSecret;
 
             let configParams;
+
             configParams.additionalIDs = {};
             if (options.applicationName) {
                 configParams = {


### PR DESCRIPTION
callstats.js now support the submission of additionalIDs, additionalIDs can be submitted in configParams of Initialize API.
More Info - https://docs.callstats.io/javascript/#callstats-initialize-with-app-secret

The following additionalIDs can be submitted, 

`
let additionalIDs = {
  customerID: "Customer Identifier. Example, walmart.",
  tenantID: "Tenant Identifier. Example, monster.",
  productName: "Product Name. Example, Jitsi.",
  meetingsName: "Meeting Name. Example, Jitsi loves callstats.",
  serverName: "Server/MiddleBox Name. Example, jvb-prod-us-east-mlkncws12.",
  pbxID: "PBX Identifier. Example, walmart.",
  pbxExtensionID: "PBX Extension Identifier. Example, 5625.",
  fqExtensionID: "Fully qualified Extension Identifier. Example, +71 (US) +5625.",
  sessionID: "Session Identifier. Example, session-12-34",
};
`

This PR adds the support for submitting the tenantID.