### PR TITLE
feat(ReceiveVideoController): Add the ability to send constraints in the new format.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3370,6 +3370,27 @@ JitsiConference.prototype.getSpeakerStats = function() {
 };
 
 /**
+ * Sets the constraints for the video that is requested from the bridge.
+ *
+ * @param {Object} videoConstraints The constraints which are specified in the
+ * following format. The message updates the fields that are present and leaves the
+ * rest unchanged on the bridge. Therefore, any field that is not applicable anymore
+ * should be cleared by passing an empty object or list (whatever is applicable).
+ * {
+ *      'lastN': 20,
+ *      'selectedEndpoints': ['A', 'B', 'C'],
+ *      'onStageEndpoints': ['A'],
+ *      'defaultConstraints': { 'maxHeight': 180 },
+ *      'constraints': {
+ *          'A': { 'maxHeight': 720 }
+ *      }
+ * }
+ */
+JitsiConference.prototype.setReceiverConstraints = function(videoConstraints) {
+    this.receiveVideoController.setReceiverConstraints(videoConstraints);
+};
+
+/**
  * Sets the maximum video size the local participant should receive from remote
  * participants.
  *

--- a/modules/qualitycontrol/ReceiveVideoController.js
+++ b/modules/qualitycontrol/ReceiveVideoController.js
@@ -1,4 +1,5 @@
 import { getLogger } from 'jitsi-meet-logger';
+import isEqual from 'lodash.isequal';
 
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 
@@ -118,6 +119,23 @@ export class ReceiverVideoConstraints {
         if (changed) {
             this._maxFrameHeight = maxFrameHeight;
             logger.debug(`Updating receive maxFrameHeight: ${maxFrameHeight}`);
+        }
+
+        return changed;
+    }
+
+    /**
+     * Updates the receiver constraints sent to the bridge.
+     *
+     * @param {Object} videoConstraints
+     * @returns {boolean} Returns true if the the value has been updated, false otherwise.
+     */
+    updateReceiverVideoConstraints(videoConstraints) {
+        const changed = !isEqual(this._receiverVideoConstraints, videoConstraints);
+
+        if (changed) {
+            this._receiverVideoConstraints = videoConstraints;
+            logger.debug(`Updating ReceiverVideoConstraints ${JSON.stringify(videoConstraints)}`);
         }
 
         return changed;
@@ -256,5 +274,20 @@ export class ReceiveVideoController {
                     && this._rtc.setNewReceiverVideoConstraints(this._receiverVideoConstraints.constraints);
             }
         }
+    }
+
+    /**
+     * Sets the receiver constraints for the conference.
+     *
+     * @param {Object} constraints The video constraints.
+     */
+    setReceiverConstraints(constraints) {
+        if (!this._receiverVideoConstraints) {
+            this._receiverVideoConstraints = new ReceiverVideoConstraints();
+        }
+
+        const constraintsChanged = this._receiverVideoConstraints.updateReceiverVideoConstraints(constraints);
+
+        constraintsChanged && this._rtc.setNewReceiverVideoConstraints(constraints);
     }
 }


### PR DESCRIPTION
Add the ability to send the bridge messages for the receiver video constraints in the new format directly. Applications that use lib-jitsi-meet can directly use this new format for implementing different UI layouts.