### PR TITLE
Jitsi@scale Hackathon submission: Enable HTML Media Element streaming

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1221,7 +1221,8 @@ class RTCUtils extends Listenable {
                    new Error("'htmlmedia' requested but no htmlMediaElements"));
              }
 
-             const fps = otherOptions.htmlMediaFrameRate || 10;
+             const fps = otherOptions.htmlMediaFrameRate
+                         || SS_DEFAULT_FRAME_RATE; // default to screen sharing
              for (let e of otherOptions.htmlMediaElements) {
                 const htmlMediaStream = e.captureStream(fps);
                 logger.info( `Adding HTML media captureStream at ${fps} fps` );

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1206,6 +1206,31 @@ class RTCUtils extends Listenable {
         }.bind(this);
 
         /**
+         * Creates local audio/video streams from HTML Media elements
+         * Added for Jitsi@scale hackathon project by exergy.connect@gmail.com
+         */
+         const maybeCreateAndAddHTMLMediaStreams = function() {
+             const umDevices = otherOptions.devices || [];
+             const isHTMLMediaRequested
+                 = umDevices.indexOf('htmlmedia') !== -1;
+
+             if (!isHTMLMediaRequested) {
+                 return Promise.resolve();
+             } else if (!otherOptions.htmlMediaElements) {
+                 return Promise.reject(
+                   new Error("'htmlmedia' requested but no htmlMediaElements"));
+             }
+
+             const fps = otherOptions.htmlMediaFrameRate || 10;
+             for (let e of otherOptions.htmlMediaElements) {
+                const htmlMediaStream = e.captureStream(fps);
+                logger.info( `Adding HTML media captureStream at ${fps} fps` );
+                maybeCreateAndAddAVTracks( htmlMediaStream );
+             }
+             return Promise.resolve();
+         }.bind(this);
+
+        /**
          * Creates a meta data object about the passed in desktopStream and
          * pushes the meta data to the internal array mediaStreamsMetaData to be
          * returned later.
@@ -1315,6 +1340,7 @@ class RTCUtils extends Listenable {
         return maybeRequestDesktopDevice()
             .then(maybeCreateAndAddDesktopTrack)
             .then(maybeRequestCaptureDevices)
+            .then(maybeCreateAndAddHTMLMediaStreams)
             .then(maybeCreateAndAddAVTracks)
             .then(() => mediaStreamsMetaData)
             .catch(error => {

--- a/modules/statistics/SpeakerStats.js
+++ b/modules/statistics/SpeakerStats.js
@@ -81,15 +81,20 @@ class SpeakerStats {
      * @returns {void}
      */
     setDominantSpeaker(isNowDominantSpeaker) {
+        var tsEntry;
         if (!this.isDominantSpeaker() && isNowDominantSpeaker) {
             this._dominantSpeakerStart = Date.now();
         } else if (this.isDominantSpeaker() && !isNowDominantSpeaker) {
             const now = Date.now();
             const timeElapsed = now - this._dominantSpeakerStart;
 
+            // JvB: Track history of dominant speaker changes for the conference
+            tsEntry = { start: this._dominantSpeakerStart, end: now };
+            
             this.totalDominantSpeakerTime += timeElapsed;
             this._dominantSpeakerStart = 0;
         }
+        return tsEntry;
     }
 
     /**

--- a/modules/statistics/SpeakerStatsCollector.js
+++ b/modules/statistics/SpeakerStatsCollector.js
@@ -21,7 +21,8 @@ export default class SpeakerStatsCollector {
 
                 // userId: SpeakerStats
             },
-            dominantSpeakerId: null
+            dominantSpeakerId: null,
+            speakerChanges: [], // JvB Array of { start, end, userId } speaker changes
         };
 
         const userId = conference.myUserId();
@@ -62,7 +63,13 @@ export default class SpeakerStatsCollector {
             = this.stats.users[this.stats.dominantSpeakerId];
         const newDominantSpeaker = this.stats.users[dominantSpeakerId];
 
-        oldDominantSpeaker && oldDominantSpeaker.setDominantSpeaker(false);
+        if (oldDominantSpeaker) {
+            const tsEvent = oldDominantSpeaker.setDominantSpeaker(false);
+            if (tsEvent) {
+               tsEvent.userId = this.stats.dominantSpeakerId;
+               this.stats.speakerChanges.push( tsEvent );
+            }
+        }
         newDominantSpeaker && newDominantSpeaker.setDominantSpeaker(true);
         this.stats.dominantSpeakerId = dominantSpeakerId;
     }
@@ -126,6 +133,16 @@ export default class SpeakerStatsCollector {
      */
     getStats() {
         return this.stats.users;
+    }
+    
+    /**
+     * Return a copy of the array with historic dominant speaker change events.
+     *
+     * @returns {Object} start, end, userId
+     * @private
+     */
+    getSpeakerChangeHistory() {
+        return this.stats.speakerChanges;
     }
 
     /**


### PR DESCRIPTION
This patch adds support for a new virtual device type 'htmlmedia', to enable streaming from 1 or more \<audio\>,\<video\> or \<canvas\> elements on the page

```
JitsiMeetJS.createLocalTracks({ devices: [ 'htmlmedia' ], 
                                htmlMediaElements: [ document.querySelector('canvas') ],
                                htmlMediaFrameRate: 10 }) 
```

This allows us to (for example) create a web application that aggregates multiple video streams onto a \<canvas\> element, and sends the aggregate stream back into the conference - to achieve better scale

Note: Only modules/RTC/RTCUtils.js should be part of this PR, the other files got added erroneously