### PR TITLE
Fix codec renegotiation and reverse the order of the ssrcs being signaled from Firefox to Jicofo.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1460,8 +1460,7 @@ TraceablePeerConnection.prototype._injectSsrcGroupForUnifiedSimulcast
         const sdp = transform.parse(desc.sdp);
         const video = sdp.media.find(mline => mline.type === 'video');
 
-        // Check if the browser supports RTX, add only the primary ssrcs to the
-        // SIM group if that is the case.
+        // Check if the browser supports RTX, add only the primary ssrcs to the SIM group if that is the case.
         video.ssrcGroups = video.ssrcGroups || [];
         const fidGroups = video.ssrcGroups.filter(group => group.semantics === 'FID');
 
@@ -1483,6 +1482,12 @@ TraceablePeerConnection.prototype._injectSsrcGroupForUnifiedSimulcast
                 // Group already exists, no need to do anything
                 return desc;
             }
+
+            // Reverse the order of the SSRCs when signaling them to the bridge. On Firefox, the first SSRC corresponds
+            // to the highest resolution stream whereas the bridge assumes it to be that of the lowest resolution
+            // stream as is the case with the other browsers.
+            browser.isFirefox() && ssrcs.reverse();
+
             video.ssrcGroups.push({
                 semantics: 'SIM',
                 ssrcs: ssrcs.join(' ')

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1648,7 +1648,8 @@ TraceablePeerConnection.prototype._mungeCodecOrder = function(description) {
 
         // Set the max bitrate here on the SDP so that the configured max. bitrate is effective
         // as soon as the browser switches to VP9.
-        if (this.codecPreference.mimeType === CodecMimeType.VP9) {
+        if (this.codecPreference.mimeType === CodecMimeType.VP9
+            && this.getConfiguredVideoCodec() === CodecMimeType.VP9) {
             const bitrates = this.videoBitrates.VP9 || this.videoBitrates;
             const hdBitrate = bitrates.high ? bitrates.high : HD_BITRATE;
             const limit = Math.floor((this._isSharingScreen() ? HD_BITRATE : hdBitrate) / 1000);

--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -143,10 +143,16 @@ SDP.prototype.toJingle = function(elem, thecreator) {
         }
 
         let ssrc;
+        const simGroup = SDPUtil.findLine(this.media[i], 'a=ssrc-group:SIM');
         const assrcline = SDPUtil.findLine(this.media[i], 'a=ssrc:');
 
         if (assrcline) {
-            ssrc = assrcline.substring(7).split(' ')[0]; // take the first
+            if (browser.isFirefox() && simGroup) {
+                // Use the first ssrc from the SIM group since the order of the SSRCs need to be reversed for Firefox.
+                ssrc = simGroup.substring(17).split(' ')[0];
+            } else {
+                ssrc = assrcline.substring(7).split(' ')[0]; // take the first
+            }
         } else {
             ssrc = false;
         }


### PR DESCRIPTION
Impose VP9 bitrates only when VP9 is negotiated. If Jicofo doesn't offer VP9 but the client expresses a preference for VP9, VP9 bitrates were being imposed before.
This fixes an issue where the bridge doesn't forward the HD stream from Firefox to other users in the call. The order of the ssrcs produced by the browser is from Highest resolution to lowest whereas the bridge assumes it to be from lowest to highest as is the case with Chrome and Safari.