### PR TITLE
feat: Add a new conference event for messages ignored by ENDPOINT_MESSAGE_RECEIVED

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -421,10 +421,9 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
                     JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED,
                     participant, payload);
             } else {
-                logger.warn(
-                    'Ignored XMPPEvents.JSON_MESSAGE_RECEIVED for not existing '
-                    + `participant: ${from}`,
-                    payload);
+                conference.eventEmitter.emit(
+                    JitsiConferenceEvents.NON_PARTICIPANT_MESSAGE_RECEIVED,
+                    id, payload);
             }
         });
 

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -191,6 +191,12 @@ export const NO_AUDIO_INPUT = 'conference.no_audio_input';
 export const NOISY_MIC = 'conference.noisy_mic';
 
 /**
+ * Indicates that a message from the local user or from the Prosody backend
+ * was received on the data channel.
+ */
+export const NON_PARTICIPANT_MESSAGE_RECEIVED = 'conference.non_participant_message_received';
+
+/**
  * New private text message was received.
  */
 export const PRIVATE_MESSAGE_RECEIVED = 'conference.privateMessageReceived';


### PR DESCRIPTION
Currently, JSON messages, received through the XMPPEvents.JSON_MESSAGE_RECEIVED internal event, are visible to the API user through the JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED event, but only if the sender of the message has a corresponding JitsiParticipant object; others are ignored with a warning message.

This excludes:
-  messages sent by the local client through `conference.sendMessage`, then automatically broadcast back by the Prosody backend;
- messages that were sent manually by the Prosody backend.

This is a limitation that complicated the design of the polls feature (cf. [this pull request on jitsi-meet](https://github.com/jitsi/jitsi-meet/pull/9166)).

This PR adds a new `JitsiConferenceEvents.NON_PARTICIPANT_MESSAGE_RECEIVED` event, which corresponds to the messages that were previously ignored. The callback is called with the sender JID (as opposed to a JitsiParticipant object) + the parsed JSON data.