### PR TITLE
fix(moderation): Unmuting after av moderation and no track.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1130,6 +1130,10 @@ JitsiConference.prototype.replaceTrack = function(oldTrack, newTrack) {
                 oldTrack && oldTrack.isVideoTrack() && this.rtc.setVideoType(VideoType.NONE);
             }
 
+            if (this.isMutedByFocus || this.isVideoMutedByFocus) {
+                this._fireMuteChangeEvent(newTrack);
+            }
+
             return Promise.resolve();
         })
         .catch(error => Promise.reject(new Error(error)));


### PR DESCRIPTION
When started muted and no tracks are being created and we were muted by focus (av moderation) we need to unmute the channels on the bridge after creating the tracks.