### PR TITLE
fix: logger calling wrong function typo

### DIFF
--- a/modules/e2ee/E2EEContext.js
+++ b/modules/e2ee/E2EEContext.js
@@ -44,7 +44,7 @@ export default class E2EEcontext {
         const blobUrl = window.URL.createObjectURL(workerBlob);
 
         this._worker = new Worker(blobUrl, { name: 'E2EE Worker' });
-        this._worker.onerror = e => logger.onerror(e);
+        this._worker.onerror = e => logger.error(e);
     }
 
     /**


### PR DESCRIPTION
When the worker fails to load the logger is calling onerror however jitsi-meet-logger doesn't have a function called onerror, it should be error