### PR TITLE
fix(RTC): Set transceiver direction after RTCRtpSender#replaceTrack.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2799,7 +2799,7 @@ JitsiConference.prototype._acceptP2PIncomingCall = function(
         this.p2pJingleSession.peerconnection,
         remoteID);
 
-    const localTracks = this._getInitialLocalTracks();
+    const localTracks = this.getLocalTracks();
 
     this.p2pJingleSession.acceptOffer(
         jingleOffer,
@@ -3159,7 +3159,7 @@ JitsiConference.prototype._startP2PSession = function(remoteJid) {
         this.p2pJingleSession.peerconnection,
         remoteID);
 
-    const localTracks = this._getInitialLocalTracks();
+    const localTracks = this.getLocalTracks();
 
     this.p2pJingleSession.invite(localTracks);
 };

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -403,24 +403,6 @@ export default class JitsiLocalTrack extends JitsiTrack {
 
         this._setEffectInProgress = true;
 
-        if (browser.usesUnifiedPlan()) {
-            this._switchStreamEffect(effect);
-            if (this.isVideoTrack()) {
-                this.containers.forEach(cont => RTCUtils.attachMediaStream(cont, this.stream));
-            }
-
-            return conference.replaceTrack(this, this)
-                .then(() => {
-                    this._setEffectInProgress = false;
-                })
-                .catch(error => {
-                    this._setEffectInProgress = false;
-                    this._switchStreamEffect();
-                    logger.error('Failed to switch to the new stream!', error);
-                    throw error;
-                });
-        }
-
         // TODO: Create new JingleSessionPC method for replacing a stream in JitsiLocalTrack without offer answer.
         return conference.removeTrack(this)
             .then(() => {

--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -3,6 +3,7 @@
 import { getLogger } from 'jitsi-meet-logger';
 
 import * as MediaType from '../../service/RTC/MediaType';
+import browser from '../browser';
 
 import { SdpTransformWrap } from './SdpTransformUtil';
 
@@ -189,14 +190,21 @@ export default class LocalSdpMunger {
                         }
                         ssrcLine.value = `${streamId}-${pcId} ${trackId}-${pcId}`;
                     } else {
-                        logger.warn(
-                            'Unable to munge local MSID'
-                                + `- weird format detected: ${ssrcLine.value}`);
+                        logger.warn(`Unable to munge local MSID - weird format detected: ${ssrcLine.value}`);
                     }
                 }
                 break;
             }
             }
+        }
+
+        // If the msid attribute is missing, then remove the ssrc from the transformed description so that a
+        // source-remove is signaled to Jicofo. This happens when the direction of the transceiver (or m-line)
+        // is set to 'inactive' or 'recvonly' on Firefox.
+        const msid = mediaSection.ssrcs.find(s => s.attribute === 'msid');
+
+        if (!msid && browser.isFirefox()) {
+            mediaSection.ssrcs = undefined;
         }
     }
 

--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -3,7 +3,6 @@
 import { getLogger } from 'jitsi-meet-logger';
 
 import * as MediaType from '../../service/RTC/MediaType';
-import browser from '../browser';
 
 import { SdpTransformWrap } from './SdpTransformUtil';
 
