### PR TITLE
Send error message on auth failed with invalid jwt

### DIFF
--- a/modules/xmpp/StropheLastSuccess.js
+++ b/modules/xmpp/StropheLastSuccess.js
@@ -7,6 +7,7 @@ export default class LastRequestTracker {
      */
     constructor() {
         this._lastSuccess = null;
+        this._lastFailedMessage = null;
     }
 
     /**
@@ -19,6 +20,12 @@ export default class LastRequestTracker {
         const originalRawInput = stropheConnection.rawInput;
 
         stropheConnection.rawInput = (...args) => {
+            const rawMessage = args[0];
+
+            if (rawMessage.includes('failure')) {
+                this._lastFailedMessage = rawMessage;
+            }
+
             // It's okay to use rawInput callback only once the connection has been established, otherwise it will
             // treat 'item-not-found' or other connection error on websocket reconnect as successful stanza received.
             if (xmppConnection.connected) {
@@ -26,6 +33,15 @@ export default class LastRequestTracker {
             }
             originalRawInput.apply(stropheConnection, args);
         };
+    }
+
+    /**
+     * Returns the last raw failed incoming message on the xmpp connection.
+     *
+     * @returns {string|null}
+     */
+    getLastFailedMessage() {
+        return this._lastFailedMessage;
     }
 
     /**

--- a/modules/xmpp/XmppConnection.js
+++ b/modules/xmpp/XmppConnection.js
@@ -67,8 +67,8 @@ export default class XmppConnection extends Listenable {
         // The default maxRetries is 5, which is too long.
         this._stropheConn.maxRetries = 3;
 
-        this._lastSuccessTracker = new LastSuccessTracker();
-        this._lastSuccessTracker.startTracking(this, this._stropheConn);
+        this._rawInputTracker = new LastSuccessTracker();
+        this._rawInputTracker.startTracking(this, this._stropheConn);
 
         this._resumeTask = new ResumeTask(this._stropheConn);
 
@@ -348,7 +348,16 @@ export default class XmppConnection extends Listenable {
      * @returns {number|null}
      */
     getTimeSinceLastSuccess() {
-        return this._lastSuccessTracker.getTimeSinceLastSuccess();
+        return this._rawInputTracker.getTimeSinceLastSuccess();
+    }
+
+    /**
+     * See {@link LastRequestTracker.getLastFailedMessage}.
+     *
+     * @returns {string|null}
+     */
+    getLastFailedMessage() {
+        return this._rawInputTracker.getLastFailedMessage();
     }
 
     /**


### PR DESCRIPTION
Parse the raw input from xmpp websocket for a failure on auth with jwt and emits the parsed message to consumers.

@saghul @hristoterezov @damencho 