### PR TITLE
fix(TPC): Do not add muted tracks to conference for p2p.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2890,8 +2890,7 @@ JitsiConference.prototype._acceptP2PIncomingCall = function(
         this.p2pJingleSession.peerconnection,
         remoteID);
 
-    // Ignore muted tracks.
-    const localTracks = this.getLocalTracks().filter(track => !track.isMuted());
+    const localTracks = this.getLocalTracks();
 
     this.p2pJingleSession.acceptOffer(
         jingleOffer,
@@ -3251,8 +3250,7 @@ JitsiConference.prototype._startP2PSession = function(remoteJid) {
         this.p2pJingleSession.peerconnection,
         remoteID);
 
-    // Ignore muted tracks.
-    const localTracks = this.getLocalTracks().filter(track => !track.isMuted());
+    const localTracks = this.getLocalTracks();
 
     this.p2pJingleSession.invite(localTracks);
 };

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -81,34 +81,6 @@ export class TPCUtils {
     }
 
     /**
-     * Returns the transceiver associated with a given RTCRtpSender/RTCRtpReceiver.
-     *
-     * @param {string} mediaType - type of track associated with the transceiver 'audio' or 'video'.
-     * @param {JitsiLocalTrack} localTrack - local track to be used for lookup.
-     * @returns {RTCRtpTransceiver}
-     */
-    _findTransceiver(mediaType, localTrack = null) {
-        let transceiver = null;
-
-        // Check if the local track has been removed from the peerconnection already.
-        const trackRemoved = !localTrack
-            || (localTrack
-                && browser.doesVideoMuteByStreamRemove()
-                && localTrack.isVideoTrack()
-                && localTrack.isMuted());
-
-        if (trackRemoved) {
-            transceiver = this.pc.peerconnection.getTransceivers()
-                .find(t => t.receiver?.track?.kind === mediaType);
-        } else if (localTrack) {
-            transceiver = this.pc.peerconnection.getTransceivers()
-                .find(t => t.sender?.track?.id === localTrack.getTrackId());
-        }
-
-        return transceiver;
-    }
-
-    /**
      * Obtains stream encodings that need to be configured on the given track based
      * on the track media type and the simulcast setting.
      * @param {JitsiLocalTrack} localTrack
@@ -167,6 +139,21 @@ export class TPCUtils {
             type: description.type,
             sdp: transform.write(parsedSdp)
         });
+    }
+
+    /**
+     * Returns the transceiver associated with a given RTCRtpSender/RTCRtpReceiver.
+     *
+     * @param {string} mediaType - type of track associated with the transceiver 'audio' or 'video'.
+     * @param {JitsiLocalTrack} localTrack - local track to be used for lookup.
+     * @returns {RTCRtpTransceiver}
+     */
+    findTransceiver(mediaType, localTrack = null) {
+        const transceiver = localTrack?.track && localTrack.getOriginalStream()
+            ? this.pc.peerconnection.getTransceivers().find(t => t.sender?.track?.id === localTrack.getTrackId())
+            : this.pc.peerconnection.getTransceivers().find(t => t.receiver?.track?.kind === mediaType);
+
+        return transceiver;
     }
 
     /**
@@ -272,24 +259,6 @@ export class TPCUtils {
     }
 
     /**
-     * Adds a track on the RTCRtpSender as part of the unmute operation.
-     * @param {JitsiLocalTrack} localTrack - track to be unmuted.
-     * @returns {Promise<void>} - resolved when done.
-     */
-    addTrackUnmute(localTrack) {
-        const mediaType = localTrack.getType();
-        const track = localTrack.getTrack();
-        const transceiver = this._findTransceiver(mediaType);
-
-        if (!transceiver) {
-            return Promise.reject(new Error(`RTCRtpTransceiver for ${mediaType} not found`));
-        }
-        logger.debug(`${this.pc} Adding ${localTrack}`);
-
-        return transceiver.sender.replaceTrack(track);
-    }
-
-    /**
      * Returns the calculated active state of the simulcast encodings based on the frame height requested for the send
      * stream. All the encodings that have a resolution lower than the frame height requested will be enabled.
      *
@@ -369,110 +338,22 @@ export class TPCUtils {
     }
 
     /**
-     * Removes the track from the RTCRtpSender as part of the mute operation.
-     * @param {JitsiLocalTrack} localTrack - track to be removed.
-     * @returns {Promise<void>} - resolved when done.
-     */
-    removeTrackMute(localTrack) {
-        const mediaType = localTrack.getType();
-        const transceiver = this._findTransceiver(mediaType, localTrack);
-
-        if (!transceiver) {
-            return Promise.reject(new Error(`RTCRtpTransceiver for ${mediaType} not found`));
-        }
-
-        logger.debug(`${this.pc} Removing ${localTrack}`);
-
-        return transceiver.sender.replaceTrack(null);
-    }
-
-    /**
      * Replaces the existing track on a RTCRtpSender with the given track.
      * @param {JitsiLocalTrack} oldTrack - existing track on the sender that needs to be removed.
      * @param {JitsiLocalTrack} newTrack - new track that needs to be added to the sender.
      * @returns {Promise<void>} - resolved when done.
      */
     replaceTrack(oldTrack, newTrack) {
-        if (oldTrack && newTrack) {
-            const mediaType = newTrack.getType();
-            const stream = newTrack.getOriginalStream();
+        const mediaType = newTrack?.getType() ?? oldTrack?.getType();
+        const transceiver = this.findTransceiver(mediaType, oldTrack);
+        const track = newTrack?.getTrack() ?? null;
 
-            // Ignore cases when the track is replaced while the device is in a muted state,like
-            // replacing camera when video muted or replacing mic when audio muted. These JitsiLocalTracks
-            // do not have a mediastream attached. Replace track will be called again when the device is
-            // unmuted and the track will be replaced on the peerconnection then.
-            if (!stream) {
-                this.pc.localTracks.delete(oldTrack.rtcId);
-                this.pc.localTracks.set(newTrack.rtcId, newTrack);
-
-                return Promise.resolve();
-            }
-
-            const transceiver = this._findTransceiver(mediaType, oldTrack);
-            const track = newTrack.getTrack();
-
-            if (!transceiver) {
-                return Promise.reject(new Error('replace track failed'));
-            }
-            logger.debug(`${this.pc} Replacing ${oldTrack} with ${newTrack}`);
-
-            return transceiver.sender.replaceTrack(track)
-                .then(() => {
-                    const ssrc = this.pc.localSSRCs.get(oldTrack.rtcId);
-
-                    this.pc.localTracks.delete(oldTrack.rtcId);
-                    this.pc.localSSRCs.delete(oldTrack.rtcId);
-                    this.pc._addedStreams = this.pc._addedStreams.filter(s => s !== stream);
-                    this.pc.localTracks.set(newTrack.rtcId, newTrack);
-
-                    this.pc._addedStreams.push(stream);
-                    this.pc.localSSRCs.set(newTrack.rtcId, ssrc);
-                });
-        } else if (oldTrack && !newTrack) {
-            return this.removeTrackMute(oldTrack)
-                .then(() => {
-                    const mediaType = oldTrack.getType();
-                    const transceiver = this._findTransceiver(mediaType);
-
-                    // Change the direction on the transceiver to 'recvonly' so that a 'removetrack'
-                    // is fired on the associated media stream on the remote peer.
-                    if (transceiver) {
-                        transceiver.direction = MediaDirection.RECVONLY;
-                    }
-
-                    // Remove the old track from the list of local tracks.
-                    this.pc.localTracks.delete(oldTrack.rtcId);
-                    this.pc.localSSRCs.delete(oldTrack.rtcId);
-                });
-        } else if (newTrack && !oldTrack) {
-            return this.addTrackUnmute(newTrack)
-                .then(() => {
-                    const mediaType = newTrack.getType();
-                    const transceiver = this._findTransceiver(mediaType, newTrack);
-
-                    // Change the direction on the transceiver back to 'sendrecv' so that a 'track'
-                    // event is fired on the remote peer.
-                    if (transceiver) {
-                        transceiver.direction = MediaDirection.SENDRECV;
-                    }
-
-                    // Avoid configuring the encodings on Chromium/Safari until simulcast is configured
-                    // for the newly added track using SDP munging which happens during the renegotiation.
-                    const promise = browser.usesSdpMungingForSimulcast()
-                        ? Promise.resolve()
-                        : this.setEncodings(newTrack);
-
-                    return promise
-                        .then(() => {
-                            // Add the new track to the list of local tracks.
-                            this.pc.localTracks.set(newTrack.rtcId, newTrack);
-                        });
-                });
+        if (!transceiver) {
+            return Promise.reject(new Error('replace track failed'));
         }
+        logger.debug(`${this.pc} Replacing ${oldTrack} with ${newTrack}`);
 
-        logger.info(`${this.pc} TPCUtils.replaceTrack called with no new track and no old track`);
-
-        return Promise.resolve();
+        return transceiver.sender.replaceTrack(track);
     }
 
     /**
@@ -496,7 +377,7 @@ export class TPCUtils {
      */
     setEncodings(track) {
         const mediaType = track.getType();
-        const transceiver = this._findTransceiver(mediaType, track);
+        const transceiver = this.findTransceiver(mediaType, track);
         const parameters = transceiver?.sender?.getParameters();
 
         // Resolve if the encodings are not available yet. This happens immediately after the track is added to the

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1698,19 +1698,21 @@ TraceablePeerConnection.prototype.addTrack = function(track, isInitiator = false
     }
 
     this.localTracks.set(rtcId, track);
+    const webrtcStream = track.getOriginalStream();
 
     if (this._usesUnifiedPlan) {
-        try {
-            this.tpcUtils.addTrack(track, isInitiator);
-        } catch (error) {
-            logger.error(`${this} Adding track=${track} failed: ${error?.message}`);
+        logger.debug(`${this} TPC.addTrack using unified plan`);
+        if (webrtcStream) {
+            try {
+                this.tpcUtils.addTrack(track, isInitiator);
+            } catch (error) {
+                logger.error(`${this} Adding track=${track} failed: ${error?.message}`);
 
-            return Promise.reject(error);
+                return Promise.reject(error);
+            }
         }
     } else {
         // Use addStream API for the plan-b case.
-        const webrtcStream = track.getOriginalStream();
-
         if (webrtcStream) {
             this._addStream(webrtcStream);
 
@@ -1753,7 +1755,7 @@ TraceablePeerConnection.prototype.addTrack = function(track, isInitiator = false
 
     // On Firefox, the encodings have to be configured on the sender only after the transceiver is created.
     if (browser.isFirefox()) {
-        promiseChain = promiseChain.then(() => this.tpcUtils.setEncodings(track));
+        promiseChain = promiseChain.then(() => webrtcStream && this.tpcUtils.setEncodings(track));
     }
 
     return promiseChain;
@@ -1771,9 +1773,9 @@ TraceablePeerConnection.prototype.addTrackUnmute = function(track) {
     logger.info(`${this} Adding track=${track} as unmute`);
 
     if (!this._assertTrackBelongs('addTrackUnmute', track)) {
-        // This can happen when the user has created a track but muted it before the peerconnection is created and
-        // unmutes it after the peerconnection is created.
-        return this.replaceTrack(null, track).then(() => this.isP2P || !this._usesUnifiedPlan);
+        // Abort
+
+        return Promise.reject('Track not found on the peerconnection');
     }
 
     const webRtcStream = track.getOriginalStream();
@@ -1785,7 +1787,7 @@ TraceablePeerConnection.prototype.addTrackUnmute = function(track) {
     }
 
     if (this._usesUnifiedPlan) {
-        return this.tpcUtils.addTrackUnmute(track).then(() => this.isP2P);
+        return this.tpcUtils.replaceTrack(null, track).then(() => this.isP2P);
     }
 
     this._addStream(webRtcStream);
@@ -1981,15 +1983,44 @@ TraceablePeerConnection.prototype.findSenderForTrack = function(track) {
  * Otherwise no renegotiation is needed.
  */
 TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
+    if (!(oldTrack || newTrack)) {
+        logger.info(`${this} replaceTrack called with no new track and no old track`);
+
+        return Promise.resolve();
+    }
+
     if (this._usesUnifiedPlan) {
         logger.debug(`${this} TPC.replaceTrack using unified plan`);
+        const stream = newTrack?.getOriginalStream();
+        const promise = newTrack && !stream
 
-        const oldJitsiTrack = oldTrack && this._assertTrackBelongs('replaceTrack', oldTrack)
-            ? oldTrack
-            : null;
+            // Ignore cases when the track is replaced while the device is in a muted state.
+            // The track will be replaced again on the peerconnection when the user unmutes.
+            ? Promise.resolve()
+            : this.tpcUtils.replaceTrack(oldTrack, newTrack);
 
-        // Renegotiate only in the case of P2P. We rely on 'negotiationeeded' to be fired for JVB.
-        return this.tpcUtils.replaceTrack(oldJitsiTrack, newTrack).then(() => this.isP2P);
+        return promise
+            .then(() => {
+                oldTrack && this.localTracks.delete(oldTrack.rtcId);
+                newTrack && this.localTracks.set(newTrack.rtcId, newTrack);
+
+                const mediaType = newTrack?.getType() ?? oldTrack?.getType();
+                const transceiver = this.tpcUtils.findTransceiver(mediaType, oldTrack);
+
+                if (transceiver) {
+                    // Set the transceiver direction.
+                    transceiver.direction = newTrack ? MediaDirection.SENDRECV : MediaDirection.RECVONLY;
+                }
+
+                // Avoid configuring the encodings on Chromium/Safari until simulcast is configured
+                // for the newly added track using SDP munging which happens during the renegotiation.
+                const configureEncodingsPromise = browser.usesSdpMungingForSimulcast() || !newTrack
+                    ? Promise.resolve()
+                    : this.tpcUtils.setEncodings(newTrack);
+
+                // Renegotiate only in the case of P2P. We rely on 'negotiationeeded' to be fired for JVB.
+                return configureEncodingsPromise.then(() => this.isP2P);
+            });
     }
 
     logger.debug(`${this} TPC.replaceTrack using plan B`);
@@ -2027,7 +2058,7 @@ TraceablePeerConnection.prototype.removeTrackMute = function(localTrack) {
     }
 
     if (this._usesUnifiedPlan) {
-        return this.tpcUtils.removeTrackMute(localTrack);
+        return this.tpcUtils.replaceTrack(localTrack, null);
     }
 
     if (webRtcStream) {


### PR DESCRIPTION
Tracks that are created but muted before peerconnection is created throw an error in unified plan during session creation. All source changes after that fail.
Fixes https://github.com/jitsi/jitsi-meet/issues/9988.