### PR TITLE
fix(TPC): Do not remove ssrcs from remote desc for p2p.

### DIFF
--- a/modules/RTC/MockClasses.js
+++ b/modules/RTC/MockClasses.js
@@ -4,6 +4,18 @@
  * Mock {@link TraceablePeerConnection} - add things as needed, but only things useful for all tests.
  */
 export class MockPeerConnection {
+
+    /**
+     * Constructor.
+     *
+     * @param {string} id RTC id
+     * @param {boolean} usesUnifiedPlan
+     */
+    constructor(id, usesUnifiedPlan) {
+        this.id = id;
+        this._usesUnifiedPlan = usesUnifiedPlan;
+    }
+
     /**
      * {@link TraceablePeerConnection.localDescription}.
      *
@@ -64,6 +76,13 @@ export class MockPeerConnection {
      */
     setVideoTransferActive() {
         return false;
+    }
+
+    /**
+     * {@link TraceablePeerConnection.usesUnifiedPlan}.
+     */
+    usesUnifiedPlan() {
+        return this._usesUnifiedPlan;
     }
 }
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1972,8 +1972,8 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
 
         return this.tpcUtils.replaceTrack(oldTrack, newTrack)
 
-            // renegotiate when SDP is used for simulcast munging
-            .then(() => this.isSimulcastOn() && browser.usesSdpMungingForSimulcast());
+            // Renegotiate when SDP is used for simulcast munging or when in p2p mode.
+            .then(() => (this.isSimulcastOn() && browser.usesSdpMungingForSimulcast()) || this.isP2P);
     }
 
     logger.debug(`${this} TPC.replaceTrack using plan B`);
@@ -3041,6 +3041,15 @@ TraceablePeerConnection.prototype.generateNewStreamSSRCInfo = function(track) {
     this.localSSRCs.set(rtcId, ssrcInfo);
 
     return ssrcInfo;
+};
+
+/**
+ * Returns if the peer connection uses Unified plan implementation.
+ *
+ * @returns {boolean} True if the pc uses Unified plan, false otherwise.
+ */
+TraceablePeerConnection.prototype.usesUnifiedPlan = function() {
+    return this._usesUnifiedPlan;
 };
 
 /**

--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -218,21 +218,23 @@ export default class LocalSdpMunger {
             }
         }
 
+        // Additional transformations related to MSID are applicable to Unified-plan implementation only.
+        if (!this.tpc.usesUnifiedPlan()) {
+            return;
+        }
+
         // If the msid attribute is missing, then remove the ssrc from the transformed description so that a
         // source-remove is signaled to Jicofo. This happens when the direction of the transceiver (or m-line)
         // is set to 'inactive' or 'recvonly' on Firefox, Chrome (unified) and Safari.
-        const msid = mediaSection.ssrcs.find(s => s.attribute === 'msid');
+        const mediaDirection = mediaSection.mLine?.direction;
 
-        if (!this.tpc.isP2P
-            && (!msid
-                || mediaSection.mLine?.direction === MediaDirection.RECVONLY
-                || mediaSection.mLine?.direction === MediaDirection.INACTIVE)) {
+        if (mediaDirection === MediaDirection.RECVONLY || mediaDirection === MediaDirection.INACTIVE) {
             mediaSection.ssrcs = undefined;
             mediaSection.ssrcGroups = undefined;
 
-        // Add the msid attribute if it is missing for p2p sources. Firefox doesn't produce a a=ssrc line
-        // with msid attribute.
-        } else if (this.tpc.isP2P && mediaSection.mLine?.direction === MediaDirection.SENDRECV) {
+        // Add the msid attribute if it is missing when the direction is sendrecv/sendonly. Firefox doesn't produce a
+        // a=ssrc line with msid attribute for p2p connection.
+        } else {
             const msidLine = mediaSection.mLine?.msid;
             const trackId = msidLine && msidLine.split(' ')[1];
             const sources = [ ...new Set(mediaSection.mLine?.ssrcs?.map(s => s.id)) ];


### PR DESCRIPTION
In unified plan, re-use of m-line (i.e., adding an SSRC, removing it and then adding it back) causes the browser to not render the media on Chrome and Safari. The WebRTC spec is not clear as to how browsers have to behave, this doesn't cause any issues on Firefox. As a workaround, only change the media direction and leave the ssrc in the remote desc. This automatically triggers a 'removetrack' event on the associated MediaStream and the track can be removed from the UI.

Also, add the ability to toggle unified plan on/off for jvb and p2p connections separately.