### PR TITLE
Rename QualityController to SendVideoController in preparation for using the new 'ReceiverVideoConstraints' message that invokes the new BitrateController in the bridge.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -30,7 +30,7 @@ import VADTalkMutedDetection from './modules/detection/VADTalkMutedDetection';
 import { E2EEncryption } from './modules/e2ee/E2EEncryption';
 import E2ePing from './modules/e2eping/e2eping';
 import Jvb121EventGenerator from './modules/event/Jvb121EventGenerator';
-import { QualityController } from './modules/qualitycontrol/QualityController';
+import { SendVideoController } from './modules/qualitycontrol/SendVideoController';
 import RecordingManager from './modules/recording/RecordingManager';
 import Settings from './modules/settings/Settings';
 import AudioOutputProblemDetector from './modules/statistics/AudioOutputProblemDetector';
@@ -376,7 +376,7 @@ JitsiConference.prototype._init = function(options = {}) {
         this.eventManager.setupRTCListeners();
     }
 
-    this.qualityController = new QualityController(this);
+    this.sendVideoController = new SendVideoController(this);
 
     this.participantConnectionStatus
         = new ParticipantConnectionStatusHandler(
@@ -3348,7 +3348,7 @@ JitsiConference.prototype.getSpeakerStats = function() {
  * @returns {void}
  */
 JitsiConference.prototype.setReceiverVideoConstraint = function(maxFrameHeight) {
-    this.qualityController.setPreferredReceiveMaxFrameHeight(maxFrameHeight);
+    this.sendVideoController.setPreferredReceiveMaxFrameHeight(maxFrameHeight);
 };
 
 /**
@@ -3359,7 +3359,7 @@ JitsiConference.prototype.setReceiverVideoConstraint = function(maxFrameHeight) 
  * successful and rejected otherwise.
  */
 JitsiConference.prototype.setSenderVideoConstraint = function(maxFrameHeight) {
-    return this.qualityController.setPreferredSendMaxFrameHeight(maxFrameHeight);
+    return this.sendVideoController.setPreferredSendMaxFrameHeight(maxFrameHeight);
 };
 
 /**

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -376,7 +376,7 @@ JitsiConference.prototype._init = function(options = {}) {
         this.eventManager.setupRTCListeners();
     }
 
-    this.sendVideoController = new SendVideoController(this);
+    this.sendVideoController = new SendVideoController(this, this.rtc);
 
     this.participantConnectionStatus
         = new ParticipantConnectionStatusHandler(

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -30,6 +30,7 @@ import VADTalkMutedDetection from './modules/detection/VADTalkMutedDetection';
 import { E2EEncryption } from './modules/e2ee/E2EEncryption';
 import E2ePing from './modules/e2eping/e2eping';
 import Jvb121EventGenerator from './modules/event/Jvb121EventGenerator';
+import { ReceiveVideoController } from './modules/qualitycontrol/ReceiveVideoController';
 import { SendVideoController } from './modules/qualitycontrol/SendVideoController';
 import RecordingManager from './modules/recording/RecordingManager';
 import Settings from './modules/settings/Settings';
@@ -376,6 +377,7 @@ JitsiConference.prototype._init = function(options = {}) {
         this.eventManager.setupRTCListeners();
     }
 
+    this.receiveVideoController = new ReceiveVideoController(this, this.rtc);
     this.sendVideoController = new SendVideoController(this, this.rtc);
 
     this.participantConnectionStatus
@@ -1335,7 +1337,7 @@ JitsiConference.prototype.selectParticipants = function(participantIds) {
         throw new Error('Invalid argument; participantIds must be an array.');
     }
 
-    this.rtc.selectEndpoints(participantIds);
+    this.receiveVideoController.selectEndpoints(participantIds);
 };
 
 /**
@@ -1363,7 +1365,7 @@ JitsiConference.prototype.setLastN = function(lastN) {
     if (n < -1) {
         throw new RangeError('lastN cannot be smaller than -1');
     }
-    this.rtc.setLastN(n);
+    this.receiveVideoController.setLastN(n);
 
     // If the P2P session is not fully established yet, we wait until it gets
     // established.
@@ -1391,7 +1393,7 @@ JitsiConference.prototype.setLastN = function(lastN) {
  * {@link ParticipantConnectionStatus} should be used instead.
  */
 JitsiConference.prototype.isInLastN = function(participantId) {
-    return this.rtc.isInLastN(participantId);
+    return this.receiveVideoController.isInLastN(participantId);
 };
 
 /**
@@ -3001,7 +3003,7 @@ JitsiConference.prototype._setP2PStatus = function(newStatus) {
 
         // Sync up video transfer active in case p2pJingleSession not existed
         // when the lastN value was being adjusted.
-        const isVideoActive = this.rtc.getLastN() !== 0;
+        const isVideoActive = this.receiveVideoController.lastN !== 0;
 
         this.p2pJingleSession
             .setMediaTransferActive(true, isVideoActive)
@@ -3348,7 +3350,7 @@ JitsiConference.prototype.getSpeakerStats = function() {
  * @returns {void}
  */
 JitsiConference.prototype.setReceiverVideoConstraint = function(maxFrameHeight) {
-    this.sendVideoController.setPreferredReceiveMaxFrameHeight(maxFrameHeight);
+    this.receiveVideoController.setPreferredReceiveMaxFrameHeight(maxFrameHeight);
 };
 
 /**

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1393,7 +1393,7 @@ JitsiConference.prototype.setLastN = function(lastN) {
  * {@link ParticipantConnectionStatus} should be used instead.
  */
 JitsiConference.prototype.isInLastN = function(participantId) {
-    return this.receiveVideoController.isInLastN(participantId);
+    return this.rtc.isInLastN(participantId);
 };
 
 /**
@@ -3003,7 +3003,7 @@ JitsiConference.prototype._setP2PStatus = function(newStatus) {
 
         // Sync up video transfer active in case p2pJingleSession not existed
         // when the lastN value was being adjusted.
-        const isVideoActive = this.receiveVideoController.lastN !== 0;
+        const isVideoActive = this.rtc.getLastN() !== 0;
 
         this.p2pJingleSession
             .setMediaTransferActive(true, isVideoActive)

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -21,9 +21,8 @@ export default class BridgeChannel {
      * instance.
      * @param {string} [wsUrl] WebSocket URL.
      * @param {EventEmitter} emitter the EventEmitter instance to use for event emission.
-     * @param {function} senderVideoConstraintsChanged callback to call when the sender video constraints change.
      */
-    constructor(peerconnection, wsUrl, emitter, senderVideoConstraintsChanged) {
+    constructor(peerconnection, wsUrl, emitter) {
         if (!peerconnection && !wsUrl) {
             throw new TypeError('At least peerconnection or wsUrl must be given');
         } else if (peerconnection && wsUrl) {
@@ -52,8 +51,6 @@ export default class BridgeChannel {
 
         // Indicates whether the connection was closed from the client or not.
         this._closedFromClient = false;
-
-        this._senderVideoConstraintsChanged = senderVideoConstraintsChanged;
 
         // If a RTCPeerConnection is given, listen for new RTCDataChannel
         // event.
@@ -315,7 +312,7 @@ export default class BridgeChannel {
 
                 if (videoConstraints) {
                     logger.info(`SenderVideoConstraints: ${JSON.stringify(videoConstraints)}`);
-                    this._senderVideoConstraintsChanged(videoConstraints);
+                    emitter.emit(RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED, videoConstraints);
                 }
                 break;
             }

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -212,9 +212,6 @@ export default class RTC extends Listenable {
         RTCUtils.removeListener(RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED, this._updateAudioOutputForAudioTracks);
         RTCUtils.removeListener(RTCEvents.DEVICE_LIST_CHANGED, this._onDeviceListChanged);
 
-        this.removeListener(RTCEvents.LASTN_ENDPOINT_CHANGED, this._lastNChangeListener);
-        this.removeListener(RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED, this._senderVideoConstraintsChangedListener);
-
         if (this._channelOpenListener) {
             this.removeListener(
                 RTCEvents.DATA_CHANNEL_OPEN,

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -182,8 +182,6 @@ export default class RTC extends Listenable {
         // The last N change listener.
         this._lastNChangeListener = this._onLastNChanged.bind(this);
 
-        this._senderVideoConstraintsChangedListener = this._senderVideoConstraintsChanged.bind(this);
-
         this._onDeviceListChanged = this._onDeviceListChanged.bind(this);
         this._updateAudioOutputForAudioTracks
             = this._updateAudioOutputForAudioTracks.bind(this);
@@ -307,10 +305,6 @@ export default class RTC extends Listenable {
         // Add Last N change listener.
         this.addListener(RTCEvents.LASTN_ENDPOINT_CHANGED,
             this._lastNChangeListener);
-
-        // Add sender video constraints changed listener.
-        this.addEventListener(RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED,
-            this._senderVideoConstraintsChangedListener);
     }
 
     /**
@@ -323,18 +317,6 @@ export default class RTC extends Listenable {
      */
     _onDeviceListChanged() {
         this._updateAudioOutputForAudioTracks(RTCUtils.getAudioOutputDevice());
-    }
-
-    /**
-     * Notifies this instance that the sender video constraints signaled from the bridge have changed.
-     *
-     * @param {Object} senderVideoConstraints the sender video constraints from the bridge.
-     * @private
-     */
-    _senderVideoConstraintsChanged(senderVideoConstraints) {
-        logger.info('Remote max frame height received on bridge channel: ', JSON.stringify(senderVideoConstraints));
-        this._senderVideoConstraints = senderVideoConstraints;
-        this.eventEmitter.emit(RTCEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED);
     }
 
     /**
@@ -561,13 +543,6 @@ export default class RTC extends Listenable {
      */
     getLastN() {
         return this._lastN;
-    }
-
-    /**
-     * @return {Object} The sender video constraints signaled from the brridge.
-     */
-    getSenderVideoConstraints() {
-        return this._senderVideoConstraints;
     }
 
     /**
@@ -859,8 +834,6 @@ export default class RTC extends Listenable {
             this._channel = null;
 
             this.removeListener(RTCEvents.LASTN_ENDPOINT_CHANGED, this._lastNChangeListener);
-            this.removeListener(RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED,
-                this._senderVideoConstraintsChangedListener);
         }
     }
 

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -157,11 +157,6 @@ export default class RTC extends Listenable {
          */
         this._lastNEndpoints = null;
 
-        /*
-         * Holds the sender video constraints signaled from the bridge.
-         */
-        this._senderVideoConstraints = {};
-
         /**
          * The number representing the maximum video height the local client
          * should receive from the bridge.

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2370,7 +2370,7 @@ TraceablePeerConnection.prototype.setSenderVideoConstraint = function(frameHeigh
         }
         this.tpcUtils.updateEncodingsResolution(parameters);
     } else if (newHeight > 0) {
-        // Do not scale down the desktop tracks until QualityController is able to propagate the sender constraints
+        // Do not scale down the desktop tracks until SendVideoController is able to propagate the sender constraints
         // only on the active media connection. Right now, the sender constraints received on the bridge channel
         // are propagated on both the jvb and p2p connections in cases where they both are active at the same time.
         parameters.encodings[0].scaleResolutionDownBy

--- a/modules/qualitycontrol/ReceiveVideoController.js
+++ b/modules/qualitycontrol/ReceiveVideoController.js
@@ -1,0 +1,86 @@
+
+import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
+
+/**
+ * This class manages the receive video contraints for a given {@link JitsiConference}. These constraints are
+ * determined by the application based on how the remote video streams need to be displayed. This class is responsible
+ * for communicating these constraints to the bridge over the bridge channel.
+ */
+export class ReceiveVideoController {
+    /**
+     * Creates a new instance for a given conference.
+     *
+     * @param {JitsiConference} conference the conference instance for which the new instance will be managing
+     * the receive video quality constraints.
+     * @param {RTC} rtc the rtc instance which is responsible for initializing the bridge channel.
+     */
+    constructor(conference, rtc) {
+        this.conference = conference;
+        this.rtc = rtc;
+
+        // The number of videos requested from the bridge, -1 represents unlimited or all available videos.
+        this._lastN = -1;
+
+        // The number representing the maximum video height the local client should receive from the bridge.
+        this._maxFrameHeight = 2160;
+
+        // The endpoint IDs of the participants that are currently selected.
+        this._selectedEndpoints = [];
+
+        this.conference.on(
+            JitsiConferenceEvents._MEDIA_SESSION_STARTED,
+            session => this._onMediaSessionStarted(session));
+    }
+
+    /**
+     * Handles the {@link JitsiConferenceEvents.MEDIA_SESSION_STARTED}, that is when the conference creates new media
+     * session. The preferred receive frameHeight is applied on the media session.
+     *
+     * @param {JingleSessionPC} mediaSession - the started media session.
+     * @returns {void}
+     * @private
+     */
+    _onMediaSessionStarted(mediaSession) {
+        this._maxFrameHeight && mediaSession.setReceiverVideoConstraint(this._maxFrameHeight);
+    }
+
+    /**
+     * Elects the participants with the given ids to be the selected participants in order to always receive video
+     * for this participant (even when last n is enabled).
+     *
+     * @param {Array<string>} ids - The user ids.
+     * @returns {void}
+     */
+    selectEndpoints(ids) {
+        this._selectedEndpoints = ids;
+        this.rtc.selectEndpoints(ids);
+    }
+
+    /**
+     * Selects a new value for "lastN". The requested amount of videos are going to be delivered after the value is
+     * in effect. Set to -1 for unlimited or all available videos.
+     *
+     * @param {number} value the new value for lastN.
+     * @returns {void}
+     */
+    setLastN(value) {
+        if (this._lastN !== value) {
+            this._lastN = value;
+            this.rtc.setLastN(value);
+        }
+    }
+
+    /**
+     * Sets the maximum video resolution the local participant should receive from remote participants.
+     *
+     * @param {number|undefined} maxFrameHeight - the new value.
+     * @returns {void}
+     */
+    setPreferredReceiveMaxFrameHeight(maxFrameHeight) {
+        this._maxFrameHeight = maxFrameHeight;
+
+        for (const session of this.conference._getMediaSessions()) {
+            maxFrameHeight && session.setReceiverVideoConstraint(maxFrameHeight);
+        }
+    }
+}

--- a/modules/qualitycontrol/ReceiveVideoController.js
+++ b/modules/qualitycontrol/ReceiveVideoController.js
@@ -15,8 +15,8 @@ export class ReceiveVideoController {
      * @param {RTC} rtc the rtc instance which is responsible for initializing the bridge channel.
      */
     constructor(conference, rtc) {
-        this.conference = conference;
-        this.rtc = rtc;
+        this._conference = conference;
+        this._rtc = rtc;
 
         // The number of videos requested from the bridge, -1 represents unlimited or all available videos.
         this._lastN = -1;
@@ -27,7 +27,7 @@ export class ReceiveVideoController {
         // The endpoint IDs of the participants that are currently selected.
         this._selectedEndpoints = [];
 
-        this.conference.on(
+        this._conference.on(
             JitsiConferenceEvents._MEDIA_SESSION_STARTED,
             session => this._onMediaSessionStarted(session));
     }
@@ -53,7 +53,7 @@ export class ReceiveVideoController {
      */
     selectEndpoints(ids) {
         this._selectedEndpoints = ids;
-        this.rtc.selectEndpoints(ids);
+        this._rtc.selectEndpoints(ids);
     }
 
     /**
@@ -66,7 +66,7 @@ export class ReceiveVideoController {
     setLastN(value) {
         if (this._lastN !== value) {
             this._lastN = value;
-            this.rtc.setLastN(value);
+            this._rtc.setLastN(value);
         }
     }
 
@@ -79,7 +79,7 @@ export class ReceiveVideoController {
     setPreferredReceiveMaxFrameHeight(maxFrameHeight) {
         this._maxFrameHeight = maxFrameHeight;
 
-        for (const session of this.conference._getMediaSessions()) {
+        for (const session of this._conference._getMediaSessions()) {
             maxFrameHeight && session.setReceiverVideoConstraint(maxFrameHeight);
         }
     }

--- a/modules/qualitycontrol/SendVideoController.js
+++ b/modules/qualitycontrol/SendVideoController.js
@@ -48,8 +48,6 @@ export class SendVideoController {
                     this._propagateSendMaxFrameHeight();
                 }
             });
-        this.preferredReceiveMaxFrameHeight
-            && mediaSession.setReceiverVideoConstraint(this.preferredReceiveMaxFrameHeight);
 
         // Set the degradation preference on the local video track.
         mediaSession.setSenderVideoDegradationPreference();
@@ -103,18 +101,6 @@ export class SendVideoController {
         }
 
         return this.preferredSendMaxFrameHeight;
-    }
-
-    /**
-     * Sets local preference for max receive video frame height.
-     * @param {number|undefined} maxFrameHeight - the new value.
-     */
-    setPreferredReceiveMaxFrameHeight(maxFrameHeight) {
-        this.preferredReceiveMaxFrameHeight = maxFrameHeight;
-
-        for (const session of this.conference._getMediaSessions()) {
-            maxFrameHeight && session.setReceiverVideoConstraint(maxFrameHeight);
-        }
     }
 
     /**

--- a/modules/qualitycontrol/SendVideoController.js
+++ b/modules/qualitycontrol/SendVideoController.js
@@ -1,8 +1,9 @@
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
+import RTCEvents from '../../service/RTC/RTCEvents';
 import MediaSessionEvents from '../xmpp/MediaSessionEvents';
 
 /**
- * The class manages send and receive video constraints across media sessions({@link JingleSessionPC}) which belong to
+ * The class manages send video constraints across media sessions({@link JingleSessionPC}) which belong to
  * {@link JitsiConference}. It finds the lowest common value, between the local user's send preference and
  * the remote party's receive preference. Also this module will consider only the active session's receive value,
  * because local tracks are shared and while JVB may have no preference, the remote p2p may have and they may be totally
@@ -14,15 +15,21 @@ export class SendVideoController {
      *
      * @param {JitsiConference} conference - the conference instance for which the new instance will be managing
      * the send video quality constraints.
+     * @param {RTC} rtc - the rtc instance that is responsible for sending the messages on the bridge channel.
      */
-    constructor(conference) {
+    constructor(conference, rtc) {
         this.conference = conference;
+        this.layerSuspensionEnabled = conference.options?.config?.enableLayerSuspension;
+        this.rtc = rtc;
         this.conference.on(
             JitsiConferenceEvents._MEDIA_SESSION_STARTED,
             session => this._onMediaSessionStarted(session));
         this.conference.on(
             JitsiConferenceEvents._MEDIA_SESSION_ACTIVE_CHANGED,
             () => this._propagateSendMaxFrameHeight());
+        this.rtc.on(
+            RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED,
+            videoConstraints => this._propagateSendMaxFrameHeight(videoConstraints));
     }
 
     /**
@@ -55,10 +62,14 @@ export class SendVideoController {
      * Figures out the send video constraint as specified by {@link selectSendMaxFrameHeight} and sets it on all media
      * sessions for the reasons mentioned in this class description.
      *
+     * @param {Object} constraints - the senderVideoConstraints received on the bridge channel.
      * @returns {Promise<void[]>}
      * @private
      */
-    _propagateSendMaxFrameHeight() {
+    _propagateSendMaxFrameHeight(constraints = null) {
+        if (constraints && this.layerSuspensionEnabled) {
+            this.senderVideoConstraints = constraints;
+        }
         const sendMaxFrameHeight = this.selectSendMaxFrameHeight();
         const promises = [];
 
@@ -79,7 +90,11 @@ export class SendVideoController {
      */
     selectSendMaxFrameHeight() {
         const activeMediaSession = this.conference._getActiveMediaSession();
-        const remoteRecvMaxFrameHeight = activeMediaSession && activeMediaSession.getRemoteRecvMaxFrameHeight();
+        const remoteRecvMaxFrameHeight = activeMediaSession
+            ? activeMediaSession.isP2P
+                ? activeMediaSession.getRemoteRecvMaxFrameHeight()
+                : this.senderVideoConstraints?.idealHeight
+            : undefined;
 
         if (this.preferredSendMaxFrameHeight >= 0 && remoteRecvMaxFrameHeight >= 0) {
             return Math.min(this.preferredSendMaxFrameHeight, remoteRecvMaxFrameHeight);

--- a/modules/qualitycontrol/SendVideoController.js
+++ b/modules/qualitycontrol/SendVideoController.js
@@ -8,12 +8,12 @@ import MediaSessionEvents from '../xmpp/MediaSessionEvents';
  * because local tracks are shared and while JVB may have no preference, the remote p2p may have and they may be totally
  * different.
  */
-export class QualityController {
+export class SendVideoController {
     /**
      * Creates new instance for a given conference.
      *
      * @param {JitsiConference} conference - the conference instance for which the new instance will be managing
-     * the quality constraints.
+     * the send video quality constraints.
      */
     constructor(conference) {
         this.conference = conference;

--- a/modules/qualitycontrol/SendVideoController.spec.js
+++ b/modules/qualitycontrol/SendVideoController.spec.js
@@ -83,17 +83,33 @@ class MockConference extends Listenable {
         return this.mediaSessions;
     }
 }
+
+/**
+ * Mock {@link RTC} - add things as needed, but only things useful for all tests.
+ */
+export class MockRTC extends Listenable {
+    /**
+     * constructor
+     */
+    /* eslint-disable no-useless-constructor */
+    constructor() {
+        super();
+    }
+}
+
 /* eslint-enable require-jsdoc */
 
 describe('SendVideoController', () => {
     let conference;
+    let rtc;
     let sendVideoController;
     let jvbConnection;
     let p2pConnection;
 
     beforeEach(() => {
         conference = new MockConference();
-        sendVideoController = new SendVideoController(conference);
+        rtc = new MockRTC();
+        sendVideoController = new SendVideoController(conference, rtc);
         jvbConnection = new MockJingleSessionPC();
         p2pConnection = new MockJingleSessionPC();
 
@@ -120,7 +136,7 @@ describe('SendVideoController', () => {
             expect(p2pConnection.senderVideoConstraint).toBe(720);
         });
         it('0 if it\'s the local send preference while remote are 720', () => {
-            conference.setActiveMediaSession(p2pConnection);
+            conference.setActiveMediaSession(jvbConnection);
 
             jvbConnection.setRemoteRecvMaxFrameHeight(720);
             p2pConnection.setRemoteRecvMaxFrameHeight(720);

--- a/modules/qualitycontrol/SendVideoController.spec.js
+++ b/modules/qualitycontrol/SendVideoController.spec.js
@@ -2,12 +2,12 @@ import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 import Listenable from '../util/Listenable';
 import MediaSessionEvents from '../xmpp/MediaSessionEvents';
 
-import { QualityController } from './QualityController';
+import { SendVideoController } from './SendVideoController';
 
 // JSDocs disabled for Mock classes to avoid duplication - check on the original classes for info.
 /* eslint-disable require-jsdoc */
 /**
- * A mock JingleSessionPC impl that fit the needs of the QualityController module.
+ * A mock JingleSessionPC impl that fit the needs of the SendVideoController module.
  * Should a generic, shared one exist in the future this test file should switch to use it too.
  */
 class MockJingleSessionPC extends Listenable {
@@ -85,15 +85,15 @@ class MockConference extends Listenable {
 }
 /* eslint-enable require-jsdoc */
 
-describe('QualityController', () => {
+describe('SendVideoController', () => {
     let conference;
-    let qualityController;
+    let sendVideoController;
     let jvbConnection;
     let p2pConnection;
 
     beforeEach(() => {
         conference = new MockConference();
-        qualityController = new QualityController(conference);
+        sendVideoController = new SendVideoController(conference);
         jvbConnection = new MockJingleSessionPC();
         p2pConnection = new MockJingleSessionPC();
 
@@ -125,7 +125,7 @@ describe('QualityController', () => {
             jvbConnection.setRemoteRecvMaxFrameHeight(720);
             p2pConnection.setRemoteRecvMaxFrameHeight(720);
 
-            qualityController.setPreferredSendMaxFrameHeight(0);
+            sendVideoController.setPreferredSendMaxFrameHeight(0);
 
             expect(jvbConnection.senderVideoConstraint).toBe(0);
             expect(p2pConnection.senderVideoConstraint).toBe(0);

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1425,7 +1425,6 @@ export default class JingleSessionPC extends JingleSession {
     setSenderVideoConstraint(maxFrameHeight) {
         if (this._assertNotEnded()) {
             logger.info(`${this} setSenderVideoConstraint: ${maxFrameHeight}`);
-            this.remoteRecvMaxFrameHeight = maxFrameHeight;
 
             // RN doesn't support RTCRtpSenders yet, aggresive layer suspension on RN is implemented
             // by changing the media direction in the SDP. This is applicable to jvb sessions only.

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -580,9 +580,9 @@ export default class JingleSessionPC extends JingleSession {
 
         if (!this.isP2P && options.enableLayerSuspension) {
             // If this is the bridge session, we'll listen for
-            // SENDER_VIDEO_CONSTRAINTS_CHANGED events and notify the peer connection
+            // RTCEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED events and notify the peer connection
             this._removeSenderVideoConstraintsChangeListener = this.rtc.addListener(
-                RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED, () => {
+                RTCEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED, () => {
                     this.eventEmitter.emit(
                         MediaSessionEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED, this);
                 });

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -3,7 +3,6 @@
 import { getLogger } from 'jitsi-meet-logger';
 import { $iq, Strophe } from 'strophe.js';
 
-import RTCEvents from '../../service/RTC/RTCEvents';
 import {
     ICE_DURATION,
     ICE_STATE_CHANGED
@@ -577,16 +576,6 @@ export default class JingleSessionPC extends JingleSession {
 
         // The signaling layer will bind it's listeners at this point
         this.signalingLayer.setChatRoom(this.room);
-
-        if (!this.isP2P && options.enableLayerSuspension) {
-            // If this is the bridge session, we'll listen for
-            // RTCEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED events and notify the peer connection
-            this._removeSenderVideoConstraintsChangeListener = this.rtc.addListener(
-                RTCEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED, () => {
-                    this.eventEmitter.emit(
-                        MediaSessionEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED, this);
-                });
-        }
     }
 
     /**
@@ -599,7 +588,7 @@ export default class JingleSessionPC extends JingleSession {
             return this.remoteRecvMaxFrameHeight;
         }
 
-        return this.options.enableLayerSuspension ? this.rtc.getSenderVideoConstraints().idealHeight : undefined;
+        return undefined;
     }
 
     /**
@@ -1436,6 +1425,7 @@ export default class JingleSessionPC extends JingleSession {
     setSenderVideoConstraint(maxFrameHeight) {
         if (this._assertNotEnded()) {
             logger.info(`${this} setSenderVideoConstraint: ${maxFrameHeight}`);
+            this.remoteRecvMaxFrameHeight = maxFrameHeight;
 
             // RN doesn't support RTCRtpSenders yet, aggresive layer suspension on RN is implemented
             // by changing the media direction in the SDP. This is applicable to jvb sessions only.

--- a/service/RTC/RTCEvents.js
+++ b/service/RTC/RTCEvents.js
@@ -65,11 +65,6 @@ const RTCEvents = {
     REMOTE_TRACK_UNMUTE: 'rtc.remote_track_unmute',
 
     /**
-     * Indicates that video constraints received from the bridge have changed.
-     */
-    REMOTE_VIDEO_CONSTRAINTS_CHANGED: 'rtc.remote_video_constraints_changed',
-
-    /**
      * Indicates error while set local description.
      */
     SET_LOCAL_DESCRIPTION_FAILED: 'rtc.set_local_description_failed',

--- a/service/RTC/RTCEvents.js
+++ b/service/RTC/RTCEvents.js
@@ -65,6 +65,11 @@ const RTCEvents = {
     REMOTE_TRACK_UNMUTE: 'rtc.remote_track_unmute',
 
     /**
+     * Indicates that video constraints received from the bridge have changed.
+     */
+    REMOTE_VIDEO_CONSTRAINTS_CHANGED: 'rtc.remote_video_constraints_changed',
+
+    /**
      * Indicates error while set local description.
      */
     SET_LOCAL_DESCRIPTION_FAILED: 'rtc.set_local_description_failed',


### PR DESCRIPTION
Refactor handling of SENDER_VIDEO_CONSTRAINTS_CHANGED event. Bring it inline with how other events received on the bridge channel are handled.
All the send video constraints for the client will be handled by SendVideoController and the receive video constraints like lastN, selectEndpoints and receive video resolution will be handled by ReceiveVideoController which will be added in another PR.