### PR TITLE
Workaround for Chrome ice connection failure detection

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -355,6 +355,13 @@ export default function TraceablePeerConnection(
             this.onnegotiationneeded(event);
         }
     };
+    this.onconnectionstatechange = null;
+    this.peerconnection.onconnectionstatechange = event => {
+        this.trace('onconnectionstatechange', this.connectionState);
+        if (this.onconnectionstatechange !== null) {
+            this.onconnectionstatechange(event);
+        }
+    };
     this.ondatachannel = null;
     this.peerconnection.ondatachannel = event => {
         this.trace('ondatachannel');
@@ -1495,6 +1502,9 @@ const getters = {
     },
     iceConnectionState() {
         return this.peerconnection.iceConnectionState;
+    },
+    connectionState() {
+        return this.peerconnection.connectionState;
     },
     localDescription() {
         let desc = this.peerconnection.localDescription;

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -559,6 +559,28 @@ export default class JingleSessionPC extends JingleSession {
             }
         };
 
+
+        /**
+	 * The connection state event is fired whenever the aggregate of underlying
+	 * transports change their state.
+	 */
+        this.peerconnection.onconnectionstatechange = () => {
+            const icestate = this.peerconnection.iceConnectionState;
+
+            switch (this.peerconnection.connectionState) {
+            case 'failed':
+                // Since version 76 Chrome no longer switches ICE connection
+                // state to failed (see
+                // https://bugs.chromium.org/p/chromium/issues/detail?id=982793
+                // for details) we use this workaround to recover from lost connections
+                if (icestate === 'disconnected') {
+                    this.room.eventEmitter.emit(
+                        XMPPEvents.CONNECTION_ICE_FAILED, this);
+                }
+                break;
+            }
+        };
+
         /**
          * The negotiationneeded event is fired whenever we shake the media on the
          * RTCPeerConnection object.

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -561,9 +561,9 @@ export default class JingleSessionPC extends JingleSession {
 
 
         /**
-	 * The connection state event is fired whenever the aggregate of underlying
-	 * transports change their state.
-	 */
+         * The connection state event is fired whenever the aggregate of underlying
+         * transports change their state.
+         */
         this.peerconnection.onconnectionstatechange = () => {
             const icestate = this.peerconnection.iceConnectionState;
 


### PR DESCRIPTION
This patch re-enables the detection of ICE connection failures, e.g. if the TURN connection fails in the middle of a call, which is broken since the release of Chrome 76.