### PR TITLE
feat(stats): Get audio levels for the top 5 speakers only.

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -182,7 +182,11 @@ export default class BrowserCapabilities extends BrowserDetection {
      */
     supportsReceiverStats() {
         return typeof window.RTCRtpReceiver !== 'undefined'
-            && Object.keys(RTCRtpReceiver.prototype).indexOf('getSynchronizationSources') > -1;
+            && Object.keys(RTCRtpReceiver.prototype).indexOf('getSynchronizationSources') > -1
+
+            // Disable this on Safari because it is reporting 0.000001 as the audio levels for all
+            // remote audio tracks.
+            && !this.isWebKitBased();
     }
 
     /**

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -260,6 +260,7 @@ export default function StatsCollector(
     // Updates stats interval
     this.audioLevelsIntervalMilis = audioLevelsInterval;
 
+    this.speakerList = [];
     this.statsIntervalId = null;
     this.statsIntervalMilis = statsInterval;
 
@@ -270,7 +271,15 @@ export default function StatsCollector(
     this.ssrc2stats = new Map();
 }
 
-/* eslint-enable max-params */
+/**
+ * Set the list of the remote speakers for which audio levels are to be calculated.
+ *
+ * @param {Array<string>} speakerList - Endpoint ids.
+ * @returns {void}
+ */
+StatsCollector.prototype.setSpeakerList = function(speakerList) {
+    this.speakerList = speakerList;
+};
 
 /**
  * Stops stats updates.
@@ -308,7 +317,7 @@ StatsCollector.prototype.start = function(startAudioLevelStats) {
         this.audioLevelsIntervalId = setInterval(
             () => {
                 if (browser.supportsReceiverStats()) {
-                    const audioLevels = this.peerconnection.getAudioLevels();
+                    const audioLevels = this.peerconnection.getAudioLevels(this.speakerList);
 
                     for (const ssrc in audioLevels) {
                         if (audioLevels.hasOwnProperty(ssrc)) {

--- a/modules/statistics/constants.js
+++ b/modules/statistics/constants.js
@@ -2,8 +2,7 @@ export const CALLSTATS_SCRIPT_URL = 'https://api.callstats.io/static/callstats-w
 
 /**
  * The number of remote speakers for which the audio levels will be calculated using
- * RTCRtpReceiver#getSynchronizationSources. Limit the number of endpoints to save cpu on the client sources.
- * Limit the number of endpoints to save cpu on the client as this API call is known to take longer to execute
- * when there are many audio receivers.
+ * RTCRtpReceiver#getSynchronizationSources. Limit the number of endpoints to save cpu on the client as this API call
+ * is known to take longer to execute when there are many audio receivers.
  */
 export const SPEAKERS_AUDIO_LEVELS = 5;

--- a/modules/statistics/constants.js
+++ b/modules/statistics/constants.js
@@ -1,1 +1,9 @@
 export const CALLSTATS_SCRIPT_URL = 'https://api.callstats.io/static/callstats-ws.min.js';
+
+/**
+ * The number of remote speakers for which the audio levels will be calculated using
+ * RTCRtpReceiver#getSynchronizationSources. Limit the number of endpoints to save cpu on the client sources.
+ * Limit the number of endpoints to save cpu on the client as this API call is known to take longer to execute
+ * when there are many audio receivers.
+ */
+export const SPEAKERS_AUDIO_LEVELS = 5;

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -345,6 +345,20 @@ Statistics.prototype.removeLongTasksStatsListener = function(listener) {
     this.eventEmitter.removeListener(StatisticsEvents.LONG_TASKS_STATS, listener);
 };
 
+/**
+ * Updates the list of speakers for which the audio levels are to be calculated. This is needed for the jvb pc only.
+ *
+ * @param {Array<string>} speakerList The list of remote endpoint ids.
+ * @returns {void}
+ */
+Statistics.prototype.setSpeakerList = function(speakerList) {
+    for (const rtpStats of Array.from(this.rtpStatsMap.values())) {
+        if (!rtpStats.peerconnection.isP2P) {
+            rtpStats.setSpeakerList(speakerList);
+        }
+    }
+};
+
 Statistics.prototype.dispose = function() {
     try {
         // NOTE Before reading this please see the comment in stopCallStats...


### PR DESCRIPTION
Capture the audio levels only for the top 5 speakers as RTCRtpReceiver#getSynchronizationSources can be expensive when we have too many audio receivers in the call.
Also, capture the audio levels for track that are unmuted if RTCRtpReceiver#getSynchronizationSources is not supported.
Switch Safari to using getStats since its reporting errorneous values, i.e., 0.000001 as audio level for all remote audio tracks.