### PR TITLE
Fix: Screenshare with Audio broken

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -105,7 +105,7 @@ const ScreenObtainer = {
             channelCount: 2,
             echoCancellation: false,
             noiseSuppression: false
-        } : false;
+        } : true;
 
         return audio;
     },
@@ -138,11 +138,11 @@ const ScreenObtainer = {
                         let audioConstraints = false;
 
                         if (screenShareAudio) {
-                            audioConstraints = { };
+                            audioConstraints = {};
 
-                            if (this._getAudioConstraints()) {
-                                audioConstraints.optional = {
-                                    ...this._getAudioConstraints()
+                            if (typeof this._getAudioConstraints() !== 'boolean') {
+                                audioConstraints = {
+                                    optional: this._getAudioConstraints()
                                 };
                             }
 

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -105,7 +105,7 @@ const ScreenObtainer = {
             channelCount: 2,
             echoCancellation: false,
             noiseSuppression: false
-        } : true;
+        } : false;
 
         return audio;
     },
@@ -138,11 +138,13 @@ const ScreenObtainer = {
                         let audioConstraints = false;
 
                         if (screenShareAudio) {
-                            audioConstraints = {
-                                optional: {
+                            audioConstraints = { };
+
+                            if (this._getAudioConstraints()) {
+                                audioConstraints.optional = {
                                     ...this._getAudioConstraints()
-                                }
-                            };
+                                };
+                            }
 
                             // Audio screen sharing for electron only works for screen type devices.
                             // i.e. when the user shares the whole desktop.

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -139,10 +139,11 @@ const ScreenObtainer = {
 
                         if (screenShareAudio) {
                             audioConstraints = {};
+                            const optionalConstraints = this._getAudioConstraints();
 
-                            if (typeof this._getAudioConstraints() !== 'boolean') {
+                            if (typeof optionalConstraints !== 'boolean') {
                                 audioConstraints = {
-                                    optional: this._getAudioConstraints()
+                                    optional: optionalConstraints
                                 };
                             }
 


### PR DESCRIPTION
On Screenshare with Audio the constraint is 

```js
    "audio": {
        "optional": {},
        "mandatory": {
            "chromeMediaSource": "desktop"
        }
    },
```

Electron complains with `Failed to execute 'getUserMedia' on 'MediaDevices': The object must have a callable @@iterator property.` cause of empty optional object.