### PR TITLE
Update presence and skip default values

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1184,12 +1184,12 @@ JitsiConference.prototype._setupNewTrack = function(newTrack) {
         }
     }
     if (newTrack.isVideoTrack()) {
-        this.sendCommand('videoType', {
-            value: newTrack.videoType,
-            attributes: {
-                xmlns: 'http://jitsi.org/jitmeet/video'
-            }
-        });
+        const videoTypeTagName = 'videoType';
+
+        // if video type is camera and there is no videoType in presence, we skip adding it, as this is the default one
+        if (newTrack.videoType !== VideoType.CAMERA || this.room.getFromPresence(videoTypeTagName)) {
+            this.sendCommand(videoTypeTagName, { value: newTrack.videoType });
+        }
     }
     this.rtc.addLocalTrack(newTrack);
 

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -161,11 +161,6 @@ export default class ChatRoom extends Listenable {
             });
         }
 
-        // We need to broadcast 'videomuted' status from the beginning, cause
-        // Jicofo makes decisions based on that. Initialize it with 'false'
-        // here.
-        this.addVideoInfoToPresence(false);
-
         if (options.deploymentInfo && options.deploymentInfo.userRegion) {
             this.presMap.nodes.push({
                 'tagName': 'region',

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1537,7 +1537,7 @@ export default class ChatRoom extends Listenable {
         const audioMutedTagName = 'audiomuted';
 
         // we skip adding it as muted is default value
-        if (mute && !this.getFromPresence(audioMutedTagName)) {
+        if (mute && !this.getFromPresence(audioMutedTagName) && this.options.testing.enableSkipDefaultMutedState) {
             return false;
         }
 
@@ -1569,7 +1569,7 @@ export default class ChatRoom extends Listenable {
         const videoMutedTagName = 'videomuted';
 
         // we skip adding it as muted is default value
-        if (mute && !this.getFromPresence(videoMutedTagName)) {
+        if (mute && !this.getFromPresence(videoMutedTagName) && this.options.testing.enableSkipDefaultMutedState) {
             return false;
         }
 

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1396,7 +1396,7 @@ export default class ChatRoom extends Listenable {
      * Adds the key to the presence map, overriding any previous value.
      * @param key The key to add or replace.
      * @param values The new values.
-     * @returns {boolean|null} <tt>true</tt> if the operation succeeded or <tt>false</tt> when no add or replce was
+     * @returns {boolean|null} <tt>true</tt> if the operation succeeded or <tt>false</tt> when no add or replace was
      * performed as the value was already there.
      */
     addOrReplaceInPresence(key, values) {
@@ -1539,10 +1539,16 @@ export default class ChatRoom extends Listenable {
      * @param mute
      */
     addAudioInfoToPresence(mute) {
+        const audioMutedTagName = 'audiomuted';
+
+        // we skip adding it as muted is default value
+        if (mute && !this.getFromPresence(audioMutedTagName)) {
+            return false;
+        }
+
         return this.addOrReplaceInPresence(
-            'audiomuted',
+            audioMutedTagName,
             {
-                attributes: { 'xmlns': 'http://jitsi.org/jitmeet/audio' },
                 value: mute.toString()
             });
     }
@@ -1565,10 +1571,16 @@ export default class ChatRoom extends Listenable {
      * @param mute
      */
     addVideoInfoToPresence(mute) {
+        const videoMutedTagName = 'videomuted';
+
+        // we skip adding it as muted is default value
+        if (mute && !this.getFromPresence(videoMutedTagName)) {
+            return false;
+        }
+
         return this.addOrReplaceInPresence(
-            'videomuted',
+            videoMutedTagName,
             {
-                attributes: { 'xmlns': 'http://jitsi.org/jitmeet/video' },
                 value: mute.toString()
             });
     }


### PR DESCRIPTION
Minimize the size of the initial presence. 

In the future, we can continue optimizing and totally skip the default values instead of setting those, but that needs a bigger refactor. For now it optimizes the initial presence which seems most critical in big conferences.

But overall the other optimization is dropping the namespace which is also some gain to reduce size.

We want to proceed with one cycle of updating environments before merging this, so we can give time to mobile update with the change of having the missing presence tags to be considered as muted (video type missing is already handled and in current mobile clients) as mobile may show some web participants as unmuted while those are actually muted and presence misses the a/v muted tags.
