### PR TITLE
fix(browser-support) fix detecting iOS browsers correctly

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -64,8 +64,8 @@ export default class BrowserCapabilities extends BrowserDetection {
     isIosBrowser() {
         const { userAgent, maxTouchPoints, platform } = navigator;
 
-        return userAgent.match(/iP(ad|hone|od)/i
-            || (maxTouchPoints && maxTouchPoints > 2 && /MacIntel/.test(platform)));
+        return Boolean(userAgent.match(/iP(ad|hone|od)/i))
+            || (maxTouchPoints && maxTouchPoints > 2 && /MacIntel/.test(platform));
     }
 
     /**


### PR DESCRIPTION
There was an error in the pattern match, everything was included in it. In
addition return a boolean in case we succeed in the UA pattern match, since it's
more correct than returning an array with the match.