### PR TITLE
Fixes exceptions which occurs after leaving from conference

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -698,6 +698,7 @@ JitsiConference.prototype.leave = async function() {
     room.removeListener(XMPPEvents.SOURCE_REMOVE, this._updateRoomPresence);
 
     this.eventManager.removeXMPPListeners();
+    this.destroyed = true;
 
     this._signalingLayer.setChatRoom(null);
 

--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -217,6 +217,10 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      * Handles track play events.
      */
     _playCallback() {
+        if (this.conference.destroyed) {
+            return;
+        }
+
         const type = this.isVideoTrack() ? 'video' : 'audio';
 
         const now = window.performance.now();

--- a/modules/connectivity/IceFailedHandling.js
+++ b/modules/connectivity/IceFailedHandling.js
@@ -33,7 +33,7 @@ export default class IceFailedHandling {
      */
     _actOnIceFailed() {
         if (this._conference.destroyed) {
-           return;
+            return;
         }
 
         const { enableForcedReload, enableIceRestart } = this._conference.options.config;

--- a/modules/connectivity/IceFailedHandling.js
+++ b/modules/connectivity/IceFailedHandling.js
@@ -32,6 +32,10 @@ export default class IceFailedHandling {
      * @returns {void}
      */
     _actOnIceFailed() {
+        if (this._conference.destroyed) {
+           return;
+        }
+
         const { enableForcedReload, enableIceRestart } = this._conference.options.config;
         const explicitlyDisabled = typeof enableIceRestart !== 'undefined' && !enableIceRestart;
         const supportsRestartByTerminate = this._conference.room.supportsRestartByTerminate();


### PR DESCRIPTION
Some of events can occurs after application leaves from the conference: `_playCallback` and `_actOnIceFailed`. This PR explicit mark conference as destroyed and check this in the callbacks

* fix: Cannot read property 'supportsRestartByTerminate' of null
* fix: Can't read property connectionTimes of null

Close #1476 