### PR TITLE
fix(JingleSession): Move the ssrc identifier generation to LocalSdpMunger.

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -557,6 +557,14 @@ export default class RTC extends Listenable {
     }
 
     /**
+     * Returns the endpoint id for the local user.
+     * @returns {string}
+     */
+    getLocalEndpointId() {
+        return this.conference.myUserId();
+    }
+
+    /**
      * Returns the local tracks of the given media type, or all local tracks if
      * no specific type is given.
      * @param {MediaType} [mediaType] Optional media type filter.

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -273,7 +273,7 @@ export default function TraceablePeerConnection(
      * sending SSRC updates on attach/detach and mute/unmute (for video).
      * @type {LocalSdpMunger}
      */
-    this.localSdpMunger = new LocalSdpMunger(this);
+    this.localSdpMunger = new LocalSdpMunger(this, this.rtc.getLocalEndpointId());
 
     /**
      * TracablePeerConnection uses RTC's eventEmitter
@@ -1836,7 +1836,7 @@ TraceablePeerConnection.prototype._assertTrackBelongs = function(
  * video in the local SDP.
  */
 TraceablePeerConnection.prototype.getConfiguredVideoCodec = function() {
-    const sdp = this.localDescription.sdp;
+    const sdp = this.peerconnection.localDescription.sdp;
     const defaultCodec = CodecMimeType.VP8;
 
     if (!sdp) {
@@ -2901,9 +2901,7 @@ TraceablePeerConnection.prototype._processLocalSSRCsMap = function(ssrcMap) {
 
             // eslint-disable-next-line no-negated-condition
             if (newSSRCNum !== oldSSRCNum) {
-                if (!oldSSRCNum) {
-                    logger.error(`Overwriting SSRC for ${track} ${trackMSID} in ${this} with: `, newSSRC);
-                }
+                oldSSRCNum && logger.error(`Overwriting SSRC for ${track} ${trackMSID} in ${this} with: `, newSSRC);
                 this.localSSRCs.set(track.rtcId, newSSRC);
                 this.eventEmitter.emit(RTCEvents.LOCAL_TRACK_SSRC_UPDATED, track, newSSRCNum);
             }

--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -22,9 +22,11 @@ export default class LocalSdpMunger {
      * Creates new <tt>LocalSdpMunger</tt> instance.
      *
      * @param {TraceablePeerConnection} tpc
+     * @param {string} localEndpointId - The endpoint id of the local user.
      */
-    constructor(tpc) {
+    constructor(tpc, localEndpointId) {
         this.tpc = tpc;
+        this.localEndpointId = localEndpointId;
     }
 
     /**
@@ -175,11 +177,14 @@ export default class LocalSdpMunger {
                     const streamAndTrackIDs = ssrcLine.value.split(' ');
 
                     if (streamAndTrackIDs.length === 2) {
-                        const streamId = streamAndTrackIDs[0];
+                        let streamId = streamAndTrackIDs[0];
                         const trackId = streamAndTrackIDs[1];
 
-                        ssrcLine.value
-                            = `${streamId}-${pcId} ${trackId}-${pcId}`;
+                        // eslint-disable-next-line max-depth
+                        if (streamId === '-') {
+                            streamId = this.localEndpointId;
+                        }
+                        ssrcLine.value = `${streamId}-${pcId} ${trackId}-${pcId}`;
                     } else {
                         logger.warn(
                             'Unable to munge local MSID'

--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -180,9 +180,12 @@ export default class LocalSdpMunger {
                         let streamId = streamAndTrackIDs[0];
                         const trackId = streamAndTrackIDs[1];
 
+                        // Handle a case on Firefox when the browser doesn't produce a 'a:ssrc' line with the 'msid'
+                        // attribute. Jicofo needs an unique identifier to be associated with a ssrc and uses the msid
+                        // for that. Generate the identifier using the local endpoint id.
                         // eslint-disable-next-line max-depth
                         if (streamId === '-') {
-                            streamId = this.localEndpointId;
+                            streamId = `${this.localEndpointId}-${mediaSection.type}`;
                         }
                         ssrcLine.value = `${streamId}-${pcId} ${trackId}-${pcId}`;
                     } else {

--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -118,7 +118,7 @@ SDP.prototype.containsSSRC = function(ssrc) {
 };
 
 // add content's to a jingle element
-SDP.prototype.toJingle = function(elem, thecreator, localEndpointId) {
+SDP.prototype.toJingle = function(elem, thecreator) {
     // https://xmpp.org/extensions/xep-0338.html
     SDPUtil.findLines(this.session, 'a=group:').forEach(line => {
         const parts = line.split(' ');
@@ -223,18 +223,6 @@ SDP.prototype.toJingle = function(elem, thecreator, localEndpointId) {
                             let v = kv.split(':', 2)[1];
 
                             v = SDPUtil.filterSpecialChars(v);
-
-                            // Handle a case on Firefox when the browser doesn't produce a 'a:ssrc' line
-                            // with the 'msid' attribute. Jicofo needs a unique identifier to be associated
-                            // with a ssrc and uses the msid attribute for that. Generate the identifier using
-                            // the local endpoint id.
-                            if (name === 'msid' && browser.isFirefox()) {
-                                const sourceIds = v.split(' ');
-
-                                if (sourceIds[0].includes('--') && sourceIds.length > 1) {
-                                    v = `${localEndpointId}-${mline.media} ${sourceIds[1]}`;
-                                }
-                            }
                             elem.attrs({ value: v });
                         }
                         elem.up();

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -71,7 +71,7 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
             id: iq.getAttribute('id')
         });
 
-        logger.log(`on jingle ${action} from ${fromJid}`, JSON.stringify(iq));
+        logger.log(`on jingle ${action} from ${fromJid}`, iq);
         let sess = this.sessions[sid];
 
         if (action !== 'session-initiate') {


### PR DESCRIPTION
When a msid attribute is missing in the 'a=ssrc' line, use the local endpoint id as an indentifier. Move this generation logic to LocalSdpMunger. Also suppress notifying Jicfo of a ssrc change on Firefox when the change is a result of the media being suspended on the jvb connection.