### PR TITLE
fix(LocalSdpMunger): do not fake video sdp when screen sharing

### DIFF
--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -4,6 +4,7 @@ import { getLogger } from 'jitsi-meet-logger';
 
 import MediaDirection from '../../service/RTC/MediaDirection';
 import * as MediaType from '../../service/RTC/MediaType';
+import VideoType from '../../service/RTC/VideoType';
 
 import { SdpTransformWrap } from './SdpTransformUtil';
 
@@ -72,13 +73,14 @@ export default class LocalSdpMunger {
         for (const videoTrack of localVideos) {
             const muted = videoTrack.isMuted();
             const mediaStream = videoTrack.getOriginalStream();
+            const isCamera = videoTrack.videoType === VideoType.CAMERA;
 
             // During the mute/unmute operation there are periods of time when
             // the track's underlying MediaStream is not added yet to
             // the PeerConnection. The SDP needs to be munged in such case.
             const isInPeerConnection
                 = mediaStream && this.tpc.isMediaStreamInPc(mediaStream);
-            const shouldFakeSdp = muted || !isInPeerConnection;
+            const shouldFakeSdp = isCamera && (muted || !isInPeerConnection);
 
             if (!shouldFakeSdp) {
                 continue; // eslint-disable-line no-continue


### PR DESCRIPTION
... is stopped. If there's any sRD/sLD cycle happening
while the screen sharing stops, the local track
returns muted and it was injecting fake video SSRCs
which results in invalid SSRC description.

At the time when it happens there's error log in jicofo:
"Error adding SSRCs from X"
and the client will get bad-request error in response
to the source-add request.