### PR TITLE
Disable RTX for Firefox <= 93

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1482,11 +1482,6 @@ TraceablePeerConnection.prototype._injectSsrcGroupForUnifiedSimulcast
                 return desc;
             }
 
-            // Reverse the order of the SSRCs when signaling them to the bridge. On Firefox, the first SSRC corresponds
-            // to the highest resolution stream whereas the bridge assumes it to be that of the lowest resolution
-            // stream as is the case with the other browsers.
-            browser.isFirefox() && ssrcs.reverse();
-
             video.ssrcGroups.push({
                 semantics: 'SIM',
                 ssrcs: ssrcs.join(' ')

--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -143,16 +143,10 @@ SDP.prototype.toJingle = function(elem, thecreator) {
         }
 
         let ssrc;
-        const simGroup = SDPUtil.findLine(this.media[i], 'a=ssrc-group:SIM');
         const assrcline = SDPUtil.findLine(this.media[i], 'a=ssrc:');
 
         if (assrcline) {
-            if (browser.isFirefox() && simGroup) {
-                // Use the first ssrc from the SIM group since the order of the SSRCs need to be reversed for Firefox.
-                ssrc = simGroup.substring(17).split(' ')[0];
-            } else {
-                ssrc = assrcline.substring(7).split(' ')[0]; // take the first
-            }
+            ssrc = assrcline.substring(7).split(' ')[0]; // take the first
         } else {
             ssrc = false;
         }

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -210,7 +210,7 @@ export default class XMPP extends Listenable {
 
         // Disable RTX on Firefox 83 and older versions because of
         // https://bugzilla.mozilla.org/show_bug.cgi?id=1668028
-        if (!(this.options.disableRtx || (browser.isFirefox() && browser.isVersionLessThan(84)))) {
+        if (!(this.options.disableRtx || (browser.isFirefox() && browser.isVersionLessThan(94)))) {
             this.caps.addFeature('urn:ietf:rfc:4588');
         }
         if (this.options.enableOpusRed === true && browser.supportsAudioRed()) {


### PR DESCRIPTION
- fix(Jingle): stop reverting the SSRCs from Firefox
- fix(xmpp): disable RTX for Firefox < 93, because it results in random SSRC order
