### PR TITLE
fix(SendVideoController): Apply the sender constraint only when it ch…

### DIFF
--- a/modules/qualitycontrol/SendVideoController.js
+++ b/modules/qualitycontrol/SendVideoController.js
@@ -30,8 +30,11 @@ export class SendVideoController {
         this.rtc.on(
             RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED,
             videoConstraints => {
-                this._senderVideoConstraints = videoConstraints;
-                this._propagateSendMaxFrameHeight(videoConstraints);
+                // Propagate the sender constraint only if it has changed.
+                if (this._senderVideoConstraints?.idealHeight !== videoConstraints.idealHeight) {
+                    this._senderVideoConstraints = videoConstraints;
+                    this._propagateSendMaxFrameHeight();
+                }
             });
     }
 


### PR DESCRIPTION
…anges.

There were cases where the bridge was sending the same constraint multiple times causing redundant calls to getParameters/setParameters on the RTCRtpSender.