### PR TITLE
fix(TPC): Return default codec if the local sdp is not available.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1836,7 +1836,7 @@ TraceablePeerConnection.prototype._assertTrackBelongs = function(
  * video in the local SDP.
  */
 TraceablePeerConnection.prototype.getConfiguredVideoCodec = function() {
-    const sdp = this.peerconnection.localDescription.sdp;
+    const sdp = this.peerconnection.localDescription?.sdp;
     const defaultCodec = CodecMimeType.VP8;
 
     if (!sdp) {

--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -185,7 +185,7 @@ export default class LocalSdpMunger {
                         // for that. Generate the identifier using the local endpoint id.
                         // eslint-disable-next-line max-depth
                         if (streamId === '-') {
-                            streamId = `${this.localEndpointId}-${mediaSection.type}`;
+                            streamId = `${this.localEndpointId}-${mediaSection.mLine?.type}`;
                         }
                         ssrcLine.value = `${streamId}-${pcId} ${trackId}-${pcId}`;
                     } else {


### PR DESCRIPTION
Get the correct media type when generating the source identifier.