### PR TITLE
fix(VADAudioAnalyser): NPE error evaluating this._vadEmitter.on

### DIFF
--- a/modules/detection/VADAudioAnalyser.js
+++ b/modules/detection/VADAudioAnalyser.js
@@ -100,9 +100,11 @@ export default class VADAudioAnalyser extends EventEmitter {
      * @returns {void}
      */
     _startVADEmitter() {
-        this._vadEmitter.on(VAD_SCORE_PUBLISHED, this._processVADScore);
-        this._vadEmitter.start();
-        this._isVADEmitterRunning = true;
+        if (this._vadEmitter) {
+            this._vadEmitter.on(VAD_SCORE_PUBLISHED, this._processVADScore);
+            this._vadEmitter.start();
+            this._isVADEmitterRunning = true;
+        }
     }
 
     /**
@@ -110,8 +112,10 @@ export default class VADAudioAnalyser extends EventEmitter {
      * @returns {void}
      */
     _stopVADEmitter() {
-        this._vadEmitter.removeListener(VAD_SCORE_PUBLISHED, this._processVADScore);
-        this._vadEmitter.stop();
+        if (this._vadEmitter) {
+            this._vadEmitter.removeListener(VAD_SCORE_PUBLISHED, this._processVADScore);
+            this._vadEmitter.stop();
+        }
         this._isVADEmitterRunning = false;
     }
 


### PR DESCRIPTION
The crash occurs every time the audio track is muted/unmuted, if the emitter fails to initialize ("Failed to start VADAudioAnalyser" warning is printed).

@andrei-gavrilescu I'm not sure if it's the right way to fix this. It feels like something more should be taken out of the event chain in case the vad emitter fails to start.