### PR TITLE
fix: Send videoType bridge message for mute/unmute on FF.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1047,7 +1047,9 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
     // Send the video type message to the bridge if the track is not removed/added to the pc as part of
     // the mute/unmute operation. This currently happens only on Firefox.
     if (track.isVideoTrack() && !browser.doesVideoMuteByStreamRemove()) {
-        this.rtc.setVideoType(track.getVideoType());
+        const videoType = track.isMuted() ? VideoType.NONE : track.getVideoType();
+
+        this.rtc.setVideoType(videoType);
     }
 
     this.eventEmitter.emit(JitsiConferenceEvents.TRACK_MUTE_CHANGED, track, actorParticipant);

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1044,6 +1044,12 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
         actorParticipant = this.participants[actorId];
     }
 
+    // Send the video type message to the bridge if the track is not removed/added to the pc as part of
+    // the mute/unmute operation. This currently happens only on Firefox.
+    if (track.isVideoTrack() && !browser.doesVideoMuteByStreamRemove()) {
+        this.rtc.setVideoType(track.getVideoType());
+    }
+
     this.eventEmitter.emit(JitsiConferenceEvents.TRACK_MUTE_CHANGED, track, actorParticipant);
 };
 
@@ -1127,7 +1133,7 @@ JitsiConference.prototype.replaceTrack = function(oldTrack, newTrack) {
             if (newTrack) {
                 // Now handle the addition of the newTrack at the JitsiConference level
                 this._setupNewTrack(newTrack);
-                newTrack.isVideoTrack() && this.rtc.setVideoType(newTrack.videoType);
+                newTrack.isVideoTrack() && this.rtc.setVideoType(newTrack.getVideoType());
             } else {
                 oldTrack && oldTrack.isVideoTrack() && this.rtc.setVideoType(VideoType.NONE);
             }
@@ -1251,7 +1257,7 @@ JitsiConference.prototype._addLocalTrackAsUnmute = function(track) {
     return Promise.allSettled(addAsUnmutePromises)
         .then(() => {
             // Signal the video type to the bridge.
-            track.isVideoTrack() && this.rtc.setVideoType(track.videoType);
+            track.isVideoTrack() && this.rtc.setVideoType(track.getVideoType());
         });
 };
 

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -4,7 +4,6 @@ import { getLogger } from 'jitsi-meet-logger';
 
 import * as JitsiTrackEvents from '../../JitsiTrackEvents';
 import * as MediaType from '../../service/RTC/MediaType';
-import VideoType from '../../service/RTC/VideoType';
 import browser from '../browser';
 
 import RTCUtils from './RTCUtils';
@@ -179,7 +178,7 @@ export default class JitsiTrack extends EventEmitter {
      * Returns the video type (camera or desktop) of this track.
      */
     getVideoType() {
-        return this.isVideoTrack() && !this.isMuted() ? this.videoType : VideoType.NONE;
+        return this.videoType;
     }
 
     /**

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -4,6 +4,7 @@ import { getLogger } from 'jitsi-meet-logger';
 
 import * as JitsiTrackEvents from '../../JitsiTrackEvents';
 import * as MediaType from '../../service/RTC/MediaType';
+import VideoType from '../../service/RTC/VideoType';
 import browser from '../browser';
 
 import RTCUtils from './RTCUtils';
@@ -172,6 +173,13 @@ export default class JitsiTrack extends EventEmitter {
                 this._addMediaStreamInactiveHandler(this._streamInactiveHandler);
             }
         }
+    }
+
+    /**
+     * Returns the video type (camera or desktop) of this track.
+     */
+    getVideoType() {
+        return this.isVideoTrack() && !this.isMuted() ? this.videoType : VideoType.NONE;
     }
 
     /**

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -152,7 +152,7 @@ export default class RTC extends Listenable {
             = this._updateAudioOutputForAudioTracks.bind(this);
 
         // The default video type assumed by the bridge.
-        this._videoType = VideoType.CAMERA;
+        this._videoType = VideoType.NONE;
 
         // Switch audio output device on all remote audio tracks. Local audio
         // tracks handle this event by themselves.


### PR DESCRIPTION
Set the initial video type state to NONE to cover cases when the endpoint joins video muted.