### PR TITLE
feat(dominantSpeaker): Add previous speaker list.

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -490,16 +490,15 @@ JitsiConferenceEventManager.prototype.setupRTCListeners = function() {
         conference.onRemoteTrackRemoved.bind(conference));
 
     rtc.addListener(RTCEvents.DOMINANT_SPEAKER_CHANGED,
-        id => {
-            if (conference.lastDominantSpeaker !== id && conference.room) {
-                conference.lastDominantSpeaker = id;
+        (dominant, previous) => {
+            if (conference.lastDominantSpeaker !== dominant && conference.room) {
+                conference.lastDominantSpeaker = dominant;
                 conference.eventEmitter.emit(
-                    JitsiConferenceEvents.DOMINANT_SPEAKER_CHANGED, id);
+                    JitsiConferenceEvents.DOMINANT_SPEAKER_CHANGED, dominant, previous);
 
-                if (conference.statistics && conference.myUserId() === id) {
+                if (conference.statistics && conference.myUserId() === dominant) {
                     // We are the new dominant speaker.
-                    conference.statistics.sendDominantSpeakerEvent(
-                        conference.room.roomjid);
+                    conference.statistics.sendDominantSpeakerEvent(conference.room.roomjid);
                 }
             }
         });

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -292,7 +292,7 @@ export default class BridgeChannel {
             case 'DominantSpeakerEndpointChangeEvent': {
                 const { dominantSpeakerEndpoint, previousSpeakers = [] } = obj;
 
-                logger.info(`New dominant speaker: ${dominantSpeakerEndpoint}.`);
+                logger.debug(`Dominant speaker: ${dominantSpeakerEndpoint}, previous speakers: ${previousSpeakers}`);
                 emitter.emit(RTCEvents.DOMINANT_SPEAKER_CHANGED, dominantSpeakerEndpoint, previousSpeakers);
                 break;
             }

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -290,11 +290,10 @@ export default class BridgeChannel {
 
             switch (colibriClass) {
             case 'DominantSpeakerEndpointChangeEvent': {
-                // Endpoint ID from the Videobridge.
-                const dominantSpeakerEndpoint = obj.dominantSpeakerEndpoint;
+                const { dominantSpeakerEndpoint, previousSpeakers = [] } = obj;
 
                 logger.info(`New dominant speaker: ${dominantSpeakerEndpoint}.`);
-                emitter.emit(RTCEvents.DOMINANT_SPEAKER_CHANGED, dominantSpeakerEndpoint);
+                emitter.emit(RTCEvents.DOMINANT_SPEAKER_CHANGED, dominantSpeakerEndpoint, previousSpeakers);
                 break;
             }
             case 'EndpointConnectivityStatusChangeEvent': {


### PR DESCRIPTION
The bridge now sends the list of previous speakers in addition to the dominant speaker in the `DominantSpeakerEndpointChangeEvent` message.
