### PR TITLE
fix(replace-track) Add not null check for newTrack

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1164,7 +1164,7 @@ JitsiConference.prototype.replaceTrack = function(oldTrack, newTrack) {
                 this._sendBridgeVideoTypeMessage(newTrack);
             }
 
-            if (this.isMutedByFocus || this.isVideoMutedByFocus) {
+            if (newTrack !== null && (this.isMutedByFocus || this.isVideoMutedByFocus)) {
                 this._fireMuteChangeEvent(newTrack);
             }
 


### PR DESCRIPTION
Fixes error caused by stop screen sharing call (newTrack is null) and video moderation on (isVideoMutedByFocus is true)