### PR TITLE
ref(JitsiConference): don't crash on wrong oldTrack

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1159,6 +1159,10 @@ JitsiConference.prototype.replaceTrack = function(oldTrack, newTrack) {
         }
     }
 
+    if (oldTrack && !oldTrackBelongsToConference) {
+        logger.warn(`JitsiConference.replaceTrack oldTrack (${oldTrack} does not belong to this conference`);
+    }
+
     // Now replace the stream at the lower levels
     return this._doReplaceTrack(oldTrackBelongsToConference ? oldTrack : null, newTrack)
         .then(() => {


### PR DESCRIPTION
If oldTrack was not previously in the conference this will
lead to a crash in onLocalTrackRemoved where oldTrack doesn't
have `muteHandler` and `audioLevelHandler` listeners defined.