### PR TITLE
Use SHA-256 as the webpack hash function

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,8 @@ module.exports = [
         },
         output: Object.assign({}, config.output, {
             library: 'JitsiMeetJS',
-            libraryTarget: 'umd'
+            libraryTarget: 'umd',
+            hashFunction: 'sha256'
         })
     }),
     {
@@ -19,7 +20,8 @@ module.exports = [
         mode: 'production',
         output: {
             filename: 'lib-jitsi-meet.e2ee-worker.js',
-            path: process.cwd()
+            path: process.cwd(),
+            hashFunction: 'sha256'
         },
         optimization: {
             minimize: false


### PR DESCRIPTION
Webpack [defaults to MD4](https://webpack.js.org/configuration/output/#outputhashfunction) as the output hash function. MD4 was [moved to the legacy provider](https://www.openssl.org/news/changelog.html#openssl-30) in OpenSSL 3.0 and is not available by default. As a result, webpack fails to run on any system with OpenSSL 3.0 or later.

This patch sets the hash function explicitly to SHA-256 which fixes the webpack build on such systems. SHA-256 is chosen as a reasonable modern default.

An alternative solution would be to upgrade to webpack v5.54.0 or later and use webpack's future default hash function `xxhash64`, which doesn't depend on OpenSSL and is also faster than SHA-256.

Related: jitsi/jitsi-meet#10112