### PR TITLE
Add more specific tracking of dominant speaker change events

### DIFF
--- a/modules/statistics/SpeakerStats.js
+++ b/modules/statistics/SpeakerStats.js
@@ -81,15 +81,20 @@ class SpeakerStats {
      * @returns {void}
      */
     setDominantSpeaker(isNowDominantSpeaker) {
+        var tsEntry;
         if (!this.isDominantSpeaker() && isNowDominantSpeaker) {
             this._dominantSpeakerStart = Date.now();
         } else if (this.isDominantSpeaker() && !isNowDominantSpeaker) {
             const now = Date.now();
             const timeElapsed = now - this._dominantSpeakerStart;
 
+            // JvB: Track history of dominant speaker changes for the conference
+            tsEntry = { start: this._dominantSpeakerStart, end: now };
+            
             this.totalDominantSpeakerTime += timeElapsed;
             this._dominantSpeakerStart = 0;
         }
+        return tsEntry;
     }
 
     /**

--- a/modules/statistics/SpeakerStatsCollector.js
+++ b/modules/statistics/SpeakerStatsCollector.js
@@ -21,7 +21,8 @@ export default class SpeakerStatsCollector {
 
                 // userId: SpeakerStats
             },
-            dominantSpeakerId: null
+            dominantSpeakerId: null,
+            speakerChanges: [], // JvB Array of { start, end, userId } speaker changes
         };
 
         const userId = conference.myUserId();
@@ -62,7 +63,13 @@ export default class SpeakerStatsCollector {
             = this.stats.users[this.stats.dominantSpeakerId];
         const newDominantSpeaker = this.stats.users[dominantSpeakerId];
 
-        oldDominantSpeaker && oldDominantSpeaker.setDominantSpeaker(false);
+        if (oldDominantSpeaker) {
+            const tsEvent = oldDominantSpeaker.setDominantSpeaker(false);
+            if (tsEvent) {
+               tsEvent.userId = this.stats.dominantSpeakerId;
+               this.stats.speakerChanges.push( tsEvent );
+            }
+        }
         newDominantSpeaker && newDominantSpeaker.setDominantSpeaker(true);
         this.stats.dominantSpeakerId = dominantSpeakerId;
     }
@@ -126,6 +133,16 @@ export default class SpeakerStatsCollector {
      */
     getStats() {
         return this.stats.users;
+    }
+    
+    /**
+     * Return a copy of the array with historic dominant speaker change events.
+     *
+     * @returns {Object} start, end, userId
+     * @private
+     */
+    getSpeakerChangeHistory() {
+        return this.stats.speakerChanges;
     }
 
     /**


### PR DESCRIPTION
This patch adds tracking of { start, end, userId } for each dominant speaker change event, enabling richer conference statistics.

For example, see https://slack-files.com/T01U4KTU8TD-F02055Z3LG6-4ecd080671 - this type of meeting summary, showing the alternating participation of users, could be presented at the end of the conference (if enabled)