### PR TITLE
feat(BridgeChannel): Signal a new videoType for high fps screenshare.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -15,6 +15,7 @@ import * as JitsiTrackEvents from './JitsiTrackEvents';
 import authenticateAndUpgradeRole from './authenticateAndUpgradeRole';
 import { CodecSelection } from './modules/RTC/CodecSelection';
 import RTC from './modules/RTC/RTC';
+import { SS_DEFAULT_FRAME_RATE } from './modules/RTC/ScreenObtainer';
 import browser from './modules/browser';
 import ConnectionQuality from './modules/connectivity/ConnectionQuality';
 import IceFailedHandling
@@ -49,6 +50,7 @@ import {
     FEATURE_JIGASI,
     JITSI_MEET_MUC_TYPE
 } from './modules/xmpp/xmpp';
+import BridgeVideoType from './service/RTC/BridgeVideoType';
 import CodecMimeType from './service/RTC/CodecMimeType';
 import * as MediaType from './service/RTC/MediaType';
 import VideoType from './service/RTC/VideoType';
@@ -687,6 +689,24 @@ JitsiConference.prototype._getMediaSessions = function() {
 };
 
 /**
+ * Sends the 'VideoTypeMessage' to the bridge on the bridge channel so that the bridge can make bitrate allocation
+ * decisions based on the video type of the local source.
+ *
+ * @param {JitsiLocalTrack} localtrack - The track associated with the local source signaled to the bridge.
+ * @returns {void}
+ * @private
+ */
+JitsiConference.prototype._sendBridgeVideoTypeMessage = function(localtrack) {
+    let videoType = !localtrack || localtrack.isMuted() ? BridgeVideoType.NONE : localtrack.getVideoType();
+
+    if (videoType === BridgeVideoType.DESKTOP && this._desktopSharingFrameRate > SS_DEFAULT_FRAME_RATE) {
+        videoType = BridgeVideoType.DESKTOP_HIGH_FPS;
+    }
+
+    this.rtc.setVideoType(videoType);
+};
+
+/**
  * Returns name of this conference.
  */
 JitsiConference.prototype.getName = function() {
@@ -1047,9 +1067,7 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
     // Send the video type message to the bridge if the track is not removed/added to the pc as part of
     // the mute/unmute operation. This currently happens only on Firefox.
     if (track.isVideoTrack() && !browser.doesVideoMuteByStreamRemove()) {
-        const videoType = track.isMuted() ? VideoType.NONE : track.getVideoType();
-
-        this.rtc.setVideoType(videoType);
+        this._sendBridgeVideoTypeMessage(track);
     }
 
     this.eventEmitter.emit(JitsiConferenceEvents.TRACK_MUTE_CHANGED, track, actorParticipant);
@@ -1127,17 +1145,12 @@ JitsiConference.prototype.replaceTrack = function(oldTrack, newTrack) {
     // Now replace the stream at the lower levels
     return this._doReplaceTrack(oldTrack, newTrack)
         .then(() => {
-            if (oldTrack) {
-                this.onLocalTrackRemoved(oldTrack);
-            }
+            oldTrack && this.onLocalTrackRemoved(oldTrack);
+            newTrack && this._setupNewTrack(newTrack);
 
-            // Send 'VideoTypeMessage' on the bridge channel for the new track.
-            if (newTrack) {
-                // Now handle the addition of the newTrack at the JitsiConference level
-                this._setupNewTrack(newTrack);
-                newTrack.isVideoTrack() && this.rtc.setVideoType(newTrack.getVideoType());
-            } else {
-                oldTrack && oldTrack.isVideoTrack() && this.rtc.setVideoType(VideoType.NONE);
+            // Send 'VideoTypeMessage' on the bridge channel when a video track is added/removed.
+            if (oldTrack?.isVideoTrack() || newTrack?.isVideoTrack()) {
+                this._sendBridgeVideoTypeMessage(newTrack);
             }
 
             if (this.isMutedByFocus || this.isVideoMutedByFocus) {
@@ -1259,7 +1272,7 @@ JitsiConference.prototype._addLocalTrackAsUnmute = function(track) {
     return Promise.allSettled(addAsUnmutePromises)
         .then(() => {
             // Signal the video type to the bridge.
-            track.isVideoTrack() && this.rtc.setVideoType(track.getVideoType());
+            track.isVideoTrack() && this._sendBridgeVideoTypeMessage(track);
         });
 };
 
@@ -1287,7 +1300,7 @@ JitsiConference.prototype._removeLocalTrackAsMute = function(track) {
     return Promise.allSettled(removeAsMutePromises)
         .then(() => {
             // Signal the video type to the bridge.
-            track.isVideoTrack() && this.rtc.setVideoType(VideoType.NONE);
+            track.isVideoTrack() && this._sendBridgeVideoTypeMessage();
         });
 };
 

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -3,9 +3,9 @@
 import { getLogger } from 'jitsi-meet-logger';
 
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
+import BridgeVideoType from '../../service/RTC/BridgeVideoType';
 import * as MediaType from '../../service/RTC/MediaType';
 import RTCEvents from '../../service/RTC/RTCEvents';
-import VideoType from '../../service/RTC/VideoType';
 import browser from '../browser';
 import Statistics from '../statistics/statistics';
 import GlobalOnErrorHandler from '../util/GlobalOnErrorHandler';
@@ -152,7 +152,7 @@ export default class RTC extends Listenable {
             = this._updateAudioOutputForAudioTracks.bind(this);
 
         // The default video type assumed by the bridge.
-        this._videoType = VideoType.NONE;
+        this._videoType = BridgeVideoType.NONE;
 
         // Switch audio output device on all remote audio tracks. Local audio
         // tracks handle this event by themselves.

--- a/service/RTC/BridgeVideoType.js
+++ b/service/RTC/BridgeVideoType.js
@@ -1,0 +1,28 @@
+/* global module */
+/**
+ * Enumeration of the video types that are signaled to the bridge
+ * @type {{CAMERA: string, DESKTOP: string, DESKTOP_HIGH_FPS: string, NONE: string}}
+ */
+const BridgeVideoType = {
+    /**
+     * The camera video type.
+     */
+    CAMERA: 'camera',
+
+    /**
+     * The low fps desktop video type.
+     */
+    DESKTOP: 'desktop',
+
+    /**
+     * The high fps desktop video type.
+     */
+    DESKTOP_HIGH_FPS: 'desktop_high_fps',
+
+    /**
+     * Video type when no local source is present.
+     */
+    NONE: 'none'
+};
+
+module.exports = BridgeVideoType;

--- a/service/RTC/VideoType.js
+++ b/service/RTC/VideoType.js
@@ -1,7 +1,7 @@
 /* global module */
 /**
  * Enumeration of the video types
- * @type {{CAMERA: string, DESKTOP: string, NONE: string}}
+ * @type {{CAMERA: string, DESKTOP: string}}
  */
 const VideoType = {
     /**
@@ -12,12 +12,7 @@ const VideoType = {
     /**
      * The desktop video type.
      */
-    DESKTOP: 'desktop',
-
-    /**
-     * No local video source.
-     */
-    NONE: 'none'
+    DESKTOP: 'desktop'
 };
 
 module.exports = VideoType;


### PR DESCRIPTION
This lets the bridge adjust the bitrate allocation for this source so that layers with higher fps are prioritized over layers with higher resolution.
As a result, endpoints with restricted downlink will receive a high fps low resolution share as opposed to a high resolution low fps screenshare.