### PR TITLE
fix(xmpp) Fixed Strophe.JS calls to match the API (underlying cause of issue #1592)

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -847,10 +847,9 @@ export default class ChatRoom extends Listenable {
         // is different from 'body', we add a custom namespace.
         // e.g. for 'json-message' extension of message stanza.
         if (elementName === 'body') {
-            msg.c(elementName, message).up();
+            msg.c(elementName, {}, message);
         } else {
-            msg.c(elementName, { xmlns: 'http://jitsi.org/jitmeet' }, message)
-                .up();
+            msg.c(elementName, { xmlns: 'http://jitsi.org/jitmeet' }, message);
         }
 
         this.connection.send(msg);


### PR DESCRIPTION
Issue #1592, regarding a crash when using the `JitsiConference.sendMessage` method with an object, was fixed in #1600, but I believe this to only be an ad hoc fix, which does not address the underlying issue.

## Relevant original code

```js
if (elementName === 'body') {
    msg.c(elementName, message).up();
} else {
    msg.c(elementName, { xmlns: 'http://jitsi.org/jitmeet' }, message)
        .up();
}
if (nickname) {
    msg.c('nick', { xmlns: 'http://jabber.org/protocol/nick' })
        .t(nickname)
        .up()
        .up();
}
```

## Relevant Strophe.JS documentation

**For Strophe.Builder.c:**

> Add a child to the current element and make it the new current element.
> This function moves the current element pointer to the child, **unless text is provided**. If you need to add another child, it is necessary to use up() to go back to the parent in the tree.
> 
> Parameters:
> (String) name | The name of the child.
> (Object) attrs | The attributes of the child in object notation.
> (String) text | The text to add to the child.

**For Strophe.Builder.t:**

> Add a child text element.
> This does not make the child the new current element since there are no children of text elements.

## The problem

In the first two uses of `.c()` in the above code, a `message` is provided, which implies that the "current element pointer" is not moved by the call. Thus, calling `.up()` is unnecessary in those cases, and doing it anyways ends up setting that pointer to `null`.

(The same thing happens with the `.t()` call, which never moves the current element pointer, thus only 1 `.up()` is required there.)

This causes a crash during the third `.c()` call, because the builder attempts to add a child element to the "null" pointer, causing the "Cannot read property 'appendChild' of null" exception mentioned in the original issue.

## The trigger

The reason the crash only occurs when sending an object through `sendMessage` and not when sending a text message, is because of another mistake when calling the Strophe API.

In the first branch of the first "if" statement, which is taken when sending a text message rather than a JSON message, the *middle* argument of `.c()` (`attrs`) is omitted. This is not planned by the Strophe API, for which only the final argument can be omitted.

The reason this somehow still sets the message correctly is complicated and has to do with the internals of the `.c()` function. But in the end, because the proper `message` argument is left undefined, the function does not respect the documented behavior and sets the current element pointer to the new child element, preventing the crash afterwards.

## The current fix

#1600 fixed the original reported crash by simply removing the nickname tag addition (the third block), which, it turns out, was not actually being used for anything.

Since the message is sent right afterwards, and the builder is not used again, this does technically prevent the crash.

## Conclusion

I hope I have made clear that:
- The reason this code currently works is nothing short of a miracle: two incorrect API calls somehow "cancel each other out" in the case of text messages, but cause an invalid state in the case of JSON messages, which is no longer depended on after the fix.
- Any further modifications or additions to this function risk breaking it again.

I believe this simple PR should address these concerns.
