### PR TITLE
fix(TPCUtils): undefined is not an object (evaluating 'this.tpcUtils.…

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -365,6 +365,8 @@ export class TPCUtils {
                     this.pc.localSSRCs.set(newTrack.rtcId, ssrc);
                 });
         }
+
+        return Promise.resolve();
     }
 
     /**


### PR DESCRIPTION
…replaceTrack(e,t).then')

By looking at the replaceTrack usages it's possible for it to be called with both new and old tracks null/undefined.

I know it happens when both audio and video permissions are denied on Safari, but not sure exactly.