### PR TITLE
Remove ssrcs on leave

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1670,22 +1670,34 @@ JitsiConference.prototype.onMemberLeft = function(jid) {
 
     // Remove the ssrcs from the remote description.
     const mediaSessions = this._getMediaSessions();
+    const removePromises = [];
 
     for (const session of mediaSessions) {
-        session.removeRemoteStreamsOnLeave(id);
-    }
-    const removedTracks = this.rtc.removeRemoteTracks(id);
-
-    removedTracks.forEach(
-        track => this.eventEmitter.emit(JitsiConferenceEvents.TRACK_REMOVED, track));
-
-    // there can be no participant in case the member that left is focus
-    if (participant) {
-        this.eventEmitter.emit(JitsiConferenceEvents.USER_LEFT, id, participant);
+        removePromises.push(session.removeRemoteStreamsOnLeave(id));
     }
 
-    this._maybeStartOrStopP2P(true /* triggered by user left event */);
-    this._maybeClearSITimeout();
+    Promise.allSettled(removePromises)
+        .then(results => {
+            let removedTracks = [];
+
+            results.map(result => result.value).forEach(value => {
+                if (value) {
+                    removedTracks = removedTracks.concat(value);
+                }
+            });
+
+            removedTracks.forEach(track => {
+                this.eventEmitter.emit(JitsiConferenceEvents.TRACK_REMOVED, track);
+            });
+
+            // There can be no participant in case the member that left is focus.
+            if (participant) {
+                this.eventEmitter.emit(JitsiConferenceEvents.USER_LEFT, id, participant);
+            }
+
+            this._maybeStartOrStopP2P(true /* triggered by user left event */);
+            this._maybeClearSITimeout();
+        });
 };
 
 /**

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1668,16 +1668,20 @@ JitsiConference.prototype.onMemberLeft = function(jid) {
 
     delete this.participants[id];
 
+    // Remove the ssrcs from the remote description.
+    const mediaSessions = this._getMediaSessions();
+
+    for (const session of mediaSessions) {
+        session.removeRemoteStreamsOnLeave(id);
+    }
     const removedTracks = this.rtc.removeRemoteTracks(id);
 
     removedTracks.forEach(
-        track =>
-            this.eventEmitter.emit(JitsiConferenceEvents.TRACK_REMOVED, track));
+        track => this.eventEmitter.emit(JitsiConferenceEvents.TRACK_REMOVED, track));
 
     // there can be no participant in case the member that left is focus
     if (participant) {
-        this.eventEmitter.emit(
-            JitsiConferenceEvents.USER_LEFT, id, participant);
+        this.eventEmitter.emit(JitsiConferenceEvents.USER_LEFT, id, participant);
     }
 
     this._maybeStartOrStopP2P(true /* triggered by user left event */);

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -649,29 +649,6 @@ export default class RTC extends Listenable {
     }
 
     /**
-     * Removes all JitsiRemoteTracks associated with given MUC nickname
-     * (resource part of the JID). Returns array of removed tracks.
-     *
-     * @param {string} Owner The resource part of the MUC JID.
-     * @returns {JitsiRemoteTrack[]}
-     */
-    removeRemoteTracks(owner) {
-        let removedTracks = [];
-
-        for (const tpc of this.peerConnections.values()) {
-            const pcRemovedTracks = tpc.removeRemoteTracks(owner);
-
-            removedTracks = removedTracks.concat(pcRemovedTracks);
-        }
-
-        logger.debug(
-            `Removed remote tracks for ${owner}`
-                + ` count: ${removedTracks.length}`);
-
-        return removedTracks;
-    }
-
-    /**
      *
      */
     static getPCConstraints(isP2P) {


### PR DESCRIPTION
Remove the ssrcs (associated with remote sources) from the remote desc along with the removal of the remote tracks when an endpoint leaves the call. The source-remove signaling message from Jicofo will no longer be needed in this case and can be dropped by Jicofo.
Properly configure degradation preference on RTCRtpSendParameters instead of RTCRtpEncodingParameters. Fixes #1510.