@@ -200,11 +199,13 @@ export default class LocalSdpMunger {
 
         // If the msid attribute is missing, then remove the ssrc from the transformed description so that a
         // source-remove is signaled to Jicofo. This happens when the direction of the transceiver (or m-line)
-        // is set to 'inactive' or 'recvonly' on Firefox.
+        // is set to 'inactive' or 'recvonly' on Firefox, Chrome (unified) and Safari.
         const msid = mediaSection.ssrcs.find(s => s.attribute === 'msid');
 
-        if (!msid && browser.isFirefox()) {
+        if (!this.tpc.isP2P
+            && (!msid || mediaSection.direction === 'recvonly' || mediaSection.direction === 'inactive')) {
             mediaSection.ssrcs = undefined;
+            mediaSection.ssrcGroups = undefined;
         }
     }
 

--- a/modules/sdp/LocalSdpMunger.spec.js
+++ b/modules/sdp/LocalSdpMunger.spec.js
@@ -1,0 +1,80 @@
+
+import * as transform from 'sdp-transform';
+
+import LocalSdpMunger from './LocalSdpMunger';
+import { default as SampleSdpStrings } from './SampleSdpStrings.js';
+
+/**
+ * Returns the associated ssrc lines for a given media type.
+ *
+ * @param {RTCSessionDescription} desc
+ * @param {string} mediaType
+ * @returns
+ */
+function getSsrcLines(desc, mediaType) {
+    const mline = desc.media.find(m => m.type === mediaType);
+
+    return mline.ssrcs ?? [];
+}
+
+describe('TransformRecvOnly', () => {
+    let localSdpMunger;
+    const tpc = { id: '1' };
+    const localEndpointId = 'sRdpsdg';
+
+    beforeEach(() => {
+        localSdpMunger = new LocalSdpMunger(tpc, localEndpointId);
+    });
+    describe('stripSsrcs', () => {
+        beforeEach(() => { }); // eslint-disable-line no-empty-function
+        it('should strip ssrcs from an sdp with no msid', () => {
+            const sdpStr = transform.write(SampleSdpStrings.recvOnlySdp);
+            const desc = new RTCSessionDescription({
+                type: 'offer',
+                sdp: sdpStr
+            });
+            const transformedDesc = localSdpMunger.transformStreamIdentifiers(desc);
+            const newSdp = transform.parse(transformedDesc.sdp);
+            const audioSsrcs = getSsrcLines(newSdp, 'audio');
+            const videoSsrcs = getSsrcLines(newSdp, 'video');
+
+            expect(audioSsrcs.length).toEqual(0);
+            expect(videoSsrcs.length).toEqual(0);
+        });
+
+        it('should do nothing to an sdp with msid', () => {
+            const sdpStr = transform.write(SampleSdpStrings.simulcastSdp);
+            const desc = new RTCSessionDescription({
+                type: 'offer',
+                sdp: sdpStr
+            });
+            const transformedDesc = localSdpMunger.transformStreamIdentifiers(desc);
+            const newSdp = transform.parse(transformedDesc.sdp);
+            const audioSsrcs = getSsrcLines(newSdp, 'audio');
+            const videoSsrcs = getSsrcLines(newSdp, 'video');
+
+            expect(audioSsrcs.length).toEqual(4);
+            expect(videoSsrcs.length).toEqual(6);
+        });
+
+        it('should add endpointId to msid', () => {
+            const sdpStr = transform.write(SampleSdpStrings.firefoxSdp);
+            const desc = new RTCSessionDescription({
+                type: 'offer',
+                sdp: sdpStr
+            });
+            const transformedDesc = localSdpMunger.transformStreamIdentifiers(desc);
+            const newSdp = transform.parse(transformedDesc.sdp);
+
+            const videoSsrcs = getSsrcLines(newSdp, 'video');
+
+            for (const ssrcLine of videoSsrcs) {
+                if (ssrcLine.attribute === 'msid') {
+                    const msid = ssrcLine.value.split(' ')[0];
+
+                    expect(msid).toBe(`${localEndpointId}-video-${tpc.id}`);
+                }
+            }
+        });
+    });
+});

--- a/modules/sdp/LocalSdpMunger.spec.js
+++ b/modules/sdp/LocalSdpMunger.spec.js
@@ -76,5 +76,22 @@ describe('TransformRecvOnly', () => {
                 }
             }
         });
+
+        it('should add msid', () => {
+            // P2P case only.
+            localSdpMunger.tpc.isP2P = true;
+
+            const sdpStr = transform.write(SampleSdpStrings.firefoxP2pSdp);
+            const desc = new RTCSessionDescription({
+                type: 'offer',
+                sdp: sdpStr
+            });
+            const transformedDesc = localSdpMunger.transformStreamIdentifiers(desc);
+            const newSdp = transform.parse(transformedDesc.sdp);
+            const videoSsrcs = getSsrcLines(newSdp, 'video');
+            const msidExists = videoSsrcs.find(s => s.attribute === 'msid');
+
+            expect(msidExists).toBeDefined();
+        });
     });
 });

--- a/modules/sdp/SampleSdpStrings.js
+++ b/modules/sdp/SampleSdpStrings.js
@@ -359,6 +359,27 @@ const videoMlineFF = ''
 + 'a=ssrc:984899560 cname:peDGrDD6WsxUOki/\r\n'
 + 'a=rtcp-mux\r\n';
 
