### PR TITLE
Add parameter for adding custom constraints to RTCPeerConnection

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1950,6 +1950,7 @@ JitsiConference.prototype._acceptJvbIncomingCall = function(
     try {
         jingleSession.initialize(this.room, this.rtc, {
             ...this.options.config,
+            customOptionalConstraints: this.connection.options.customOptionalConstraints || [],
             enableInsertableStreams: this._isE2EEEnabled()
         });
     } catch (error) {
@@ -2705,6 +2706,7 @@ JitsiConference.prototype._acceptP2PIncomingCall = function(
         this.room,
         this.rtc, {
             ...this.options.config,
+            customOptionalConstraints: this.connection.options.customOptionalConstraints || [],
             enableInsertableStreams: this._isE2EEEnabled()
         });
 
@@ -3065,6 +3067,7 @@ JitsiConference.prototype._startP2PSession = function(remoteJid) {
         this.room,
         this.rtc, {
             ...this.options.config,
+            customOptionalConstraints: this.connection.options.customOptionalConstraints || [],
             enableInsertableStreams: this._isE2EEEnabled()
         });
 

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -477,7 +477,7 @@ export default class RTC extends Listenable {
      * @return {TraceablePeerConnection}
      */
     createPeerConnection(signaling, iceConfig, isP2P, options) {
-        const pcConstraints = RTC.getPCConstraints(isP2P);
+        const pcConstraints = RTC.getPCConstraints(isP2P, options.customOptionalConstraints || []);
 
         if (typeof options.abtestSuspendVideo !== 'undefined') {
             RTCUtils.setSuspendVideo(pcConstraints, options.abtestSuspendVideo);
@@ -693,7 +693,7 @@ export default class RTC extends Listenable {
     /**
      *
      */
-    static getPCConstraints(isP2P) {
+    static getPCConstraints(isP2P, customOptionalConstraints) {
         const pcConstraints
             = isP2P ? RTCUtils.p2pPcConstraints : RTCUtils.pcConstraints;
 
@@ -701,7 +701,14 @@ export default class RTC extends Listenable {
             return {};
         }
 
-        return JSON.parse(JSON.stringify(pcConstraints));
+        const resultConstraints = JSON.parse(JSON.stringify(pcConstraints));
+
+        if (customOptionalConstraints && customOptionalConstraints !== []) {
+            resultConstraints.optional = resultConstraints.optional || [];
+            resultConstraints.optional.concat(customOptionalConstraints);
+        }
+
+        return resultConstraints;
     }
 
     /**

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -44,6 +44,7 @@ const DEFAULT_MAX_STATS = 300;
  * @property {Object} abTesting - A/B testing related options (ask George).
  * @property {boolean} abTesting.enableSuspendVideoTest - enables the suspend
  * video test ?(ask George).
+ * @property {Array} customOptionalConstraints - custom optional constraints to pass into RTCPeerConnecition
  * @property {boolean} disableH264 - Described in the config.js[1].
  * @property {boolean} disableRtx - Described in the config.js[1].
  * @property {boolean} disableSimulcast - Described in the config.js[1].
@@ -363,6 +364,8 @@ export default class JingleSessionPC extends JingleSession {
         if (options.startSilent) {
             pcOptions.startSilent = true;
         }
+
+        pcOptions.customOptionalConstraints = options.customOptionalConstraints;
 
         this.peerconnection
             = this.rtc.createPeerConnection(


### PR DESCRIPTION
I tried to add my custom data to rtcstats as it described in here (https://github.com/jitsi/rtcstats/blob/master/README.md#usage) but actually I was not able to do that by using jitsi-meet or lib-jitsi-meet. So here it is!

Also I will file a PR for jitsi-meet with customOptionalConstraints option in config.js
