### PR TITLE
feat(browser-support): Add support for WKWebview based browsers.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -439,7 +439,7 @@ JitsiConference.prototype._init = function(options = {}) {
 
     // Disable VAD processing on Safari since it causes audio input to
     // fail on some of the mobile devices.
-    if (config.enableTalkWhileMuted && !browser.isSafari()) {
+    if (config.enableTalkWhileMuted && !browser.isWebKitBased()) {
 
         // If VAD processor factory method is provided uses VAD based detection, otherwise fallback to audio level
         // based detection.
@@ -463,7 +463,7 @@ JitsiConference.prototype._init = function(options = {}) {
 
     // Disable noisy mic detection on safari since it causes the audio input to
     // fail on Safari on iPadOS.
-    if (config.enableNoisyMicDetection && !browser.isSafari()) {
+    if (config.enableNoisyMicDetection && !browser.isWebKitBased()) {
         if (config.createVADProcessor) {
             if (!this._audioAnalyser) {
                 this._audioAnalyser = new VADAudioAnalyser(this, config.createVADProcessor);

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -175,7 +175,7 @@ function getConstraints(um, options = {}) {
     // @see https://github.com/jitsi/lib-jitsi-meet/pull/136
     const isNewStyleConstraintsSupported
         = browser.isFirefox()
-            || browser.isSafari()
+            || browser.isWebKitBased()
             || browser.isReactNative();
 
     if (um.indexOf('video') >= 0) {
@@ -383,7 +383,7 @@ function newGetConstraints(um = [], options = {}) {
         // https://bugs.webkit.org/show_bug.cgi?id=210932
         // Camera doesn't start on older macOS versions if min/max constraints are specified.
         // TODO: remove this hack when the bug fix is available on Mojave, Sierra and High Sierra.
-        if (browser.isSafari()) {
+        if (browser.isWebKitBased()) {
             if (constraints.video.height && constraints.video.height.ideal) {
                 constraints.video.height = { ideal: clonedeep(constraints.video.height.ideal) };
             } else {
@@ -412,7 +412,7 @@ function newGetConstraints(um = [], options = {}) {
         }
 
         // Use the standard audio constraints on non-chromium browsers.
-        if (browser.isFirefox() || browser.isSafari()) {
+        if (browser.isFirefox() || browser.isWebKitBased()) {
             constraints.audio = {
                 deviceId: options.micDeviceId,
                 autoGainControl: !disableAGC && !disableAP,

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -448,7 +448,7 @@ export class TPCUtils {
      * @returns {void}
      */
     updateEncodingsResolution(parameters) {
-        if (!(browser.isSafari() && parameters.encodings && Array.isArray(parameters.encodings))) {
+        if (!(browser.isWebKitBased() && parameters.encodings && Array.isArray(parameters.encodings))) {
             return;
         }
         const allEqualEncodings

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -879,7 +879,7 @@ TraceablePeerConnection.prototype._createRemoteTrack = function(
     // Delete the existing track and create the new one because of a known bug on Safari.
     // RTCPeerConnection.ontrack fires when a new remote track is added but MediaStream.onremovetrack doesn't so
     // it needs to be removed whenever a new track is received for the same endpoint id.
-    if (existingTrack && browser.isSafari()) {
+    if (existingTrack && browser.isWebKitBased()) {
         this._remoteTrackRemoved(existingTrack.getOriginalStream(), existingTrack.getTrack());
     }
 
@@ -2761,7 +2761,7 @@ TraceablePeerConnection.prototype.getStats = function(callback, errback) {
     // TODO (brian): After moving all browsers to adapter, check if adapter is
     // accounting for different getStats apis, making the browser-checking-if
     // unnecessary.
-    if (browser.isSafari() || browser.isFirefox() || browser.isReactNative()) {
+    if (browser.isWebKitBased() || browser.isFirefox() || browser.isReactNative()) {
         // uses the new Promise based getStats
         this.peerconnection.getStats()
             .then(callback)

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -33,7 +33,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * strategy or <tt>false</tt> otherwise.
      */
     doesVideoMuteByStreamRemove() {
-        return this.isChromiumBased() || this.isSafari();
+        return this.isChromiumBased() || this.isWebKitBased();
     }
 
     /**
@@ -100,7 +100,7 @@ export default class BrowserCapabilities extends BrowserDetection {
         return (this.isChromiumBased() && this._getChromiumBasedVersion() >= MIN_REQUIRED_CHROME_VERSION)
             || this.isFirefox()
             || this.isReactNative()
-            || (this.isSafari() && !this.isVersionLessThan('12.1'));
+            || this.isWebKitBased();
     }
 
     /**
@@ -120,7 +120,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * otherwise.
      */
     supportsVideoMuteOnConnInterrupted() {
-        return this.isChromiumBased() || this.isReactNative() || this.isSafari();
+        return this.isChromiumBased() || this.isReactNative() || this.isWebKitBased();
     }
 
     /**
@@ -131,7 +131,7 @@ export default class BrowserCapabilities extends BrowserDetection {
     supportsBandwidthStatistics() {
         // FIXME bandwidth stats are currently not implemented for FF on our
         // side, but not sure if not possible ?
-        return !this.isFirefox() && !this.isSafari();
+        return !this.isFirefox() && !this.isWebKitBased();
     }
 
     /**
@@ -146,7 +146,7 @@ export default class BrowserCapabilities extends BrowserDetection {
 
             // this is not working on Safari because of the following bug
             // https://bugs.webkit.org/show_bug.cgi?id=215567
-            && !this.isSafari();
+            && !this.isWebKitBased();
     }
 
     /**
@@ -164,7 +164,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * candidates through the legacy getStats() API.
      */
     supportsLocalCandidateRttStatistics() {
-        return this.isChromiumBased() || this.isReactNative() || this.isSafari();
+        return this.isChromiumBased() || this.isReactNative() || this.isWebKitBased();
     }
 
     /**
@@ -217,7 +217,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     usesSdpMungingForSimulcast() {
-        return this.isChromiumBased() || this.isReactNative() || this.isSafari();
+        return this.isChromiumBased() || this.isReactNative() || this.isWebKitBased();
     }
 
     /**
@@ -242,7 +242,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     usesNewGumFlow() {
-        if (this.isChromiumBased() || this.isFirefox() || this.isSafari()) {
+        if (this.isChromiumBased() || this.isFirefox() || this.isWebKitBased()) {
             return true;
         }
 

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -232,7 +232,7 @@ export default function StatsCollector(
      * @type {boolean}
      */
     this._usesPromiseGetStats
-        = browser.isSafari() || browser.isFirefox() || browser.isReactNative();
+        = browser.isWebKitBased() || browser.isFirefox() || browser.isReactNative();
 
     /**
      * The function which is to be used to retrieve the value associated in a


### PR DESCRIPTION
Apple added getUserMedia support for WkWebview based browsers like chrome and Firefox on iOS 14.3. These browsers behave as Safari does on iOS. Therefore, extend the Safari checks to these webkit based browsers as well.