### PR TITLE
Fix media direction p2p

### DIFF
--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -2,6 +2,7 @@
 
 import { getLogger } from 'jitsi-meet-logger';
 
+import MediaDirection from '../../service/RTC/MediaDirection';
 import * as MediaType from '../../service/RTC/MediaType';
 
 import { SdpTransformWrap } from './SdpTransformUtil';
@@ -101,7 +102,7 @@ export default class LocalSdpMunger {
             // NOTE the SDP produced here goes only to Jicofo and is never set
             // as localDescription. That's why
             // TraceablePeerConnection.mediaTransferActive is ignored here.
-            videoMLine.direction = 'sendrecv';
+            videoMLine.direction = MediaDirection.SENDRECV;
 
             // Check if the recvonly has MSID
             const primarySSRC = requiredSSRCs[0];
@@ -224,14 +225,14 @@ export default class LocalSdpMunger {
 
         if (!this.tpc.isP2P
             && (!msid
-                || mediaSection.mLine?.direction === 'recvonly'
-                || mediaSection.mLine?.direction === 'inactive')) {
+                || mediaSection.mLine?.direction === MediaDirection.RECVONLY
+                || mediaSection.mLine?.direction === MediaDirection.INACTIVE)) {
             mediaSection.ssrcs = undefined;
             mediaSection.ssrcGroups = undefined;
 
         // Add the msid attribute if it is missing for p2p sources. Firefox doesn't produce a a=ssrc line
         // with msid attribute.
-        } else if (this.tpc.isP2P && mediaSection.mLine?.direction === 'sendrecv') {
+        } else if (this.tpc.isP2P && mediaSection.mLine?.direction === MediaDirection.SENDRECV) {
             const msidLine = mediaSection.mLine?.msid;
             const trackId = msidLine && msidLine.split(' ')[1];
             const sources = [ ...new Set(mediaSection.mLine?.ssrcs?.map(s => s.id)) ];

--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -1,5 +1,6 @@
 /* global $ */
 
+import MediaDirection from '../../service/RTC/MediaDirection';
 import browser from '../browser';
 
 import SDPUtil from './SDPUtil';
@@ -304,16 +305,16 @@ SDP.prototype.toJingle = function(elem, thecreator) {
 
                     // eslint-disable-next-line max-depth
                     switch (extmap.direction) {
-                    case 'sendonly':
+                    case MediaDirection.SENDONLY:
                         elem.attrs({ senders: 'responder' });
                         break;
-                    case 'recvonly':
+                    case MediaDirection.RECVONLY:
                         elem.attrs({ senders: 'initiator' });
                         break;
-                    case 'sendrecv':
+                    case MediaDirection.SENDRECV:
                         elem.attrs({ senders: 'both' });
                         break;
-                    case 'inactive':
+                    case MediaDirection.INACTIVE:
                         elem.attrs({ senders: 'none' });
                         break;
                     }
@@ -330,13 +331,13 @@ SDP.prototype.toJingle = function(elem, thecreator) {
 
         const m = this.media[i];
 
-        if (SDPUtil.findLine(m, 'a=sendrecv', this.session)) {
+        if (SDPUtil.findLine(m, `a=${MediaDirection.SENDRECV}`, this.session)) {
             elem.attrs({ senders: 'both' });
-        } else if (SDPUtil.findLine(m, 'a=sendonly', this.session)) {
+        } else if (SDPUtil.findLine(m, `a=${MediaDirection.SENDONLY}`, this.session)) {
             elem.attrs({ senders: 'initiator' });
-        } else if (SDPUtil.findLine(m, 'a=recvonly', this.session)) {
+        } else if (SDPUtil.findLine(m, `a=${MediaDirection.RECVONLY}`, this.session)) {
             elem.attrs({ senders: 'responder' });
-        } else if (SDPUtil.findLine(m, 'a=inactive', this.session)) {
+        } else if (SDPUtil.findLine(m, `a=${MediaDirection.INACTIVE}`, this.session)) {
             elem.attrs({ senders: 'none' });
         }
 
@@ -631,16 +632,16 @@ SDP.prototype.jingle2media = function(content) {
 
     switch (content.attr('senders')) {
     case 'initiator':
-        sdp += 'a=sendonly\r\n';
+        sdp += `a=${MediaDirection.SENDONLY}\r\n`;
         break;
     case 'responder':
-        sdp += 'a=recvonly\r\n';
+        sdp += `a=${MediaDirection.RECVONLY}\r\n`;
         break;
     case 'none':
-        sdp += 'a=inactive\r\n';
+        sdp += `a=${MediaDirection.INACTIVE}\r\n`;
         break;
     case 'both':
-        sdp += 'a=sendrecv\r\n';
+        sdp += `a=${MediaDirection.SENDRECV}\r\n`;
         break;
     }
     sdp += `a=mid:${content.attr('name')}\r\n`;

--- a/modules/sdp/SDPUtil.js
+++ b/modules/sdp/SDPUtil.js
@@ -2,6 +2,7 @@ import { getLogger } from 'jitsi-meet-logger';
 const logger = getLogger(__filename);
 
 import CodecMimeType from '../../service/RTC/CodecMimeType';
+import MediaDirection from '../../service/RTC/MediaDirection';
 import browser from '../browser';
 import RandomUtil from '../util/RandomUtil';
 
@@ -657,7 +658,7 @@ const SDPUtil = {
             if (keepPts.length === 0) {
                 // There are no other codecs, disable the stream.
                 mLine.port = 0;
-                mLine.direction = 'inactive';
+                mLine.direction = MediaDirection.INACTIVE;
                 mLine.payloads = '*';
             } else {
                 mLine.payloads = keepPts.join(' ');

--- a/service/RTC/MediaDirection.js
+++ b/service/RTC/MediaDirection.js
@@ -1,0 +1,28 @@
+/* global module */
+/**
+ * Enumeration of the media direction types.
+ * @type {{INACTIVE: string, RECVONLY: string, SENDONLY: string, SENDRECV: string}}
+ */
+const MediaDirection = {
+    /**
+     * Media is send and receive is suspended.
+     */
+    INACTIVE: 'inactive',
+
+    /**
+     * Media is only received from remote peer.
+     */
+    RECVONLY: 'recvonly',
+
+    /**
+     * Media is only sent to the remote peer.
+     */
+    SENDONLY: 'sendonly',
+
+    /**
+     * Media is sent and received.
+     */
+    SENDRECV: 'sendrecv'
+};
+
+module.exports = MediaDirection;


### PR DESCRIPTION
Introduce an enum for media direction.
For p2p connections, the media direction needs to be adjusted after every source-add/source-remove is processed based on the availability of local sources.
