### PR TITLE
fix(caps): Disable TCC on Firefox.

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -219,7 +219,9 @@ export default class XMPP extends Listenable {
         if (typeof this.options.enableRemb === 'undefined' || this.options.enableRemb) {
             this.caps.addFeature('http://jitsi.org/remb');
         }
-        if (typeof this.options.enableTcc === 'undefined' || this.options.enableTcc) {
+
+        // Disable TCC on Firefox because of a known issue where BWE is halved on every renegotiation.
+        if (!browser.isFirefox() && (typeof this.options.enableTcc === 'undefined' || this.options.enableTcc)) {
             this.caps.addFeature('http://jitsi.org/tcc');
         }
 


### PR DESCRIPTION
There is a known issue with Firefox where the BWE gets halved on every renegotiation causing the low upload bitrates from the Firefox clients.