### PR TITLE
Two JitsiConference instances with the same room name issue

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -126,6 +126,17 @@ export default function JitsiConference(options) {
         logger.error(errmsg);
         throw new Error(errmsg);
     }
+    this.connection = options.connection;
+    this.xmpp = this.connection?.xmpp;
+
+    if (this.xmpp.isRoomCreated(options.name, options.customDomain)) {
+        const errmsg = 'A coference with the same name has already been created!';
+
+        delete this.connection;
+        delete this.xmpp;
+        logger.error(errmsg);
+        throw new Error(errmsg);
+    }
     this.eventEmitter = new EventEmitter();
     this.options = options;
     this.eventManager = new JitsiConferenceEventManager(this);
@@ -310,15 +321,7 @@ JitsiConference.resourceCreator = function(jid, isAuthenticatedUser) {
  * @param options.connection {JitsiConnection} overrides this.connection
  */
 JitsiConference.prototype._init = function(options = {}) {
-    // Override connection and xmpp properties (Useful if the connection
-    // reloaded)
-    if (options.connection) {
-        this.connection = options.connection;
-        this.xmpp = this.connection.xmpp;
-
-        // Setup XMPP events only if we have new connection object.
-        this.eventManager.setupXMPPListeners();
-    }
+    this.eventManager.setupXMPPListeners();
 
     const { config } = this.options;
 

--- a/modules/xmpp/strophe.emuc.js
+++ b/modules/xmpp/strophe.emuc.js
@@ -55,7 +55,7 @@ export default class MucConnectionPlugin extends ConnectionPluginListenable {
     createRoom(jid, password, options) {
         const roomJid = Strophe.getBareJidFromJid(jid);
 
-        if (this.rooms[roomJid]) {
+        if (this.isRoomCreated(roomJid)) {
             const errmsg = 'You are already in the room!';
 
             logger.error(errmsg);
@@ -67,6 +67,16 @@ export default class MucConnectionPlugin extends ConnectionPluginListenable {
             XMPPEvents.EMUC_ROOM_ADDED, this.rooms[roomJid]);
 
         return this.rooms[roomJid];
+    }
+
+    /**
+     *  Check if a room with the passed JID is already created.
+     *
+     * @param {string} roomJid - The JID of the room.
+     * @returns {boolean}
+     */
+    isRoomCreated(roomJid) {
+        return roomJid in this.rooms;
     }
 
     /**

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -635,8 +635,7 @@ export default class XMPP extends Listenable {
      */
     createRoom(roomName, options, onCreateResource) {
         // There are cases (when using subdomain) where muc can hold an uppercase part
-        let roomjid = `${roomName}@${options.customDomain
-            ? options.customDomain : this.options.hosts.muc.toLowerCase()}/`;
+        let roomjid = `${this.getRoomJid(roomName, options.customDomain)}/`;
 
         const mucNickname = onCreateResource
             ? onCreateResource(this.connection.jid, this.authenticatedUser)
@@ -646,6 +645,27 @@ export default class XMPP extends Listenable {
         roomjid += mucNickname;
 
         return this.connection.emuc.createRoom(roomjid, null, options);
+    }
+
+    /**
+     * Returns the room JID based on the passed room name and domain.
+     *
+     * @param {string} roomName - The room name.
+     * @param {string} domain - The domain.
+     * @returns {string} - The room JID.
+     */
+    getRoomJid(roomName, domain) {
+        return `${roomName}@${domain ? domain : this.options.hosts.muc.toLowerCase()}`;
+    }
+
+    /**
+     * Check if a room with the passed JID is already created.
+     *
+     * @param {string} roomJid - The JID of the room.
+     * @returns {boolean}
+     */
+    isRoomCreated(roomName, domain) {
+        return this.connection.emuc.isRoomCreated(this.getRoomJid(roomName, domain));
     }
 
     /**


### PR DESCRIPTION
If a second JitsiConference instance for the same room is created we were
throwing an error but some listeners were already attached. This commit
makes sure that we throw the error as soon as possible and no listeners
are added.