### PR TITLE
fix(browser-support): Add audio track to pc always on mobile Safari.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1092,8 +1092,10 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
  * @returns {Array<JitsiLocalTrack>} - list of local tracks that are unmuted.
  */
 JitsiConference.prototype._getInitialLocalTracks = function() {
+    // Always add the audio track on mobile Safari because of a known issue where audio playout doesn't happen
+    // if the user joins audio and video muted.
     return this.getLocalTracks()
-        .filter(track => (track.getType() === MediaType.AUDIO && !this.isStartAudioMuted())
+        .filter(track => (track.getType() === MediaType.AUDIO && (!this.isStartAudioMuted() || browser.isIosBrowser()))
         || (track.getType() === MediaType.VIDEO && !this.isStartVideoMuted()));
 };
 

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -57,6 +57,18 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
+     * Checks if the current platform is iOS.
+     *
+     * @returns {boolean}
+     */
+    isIosBrowser() {
+        const { userAgent, maxTouchPoints, platform } = navigator;
+
+        return userAgent.match(/iP(ad|hone|od)/i
+            || (maxTouchPoints && maxTouchPoints > 2 && /MacIntel/.test(platform)));
+    }
+
+    /**
      * Checks if the current browser is WebKit based. It's either
      * Safari or uses WebKit as its engine.
      *


### PR DESCRIPTION
On mobile Safari, if a user joins audio and video muted, the browser doesn't decode the incoming audio. Workaround is to always add the audio track to pc and mute it if needed.