### PR TITLE
Enable unified-plan for chrome

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -244,12 +244,19 @@ export class TPCUtils {
             const stream = localTrack.getOriginalStream();
 
             if (stream) {
-                this.pc.peerconnection.addStream(localTrack.getOriginalStream());
-
-                return this.setEncodings(localTrack).then(() => {
+                if (browser.isChromiumBased()) {
+                    // stream.getTracks().forEach(t => this.pc.peerconnection.addTrack(t, stream) );
+                    this.pc.peerconnection.addTrack(localTrack.getTrack(), stream);
                     this.pc.localTracks.set(localTrack.rtcId, localTrack);
                     transceiver.direction = 'sendrecv';
-                });
+                } else {
+                    this.pc.peerconnection.addStream(localTrack.getOriginalStream());
+
+                    return this.setEncodings(localTrack).then(() => {
+                        this.pc.localTracks.set(localTrack.rtcId, localTrack);
+                        transceiver.direction = 'sendrecv';
+                    });
+                }
             }
 
             return Promise.resolve();

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -231,7 +231,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     usesUnifiedPlan() {
-        if (this.isFirefox() || this.isWebKitBased()) {
+        if (this.isFirefox() || this.isWebKitBased() || this.isChromiumBased()) {
             return true;
         }
 
@@ -326,7 +326,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     supportsSdpSemantics() {
-        return this.isChromiumBased();
+        return false;
     }
 
     /**


### PR DESCRIPTION
@jallamsetty1, @smilingthax

Follow up from: #1089 

As you can see we didn't do much.
This main thing after enabling it was that chrome complains about modifying _read-only parameter_  encodings. Looks like `setMaxBitrate()` does this for us later in the flow so the `videoQuality.maxBitratesVideo{low,standard,high}` from config.js are set on pc-senders.

Also `addStream()` is deprecated so we used `addTrack()` here.
