### PR TITLE
feat(stats): Add a new bridge message "EndpointStats" for stats.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2599,6 +2599,15 @@ JitsiConference.prototype.sendEndpointMessage = function(to, payload) {
 };
 
 /**
+ * Sends local stats via the bridge channel which then forwards to other endpoints selectively.
+ * @param {Object} payload The payload of the message.
+ * @throws NetworkError/InvalidStateError/Error if the operation fails or if there is no data channel created.
+ */
+JitsiConference.prototype.sendEndpointStatsMessage = function(payload) {
+    this.rtc.sendEndpointStatsMessage(payload);
+};
+
+/**
  * Sends a broadcast message via the data channel.
  * @param payload {object} the payload of the message.
  * @throws NetworkError or InvalidStateError or Error if the operation fails.

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -556,6 +556,17 @@ JitsiConferenceEventManager.prototype.setupRTCListeners = function() {
             }
         });
 
+    rtc.addListener(RTCEvents.ENDPOINT_STATS_RECEIVED,
+        (from, payload) => {
+            const participant = conference.getParticipantById(from);
+
+            if (participant) {
+                conference.eventEmitter.emit(JitsiConferenceEvents.ENDPOINT_STATS_RECEIVED, participant, payload);
+            } else {
+                logger.warn(`Ignoring ENDPOINT_STATS_RECEIVED for a non-existant participant: ${from}`);
+            }
+        });
+
     rtc.addListener(RTCEvents.LOCAL_UFRAG_CHANGED,
         (tpc, ufrag) => {
             if (!tpc.isP2P) {

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -98,6 +98,11 @@ export const DTMF_SUPPORT_CHANGED = 'conference.dtmfSupportChanged';
 export const ENDPOINT_MESSAGE_RECEIVED = 'conference.endpoint_message_received';
 
 /**
+ * Indicates that a message for the remote endpoint statistics has been received on the bridge channel.
+ */
+export const ENDPOINT_STATS_RECEIVED = 'conference.endpoint_stats_received';
+
+/**
  * NOTE This is lib-jitsi-meet internal event and can be removed at any time !
  *
  * Event emitted when conference transits, between one to one and multiparty JVB

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -175,6 +175,19 @@ export default class BridgeChannel {
     }
 
     /**
+     * Sends local stats via the bridge channel.
+     * @param {Object} payload The payload of the message.
+     * @throws NetworkError/InvalidStateError/Error if the operation fails or if there is no data channel created.
+     */
+    sendEndpointStatsMessage(payload) {
+        logger.debug(`Sending endpoint stats ${JSON.stringify(payload)}`);
+        this._send({
+            colibriClass: 'EndpointStats',
+            ...payload
+        });
+    }
+
+    /**
      * Sends message via the channel.
      * @param {string} to The id of the endpoint that should receive the
      * message. If "" the message will be sent to all participants.
@@ -307,6 +320,11 @@ export default class BridgeChannel {
             }
             case 'EndpointMessage': {
                 emitter.emit(RTCEvents.ENDPOINT_MESSAGE_RECEIVED, obj.from, obj.msgPayload);
+
+                break;
+            }
+            case 'EndpointStats': {
+                emitter.emit(RTCEvents.ENDPOINT_STATS_RECEIVED, obj.from, obj);
 
                 break;
             }

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -845,8 +845,6 @@ export default class RTC extends Listenable {
         track.setAudioLevel(audioLevel, tpc);
     }
 
-    /* eslint-enable max-params */
-
     /**
      * Sends message via the bridge channel.
      * @param {string} to The id of the endpoint that should receive the
@@ -860,6 +858,17 @@ export default class RTC extends Listenable {
             this._channel.sendMessage(to, payload);
         } else {
             throw new Error('Channel support is disabled!');
+        }
+    }
+
+    /**
+     * Sends the local stats via the bridge channel.
+     * @param {Object} payload The payload of the message.
+     * @throws NetworkError/InvalidStateError/Error if the operation fails or if there is no data channel created.
+     */
+    sendEndpointStatsMessage(payload) {
+        if (this._channel && this._channel.isOpen()) {
+            this._channel.sendEndpointStatsMessage(payload);
         }
     }
 

--- a/service/RTC/RTCEvents.js
+++ b/service/RTC/RTCEvents.js
@@ -89,6 +89,11 @@ const RTCEvents = {
     ENDPOINT_MESSAGE_RECEIVED: 'rtc.endpoint_message_received',
 
     /**
+     * Indicates that the remote endpoint stats have been received on data channnel.
+     */
+    ENDPOINT_STATS_RECEIVED: 'rtc.endpoint_stats_received',
+
+    /**
      * Designates an event indicating that the local ICE username fragment of
      * the jingle session has changed.
      * The first argument of the vent is <tt>TraceablePeerConnection</tt> which


### PR DESCRIPTION
Use the new Colibri message "EndpointStats" for broadcasting the local stats. The bridge then will be able to filter the endpoint stats and send them only to the interested parties instead of broadcasting it to all the endpoints in the call.