### PR TITLE
Switch chrome to unified plan by default unless explicitly disabled.

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1611,7 +1611,7 @@ export default class JingleSessionPC extends JingleSession {
                             })
                             .get();
 
-                    if (ssrcs.length && !currentRemoteSdp.containsSSRC(ssrcs[0])) {
+                    if (ssrcs.length) {
                         lines += `a=ssrc-group:${semantics} ${ssrcs.join(' ')}\r\n`;
                     }
                 });

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -341,7 +341,9 @@ export default class JingleSessionPC extends JingleSession {
                     || (browser.isChromiumBased()
 
                         // Provide a way to control the behavior for jvb and p2p connections independently.
-                        && this.isP2P ? options.p2p?.enableUnifiedOnChrome : options.enableUnifiedOnChrome));
+                        && this.isP2P
+                        ? options.p2p?.enableUnifiedOnChrome ?? true
+                        : options.enableUnifiedOnChrome ?? true));
 
         if (this.isP2P) {
             // simulcast needs to be disabled for P2P (121) calls


### PR DESCRIPTION
Switch chrome to unified plan by default unless explicitly disabled.
Also, remove the check for ssrc in remote description when adding a ssrc-group from source-add. Jicofo seems to be producing a source-add for a ssrcs that have already been signaled in session-initiate. This happens at random and only in torture tests probably because of a race condition that is hit only through automated tests.
The client throws an exception that the sRD has failed and reloads as a result of this. Leaving in the ssrc-group doesn't seem to cause the browser to throw the exception.