### PR TITLE
fix(log) lower severity of overly verbose logs (2)

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1248,7 +1248,7 @@ export default class JingleSessionPC extends JingleSession {
         // NOTE: since we're just reading from it, we don't need to be within
         //  the modification queue to access the local description
         const localSDP = new SDP(this.peerconnection.localDescription.sdp);
-        let accept = $iq({ to: this.remoteJid,
+        const accept = $iq({ to: this.remoteJid,
             type: 'set' })
             .c('jingle', { xmlns: 'urn:xmpp:jingle:1',
                 action: 'session-accept',
@@ -1269,9 +1269,8 @@ export default class JingleSessionPC extends JingleSession {
             accept,
             this.initiatorJid === this.localJid ? 'initiator' : 'responder');
 
-        // Calling tree() to print something useful
-        accept = accept.tree();
-        logger.debug(`${this} Sending session-accept`, accept);
+        logger.info(`${this} Sending session-accept`);
+        logger.debug(accept.tree());
         this.connection.sendIQ(accept,
             success,
             this.newJingleErrorHandler(accept, error => {
@@ -1337,6 +1336,7 @@ export default class JingleSessionPC extends JingleSession {
         }
 
         logger.info(`${this} sending content-modify, video senders: ${senders}, max frame height: ${maxFrameHeight}`);
+        logger.debug(sessionModify.tree());
 
         this.connection.sendIQ(
             sessionModify,
@@ -1378,7 +1378,7 @@ export default class JingleSessionPC extends JingleSession {
      * @private
      */
     sendTransportAccept(localSDP, success, failure) {
-        let transportAccept = $iq({ to: this.remoteJid,
+        const transportAccept = $iq({ to: this.remoteJid,
             type: 'set' })
             .c('jingle', {
                 xmlns: 'urn:xmpp:jingle:1',
@@ -1403,9 +1403,8 @@ export default class JingleSessionPC extends JingleSession {
             transportAccept.up();
         });
 
-        // Calling tree() to print something useful to the logger
-        transportAccept = transportAccept.tree();
-        logger.info(`${this} Sending transport-accept: `, transportAccept);
+        logger.info(`${this} Sending transport-accept`);
+        logger.debug(transportAccept.tree());
 
         this.connection.sendIQ(transportAccept,
             success,
@@ -1427,7 +1426,7 @@ export default class JingleSessionPC extends JingleSession {
     sendTransportReject(success, failure) {
         // Send 'transport-reject', so that the focus will
         // know that we've failed
-        let transportReject = $iq({ to: this.remoteJid,
+        const transportReject = $iq({ to: this.remoteJid,
             type: 'set' })
             .c('jingle', {
                 xmlns: 'urn:xmpp:jingle:1',
@@ -1436,8 +1435,8 @@ export default class JingleSessionPC extends JingleSession {
                 sid: this.sid
             });
 
-        transportReject = transportReject.tree();
-        logger.info(`${this} Sending 'transport-reject'`, transportReject);
+        logger.info(`${this} Sending 'transport-reject'`);
+        logger.debug(transportReject.tree());
 
         this.connection.sendIQ(transportReject,
             success,
@@ -1506,7 +1505,7 @@ export default class JingleSessionPC extends JingleSession {
         }
 
         if (!options || Boolean(options.sendSessionTerminate)) {
-            let sessionTerminate
+            const sessionTerminate
                 = $iq({
                     to: this.remoteJid,
                     type: 'set'
@@ -1539,9 +1538,9 @@ export default class JingleSessionPC extends JingleSession {
                         restart: options && options.requestRestart === true
                     }).up();
 
-            // Calling tree() to print something useful
-            sessionTerminate = sessionTerminate.tree();
-            logger.info(`${this} Sending session-terminate`, sessionTerminate);
+            logger.info(`${this} Sending session-terminate`);
+            logger.debug(sessionTerminate.tree());
+
             this.connection.sendIQ(
                 sessionTerminate,
                 success,
@@ -2521,7 +2520,8 @@ export default class JingleSessionPC extends JingleSession {
         const removedAnySSRCs = sdpDiffer.toJingle(remove);
 
         if (removedAnySSRCs) {
-            logger.info(`${this} Sending source-remove`, remove.tree());
+            logger.info(`${this} Sending source-remove`);
+            logger.debug(remove.tree());
             this.connection.sendIQ(
                 remove, null,
                 this.newJingleErrorHandler(remove), IQ_TIMEOUT);
@@ -2542,7 +2542,8 @@ export default class JingleSessionPC extends JingleSession {
         const containsNewSSRCs = sdpDiffer.toJingle(add);
 
         if (containsNewSSRCs) {
-            logger.info(`${this} Sending source-add`, add.tree());
+            logger.info(`${this} Sending source-add`);
+            logger.debug(add.tree());
             this.connection.sendIQ(
                 add, null, this.newJingleErrorHandler(add), IQ_TIMEOUT);
         }


### PR DESCRIPTION
Hurts mobile performance. They can still be enabled by setting the level at the
right value (debug / trace).