### PR TITLE
fix(JingleSession): Add a unique identifier for source on Firefox.

### DIFF
--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -118,7 +118,7 @@ SDP.prototype.containsSSRC = function(ssrc) {
 };
 
 // add content's to a jingle element
-SDP.prototype.toJingle = function(elem, thecreator, localId) {
+SDP.prototype.toJingle = function(elem, thecreator, localEndpointId) {
     // https://xmpp.org/extensions/xep-0338.html
     SDPUtil.findLines(this.session, 'a=group:').forEach(line => {
         const parts = line.split(' ');
@@ -232,7 +232,7 @@ SDP.prototype.toJingle = function(elem, thecreator, localId) {
                                 const sourceIds = v.split(' ');
 
                                 if (sourceIds[0].includes('--') && sourceIds.length > 1) {
-                                    v = `${localId}-${mline.media} ${sourceIds[1]}`;
+                                    v = `${localEndpointId}-${mline.media} ${sourceIds[1]}`;
                                 }
                             }
                             elem.attrs({ value: v });

--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -118,7 +118,7 @@ SDP.prototype.containsSSRC = function(ssrc) {
 };
 
 // add content's to a jingle element
-SDP.prototype.toJingle = function(elem, thecreator) {
+SDP.prototype.toJingle = function(elem, thecreator, localId) {
     // https://xmpp.org/extensions/xep-0338.html
     SDPUtil.findLines(this.session, 'a=group:').forEach(line => {
         const parts = line.split(' ');
@@ -223,6 +223,18 @@ SDP.prototype.toJingle = function(elem, thecreator) {
                             let v = kv.split(':', 2)[1];
 
                             v = SDPUtil.filterSpecialChars(v);
+
+                            // Handle a case on Firefox when the browser doesn't produce a 'a:ssrc' line
+                            // with the 'msid' attribute. Jicofo needs a unique identifier to be associated
+                            // with a ssrc and uses the msid attribute for that. Generate the identifier using
+                            // the local endpoint id.
+                            if (name === 'msid' && browser.isFirefox()) {
+                                const sourceIds = v.split(' ');
+
+                                if (sourceIds[0].includes('--') && sourceIds.length > 1) {
+                                    v = `${localId}-${mline.media} ${sourceIds[1]}`;
+                                }
+                            }
                             elem.attrs({ value: v });
                         }
                         elem.up();

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -978,7 +978,8 @@ export default class JingleSessionPC extends JingleSession {
 
         new SDP(offerSdp).toJingle(
             init,
-            this.isInitiator ? 'initiator' : 'responder');
+            this.isInitiator ? 'initiator' : 'responder',
+            Strophe.getResourceFromJid(this.localJid));
         init = init.tree();
         logger.info('Session-initiate: ', init);
         this.connection.sendIQ(init,
@@ -1245,7 +1246,7 @@ export default class JingleSessionPC extends JingleSession {
         localSDP.toJingle(
             accept,
             this.initiatorJid === this.localJid ? 'initiator' : 'responder',
-            null);
+            Strophe.getResourceFromJid(this.localJid));
 
         // Calling tree() to print something useful
         accept = accept.tree();


### PR DESCRIPTION
In certain cases, when RTCPeerconnection#addTrack is used, the browser doesn't produce the streamid in the 'a=msid' line which is being used by Jicofo as a unique identifier for the associated ssrc. Whenever the msid is missing in the local description, generate an ID using the local endpoint id.