### PR TITLE
fix(log) lower severity of overly verbose logs

### DIFF
--- a/modules/sdp/SDPUtil.js
+++ b/modules/sdp/SDPUtil.js
@@ -184,7 +184,7 @@ const SDPUtil = {
                 candidate.tcptype = elems[i + 1];
                 break;
             default: // TODO
-                logger.log(
+                logger.debug(
                     `parseICECandidate not translating "${
                         elems[i]}" = "${elems[i + 1]}"`);
             }
@@ -341,10 +341,10 @@ const SDPUtil = {
             // eslint-disable-next-line no-param-reassign
             line = `a=${line}`;
         } else if (line.substring(0, 12) !== 'a=candidate:') {
-            logger.log(
+            logger.warn(
                 'parseCandidate called with a line that is not a candidate'
                     + ' line');
-            logger.log(line);
+            logger.warn(line);
 
             return null;
         }
@@ -356,8 +356,8 @@ const SDPUtil = {
         const elems = line.split(' ');
 
         if (elems[6] !== 'typ') {
-            logger.log('did not find typ in the right place');
-            logger.log(line);
+            logger.warn('did not find typ in the right place');
+            logger.warn(line);
 
             return null;
         }
@@ -387,7 +387,7 @@ const SDPUtil = {
                 candidate.tcptype = elems[i + 1];
                 break;
             default: // TODO
-                logger.log(`not translating "${elems[i]}" = "${elems[i + 1]}"`);
+                logger.debug(`not translating "${elems[i]}" = "${elems[i + 1]}"`);
             }
         }
         candidate.network = '1';

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -992,7 +992,7 @@ export default class JingleSessionPC extends JingleSession {
             init,
             this.isInitiator ? 'initiator' : 'responder');
         init = init.tree();
-        logger.info(`${this} Session-initiate: `, init);
+        logger.debug(`${this} Session-initiate: `, init);
         this.connection.sendIQ(init,
             () => {
                 logger.info(`${this} Got RESULT for "session-initiate"`);
@@ -1271,7 +1271,7 @@ export default class JingleSessionPC extends JingleSession {
 
         // Calling tree() to print something useful
         accept = accept.tree();
-        logger.info(`${this} Sending session-accept`, accept);
+        logger.debug(`${this} Sending session-accept`, accept);
         this.connection.sendIQ(accept,
             success,
             this.newJingleErrorHandler(accept, error => {

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -71,7 +71,7 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
             id: iq.getAttribute('id')
         });
 
-        logger.log(`on jingle ${action} from ${fromJid}`, iq);
+        logger.debug(`on jingle ${action} from ${fromJid}`, iq);
         let sess = this.sessions[sid];
 
         if (action !== 'session-initiate') {
@@ -85,7 +85,8 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
                     .c('unknown-session', {
                         xmlns: 'urn:xmpp:jingle:errors:1'
                     });
-                logger.warn('invalid session id', iq);
+                logger.warn(`invalid session id: ${sid}`);
+                logger.debug(iq);
                 this.connection.send(ack);
 
                 return true;


### PR DESCRIPTION
Hurts mobile performance. They can still be enabled by setting the level at the
right value (debug / trace).