### PR TITLE
fix(TPC): Use addTrack instead of addStream in Unified-plan impl.

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -192,11 +192,10 @@ export class TPCUtils {
     * Adds {@link JitsiLocalTrack} to the WebRTC peerconnection for the first time.
     * @param {JitsiLocalTrack} track - track to be added to the peerconnection.
     * @param {boolean} isInitiator - boolean that indicates if the endpoint is offerer in a p2p connection.
-    * @returns {Promise<void>} - resolved when done, rejected otherwise.
+    * @returns {void}
     */
     addTrack(localTrack, isInitiator) {
         const track = localTrack.getTrack();
-        let promise = Promise.resolve();
 
         if (isInitiator) {
             // Use pc.addTransceiver() for the initiator case when local tracks are getting added
@@ -210,25 +209,13 @@ export class TPCUtils {
             if (!browser.isFirefox()) {
                 transceiverInit.sendEncodings = this._getStreamEncodings(localTrack);
             }
-            try {
-                this.pc.peerconnection.addTransceiver(track, transceiverInit);
-            } catch (error) {
-                logger.error(`Adding ${localTrack} failed on ${this.pc}: ${error?.message}`);
-                promise = Promise.reject();
-            }
+            this.pc.peerconnection.addTransceiver(track, transceiverInit);
         } else {
             // Use pc.addTrack() for responder case so that we can re-use the m-lines that were created
             // when setRemoteDescription was called. pc.addTrack() automatically  attaches to any existing
             // unused "recv-only" transceiver.
-            try {
-                this.pc.peerconnection.addTrack(track);
-            } catch (error) {
-                logger.error(`Adding ${localTrack} failed on ${this.pc}: ${error?.message}`);
-                promise = Promise.reject();
-            }
+            this.pc.peerconnection.addTrack(track);
         }
-
-        return promise;
     }
 
     /**

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1686,10 +1686,15 @@ TraceablePeerConnection.prototype.addTrack = function(track, isInitiator = false
     }
 
     this.localTracks.set(rtcId, track);
-    let promiseChain = Promise.resolve();
 
     if (browser.usesUnifiedPlan()) {
-        promiseChain = this.tpcUtils.addTrack(track, isInitiator);
+        try {
+            this.tpcUtils.addTrack(track, isInitiator);
+        } catch (error) {
+            logger.error(`Adding ${track} failed on ${this}: ${error?.message}`);
+
+            return Promise.reject(error);
+        }
     } else {
         // In all other cases, i.e., plan-b and unified plan bridge case, use addStream API to
         // add the track to the peerconnection.
@@ -1736,6 +1741,7 @@ TraceablePeerConnection.prototype.addTrack = function(track, isInitiator = false
             }
         }
     }
+    let promiseChain = Promise.resolve();
 
     // On Firefox, the encodings have to be configured on the sender only after the transceiver is created.
     if (browser.isFirefox()) {


### PR DESCRIPTION
Do not try to configure encodings on the sender until they are available. This fixes an issue on Chrome (running in unified-plan mode) where unmuting the local source throws a 'Read-only field modified in setParameters()' error.