### PR TITLE
fix(codec-selection): Fix VP9 codec switching issue in Chrome unified plan.

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -132,7 +132,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      */
     supportsCodecPreferences() {
         return Boolean(window.RTCRtpTransceiver
-            && typeof window.RTCRtpTransceiver.setCodecPreferences !== 'undefined'
+            && 'setCodecPreferences' in window.RTCRtpTransceiver.prototype
             && window.RTCRtpReceiver
             && typeof window.RTCRtpReceiver.getCapabilities !== 'undefined')
 


### PR DESCRIPTION

Munge only the m-line that corresponds to the source that the browser will be sending.
Do not select VP9 on Firefox.
Detect support for RTCRtpTransceiver#setCodecPreferences correctly.