### PR TITLE
fix(iOS15) fix not being able to unmute if "everyone starts muted" is…

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1104,11 +1104,23 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
  * @returns {Array<JitsiLocalTrack>} - list of local tracks that are unmuted.
  */
 JitsiConference.prototype._getInitialLocalTracks = function() {
-    // Always add the audio track on mobile Safari because of a known issue where audio playout doesn't happen
-    // if the user joins audio and video muted.
+    // Always add the audio track on certain platforms:
+    //  * Mobile Safari: because of a known issue where audio playout doesn't happen
+    //    if the user joins audio and video muted.
+    //  * React Native: after iOS 15, if a user joins muted they won't be able to unmute.
     return this.getLocalTracks()
-        .filter(track => (track.getType() === MediaType.AUDIO && (!this.isStartAudioMuted() || browser.isIosBrowser()))
-        || (track.getType() === MediaType.VIDEO && !this.isStartVideoMuted()));
+        .filter(track => {
+            const trackType = track.getType();
+
+            if (trackType === MediaType.AUDIO
+                    && (!this.isStartAudioMuted() || browser.isIosBrowser() || browser.isReactNative())) {
+                return true;
+            } else if (trackType === MediaType.VIDEO && !this.isStartVideoMuted()) {
+                return true;
+            }
+
+            return false;
+        });
 };
 
 /**

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1105,7 +1105,7 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
  */
 JitsiConference.prototype._getInitialLocalTracks = function() {
     // Always add the audio track on certain platforms:
-    //  * Mobile Safari: because of a known issue where audio playout doesn't happen
+    //  * Safari / WebKit: because of a known issue where audio playout doesn't happen
     //    if the user joins audio and video muted.
     //  * React Native: after iOS 15, if a user joins muted they won't be able to unmute.
     return this.getLocalTracks()

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1113,7 +1113,7 @@ JitsiConference.prototype._getInitialLocalTracks = function() {
             const trackType = track.getType();
 
             if (trackType === MediaType.AUDIO
-                    && (!this.isStartAudioMuted() || browser.isIosBrowser() || browser.isReactNative())) {
+                    && (!this.isStartAudioMuted() || browser.isWebKitBased() || browser.isReactNative())) {
                 return true;
             } else if (trackType === MediaType.VIDEO && !this.isStartVideoMuted()) {
                 return true;


### PR DESCRIPTION
… set

We need to make sure the audio track is added to the JVB connection, or we won't
be able to unmute.

Why this happens is a mystery wrapped in an enigma, it started happening with
iOS 15.

Fixes: https://github.com/jitsi/jitsi-meet/issues/10104