### PR TITLE
fix(modificationQueue): error handling & logs

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1127,7 +1127,8 @@ JitsiConference.prototype.replaceTrack = function(oldTrack, newTrack) {
             }
 
             return Promise.resolve();
-        }, error => Promise.reject(new Error(error)));
+        })
+        .catch(error => Promise.reject(new Error(error)));
 };
 
 /**

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -366,6 +366,8 @@ export class TPCUtils {
                 });
         }
 
+        logger.info('TPCUtils.replaceTrack called with no new track and no old track');
+
         return Promise.resolve();
     }
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1878,11 +1878,15 @@ TraceablePeerConnection.prototype.findSenderForTrack = function(track) {
  */
 TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
     if (browser.usesUnifiedPlan()) {
+        logger.debug('TPC.replaceTrack using unified plan.');
+
         return this.tpcUtils.replaceTrack(oldTrack, newTrack)
 
             // renegotiate when SDP is used for simulcast munging
             .then(() => this.isSimulcastOn() && browser.usesSdpMungingForSimulcast());
     }
+
+    logger.debug('TPC.replaceTrack using plan B.');
 
     let promiseChain = Promise.resolve();
 

--- a/modules/util/AsyncQueue.js
+++ b/modules/util/AsyncQueue.js
@@ -1,4 +1,9 @@
+/* global __filename */
+
 import async from 'async';
+import { getLogger } from 'jitsi-meet-logger';
+
+const logger = getLogger(__filename);
 
 /**
  * A queue for async task execution.
@@ -23,7 +28,12 @@ export default class AsyncQueue {
      * Internal task processing implementation which makes things work.
      */
     _processQueueTasks(task, finishedCallback) {
-        task(finishedCallback);
+        try {
+            task(finishedCallback);
+        } catch (error) {
+            logger.error(`Task failed: ${error}`);
+            finishedCallback(error);
+        }
     }
 
     /**


### PR DESCRIPTION
Add try catch when executing the task in modificationQueue. This should prevent the queue for being blocked if the  task throws an exception.

Add more logging around the modificationQueue in order to be able to debug reports for blocked queue. 