### PR TITLE
feat: Consider absence of A/V muted from presence as muted.

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1601,7 +1601,7 @@ export default class ChatRoom extends Listenable {
             return null;
         }
         const data = {
-            muted: false, // unmuted by default
+            muted: true, // muted by default
             videoType: undefined // no video type by default
         };
         let mutedNode = null;
@@ -1625,7 +1625,9 @@ export default class ChatRoom extends Listenable {
             return null;
         }
 
-        data.muted = mutedNode.length > 0 && mutedNode[0].value === 'true';
+        if (mutedNode.length > 0) {
+            data.muted = mutedNode[0].value === 'true';
+        }
 
         return data;
     }


### PR DESCRIPTION
We want to push this to the mobile clients, so they will act correctly when we start dropping that part from the presence, as mobile updates take time.

The idea is that in big meetings most of the people will be muted from the beginning and their join presence will miss the muted part. That will limit the size of the presence packages.