### PR TITLE
fix(loggging) fix exceptions on mobile

### DIFF
--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -212,15 +212,17 @@ function _parseIceCandidates(transport) {
     const parseCandidates = [];
 
     // Extract the candidate information from the IQ.
-    for (const candidate of candidates) {
+    candidates.each((_, candidate) => {
         const attributes = candidate.attributes;
         const candidateAttrs = [];
 
-        for (const attr of attributes) {
+        for (let i = 0; i < attributes.length; i++) {
+            const attr = attributes[i];
+
             candidateAttrs.push(`${attr.name}: ${attr.value}`);
         }
         parseCandidates.push(candidateAttrs.join(' '));
-    }
+    });
 
     return parseCandidates;
 }


### PR DESCRIPTION
Maybe due to our DOM wrappers, the Symbol.iterator is not implemented, so
iterate over the IQ fields old-school style.