### PR TITLE
Added mute video moderation feature

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -150,6 +150,11 @@ export default function JitsiConference(options) {
     // when muted by focus we receive the jid of the initiator of the mute
     this.mutedByFocusActor = null;
 
+    this.isVideoMutedByFocus = false;
+
+    // when video muted by focus we receive the jid of the initiator of the mute
+    this.mutedVideoByFocusActor = null;
+
     // Flag indicates if the 'onCallEnded' method was ever called on this
     // instance. Used to log extra analytics event for debugging purpose.
     // We need to know if the potential issue happened before or after
@@ -1018,12 +1023,21 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
 
         // unmute local user on server
         this.room.muteParticipant(this.room.myroomjid, false, MediaType.AUDIO);
+    } else if (this.isVideoMutedByFocus && track.isVideoTrack() && !track.isMuted()) {
+        this.isVideoMutedByFocus = false;
+
+        // unmute local user on server
+        this.room.muteParticipant(this.room.myroomjid, false, MediaType.VIDEO);
     }
 
     let actorParticipant;
 
     if (this.mutedByFocusActor) {
         const actorId = Strophe.getResourceFromJid(this.mutedByFocusActor);
+
+        actorParticipant = this.participants[actorId];
+    } else if (this.mutedVideoByFocusActor) {
+        const actorId = Strophe.getResourceFromJid(this.mutedVideoByFocusActor);
 
         actorParticipant = this.participants[actorId];
     }

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1017,7 +1017,7 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
         this.isMutedByFocus = false;
 
         // unmute local user on server
-        this.room.muteParticipant(this.room.myroomjid, false);
+        this.room.muteParticipant(this.room.myroomjid, false, MediaType.AUDIO);
     }
 
     let actorParticipant;
