### PR TITLE
fix(ice-restart): Force client reloads when call is migrated.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2622,6 +2622,19 @@ JitsiConference.prototype.isConnectionInterrupted = function() {
 };
 
 /**
+ * Handles {@link XMPPEvents.CONNECTION_RESTARTED} event. This happens when the bridge goes down
+ * and Jicofo moves conferences away to a different bridge.
+ * @param {JingleSessionPC} session
+ * @private
+ */
+JitsiConference.prototype._onConferenceRestarted = function(session) {
+    if (!session.isP2P && this.options.config.enableForcedReload) {
+        this.restartInProgress = true;
+        this.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_FAILED, JitsiConferenceErrors.CONFERENCE_RESTARTED);
+    }
+};
+
+/**
  * Handles {@link XMPPEvents.CONNECTION_INTERRUPTED}
  * @param {JingleSessionPC} session
  * @private

--- a/JitsiConferenceErrors.js
+++ b/JitsiConferenceErrors.js
@@ -28,6 +28,12 @@ export const CONFERENCE_MAX_USERS = 'conference.max_users';
 export const CONNECTION_ERROR = 'conference.connectionError';
 
 /**
+ * Indicates that the client has been forced to restart by jicofo when the
+ * conference was migrated from one bridge to another.
+ */
+export const CONFERENCE_RESTARTED = 'conference.restarted';
+
+/**
  * Indicates that a connection error is due to not allowed,
  * occurred when trying to join a conference.
  */

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -185,6 +185,11 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
         XMPPEvents.BRIDGE_DOWN,
         () => Statistics.sendAnalytics(createBridgeDownEvent()));
 
+    chatRoom.addListener(XMPPEvents.CONNECTION_RESTARTED,
+        jingleSession => {
+            conference._onConferenceRestarted(jingleSession);
+        });
+
     this.chatRoomForwarder.forward(XMPPEvents.RESERVATION_ERROR,
         JitsiConferenceEvents.CONFERENCE_FAILED,
         JitsiConferenceErrors.RESERVATION_ERROR);

--- a/modules/connectivity/IceFailedHandling.js
+++ b/modules/connectivity/IceFailedHandling.js
@@ -33,16 +33,19 @@ export default class IceFailedHandling {
      * @returns {void}
      */
     _actOnIceFailed() {
-        const { enableIceRestart } = this._conference.options.config;
+        const { enableForcedReload, enableIceRestart } = this._conference.options.config;
         const explicitlyDisabled = typeof enableIceRestart !== 'undefined' && !enableIceRestart;
         const supportsRestartByTerminate = this._conference.room.supportsRestartByTerminate();
         const useTerminateForRestart = supportsRestartByTerminate && !enableIceRestart;
+        const reloadClient = this._conference.restartInProgress && enableForcedReload;
 
         logger.info('ICE failed,'
+            + ` enableForcedReload: ${enableForcedReload},`
             + ` enableIceRestart: ${enableIceRestart},`
+            + ` restartInProgress: ${this._conference.restartInProgress},`
             + ` supports restart by terminate: ${supportsRestartByTerminate}`);
 
-        if (explicitlyDisabled || (!enableIceRestart && !supportsRestartByTerminate)) {
+        if (explicitlyDisabled || (!enableIceRestart && !supportsRestartByTerminate) || reloadClient) {
             logger.info('ICE failed, but ICE restarts are disabled');
             this._conference.eventEmitter.emit(
                 JitsiConferenceEvents.CONFERENCE_FAILED,

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1137,6 +1137,14 @@ export default class JingleSessionPC extends JingleSession {
      * @param failure function(error) called when we fail to accept new offer.
      */
     replaceTransport(jingleOfferElem, success, failure) {
+        if (this.options.enableForcedReload) {
+            const sdp = new SDP(this.peerconnection.localDescription.sdp);
+
+            this.sendTransportAccept(sdp, success, failure);
+            this.room.eventEmitter.emit(XMPPEvents.CONNECTION_RESTARTED, this);
+
+            return;
+        }
         this.room.eventEmitter.emit(XMPPEvents.ICE_RESTARTING, this);
 
         // We need to first reject the 'data' section to have the SCTP stack

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -50,6 +50,10 @@ const XMPPEvents = {
     // This should go to the RTC module.
     CONNECTION_ICE_FAILED: 'xmpp.connection.ice.failed',
 
+    // Designates an event indicating that the call has been migrated to a different
+    // bridge and that the client needs to be restarted for a successful transition.
+    CONNECTION_RESTARTED: 'xmpp.connection.restart',
+
     /**
      * Designates an event indicating connection status changes.
      */


### PR DESCRIPTION
Force the client to reload when the bridge that is handling the media goes down.
This mitigates issues seen on the bridge because of a client re-joining the call with the same endpointId, BWE issues, etc.
This behavior is configurable through 'enableForcedReload' setting in config.js.