+const videoLineP2pFF = ''
++ 'm=video 9 RTP/SAVPF 100 96\r\n'
++ 'c=IN IP4 0.0.0.0\r\n'
++ 'a=rtpmap:100 VP8/90000\r\n'
++ 'a=fmtp:96 apt=100\r\n'
++ 'a=rtcp:9 IN IP4 0.0.0.0\r\n'
++ 'a=rtcp-fb:100 ccm fir\r\n'
++ 'a=rtcp-fb:100 nack\r\n'
++ 'a=rtcp-fb:100 nack pli\r\n'
++ 'a=rtcp-fb:100 goog-remb\r\n'
++ 'a=msid:6149665b-f876-4a28-ac10-f92fc308b01a 5d5d4fbd-edbb-404f-8285-2543a401c426\r\n'
++ 'a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\n'
++ 'a=setup:passive\r\n'
++ 'a=mid:video\r\n'
++ 'a=sendrecv\r\n'
++ 'a=ice-ufrag:adPg\r\n'
++ 'a=ice-pwd:Xsr05Mq8S7CR44DAnusZE26F\r\n'
++ 'a=fingerprint:sha-256 6A:39:DE:11:24:AD:2E:4E:63:D6:69:D3:85:05:53:C7:3C:38:A4:B7:91:74:C0:91:44:FC:94:63:7F:01:AB:A9\r\n'
++ 'a=ssrc:984899560 cname:peDGrDD6WsxUOki/\r\n'
++ 'a=rtcp-mux\r\n';
+
 // A full sdp string representing a client doing simulcast
 const simulcastSdpStr = baseSessionSdp + baseAudioMLineSdp + simulcastVideoMLineSdp + baseDataMLineSdp;
 
@@ -380,7 +401,11 @@ const flexFecSdpStr = baseSessionSdp + baseAudioMLineSdp + flexFecVideoMLineSdp 
 // A full sdp string representing a client that doesn't have local sources added on Firefox.
 const recvOnlySdpStr = baseSessionSdp + recvOnlyAudioMline + recvOnlyVideoMline;
 
+// A full sdp string representing a Firefox client with msid set to '-'.
 const sdpFirefoxStr = baseSessionSdp + baseAudioMLineSdp + videoMlineFF;
