### PR TITLE
fix(screensharing-options): allow to config screenshare video settings

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -164,7 +164,7 @@ const ScreenObtainer = {
         }
 
         getDisplayMedia({
-            video: true,
+            video: options.video ? options.video : true,
             audio: true,
             cursor: 'always'
         })


### PR DESCRIPTION
I wasn't able to get a proper 720p screensharing downscale without allowing to pass options along here, not sure if this is the right way to approach?