### PR TITLE
fix(RTC): Remove stream effect before disposing the track.

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -352,7 +352,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
             this._streamEffect.stopEffect();
             this._setStream(this._originalStream);
             this._originalStream = null;
-            this.track = this.stream.getTracks()[0];
+            this.track = this.stream ? this.stream.getTracks()[0] : null;
         }
     }
 
@@ -684,12 +684,16 @@ export default class JitsiLocalTrack extends JitsiTrack {
      * @returns {Promise}
      */
     dispose() {
-        this._switchStreamEffect();
-
         let promise = Promise.resolve();
 
+        // Remove the effect instead of stopping it so that the original stream is restored
+        // on both the local track and on the peerconnection.
+        if (this._streamEffect) {
+            promise = this.setEffect();
+        }
+
         if (this.conference) {
-            promise = this.conference.removeTrack(this);
+            promise = promise.then(() => this.conference.removeTrack(this));
         }
 
         if (this.stream) {

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1630,12 +1630,13 @@ TraceablePeerConnection.prototype._mungeCodecOrder = function(description) {
             if (this.codecPreference.mimeType === CodecMimeType.VP9) {
                 const bitrates = this.videoBitrates.VP9 || this.videoBitrates;
                 const hdBitrate = bitrates.high ? bitrates.high : HD_BITRATE;
+                const limit = Math.floor((this._isSharingScreen() ? HD_BITRATE : hdBitrate) / 1000);
 
                 // Use only the HD bitrate for now as there is no API available yet for configuring
                 // the bitrates on the individual SVC layers.
                 mLine.bandwidth = [ {
                     type: 'AS',
-                    limit: this._isSharingScreen() ? HD_BITRATE : Math.floor(hdBitrate / 1000)
+                    limit
                 } ];
             } else {
                 // Clear the bandwidth limit in SDP when VP9 is no longer the preferred codec.


### PR DESCRIPTION
Remove the effect instead of stopping it so that the original stream is restored on both the local track and on the peerconnection. Fixes issues when a stream with effect applied is replaced on the pc after it is muted, also fixes https://github.com/jitsi/lib-jitsi-meet/issues/1537.