### PR TITLE
feat(replace-participant): Replace participant with same jwt in the conf

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -516,10 +516,12 @@ JitsiConference.prototype._init = function(options = {}) {
 /**
  * Joins the conference.
  * @param password {string} the password
+ * @param replaceParticipant {boolean} whether the current join replaces
+ * an existing participant with same jwt from the meeting.
  */
-JitsiConference.prototype.join = function(password) {
+JitsiConference.prototype.join = function(password, replaceParticipant = false) {
     if (this.room) {
-        this.room.join(password).then(() => this._maybeSetSITimeout());
+        this.room.join(password, replaceParticipant).then(() => this._maybeSetSITimeout());
     }
 };
 
@@ -1584,9 +1586,11 @@ JitsiConference.prototype.muteParticipant = function(id, mediaType) {
  * @param botType the member botType, if any
  * @param fullJid the member full jid, if any
  * @param features the member botType, if any
+ * @param isReplaceParticipant whether this join replaces a participant with
+ * the same jwt.
  */
 JitsiConference.prototype.onMemberJoined = function(
-        jid, nick, role, isHidden, statsID, status, identity, botType, fullJid, features) {
+        jid, nick, role, isHidden, statsID, status, identity, botType, fullJid, features, isReplaceParticipant) {
     const id = Strophe.getResourceFromJid(jid);
 
     if (id === 'focus' || this.myUserId() === id) {
@@ -1599,6 +1603,7 @@ JitsiConference.prototype.onMemberJoined = function(
     participant.setRole(role);
     participant.setBotType(botType);
     participant.setFeatures(features);
+    participant.setIsReplacing(isReplaceParticipant);
 
     this.participants[id] = participant;
     this.eventEmitter.emit(
@@ -1727,6 +1732,8 @@ JitsiConference.prototype.onMemberLeft = function(jid) {
         });
 };
 
+/* eslint-disable max-params */
+
 /**
  * Designates an event indicating that we were kicked from the XMPP MUC.
  * @param {boolean} isSelfPresence - whether it is for local participant
@@ -1736,8 +1743,15 @@ JitsiConference.prototype.onMemberLeft = function(jid) {
  * @param {string?} kickedParticipantId - when it is not a kick for local participant,
  * this is the id of the participant which was kicked.
  * @param {string} reason - reason of the participant to kick
+ * @param {boolean?} isReplaceParticipant - whether this is a server initiated kick in order
+ * to replace it with a participant with same jwt.
  */
-JitsiConference.prototype.onMemberKicked = function(isSelfPresence, actorId, kickedParticipantId, reason) {
+JitsiConference.prototype.onMemberKicked = function(
+        isSelfPresence,
+        actorId,
+        kickedParticipantId,
+        reason,
+        isReplaceParticipant) {
     // This check which be true when we kick someone else. With the introduction of lobby
     // the ChatRoom KICKED event is now also emitted for ourselves (the kicker) so we want to
     // avoid emitting an event where `undefined` kicked someone.
@@ -1749,7 +1763,7 @@ JitsiConference.prototype.onMemberKicked = function(isSelfPresence, actorId, kic
 
     if (isSelfPresence) {
         this.eventEmitter.emit(
-            JitsiConferenceEvents.KICKED, actorParticipant, reason);
+            JitsiConferenceEvents.KICKED, actorParticipant, reason, isReplaceParticipant);
 
         this.leave();
 
@@ -1757,6 +1771,8 @@ JitsiConference.prototype.onMemberKicked = function(isSelfPresence, actorId, kic
     }
 
     const kickedParticipant = this.participants[kickedParticipantId];
+
+    kickedParticipant.setIsReplaced(isReplaceParticipant);
 
     this.eventEmitter.emit(
         JitsiConferenceEvents.PARTICIPANT_KICKED, actorParticipant, kickedParticipant, reason);

--- a/JitsiParticipant.js
+++ b/JitsiParticipant.js
@@ -26,8 +26,10 @@ export default class JitsiParticipant {
      * @param {string} statsID - optional participant statsID
      * @param {string} status - the initial status if any.
      * @param {object} identity - the xmpp identity
+     * @param {boolean?} isReplacing - whether this is a participant replacing another into the meeting.
+     * @param {boolean?} isReplaced - whether this is a participant to be kicked and replaced into the meeting.
      */
-    constructor(jid, conference, displayName, hidden, statsID, status, identity) {
+    constructor(jid, conference, displayName, hidden, statsID, status, identity, isReplacing, isReplaced) {
         this._jid = jid;
         this._id = Strophe.getResourceFromJid(jid);
         this._conference = conference;
@@ -41,6 +43,8 @@ export default class JitsiParticipant {
         this._connectionStatus = ParticipantConnectionStatus.ACTIVE;
         this._properties = {};
         this._identity = identity;
+        this._isReplacing = isReplacing;
+        this._isReplaced = isReplaced;
         this._features = new Set();
     }
 
@@ -187,6 +191,22 @@ export default class JitsiParticipant {
     }
 
     /**
+     * @returns {Boolean} Wheter this participants replaces another participant
+     * from the meeting.
+     */
+    isReplacing() {
+        return this._isReplacing;
+    }
+
+    /**
+     * @returns {Boolean} Wheter this participants will be replaced by another
+     * participant in the meeting.
+     */
+    isReplaced() {
+        return this._isReplaced;
+    }
+
+    /**
      * @returns {Boolean} Whether this participant has muted their audio.
      */
     isAudioMuted() {
@@ -231,6 +251,22 @@ export default class JitsiParticipant {
      */
     setRole(newRole) {
         this._role = newRole;
+    }
+
+    /**
+     * Sets whether participant is replacing another based on jwt.
+     * @param {String} newIsReplacing - whether is replacing.
+     */
+    setIsReplacing(newIsReplacing) {
+        this._isReplacing = newIsReplacing;
+    }
+
+    /**
+     * Sets whether participant is being replaced by another based on jwt.
+     * @param {String} newIsReplacing - whether is being replaced.
+     */
+    setIsReplaced(newIsReplaced) {
+        this._isReplaced = newIsReplaced;
     }
 
     /**

--- a/modules/xmpp/ChatRoom.spec.js
+++ b/modules/xmpp/ChatRoom.spec.js
@@ -177,7 +177,8 @@ describe('ChatRoom', () => {
                 undefined,
                 undefined,
                 'fulljid',
-                undefined // features
+                undefined, // features
+                0 // isReplaceParticipant
             ]);
         });
 
@@ -207,7 +208,39 @@ describe('ChatRoom', () => {
                 undefined,
                 undefined,
                 'jid=attr',
-                undefined); // features
+                undefined, // features
+                0); // isReplaceParticipant
+        });
+
+        it('parses muc user replacing other user correctly', () => {
+            const presStr = '' +
+              '<presence to="tojid" from="fromjid">' +
+                  '<x xmlns="http://jabber.org/protocol/muc#user">' +
+                      '<item jid="jid=attr" affiliation="affiliation-attr" role="role-attr"/>' +
+                  '</x>' +
+                  '<flip_device />' +
+              '</presence>';
+            const pres = new DOMParser().parseFromString(presStr, 'text/xml').documentElement;
+
+            room.onPresence(pres);
+            expect(emitterSpy.calls.count()).toEqual(2);
+            expect(emitterSpy.calls.argsFor(0)).toEqual([
+                XMPPEvents.PRESENCE_RECEIVED,
+                jasmine.any(Object)
+            ]);
+            expect(emitterSpy).toHaveBeenCalledWith(
+              XMPPEvents.MUC_MEMBER_JOINED,
+              'fromjid',
+              undefined, // nick
+              'role-attr', // role
+              jasmine.any(Boolean), // isHiddenDomain
+              undefined, // statsID
+              undefined,
+              undefined,
+              undefined,
+              'jid=attr',
+              undefined, // features
+              1); // isReplaceParticipant
         });
 
         it('parses identity correctly', () => {
@@ -254,7 +287,8 @@ describe('ChatRoom', () => {
                 expectedIdentity,
                 undefined,
                 'fulljid',
-                undefined // features
+                undefined, // features
+                0 // isReplaceParticipant
             ]);
         });
 
@@ -287,7 +321,8 @@ describe('ChatRoom', () => {
                 undefined,
                 expectedBotType,
                 'fulljid',
-                undefined // features
+                undefined, // features
+                0 // isReplaceParticipant
             ]);
         });
 


### PR DESCRIPTION
Replaces a participant with the same jwt relevant data into a conference when this is specifically asked on joining the conference.