@@ -1495,13 +1495,21 @@ JitsiConference.prototype._maybeSetSITimeout = function() {
  * Mutes a participant.
  * @param {string} id The id of the participant to mute.
  */
-JitsiConference.prototype.muteParticipant = function(id) {
+JitsiConference.prototype.muteParticipant = function(id, mediaType) {
+    if(!mediaType) {
+        // Fallback to audio for backwards compatibility
+        mediaType = MediaType.AUDIO;
+    } else if(mediaType !== MediaType.AUDIO && mediaType !== MediaType.VIDEO) {
+        logger.error(`Unsupported media type: ${mediaType}`);
+        return;
+    }
+
     const participant = this.getParticipantById(id);
 
     if (!participant) {
         return;
     }
-    this.room.muteParticipant(participant.getJid(), true);
+    this.room.muteParticipant(participant.getJid(), true, mediaType);
 };
 
 /* eslint-disable max-params */

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1512,11 +1512,11 @@ JitsiConference.prototype._maybeSetSITimeout = function() {
  * @param {string} id The id of the participant to mute.
  */
 JitsiConference.prototype.muteParticipant = function(id, mediaType) {
-    if(!mediaType) {
-        // Fallback to audio for backwards compatibility
-        mediaType = MediaType.AUDIO;
-    } else if(mediaType !== MediaType.AUDIO && mediaType !== MediaType.VIDEO) {
-        logger.error(`Unsupported media type: ${mediaType}`);
+    const muteMediaType = mediaType ? mediaType : MediaType.AUDIO;
+
+    if (muteMediaType !== MediaType.AUDIO && muteMediaType !== MediaType.VIDEO) {
+        logger.error(`Unsupported media type: ${muteMediaType}`);
+
         return;
     }
 
@@ -1525,7 +1525,7 @@ JitsiConference.prototype.muteParticipant = function(id, mediaType) {
     if (!participant) {
         return;
     }
-    this.room.muteParticipant(participant.getJid(), true, mediaType);
+    this.room.muteParticipant(participant.getJid(), true, muteMediaType);
 };
 
 /* eslint-disable max-params */

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1032,11 +1032,11 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
 
     let actorParticipant;
 
-    if (this.mutedByFocusActor) {
+    if (this.mutedByFocusActor && track.isAudioTrack()) {
         const actorId = Strophe.getResourceFromJid(this.mutedByFocusActor);
 
         actorParticipant = this.participants[actorId];
-    } else if (this.mutedVideoByFocusActor) {
+    } else if (this.mutedVideoByFocusActor && track.isVideoTrack()) {
         const actorId = Strophe.getResourceFromJid(this.mutedVideoByFocusActor);
 
         actorParticipant = this.participants[actorId];

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -111,6 +111,30 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
         }
     );
 
+    chatRoom.addListener(XMPPEvents.VIDEO_MUTED_BY_FOCUS,
+        actor => {
+            // TODO: Add a way to differentiate between commands which caused
+            // us to mute and those that did not change our state (i.e. we were
+            // already muted).
+            Statistics.sendAnalytics(createRemotelyMutedEvent());
+
+            conference.mutedVideoByFocusActor = actor;
+
+            // set isVideoMutedByFocus when setVideoMute Promise ends
+            conference.rtc.setVideoMute(true).then(
+                () => {
+                    conference.isVideoMutedByFocus = true;
+                    conference.mutedVideoByFocusActor = null;
+                })
+                .catch(
+                    error => {
+                        conference.mutedVideoByFocusActor = null;
+                        logger.warn(
+                            'Error while video muting due to focus request', error);
+                    });
+        }
+    );
+
     this.chatRoomForwarder.forward(XMPPEvents.SUBJECT_CHANGED,
         JitsiConferenceEvents.SUBJECT_CHANGED);
 

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -92,7 +92,7 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
             // TODO: Add a way to differentiate between commands which caused
             // us to mute and those that did not change our state (i.e. we were
             // already muted).
-            Statistics.sendAnalytics(createRemotelyMutedEvent());
+            Statistics.sendAnalytics(createRemotelyMutedEvent(MediaType.AUDIO));
 
             conference.mutedByFocusActor = actor;
 
@@ -116,7 +116,7 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
             // TODO: Add a way to differentiate between commands which caused
             // us to mute and those that did not change our state (i.e. we were
             // already muted).
-            Statistics.sendAnalytics(createRemotelyMutedEvent());
+            Statistics.sendAnalytics(createRemotelyMutedEvent(MediaType.VIDEO));
 
             conference.mutedVideoByFocusActor = actor;
 

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -617,7 +617,7 @@ export default class RTC extends Listenable {
         return Promise.all(mutePromises);
     }
 
-   /**
+    /**
     * Set mute for all local video streams attached to the conference.
     * @param value The mute value.
     * @returns {Promise}
@@ -625,7 +625,8 @@ export default class RTC extends Listenable {
     setVideoMute(value) {
         const mutePromises = [];
 
-        this.getLocalTracks(MediaType.VIDEO).concat(this.getLocalTracks(MediaType.PRESENTER)).forEach(videoTrack => {
+        this.getLocalTracks(MediaType.VIDEO).concat(this.getLocalTracks(MediaType.PRESENTER))
+            .forEach(videoTrack => {
             // this is a Promise
             mutePromises.push(value ? videoTrack.mute() : videoTrack.unmute());
         });

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -653,6 +653,24 @@ export default class RTC extends Listenable {
         return Promise.all(mutePromises);
     }
 
+   /**
+    * Set mute for all local video streams attached to the conference.
+    * @param value The mute value.
+    * @returns {Promise}
+    */
+   setVideoMute(value) {
+       const mutePromises = [];
+
+       this.getLocalTracks(MediaType.VIDEO).forEach(videoTrack => {
+           // this is a Promise
+           mutePromises.push(value ? videoTrack.mute() : videoTrack.unmute());
+       });
+
+       // We return a Promise from all Promises so we can wait for their
+       // execution.
+       return Promise.all(mutePromises);
+   }
+
     /**
      *
      * @param track

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -627,9 +627,9 @@ export default class RTC extends Listenable {
 
         this.getLocalTracks(MediaType.VIDEO).concat(this.getLocalTracks(MediaType.PRESENTER))
             .forEach(videoTrack => {
-            // this is a Promise
-            mutePromises.push(value ? videoTrack.mute() : videoTrack.unmute());
-        });
+                // this is a Promise
+                mutePromises.push(value ? videoTrack.mute() : videoTrack.unmute());
+            });
 
         // We return a Promise from all Promises so we can wait for their
         // execution.

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -622,18 +622,18 @@ export default class RTC extends Listenable {
     * @param value The mute value.
     * @returns {Promise}
     */
-   setVideoMute(value) {
-       const mutePromises = [];
+    setVideoMute(value) {
+        const mutePromises = [];
 
-       this.getLocalTracks(MediaType.VIDEO).forEach(videoTrack => {
-           // this is a Promise
-           mutePromises.push(value ? videoTrack.mute() : videoTrack.unmute());
-       });
+        this.getLocalTracks(MediaType.VIDEO).concat(this.getLocalTracks(MediaType.PRESENTER)).forEach(videoTrack => {
+            // this is a Promise
+            mutePromises.push(value ? videoTrack.mute() : videoTrack.unmute());
+        });
 
-       // We return a Promise from all Promises so we can wait for their
-       // execution.
-       return Promise.all(mutePromises);
-   }
+        // We return a Promise from all Promises so we can wait for their
+        // execution.
+        return Promise.all(mutePromises);
+    }
 
     /**
      *

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1672,14 +1672,15 @@ export default class ChatRoom extends Listenable {
      * Mutes remote participant.
      * @param jid of the participant
      * @param mute
+     * @param mediaType
      */
-    muteParticipant(jid, mute) {
+    muteParticipant(jid, mute, mediaType) {
         logger.info('set mute', mute);
         const iqToFocus = $iq(
             { to: this.focusMucJid,
                 type: 'set' })
             .c('mute', {
-                xmlns: 'http://jitsi.org/jitmeet/audio',
+                xmlns: `http://jitsi.org/jitmeet/${mediaType}`,
                 jid
             })
             .t(mute.toString())

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1718,6 +1718,31 @@ export default class ChatRoom extends Listenable {
     }
 
     /**
+     * TODO: Document
+     * @param iq
+     */
+    onMuteVideo(iq) {
+        const from = iq.getAttribute('from');
+
+        if (from !== this.focusMucJid) {
+            logger.warn('Ignored mute from non focus peer');
+
+            return;
+        }
+        const mute = $(iq).find('mute');
+
+        if (mute.length && mute.text() === 'true') {
+            this.eventEmitter.emit(XMPPEvents.AUDIO_MUTED_VIDEO_BY_FOCUS, mute.attr('actor'));
+        } else {
+            // XXX Why do we support anything but muting? Why do we encode the
+            // value in the text of the element? Why do we use a separate XML
+            // namespace?
+            logger.warn('Ignoring a mute request which does not explicitly '
+                + 'specify a positive mute command.');
+        }
+    }
+
+    /**
      * Clean any listeners or resources, executed on leaving.
      */
     clean() {

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1732,7 +1732,7 @@ export default class ChatRoom extends Listenable {
         const mute = $(iq).find('mute');
 
         if (mute.length && mute.text() === 'true') {
-            this.eventEmitter.emit(XMPPEvents.AUDIO_MUTED_VIDEO_BY_FOCUS, mute.attr('actor'));
+            this.eventEmitter.emit(XMPPEvents.VIDEO_MUTED_BY_FOCUS, mute.attr('actor'));
         } else {
             // XXX Why do we support anything but muting? Why do we encode the
             // value in the text of the element? Why do we use a separate XML

--- a/modules/xmpp/strophe.emuc.js
+++ b/modules/xmpp/strophe.emuc.js
@@ -42,6 +42,8 @@ export default class MucConnectionPlugin extends ConnectionPluginListenable {
             'message', null, null);
         this.connection.addHandler(this.onMute.bind(this),
             'http://jitsi.org/jitmeet/audio', 'iq', 'set', null, null);
+        this.connection.addHandler(this.onMuteVideo.bind(this),
+            'http://jitsi.org/jitmeet/video', 'iq', 'set', null, null);
     }
 
     /**
@@ -172,6 +174,24 @@ export default class MucConnectionPlugin extends ConnectionPluginListenable {
         }
 
         room.onMute(iq);
+
+        return true;
+    }
+
+    /**
+     * TODO: Document
+     * @param iq
+     */
+    onMuteVideo(iq) {
+        const from = iq.getAttribute('from');
+        const room = this.rooms[Strophe.getBareJidFromJid(from)];
+
+        // Returning false would result in the listener being deregistered by Strophe
+        if (!room) {
+            return true;
+        }
+
+        room.onMuteVideo(iq);
 
         return true;
     }

--- a/service/statistics/AnalyticsEvents.js
+++ b/service/statistics/AnalyticsEvents.js
@@ -420,10 +420,11 @@ export const createP2PEvent = function(action, attributes = {}) {
 /**
  * Indicates that we received a remote command to mute.
  */
-export const createRemotelyMutedEvent = function() {
+export const createRemotelyMutedEvent = function(mediaType) {
     return {
         type: TYPE_OPERATIONAL,
-        action: 'remotely.muted'
+        action: 'remotely.muted',
+        mediaType
     };
 };
 

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -9,7 +9,7 @@ const XMPPEvents = {
     AUDIO_MUTED_BY_FOCUS: 'xmpp.audio_muted_by_focus',
     // Designates an event indicating that the focus has asked us to disable our
     // camera.
-    AUDIO_MUTED_VIDEO_BY_FOCUS: 'xmpp.video_muted_by_focus',
+    VIDEO_MUTED_BY_FOCUS: 'xmpp.video_muted_by_focus',
     AUTHENTICATION_REQUIRED: 'xmpp.authentication_required',
     BRIDGE_DOWN: 'xmpp.bridge_down',
 

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -7,6 +7,7 @@ const XMPPEvents = {
     // Designates an event indicating that the focus has asked us to mute our
     // audio.
     AUDIO_MUTED_BY_FOCUS: 'xmpp.audio_muted_by_focus',
+
     // Designates an event indicating that the focus has asked us to disable our
     // camera.
     VIDEO_MUTED_BY_FOCUS: 'xmpp.video_muted_by_focus',

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -7,6 +7,9 @@ const XMPPEvents = {
     // Designates an event indicating that the focus has asked us to mute our
     // audio.
     AUDIO_MUTED_BY_FOCUS: 'xmpp.audio_muted_by_focus',
+    // Designates an event indicating that the focus has asked us to disable our
+    // camera.
+    AUDIO_MUTED_VIDEO_BY_FOCUS: 'xmpp.video_muted_by_focus',
     AUTHENTICATION_REQUIRED: 'xmpp.authentication_required',
     BRIDGE_DOWN: 'xmpp.bridge_down',
 


### PR DESCRIPTION
This change adds the ability for a moderator to deactivate the camera of other participants. The implementation uses the same approach that was implemented to mute audio of other participants.

This feature consists of multiple PRs:
- https://github.com/jitsi/jitsi-media-transform/pull/329
- https://github.com/jitsi/jitsi-videobridge/pull/1570
- https://github.com/jitsi/jitsi-xmpp-extensions/pull/37
- https://github.com/jitsi/jicofo/pull/695
- https://github.com/jitsi/lib-jitsi-meet/pull/1496
- https://github.com/jitsi/jitsi-meet/pull/8630