### PR TITLE
feat: allow json messages from focus

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -413,13 +413,13 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
 
     chatRoom.addListener(XMPPEvents.JSON_MESSAGE_RECEIVED,
         (from, payload) => {
-            const id = Strophe.getResourceFromJid(from);
-            const participant = conference.getParticipantById(id);
+            const _id = Strophe.getResourceFromJid(from);
+            const participant = conference.getParticipantById(_id);
 
-            if (participant) {
+            if (participant || _id === 'focus') {
                 conference.eventEmitter.emit(
                     JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED,
-                    participant, payload);
+                    participant || { _id }, payload);
             } else {
                 logger.warn(
                     'Ignored XMPPEvents.JSON_MESSAGE_RECEIVED for not existing '


### PR DESCRIPTION
This patch allows participants to receive json messages from the focus user. This is a dependency of the breakout rooms feature. See [this](https://github.com/jitsi/jitsi-meet/pull/9131) jitsi-meet pull request.