### PR TITLE
fix(replaceTrack):  Don't wrap Error in Error.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1174,7 +1174,11 @@ JitsiConference.prototype.replaceTrack = function(oldTrack, newTrack) {
 
             return Promise.resolve();
         })
-        .catch(error => Promise.reject(new Error(error)));
+        .catch(error => {
+            logger.error(`replaceTrack failed: ${error?.stack}`);
+
+            return Promise.reject(error);
+        });
 };
 
 /**


### PR DESCRIPTION
This swallows the stack trace.