### PR TITLE
fix(JingleSessionPC): Disable unified-plan for p2p chrome.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2151,7 +2151,9 @@ TraceablePeerConnection.prototype._adjustRemoteMediaDirection = function(remoteD
 
         media.direction = hasLocalSource && hasRemoteSource
             ? MediaDirection.SENDRECV
-            : hasLocalSource ? MediaDirection.RECVONLY : MediaDirection.SENDONLY;
+            : hasLocalSource
+                ? MediaDirection.RECVONLY
+                : hasRemoteSource ? MediaDirection.SENDONLY : MediaDirection.INACTIVE;
     });
 
     return new RTCSessionDescription({

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -342,7 +342,7 @@ export default class JingleSessionPC extends JingleSession {
 
                         // Provide a way to control the behavior for jvb and p2p connections independently.
                         && this.isP2P
-                        ? options.p2p?.enableUnifiedOnChrome ?? true
+                        ? options.p2p?.enableUnifiedOnChrome
                         : options.enableUnifiedOnChrome ?? true));
 
         if (this.isP2P) {


### PR DESCRIPTION
Do not enable unified plan for p2p chrome by default until StartMutedTest is fixed.
Fix media direction for case when there are no local and remote sources, should be set to 'inactive' in that case.