### PR TITLE
remove jquery

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1,4 +1,4 @@
-/* global __filename, $, Promise */
+/* global __filename, Promise */
 
 import EventEmitter from 'events';
 import { getLogger } from 'jitsi-meet-logger';
@@ -39,6 +39,7 @@ import AvgRTPStatsReporter from './modules/statistics/AvgRTPStatsReporter';
 import SpeakerStatsCollector from './modules/statistics/SpeakerStatsCollector';
 import Statistics from './modules/statistics/statistics';
 import Transcriber from './modules/transcription/transcriber';
+import { $_ } from './modules/util/DomUtil';
 import GlobalOnErrorHandler from './modules/util/GlobalOnErrorHandler';
 import RandomUtil from './modules/util/RandomUtil';
 import ComponentsVersions from './modules/version/ComponentsVersions';
@@ -1965,9 +1966,7 @@ JitsiConference.prototype._acceptJvbIncomingCall = function(
     }
 
     const serverRegion
-        = $(jingleOffer)
-            .find('>bridge-session[xmlns="http://jitsi.org/protocol/focus"]')
-            .attr('region');
+        = $_(jingleOffer, '>bridge-session[xmlns="http://jitsi.org/protocol/focus"]').getAttribute('region');
 
     this.eventEmitter.emit(
         JitsiConferenceEvents.SERVER_REGION_CHANGED,
@@ -2051,19 +2050,15 @@ JitsiConference.prototype._acceptJvbIncomingCall = function(
  * to listen for new WebRTC Data Channels (in the 'datachannel' mode).
  */
 JitsiConference.prototype._setBridgeChannel = function(offerIq, pc) {
-    let wsUrl = null;
-    const webSocket
-        = $(offerIq)
-            .find('>content>transport>web-socket')
-            .first();
+    const webSocket = $_(offerIq, '>content>transport>web-socket');
 
-    if (webSocket.length === 1) {
-        wsUrl = webSocket[0].getAttribute('url');
-    }
+    if (webSocket) {
+        const wsUrl = webSocket.getAttribute('url');
 
-    if (wsUrl) {
-        // If the offer contains a websocket use it.
-        this.rtc.initializeBridgeChannel(null, wsUrl);
+        if (wsUrl) {
+            // If the offer contains a websocket use it.
+            this.rtc.initializeBridgeChannel(null, wsUrl);
+        }
     } else {
         // Otherwise, fall back to an attempt to use SCTP.
         this.rtc.initializeBridgeChannel(pc, null);

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1966,7 +1966,7 @@ JitsiConference.prototype._acceptJvbIncomingCall = function(
     }
 
     const serverRegion
-        = $_(jingleOffer, '>bridge-session[xmlns="http://jitsi.org/protocol/focus"]').getAttribute('region');
+        = $_(jingleOffer, '>bridge-session[*|xmlns="http://jitsi.org/protocol/focus"]').getAttribute('region');
 
     this.eventEmitter.emit(
         JitsiConferenceEvents.SERVER_REGION_CHANGED,

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1820,7 +1820,7 @@ JitsiConference.prototype.onRemoteTrackAdded = function(track) {
  * Callback called by the Jingle plugin when 'session-answer' is received.
  * @param {JingleSessionPC} session the Jingle session for which an answer was
  * received.
- * @param {jQuery} answer a jQuery selector pointing to 'jingle' IQ element
+ * @param {Element} answer a 'jingle' IQ element
  */
 // eslint-disable-next-line no-unused-vars
 JitsiConference.prototype.onCallAccepted = function(session, answer) {
@@ -1836,7 +1836,7 @@ JitsiConference.prototype.onCallAccepted = function(session, answer) {
  * Callback called by the Jingle plugin when 'transport-info' is received.
  * @param {JingleSessionPC} session the Jingle session for which the IQ was
  * received
- * @param {jQuery} transportInfo a jQuery selector pointing to 'jingle' IQ
+ * @param {Element} transportInfo a 'jingle' IQ element
  * element
  */
 // eslint-disable-next-line no-unused-vars
@@ -2043,7 +2043,7 @@ JitsiConference.prototype._acceptJvbIncomingCall = function(
 /**
  * Sets the BridgeChannel.
  *
- * @param {jQuery} offerIq a jQuery selector pointing to the jingle element of
+ * @param {Element} offerIq a jingle element of
  * the offer IQ which may carry the WebSocket URL for the 'websocket'
  * BridgeChannel mode.
  * @param {TraceablePeerConnection} pc the peer connection which will be used
@@ -2716,7 +2716,7 @@ JitsiConference.prototype._onIceConnectionRestored = function(session) {
 /**
  * Accept incoming P2P Jingle call.
  * @param {JingleSessionPC} jingleSession the session instance
- * @param {jQuery} jingleOffer a jQuery selector pointing to 'jingle' IQ element
+ * @param {Element} jingleOffer a 'jingle' IQ element
  * @private
  */
 JitsiConference.prototype._acceptP2PIncomingCall = function(

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,6 @@ module.exports = function(config) {
 
         // list of files / patterns to load in the browser
         files: [
-            'https://code.jquery.com/jquery-3.5.1.min.js',
             'node_modules/core-js/index.js',
             './modules/**/*.spec.js'
         ],

--- a/modules/proxyconnection/ProxyConnectionPC.js
+++ b/modules/proxyconnection/ProxyConnectionPC.js
@@ -323,29 +323,29 @@ export default class ProxyConnectionPC {
      * The passed in jingle element should contain an SDP answer to a previously
      * sent SDP offer.
      *
-     * @param {Object} $jingle - The jingle element wrapped in jQuery.
+     * @param {Element} jingle - The jingle element
      * @private
      * @returns {void}
      */
-    _onSessionAccept($jingle) {
+    _onSessionAccept(jingle) {
         if (!this._peerConnection) {
             logger.error('Received an answer when no peer connection exists.');
 
             return;
         }
 
-        this._peerConnection.setAnswer($jingle);
+        this._peerConnection.setAnswer(jingle);
     }
 
     /**
      * Callback invoked in response to a request to start a proxy connection.
      * The passed in jingle element should contain an SDP offer.
      *
-     * @param {Object} $jingle - The jingle element wrapped in jQuery.
+     * @param {Element} jingle - The jingle element.
      * @private
      * @returns {void}
      */
-    _onSessionInitiate($jingle) {
+    _onSessionInitiate(jingle) {
         if (this._peerConnection) {
             logger.error('Received an offer when an offer was already sent.');
 
@@ -355,7 +355,7 @@ export default class ProxyConnectionPC {
         this._peerConnection = this._createPeerConnection();
 
         this._peerConnection.acceptOffer(
-            $jingle,
+            jingle,
             () => { /** no-op */ },
             () => this._onError(
                 this._options.peerJid,
@@ -394,11 +394,11 @@ export default class ProxyConnectionPC {
      * Callback invoked in response to ICE candidates from the remote peer.
      * The passed in jingle element should contain an ICE candidate.
      *
-     * @param {Object} $jingle - The jingle element wrapped in jQuery.
+     * @param {Element} jingle - The jingle element.
      * @private
      * @returns {void}
      */
-    _onTransportInfo($jingle) {
-        this._peerConnection.addIceCandidates($jingle);
+    _onTransportInfo(jingle) {
+        this._peerConnection.addIceCandidates(jingle);
     }
 }

--- a/modules/proxyconnection/ProxyConnectionPC.js
+++ b/modules/proxyconnection/ProxyConnectionPC.js
@@ -80,26 +80,26 @@ export default class ProxyConnectionPC {
     /**
      * Updates the peer connection based on the passed in jingle.
      *
-     * @param {Object} $jingle - An XML jingle element, wrapped in query,
+     * @param {Object} jingle - An XML jingle element, wrapped in query,
      * describing how the peer connection should be updated.
      * @returns {void}
      */
-    processMessage($jingle) {
-        switch ($jingle.attr('action')) {
+    processMessage(jingle) {
+        switch (jingle.getAttribute('action')) {
         case ACTIONS.ACCEPT:
-            this._onSessionAccept($jingle);
+            this._onSessionAccept(jingle);
             break;
 
         case ACTIONS.INITIATE:
-            this._onSessionInitiate($jingle);
+            this._onSessionInitiate(jingle);
             break;
 
         case ACTIONS.TERMINATE:
-            this._onSessionTerminate($jingle);
+            this._onSessionTerminate(jingle);
             break;
 
         case ACTIONS.TRANSPORT_INFO:
-            this._onTransportInfo($jingle);
+            this._onTransportInfo(jingle);
             break;
         }
     }

--- a/modules/proxyconnection/ProxyConnectionService.js
+++ b/modules/proxyconnection/ProxyConnectionService.js
@@ -1,4 +1,4 @@
-/* globals $ */
+/* globals */
 
 import { getLogger } from 'jitsi-meet-logger';
 import { $iq } from 'strophe.js';
@@ -6,6 +6,7 @@ import { $iq } from 'strophe.js';
 import * as MediaType from '../../service/RTC/MediaType';
 import VideoType from '../../service/RTC/VideoType';
 import RTC from '../RTC/RTC';
+import { $_ } from '../util/DomUtil';
 
 import ProxyConnectionPC from './ProxyConnectionPC';
 import { ACTIONS } from './constants';
@@ -102,8 +103,8 @@ export default class ProxyConnectionService {
         }
 
         const iq = this._convertStringToXML(message.data.iq);
-        const $jingle = iq && iq.find('jingle');
-        const action = $jingle && $jingle.attr('action');
+        const jingle = iq && $_(iq, 'jingle');
+        const action = jingle && $_(iq, 'jingle').getAttribute('action');
 
         if (action === ACTIONS.INITIATE) {
             this._peerConnection = this._createPeerConnection(peerJid, {
@@ -115,7 +116,7 @@ export default class ProxyConnectionService {
         // Truthy check for peer connection added to protect against possibly
         // receiving actions before an ACTIONS.INITIATE.
         if (this._peerConnection) {
-            this._peerConnection.processMessage($jingle);
+            this._peerConnection.processMessage(jingle);
         }
 
         // Take additional steps to ensure the peer connection is cleaned up
@@ -172,7 +173,7 @@ export default class ProxyConnectionService {
         try {
             const xmlDom = new DOMParser().parseFromString(xml, 'text/xml');
 
-            return $(xmlDom);
+            return xmlDom;
         } catch (e) {
             logger.error('Attempted to convert incorrectly formatted xml');
 

--- a/modules/proxyconnection/ProxyConnectionService.js
+++ b/modules/proxyconnection/ProxyConnectionService.js
@@ -162,11 +162,11 @@ export default class ProxyConnectionService {
     }
 
     /**
-     * Transforms a stringified xML into a XML wrapped in jQuery.
+     * Transforms a stringified xML into an xml document.
      *
      * @param {string} xml - The XML in string form.
      * @private
-     * @returns {Object|null} A jQuery version of the xml. Null will be returned
+     * @returns {XMLDocument|null} An xml node representing the xml document. Null will be returned
      * if an error is encountered during transformation.
      */
     _convertStringToXML(xml) {

--- a/modules/util/DomUtil.js
+++ b/modules/util/DomUtil.js
@@ -1,0 +1,3 @@
+export const $_ = (el, selector) => el.querySelector(`:scope ${selector}`);
+export const $$_ = (el, selector) => [ ...el.querySelectorAll(`:scope ${selector}`) ];
+export const attr = (el, key) => el.getAttribute(key);

--- a/modules/xmpp/Caps.js
+++ b/modules/xmpp/Caps.js
@@ -1,8 +1,9 @@
-/* global $ */
+/* global */
 
 import { b64_sha1, Strophe } from 'strophe.js'; // eslint-disable-line camelcase
 
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
+import { $_ } from '../util/DomUtil';
 import Listenable from '../util/Listenable';
 
 /**
@@ -190,21 +191,22 @@ export default class Caps extends Listenable {
                 const features = new Set();
                 const identities = new Set();
 
-                $(response)
-                    .find('>query>feature')
-                    .each(
-                        (_, el) => features.add(el.getAttribute('var')));
-                $(response)
-                    .find('>query>identity')
-                    .each(
-                        (_, el) => identities.add({
-                            type: el.getAttribute('type'),
-                            name: el.getAttribute('name'),
-                            category: el.getAttribute('category')
-                        }));
+                $_(response, '>query>feature').forEach(el => {
+                    features.add(el.getAttribute('var'));
+                });
+
+                $_(response, '>query>identity').forEach(el => {
+                    identities.add({
+                        type: el.getAttribute('type'),
+                        name: el.getAttribute('name'),
+                        category: el.getAttribute('category')
+                    });
+                });
+
                 resolve({
                     features,
-                    identities });
+                    identities
+                });
             }, reject, timeout)
         );
     }

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -964,7 +964,7 @@ export default class ChatRoom extends Listenable {
         if (isKick) {
             const actorSelect = $_(pres, '>x[xmlns="http://jabber.org/protocol/muc#user"]>item>actor');
 
-            const actorNick = actorSelect?.getAttribute('nick') || undefined;
+            const actorNick = actorSelect?.getAttribute('nick');
 
             // we first fire the kicked so we can show the participant
             // who kicked, before notifying that participant left

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -68,14 +68,14 @@ const DEFAULT_MAX_STATS = 300;
 export default class JingleSessionPC extends JingleSession {
     /**
      * Parses 'senders' attribute of the video content.
-     * @param {jQuery} jingleContents
+     * @param {Element} jingleContent
      * @return {string|null} one of the values of content "senders" attribute
      * defined by Jingle. If there is no "senders" attribute or if the value is
      * invalid then <tt>null</tt> will be returned.
      * @private
      */
-    static parseVideoSenders(jingleContents) {
-        const videoContents = $_(jingleContents, '>content[name="video"]');
+    static parseVideoSenders(jingleContent) {
+        const videoContents = $_(jingleContent, '>content[name="video"]');
 
         if (videoContents) {
             const senders = videoContents.getAttribute('senders');
@@ -94,7 +94,7 @@ export default class JingleSessionPC extends JingleSession {
     /**
      * Parses the video max frame height value out of the 'content-modify' IQ.
      *
-     * @param {jQuery} jingleContents - A jQuery selector pointing to the '>jingle' element.
+     * @param {Element} jingleContents - A 'jingle' element.
      * @returns {Number|null}
      */
     static parseMaxFrameHeight(jingleContents) {
@@ -882,8 +882,7 @@ export default class JingleSessionPC extends JingleSession {
     /**
      * Accepts incoming Jingle 'session-initiate' and should send
      * 'session-accept' in result.
-     * @param jingleOffer jQuery selector pointing to the jingle element of
-     * the offer IQ
+     * @param jingleOffer jingle element of the offer IQ
      * @param success callback called when we accept incoming session
      * successfully and receive RESULT packet to 'session-accept' sent.
      * @param failure function(error) called if for any reason we fail to accept
@@ -1011,7 +1010,7 @@ export default class JingleSessionPC extends JingleSession {
      * This is a setRemoteDescription/setLocalDescription cycle which starts at
      * converting Strophe Jingle IQ into remote offer SDP. Once converted
      * setRemoteDescription, createAnswer and setLocalDescription calls follow.
-     * @param jingleOfferAnswerIq jQuery selector pointing to the jingle element
+     * @param jingleOfferAnswerIq node containing the jingle element
      *        of the offer (or answer) IQ
      * @param success callback called when sRD/sLD cycle finishes successfully.
      * @param failure callback called with an error object as an argument if we
@@ -1543,9 +1542,9 @@ export default class JingleSessionPC extends JingleSession {
     /**
      * Parse the information from the xml sourceAddElem and translate it
      *  into sdp lines
-     * @param {jquery xml element} sourceAddElem the source-add
-     *  element from jingle
-     * @param {SDP object} currentRemoteSdp the current remote
+     * @param {Element[]} sourceAddElem the source-add
+     *  elements from jingle
+     * @param {Object} currentRemoteSdp the current remote
      *  sdp (as of this new source-add)
      * @returns {list} a list of SDP line strings that should
      *  be added to the remote SDP
@@ -1687,8 +1686,8 @@ export default class JingleSessionPC extends JingleSession {
 
     /**
      * Takes in a jingle offer iq, returns the new sdp offer
-     * @param {jquery xml element} offerIq the incoming offer
-     * @returns {SDP object} the jingle offer translated to SDP
+     * @param {Element} offerIq the incoming offer
+     * @returns {Object} the jingle offer translated to SDP
      */
     _processNewJingleOfferIq(offerIq) {
         const remoteSdp = new SDP('');
@@ -1956,9 +1955,9 @@ export default class JingleSessionPC extends JingleSession {
     /**
      * Parse the information from the xml sourceRemoveElem and translate it
      *  into sdp lines
-     * @param {jquery xml element} sourceRemoveElem the source-remove
+     * @param {Element[]} sourceRemoveElem the source-remove
      *  element from jingle
-     * @param {SDP object} currentRemoteSdp the current remote
+     * @param {Object} currentRemoteSdp the current remote
      *  sdp (as of this new source-remove)
      * @returns {list} a list of SDP line strings that should
      *  be removed from the remote SDP
@@ -2233,16 +2232,15 @@ export default class JingleSessionPC extends JingleSession {
      * only checks the senders attribute of the video content in order to figure
      * out if the remote peer has video in the inactive state (stored locally
      * in {@link _remoteVideoActive} - see field description for more info).
-     * @param {jQuery} jingleContents jQuery selector pointing to the jingle
-     * element of the session modify IQ.
+     * @param {Element} jingleContent jingle element of the session modify IQ.
      * @see {@link _remoteVideoActive}
      * @see {@link _localVideoActive}
      */
-    modifyContents(jingleContents) {
+    modifyContents(jingleContent) {
         const newVideoSenders
-            = JingleSessionPC.parseVideoSenders(jingleContents);
+            = JingleSessionPC.parseVideoSenders(jingleContent);
         const newMaxFrameHeight
-            = JingleSessionPC.parseMaxFrameHeight(jingleContents);
+            = JingleSessionPC.parseMaxFrameHeight(jingleContent);
 
         // frame height is optional in our content-modify protocol
         if (newMaxFrameHeight) {

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1035,7 +1035,7 @@ export default class JingleSessionPC extends JingleSession {
 
             const bridgeSession
                 = $_(jingleOfferAnswerIq, '>bridge-session[*|xmlns="http://jitsi.org/protocol/focus"]');
-            const bridgeSessionId = bridgeSession.setAttribute('id');
+            const bridgeSessionId = bridgeSession.getAttribute('id');
 
             if (bridgeSessionId !== this._bridgeSessionId) {
                 this._bridgeSessionId = bridgeSessionId;
@@ -1553,7 +1553,7 @@ export default class JingleSessionPC extends JingleSession {
         const addSsrcInfo = [];
 
         $$_(sourceAddElem).forEach(content => {
-            const name = content.setAttribute('name');
+            const name = content.getAttribute('name');
             let lines = '';
 
             $$_(content, 'ssrc-group[*|xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]')

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1035,7 +1035,7 @@ export default class JingleSessionPC extends JingleSession {
 
             const bridgeSession
                 = $_(jingleOfferAnswerIq, '>bridge-session[*|xmlns="http://jitsi.org/protocol/focus"]');
-            const bridgeSessionId = bridgeSession.getAttribute('id');
+            const bridgeSessionId = bridgeSession?.getAttribute('id') || null;
 
             if (bridgeSessionId !== this._bridgeSessionId) {
                 this._bridgeSessionId = bridgeSessionId;

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -826,7 +826,7 @@ export default class JingleSessionPC extends JingleSession {
     readSsrcInfo(contents) {
         contents.forEach(content => {
 
-            const ssrcs = $$_(content, '>description>source[xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]');
+            const ssrcs = $$_(content, '>description>source[*|xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]');
 
             ssrcs.forEach(ssrcElement => {
                 const ssrc = Number(ssrcElement.getAttribute('ssrc'));
@@ -836,7 +836,7 @@ export default class JingleSessionPC extends JingleSession {
                     this.signalingLayer.setSSRCOwner(
                     ssrc, Strophe.getResourceFromJid(this.remoteJid));
                 } else {
-                    $$_(ssrcElement, '>ssrc-info[xmlns="http://jitsi.org/jitmeet"]')
+                    $$_(ssrcElement, '>ssrc-info[*|xmlns="http://jitsi.org/jitmeet"]')
                     .forEach(ssrcInfoElement => {
                         const owner = ssrcInfoElement.getAttribute('owner');
 
@@ -1034,7 +1034,7 @@ export default class JingleSessionPC extends JingleSession {
                 = this.peerconnection.localDescription.sdp;
 
             const bridgeSession
-                = $_(jingleOfferAnswerIq, '>bridge-session[xmlns="http://jitsi.org/protocol/focus"]');
+                = $_(jingleOfferAnswerIq, '>bridge-session[*|xmlns="http://jitsi.org/protocol/focus"]');
             const bridgeSessionId = bridgeSession.setAttribute('id');
 
             if (bridgeSessionId !== this._bridgeSessionId) {
@@ -1556,7 +1556,7 @@ export default class JingleSessionPC extends JingleSession {
             const name = content.setAttribute('name');
             let lines = '';
 
-            $$_(content, 'ssrc-group[xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]')
+            $$_(content, 'ssrc-group[*|xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]')
                 .forEach(element => {
                     const semantics = element.getAttribute('semantics');
                     const ssrcs = $$_(element, '>source').map(() => element.getAttribute('ssrc'));
@@ -1569,7 +1569,7 @@ export default class JingleSessionPC extends JingleSession {
                 });
 
             // handles both >source and >description>source
-            const tmp = $$_(content, 'source[xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]');
+            const tmp = $$_(content, 'source[*|xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]');
 
             tmp.forEach(element => {
                 const ssrc = element.getAttribute('ssrc');
@@ -1969,7 +1969,7 @@ export default class JingleSessionPC extends JingleSession {
             const name = content.getAttribute('name');
             let lines = '';
 
-            $$_(content, 'ssrc-group[xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]')
+            $$_(content, 'ssrc-group[*|xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]')
                 .forEach(element => {
                     const semantics = element.getAttribute('semantics');
                     const ssrcs = $$_(element, '>source').map(() => element.getAttribute('ssrc'));
@@ -1984,7 +1984,7 @@ export default class JingleSessionPC extends JingleSession {
             const ssrcs = [];
 
             // handles both >source and >description>source versions
-            const tmp = $$_(content, 'source[xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]');
+            const tmp = $$_(content, 'source[*|xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]');
 
             tmp.forEach(element => {
                 const ssrc = element.getAttribute('ssrc');

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1965,7 +1965,7 @@ export default class JingleSessionPC extends JingleSession {
     _parseSsrcInfoFromSourceRemove(sourceRemoveElem, currentRemoteSdp) {
         const removeSsrcInfo = [];
 
-        $$_(sourceRemoveElem).forEach(content => {
+        sourceRemoveElem.forEach(content => {
             const name = content.getAttribute('name');
             let lines = '';
 

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1552,7 +1552,7 @@ export default class JingleSessionPC extends JingleSession {
     _parseSsrcInfoFromSourceAdd(sourceAddElem, currentRemoteSdp) {
         const addSsrcInfo = [];
 
-        $$_(sourceAddElem).forEach(content => {
+        sourceAddElem.forEach(content => {
             const name = content.getAttribute('name');
             let lines = '';
 

--- a/modules/xmpp/JingleSessionPC.spec.js
+++ b/modules/xmpp/JingleSessionPC.spec.js
@@ -1,4 +1,4 @@
-/* global $, jQuery */
+/* global */
 import { MockRTC } from '../RTC/MockClasses';
 
 import JingleSessionPC from './JingleSessionPC';
@@ -13,14 +13,19 @@ import { MockChatRoom, MockStropheConnection } from './MockClasses';
  * @returns {jQuery}
  */
 function createContentModify(senders = 'both', maxFrameHeight) {
-    const modifyContentsIq = jQuery.parseXML(
-        '<jingle action="content-modify" initiator="peer2" sid="sid12345" xmlns="urn:xmpp:jingle:1">'
-        + `<content name="video" senders="${senders}">`
-        + `<max-frame-height xmlns="http://jitsi.org/jitmeet/video">${maxFrameHeight}</max-frame-height>`
-        + '</content>'
-        + '</jingle>');
+    const jingle = document.createElementNS('urn:xmpp:jingle:1', 'jingle');
 
-    return $(modifyContentsIq).find('>jingle');
+    jingle.setAttribute('action', 'content-modify');
+    jingle.setAttribute('initiator', 'peer2');
+    jingle.setAttribute('sid', 'sid12345');
+    jingle.setAttribute('xmlns', 'urn:xmpp:jingle:1');
+
+    jingle.innerHTML
+        = `<content name="video" senders="${senders}">`
+        + `<max-frame-height xmlns="http://jitsi.org/jitmeet/video">${maxFrameHeight}</max-frame-height>`
+        + '</content>';
+
+    return jingle;
 }
 
 describe('JingleSessionPC', () => {

--- a/modules/xmpp/JingleSessionPC.spec.js
+++ b/modules/xmpp/JingleSessionPC.spec.js
@@ -32,14 +32,7 @@ describe('JingleSessionPC', () => {
     let jingleSession;
     let connection;
     let rtc;
-    const offerIQ = {
-        find: () => {
-            return {
-                // eslint-disable-next-line no-empty-function
-                each: () => { }
-            };
-        }
-    };
+    const offerIQ = document.createElementNS('jabber:client', 'iq');
 
     const SID = 'sid12345';
 

--- a/modules/xmpp/JingleSessionPC.spec.js
+++ b/modules/xmpp/JingleSessionPC.spec.js
@@ -10,7 +10,7 @@ import { MockChatRoom, MockStropheConnection } from './MockClasses';
  * Creates 'content-modify' Jingle IQ.
  * @param {string} senders - 'both' or 'none'.
  * @param {number|undefined} maxFrameHeight - the receive max video frame height.
- * @returns {jQuery}
+ * @returns {Element}
  */
 function createContentModify(senders = 'both', maxFrameHeight) {
     const jingle = document.createElementNS('urn:xmpp:jingle:1', 'jingle');

--- a/modules/xmpp/SDP.js
+++ b/modules/xmpp/SDP.js
@@ -470,7 +470,7 @@ SDP.prototype.rtcpFbToJingle = function(mediaindex, elem, payloadtype) {
 SDP.prototype.rtcpFbFromJingle = function(elem, payloadtype) { // XEP-0293
     let sdp = '';
     const feedbackElementTrrInt
-        = $_(elem, '>rtcp-fb-trr-int[xmlns="urn:xmpp:jingle:apps:rtp:rtcp-fb:0"]');
+        = $_(elem, '>rtcp-fb-trr-int[*|xmlns="urn:xmpp:jingle:apps:rtp:rtcp-fb:0"]');
 
     if (feedbackElementTrrInt) {
         sdp += 'a=rtcp-fb:* trr-int ';
@@ -482,7 +482,7 @@ SDP.prototype.rtcpFbFromJingle = function(elem, payloadtype) { // XEP-0293
         sdp += '\r\n';
     }
 
-    const feedbackElements = $$_(elem, '>rtcp-fb[xmlns="urn:xmpp:jingle:apps:rtp:rtcp-fb:0"]');
+    const feedbackElements = $$_(elem, '>rtcp-fb[*|xmlns="urn:xmpp:jingle:apps:rtp:rtcp-fb:0"]');
 
     feedbackElements.forEach(fb => {
         sdp += `a=rtcp-fb:${payloadtype} ${fb.getAttribute('type')}`;
@@ -507,7 +507,7 @@ SDP.prototype.fromJingle = function(jingle) {
 
     // http://tools.ietf.org/html/draft-ietf-mmusic-sdp-bundle-negotiation-04
     // #section-8
-    const groups = $$_(jingle, '>group[xmlns="urn:xmpp:jingle:apps:grouping:0"]');
+    const groups = $$_(jingle, '>group[*|xmlns="urn:xmpp:jingle:apps:grouping:0"]');
 
     if (groups.length) {
         groups.forEach(group => {
@@ -545,10 +545,10 @@ SDP.prototype.fromJingle = function(jingle) {
 SDP.prototype.jingle2media = function(content) {
 
     const desc = $_(content, '>description');
-    const transport = $_(content, '>transport[xmlns="urn:xmpp:jingle:transports:ice-udp:1"]');
+    const transport = $_(content, '>transport[*|xmlns="urn:xmpp:jingle:transports:ice-udp:1"]');
 
     let sdp = '';
-    const sctp = $_(transport, '>sctpmap[xmlns="urn:xmpp:jingle:transports:dtls-sctp:1"]');
+    const sctp = $_(transport, '>sctpmap[*|xmlns="urn:xmpp:jingle:transports:dtls-sctp:1"]');
 
     const media = { media: desc.getAttribute('media') };
 
@@ -557,7 +557,7 @@ SDP.prototype.jingle2media = function(content) {
         // estos hack to reject an m-line.
         media.port = '0';
     }
-    if ($_(transport, '>fingerprint[xmlns="urn:xmpp:jingle:apps:dtls:0"]')) {
+    if ($_(transport, '>fingerprint[*|xmlns="urn:xmpp:jingle:apps:dtls:0"]')) {
         media.proto = sctp ? 'DTLS/SCTP' : 'RTP/SAVPF';
     } else {
         media.proto = 'RTP/AVPF';
@@ -593,7 +593,7 @@ SDP.prototype.jingle2media = function(content) {
         if (transport.getAttribute('pwd')) {
             sdp += `${SDPUtil.buildICEPwd(transport.getAttribute('pwd'))}\r\n`;
         }
-        $$_(transport, '>fingerprint[xmlns="urn:xmpp:jingle:apps:dtls:0"]').forEach(fingerprint => {
+        $$_(transport, '>fingerprint[*|xmlns="urn:xmpp:jingle:apps:dtls:0"]').forEach(fingerprint => {
             sdp += `a=fingerprint:${fingerprint.getAttribute('hash')}`;
             sdp += ` ${fingerprint.textContent}`;
             sdp += '\r\n';
@@ -669,14 +669,14 @@ SDP.prototype.jingle2media = function(content) {
     sdp += this.rtcpFbFromJingle(desc, '*');
 
     // xep-0294
-    $$_(desc, '>rtp-hdrext[xmlns="urn:xmpp:jingle:apps:rtp:rtp-hdrext:0"]')
+    $$_(desc, '>rtp-hdrext[*|xmlns="urn:xmpp:jingle:apps:rtp:rtp-hdrext:0"]')
         .forEach(hdrExt => {
             sdp += `a=extmap:${hdrExt.getAttribute('id')} ${
                 hdrExt.getAttribute('uri')}\r\n`;
         });
 
     // XEP-0339 handle ssrc-group attributes
-    $$_(desc, '>ssrc-group[xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]')
+    $$_(desc, '>ssrc-group[*|xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]')
         .forEach(ssrcGroup => {
             const semantics = ssrcGroup.getAttribute('semantics');
             const ssrcs = $$_(ssrcGroup, '>source')
@@ -688,7 +688,7 @@ SDP.prototype.jingle2media = function(content) {
         });
 
     // XEP-0339 handle source attributes
-    $$_(desc, '>source[xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]')
+    $$_(desc, '>source[*|xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]')
         .forEach(source => {
             const ssrc = source.getAttribute('ssrc');
 

--- a/modules/xmpp/SDP.js
+++ b/modules/xmpp/SDP.js
@@ -474,8 +474,8 @@ SDP.prototype.rtcpFbFromJingle = function(elem, payloadtype) { // XEP-0293
 
     if (feedbackElementTrrInt) {
         sdp += 'a=rtcp-fb:* trr-int ';
-        if (feedbackElementTrrInt.setAttribute('value')) {
-            sdp += feedbackElementTrrInt.setAttribute('value');
+        if (feedbackElementTrrInt.getAttribute('value')) {
+            sdp += feedbackElementTrrInt.getAttribute('value');
         } else {
             sdp += '0';
         }

--- a/modules/xmpp/SDP.spec.js
+++ b/modules/xmpp/SDP.spec.js
@@ -1,5 +1,7 @@
-/* globals $ */
+/* globals */
 import { $iq } from 'strophe.js';
+
+import { $_ } from '../util/DomUtil';
 
 import SDP from './SDP';
 
@@ -239,7 +241,9 @@ a=ssrc:3758540092 mslabel:mixedmslabel
             const offer = createStanzaElement(stanza);
             const sdp = new SDP('');
 
-            sdp.fromJingle($(offer).find('>jingle'));
+            console.log('#####################', offer.querySelector);
+            sdp.fromJingle($_(offer, '>jingle'));
+            console.log('#####################1');
             const rawSDP = sdp.raw.replace(/o=- \d+/, 'o=- 123'); // replace generated o= timestamp.
 
             expect(rawSDP).toEqual(expectedSDP);

--- a/modules/xmpp/SDP.spec.js
+++ b/modules/xmpp/SDP.spec.js
@@ -241,9 +241,7 @@ a=ssrc:3758540092 mslabel:mixedmslabel
             const offer = createStanzaElement(stanza);
             const sdp = new SDP('');
 
-            console.log('#####################', offer.querySelector);
             sdp.fromJingle($_(offer, '>jingle'));
-            console.log('#####################1');
             const rawSDP = sdp.raw.replace(/o=- \d+/, 'o=- 123'); // replace generated o= timestamp.
 
             expect(rawSDP).toEqual(expectedSDP);

--- a/modules/xmpp/strophe.emuc.js
+++ b/modules/xmpp/strophe.emuc.js
@@ -1,9 +1,10 @@
-/* global $ */
+/* global */
 
 import { getLogger } from 'jitsi-meet-logger';
 import { Strophe } from 'strophe.js';
 
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
+import { $_ } from '../util/DomUtil';
 
 import ChatRoom from './ChatRoom';
 import { ConnectionPluginListenable } from './ConnectionPlugin';
@@ -98,8 +99,7 @@ export default class MucConnectionPlugin extends ConnectionPluginListenable {
         }
 
         // Parse status.
-        if ($(pres).find('>x[xmlns="http://jabber.org/protocol/muc#user"]'
-            + '>status[code="201"]').length) {
+        if ($_(pres, '>x[xmlns="http://jabber.org/protocol/muc#user"]>status[code="201"]')) {
             room.createNonAnonymousRoom();
         }
 

--- a/modules/xmpp/strophe.emuc.js
+++ b/modules/xmpp/strophe.emuc.js
@@ -99,7 +99,7 @@ export default class MucConnectionPlugin extends ConnectionPluginListenable {
         }
 
         // Parse status.
-        if ($_(pres, '>x[xmlns="http://jabber.org/protocol/muc#user"]>status[code="201"]')) {
+        if ($_(pres, '>x[*|xmlns="http://jabber.org/protocol/muc#user"]>status[code="201"]')) {
             room.createNonAnonymousRoom();
         }
 

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -195,7 +195,7 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
             if ($_(iq, '>jingle>reason')) {
                 reasonCondition
                     = $_(iq, '>jingle>reason>:first').tagName;
-                reasonText = $_(iq, '>jingle>reason>text').textContent();
+                reasonText = $_(iq, '>jingle>reason>text').textContent;
             }
             this.terminate(sess.sid, reasonCondition, reasonText);
             this.eventEmitter.emit(XMPPEvents.CALL_ENDED,

--- a/modules/xmpp/strophe.rayo.js
+++ b/modules/xmpp/strophe.rayo.js
@@ -1,7 +1,9 @@
-/* global $ */
+/* global */
 
 import { getLogger } from 'jitsi-meet-logger';
 import { $iq } from 'strophe.js';
+
+import { $_ } from '../util/DomUtil';
 
 import ConnectionPlugin from './ConnectionPlugin';
 
@@ -77,7 +79,7 @@ export default class RayoConnectionPlugin extends ConnectionPlugin {
                     logger.info('Dial result ', result);
 
                     // eslint-disable-next-line newline-per-chained-call
-                    const resource = $(result).find('ref').attr('uri');
+                    const resource = $_(result, 'ref').getAttribute('uri');
 
                     this.callResource = resource.substr('xmpp:'.length);
                     logger.info(`Received call resource: ${this.callResource}`);

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -1,4 +1,4 @@
-/* global $ */
+/* global */
 
 import { getLogger } from 'jitsi-meet-logger';
 import { $msg, Strophe } from 'strophe.js';
@@ -9,6 +9,7 @@ import * as JitsiConnectionEvents from '../../JitsiConnectionEvents';
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
 import browser from '../browser';
 import { E2EEncryption } from '../e2ee/E2EEncryption';
+import { $_ } from '../util/DomUtil';
 import GlobalOnErrorHandler from '../util/GlobalOnErrorHandler';
 import Listenable from '../util/Listenable';
 import RandomUtil from '../util/RandomUtil';
@@ -180,11 +181,14 @@ export default class XMPP extends Listenable {
         // they wanted to utilize the connected connection in an unload handler
         // of their own. However, it should be fairly easy for them to do that
         // by registering their unload handler before us.
-        $(window).on('beforeunload unload', ev => {
+        const onUnload = ev => {
             this.disconnect(ev).catch(() => {
                 // ignore errors in order to not brake the unload.
             });
-        });
+        };
+
+        window.addEventListener('beforeunload', onUnload);
+        window.addEventListener('unload', onUnload);
     }
 
     /**
@@ -821,8 +825,8 @@ export default class XMPP extends Listenable {
             return true;
         }
 
-        const jsonMessage = $(msg).find('>json-message')
-            .text();
+        const jsonMessage = $_(msg, '>json-message')?.textContent;
+
         const parsedJson = this.tryParseJSONAndVerify(jsonMessage);
 
         if (parsedJson


### PR DESCRIPTION
This PR aims to remove jquery from the project. 3 tests are failing. I was able to identify one reason. `querySelector` is unable to match by `xmlns` attribute if the selector is not prefixed with `*|` to match all namespaces. So instead of writing `querySelector('[xmlns="something"]')`, it has to be `querySelector('[*|xmlns="something"]')`. I did not include this change in the project yet because I wanted to discuss it. Imo it wouldn't break anything to add the `*|`. However, a different possibility would be to use XPath instead. jQuery is using a custom parser for this btw

To replace jquery, I simply aliased `$_` to `querySelector` and `$$_` to `querySelectorAll`. The underscore I only used to keep track of what I replaced already and it might go later on.

Hopefully, this can be merged seemingly after I fixed the 3 failing test cases. It was more work than I anticipated :D