### PR TITLE
fix(TPC) Remove video track from pc on mute for Firefox.

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -26,14 +26,14 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
-     * Tells whether or not the <tt>MediaStream/tt> is removed from
-     * the <tt>PeerConnection</tt> and disposed on video mute (in order to turn
-     * off the camera device).
-     * @return {boolean} <tt>true</tt> if the current browser supports this
-     * strategy or <tt>false</tt> otherwise.
+     * Tells whether or not the <tt>MediaStream/tt> is removed from the <tt>PeerConnection</tt> and disposed on video
+     * mute (in order to turn off the camera device). This is needed on Firefox because of the following bug
+     * https://bugzilla.mozilla.org/show_bug.cgi?id=1735951
+     *
+     * @return {boolean} <tt>true</tt> if the current browser supports this strategy or <tt>false</tt> otherwise.
      */
     doesVideoMuteByStreamRemove() {
-        return this.isChromiumBased() || this.isWebKitBased();
+        return this.isChromiumBased() || this.isWebKitBased() || this.isFirefox();
     }
 
     /**


### PR DESCRIPTION
We do not want Firefox sending video when its video muted. https://bugzilla.mozilla.org/show_bug.cgi?id=1735951