### PR TITLE
fix(quality) Enable layer suspension by default.

### DIFF
--- a/modules/qualitycontrol/SendVideoController.js
+++ b/modules/qualitycontrol/SendVideoController.js
@@ -19,7 +19,7 @@ export class SendVideoController {
      */
     constructor(conference, rtc) {
         this.conference = conference;
-        this.layerSuspensionEnabled = conference.options?.config?.enableLayerSuspension;
+        this.layerSuspensionEnabled = conference.options?.config?.enableLayerSuspension ?? true;
         this.rtc = rtc;
         this.conference.on(
             JitsiConferenceEvents._MEDIA_SESSION_STARTED,


### PR DESCRIPTION
This is needed for screensharing to work as expected on chrome in unified plan.