### PR TITLE
added support for DSCP marking outbound media packets on Chromium

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -76,6 +76,9 @@ let disableNS = false;
 // Disables Automatic Gain Control
 let disableAGC = false;
 
+// Enabled DSCP marking
+let enableDSCP = false;
+
 // Enables stereo.
 let stereo = null;
 
@@ -335,6 +338,10 @@ class RTCUtils extends Listenable {
             disableAGC = options.disableAGC;
             logger.info(`Disable AGC: ${disableAGC}`);
         }
+        if (typeof options.enableDSCP === 'boolean') {
+            enableDSCP = options.enableDSCP;
+            logger.info(`Enable DSCP: ${enableDSCP}`);
+        }
         if (typeof options.audioQuality?.stereo === 'boolean') {
             stereo = options.audioQuality.stereo;
             logger.info(`Stereo: ${stereo}`);
@@ -377,7 +384,9 @@ class RTCUtils extends Listenable {
             ? { optional: [
                 { googScreencastMinBitrate: 100 },
                 { googCpuOveruseDetection: true }
-            ] }
+            ].concat(enableDSCP ? [
+                { googDscp: enableDSCP }
+            ] : []) }
             : {};
 
         screenObtainer.init(options);


### PR DESCRIPTION
Chromium-based browsers support DSCP marking of outbound media packets, but it's disabled by default because some middleboxes on the wider Internet might drop packets with DSCP marks set. On controlled networks (e.g. corporate networks) DSCP can be very helpful for prioritising videoconferencing traffic.

This patch allows it to optionally be enabled with a `enableDSCP` option.

Relevant community discussion: https://community.jitsi.org/t/looking-for-a-way-to-configure-udp-ports-used-in-peer-to-peer-for-1-to-1-sessions-p2p4121/103706/6