### PR TITLE
fix(RTC): Specify default width of 1280px for video.

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -62,7 +62,12 @@ const DEFAULT_CONSTRAINTS = {
         height: {
             ideal: 720,
             max: 720,
-            min: 240
+            min: 180
+        },
+        width: {
+            ideal: 1280,
+            max: 1280,
+            min: 320
         }
     }
 };


### PR DESCRIPTION
Fixes https://github.com/jitsi/lib-jitsi-meet/issues/1571.