### PR TITLE
fix(ProxyConnectionPC): request to receive audio/video.

### DIFF
--- a/modules/proxyconnection/ProxyConnectionPC.js
+++ b/modules/proxyconnection/ProxyConnectionPC.js
@@ -41,8 +41,8 @@ export default class ProxyConnectionPC {
         this._options = {
             iceConfig: {},
             isInitiator: false,
-            receiveAudio: false,
-            receiveVideo: false,
+            receiveAudio: true,
+            receiveVideo: true,
             ...options
         };
 


### PR DESCRIPTION
Offering to receive audio/video during pc creation ensures that there are mlines for audio and video in the SDP, making this change to prevent any unexpected issues (in wireless screensharing for spot) with sdp->jingle translations after the unified plan switch.