### PR TITLE
Fix start muted p2p

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -342,7 +342,7 @@ export default class JingleSessionPC extends JingleSession {
 
                         // Provide a way to control the behavior for jvb and p2p connections independently.
                         && this.isP2P
-                        ? options.p2p?.enableUnifiedOnChrome
+                        ? options.p2p?.enableUnifiedOnChrome ?? true
                         : options.enableUnifiedOnChrome ?? true));
 
         if (this.isP2P) {


### PR DESCRIPTION
Chrome doesn't create a decoder for ssrc in the remote description when there is no local source and the endpoint is offerer. Initiating a renegotiation with the endpoint as a responder fixes this issue. Add a workaround until Chrome fixes this bug.
Enable unfied plan by default for chrome p2p.