+
+// A full sdp string representing a Firefox client with missing msid attribute.
+const sdpFirefoxP2pStr = baseSessionSdp + baseAudioMLineSdp + videoLineP2pFF;
 
 export default {
     get simulcastSdp() {
@@ -413,7 +438,12 @@ export default {
 
     get firefoxSdp() {
         return transform.parse(sdpFirefoxStr);
+    },
+
+    get firefoxP2pSdp() {
+        return transform.parse(sdpFirefoxP2pStr);
     }
+
 };
 
 /* eslint-enable max-len*/

--- a/modules/sdp/SampleSdpStrings.js
+++ b/modules/sdp/SampleSdpStrings.js
@@ -269,6 +269,96 @@ const flexFecVideoMLineSdp = ''
 + 'a=mid:data\r\n'
 + 'a=sctpmap:5000 webrtc-datachannel 1024\r\n';
 
+const recvOnlyAudioMline = ''
++ 'm=audio 54405 RTP/SAVPF 111 103 104 126\r\n'
++ 'c=IN IP4 172.29.32.39\r\n'
++ 'a=rtpmap:111 opus/48000/2\r\n'
++ 'a=rtpmap:103 ISAC/16000\r\n'
++ 'a=rtpmap:104 ISAC/32000\r\n'
++ 'a=rtpmap:126 telephone-event/8000\r\n'
++ 'a=fmtp:111 minptime=10;useinbandfec=1\r\n'
++ 'a=rtcp:9 IN IP4 0.0.0.0\r\n'
++ 'a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n'
++ 'a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\n'
++ 'a=setup:passive\r\n'
++ 'a=mid:audio\r\n'
++ 'a=recvonly\r\n'
++ 'a=ice-ufrag:adPg\r\n'
++ 'a=ice-pwd:Xsr05Mq8S7CR44DAnusZE26F\r\n'
++ 'a=fingerprint:sha-256 6A:39:DE:11:24:AD:2E:4E:63:D6:69:D3:85:05:53:C7:3C:38:A4:B7:91:74:C0:91:44:FC:94:63:7F:01:AB:A9\r\n'
++ 'a=candidate:1581043602 1 udp 2122260223 172.29.32.39 54405 typ host generation 0\r\n'
++ 'a=ssrc:124723944 cname:peDGrDD6WsxUOki\r\n'
++ 'a=rtcp-mux\r\n';
+
+const recvOnlyVideoMline = ''
++ 'm=video 9 RTP/SAVPF 96 97 98 99 102 121 127 120\r\n'
++ 'c=IN IP4 0.0.0.0\r\n'
++ 'a=rtpmap:96 VP8/90000\r\n'
++ 'a=rtpmap:97 rtx/90000\r\n'
++ 'a=rtpmap:98 VP9/90000\r\n'
++ 'a=rtpmap:99 rtx/90000\r\n'
++ 'a=rtpmap:102 H264/90000\r\n'
++ 'a=rtpmap:121 rtx/90000\r\n'
++ 'a=rtpmap:127 H264/90000\r\n'
++ 'a=rtpmap:120 rtx/90000\r\n'
++ 'a=rtcp:9 IN IP4 0.0.0.0\r\n'
++ 'a=rtcp-fb:96 ccm fir\r\n'
++ 'a=rtcp-fb:96 transport-cc\r\n'
++ 'a=rtcp-fb:96 nack\r\n'
++ 'a=rtcp-fb:96 nack pli\r\n'
++ 'a=rtcp-fb:96 goog-remb\r\n'
++ 'a=rtcp-fb:98 ccm fir\r\n'
++ 'a=rtcp-fb:98 transport-cc\r\n'
++ 'a=rtcp-fb:98 nack\r\n'
++ 'a=rtcp-fb:98 nack pli\r\n'
++ 'a=rtcp-fb:98 goog-remb\r\n'
++ 'a=rtcp-fb:102 ccm fir\r\n'
++ 'a=rtcp-fb:102 transport-cc\r\n'
++ 'a=rtcp-fb:102 nack\r\n'
++ 'a=rtcp-fb:102 nack pli\r\n'
++ 'a=rtcp-fb:102 goog-remb\r\n'
++ 'a=rtcp-fb:127 ccm fir\r\n'
++ 'a=rtcp-fb:127 transport-cc\r\n'
++ 'a=rtcp-fb:127 nack\r\n'
++ 'a=rtcp-fb:127 nack pli\r\n'
++ 'a=rtcp-fb:127 goog-remb\r\n'
++ 'a=fmtp:97 apt=96\r\n'
++ 'a=fmtp:98 profile-id=0\r\n'
++ 'a=fmtp:102 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1\r\n'
++ 'a=fmtp:121 apt=102\r\n'
++ 'a=fmtp:127 profile-level-id=42e01f;level-asymmetry-allowed=1:packetization-mode=0\r\n'
++ 'a=fmtp:120 apt=127\r\n'
++ 'a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\n'
++ 'a=setup:passive\r\n'
++ 'a=mid:video\r\n'
++ 'a=recvonly\r\n'
++ 'a=ice-ufrag:adPg\r\n'
++ 'a=ice-pwd:Xsr05Mq8S7CR44DAnusZE26F\r\n'
++ 'a=fingerprint:sha-256 6A:39:DE:11:24:AD:2E:4E:63:D6:69:D3:85:05:53:C7:3C:38:A4:B7:91:74:C0:91:44:FC:94:63:7F:01:AB:A9\r\n'
++ 'a=ssrc:1757014965 cname:peDGrDD6WsxUOki\r\n'
++ 'a=rtcp-mux\r\n';
+
+const videoMlineFF = ''
++ 'm=video 9 RTP/SAVPF 100 96\r\n'
++ 'c=IN IP4 0.0.0.0\r\n'
++ 'a=rtpmap:100 VP8/90000\r\n'
++ 'a=fmtp:96 apt=100\r\n'
++ 'a=rtcp:9 IN IP4 0.0.0.0\r\n'
++ 'a=rtcp-fb:100 ccm fir\r\n'
++ 'a=rtcp-fb:100 nack\r\n'
++ 'a=rtcp-fb:100 nack pli\r\n'
++ 'a=rtcp-fb:100 goog-remb\r\n'
++ 'a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\n'
++ 'a=setup:passive\r\n'
++ 'a=mid:video\r\n'
++ 'a=sendrecv\r\n'
++ 'a=ice-ufrag:adPg\r\n'
++ 'a=ice-pwd:Xsr05Mq8S7CR44DAnusZE26F\r\n'
++ 'a=fingerprint:sha-256 6A:39:DE:11:24:AD:2E:4E:63:D6:69:D3:85:05:53:C7:3C:38:A4:B7:91:74:C0:91:44:FC:94:63:7F:01:AB:A9\r\n'
++ 'a=ssrc:984899560 msid:- bdbd2c0a-7959-4578-8db5-9a6a1aec4ecf\r\n'
++ 'a=ssrc:984899560 cname:peDGrDD6WsxUOki/\r\n'
++ 'a=rtcp-mux\r\n';
+
 // A full sdp string representing a client doing simulcast
 const simulcastSdpStr = baseSessionSdp + baseAudioMLineSdp + simulcastVideoMLineSdp + baseDataMLineSdp;
 
@@ -286,6 +376,11 @@ const multiCodecVideoSdpStr = baseSessionSdp + baseAudioMLineSdp + multiCodecVid
 
 // A full sdp string representing a client doing a single video stream with flexfec
 const flexFecSdpStr = baseSessionSdp + baseAudioMLineSdp + flexFecVideoMLineSdp + baseDataMLineSdp;
+
+// A full sdp string representing a client that doesn't have local sources added on Firefox.
+const recvOnlySdpStr = baseSessionSdp + recvOnlyAudioMline + recvOnlyVideoMline;
+
+const sdpFirefoxStr = baseSessionSdp + baseAudioMLineSdp + videoMlineFF;
 
 export default {
     get simulcastSdp() {
@@ -310,6 +405,14 @@ export default {
 
     get flexFecSdp() {
         return transform.parse(flexFecSdpStr);
+    },
+
+    get recvOnlySdp() {
+        return transform.parse(recvOnlySdpStr);
+    },
+
+    get firefoxSdp() {
+        return transform.parse(sdpFirefoxStr);
     }
 };
 

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1813,13 +1813,8 @@ export default class JingleSessionPC extends JingleSession {
                     if (mid > -1) {
                         remoteSdp.media[mid] = remoteSdp.media[mid].replace(`${line}\r\n`, '');
 
-                        // Change the direction to "inactive" only on Firefox. Audio fails on
-                        // Safari (possibly Chrome in unified plan mode) when we try to re-use inactive
-                        // m-lines due to a webkit bug.
-                        // https://bugs.webkit.org/show_bug.cgi?id=211181
-                        if (browser.isFirefox()) {
-                            remoteSdp.media[mid] = remoteSdp.media[mid].replace('a=sendonly', 'a=inactive');
-                        }
+                        // Change the direction to "inactive".
+                        remoteSdp.media[mid] = remoteSdp.media[mid].replace('a=sendonly', 'a=inactive');
                     }
                 });
             }

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -558,13 +558,7 @@ export default class JingleSessionPC extends JingleSession {
                         .then(() => {
                             const newSdp = new SDP(this.peerconnection.localDescription.sdp);
 
-                            // Skip the ssrc update from Firefox when onnegotiationneeded is fired as a result of media
-                            // direction set to 'inactive' for JVB session (i.e., when media is suspended over jvb
-                            // connection). This results in a source-remove/source-add being sent to Jicofo whenever
-                            // the media direction changes which is unnecessary.
-                            const skipUpdate = browser.isFirefox() && !this.isP2P && !this._localVideoActive;
-
-                            !skipUpdate && this.notifyMySSRCUpdate(oldSdp, newSdp);
+                            this.notifyMySSRCUpdate(oldSdp, newSdp);
                             finishedCallback();
                         },
                         finishedCallback /* will be called with en error */);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1314,9 +1314,8 @@
       }
     },
     "@jitsi/sdp-interop": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jitsi/sdp-interop/-/sdp-interop-1.0.3.tgz",
-      "integrity": "sha512-3dua2TTDWwpFpdEl+sMEei4d/+VgVXMpQRCPdvzzOidiiHnJ0vAJONfndKJmhhaqYv+e71Ry5IPGV1ZSWjIDJw==",
+      "version": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",
+      "from": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",
       "requires": {
         "lodash.clonedeep": "4.5.0",
         "sdp-transform": "2.3.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "@jitsi/js-utils": "1.0.2",
-    "@jitsi/sdp-interop": "1.0.3",
+    "@jitsi/sdp-interop": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",
     "@jitsi/sdp-simulcast": "0.4.0",
     "async": "0.9.0",
     "base64-js": "1.3.1",


### PR DESCRIPTION
This fixes the issue where TRACK_REMOVED event is not fired when a remote track is removed from the peerconnection.
Fixes https://github.com/jitsi/lib-jitsi-meet/issues/1612 and https://github.com/jitsi/jitsi-meet/issues/8482.