### PR TITLE
fix(SS): missing.

### DIFF
--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -699,10 +699,15 @@ SDP.prototype.jingle2media = function(content) {
         });
 
     // XEP-0339 handle source attributes
+    let userSources = '';
+    let nonUserSources = '';
+
     desc
         .find('>source[xmlns="urn:xmpp:jingle:apps:rtp:ssma:0"]')
         .each((_, source) => {
             const ssrc = source.getAttribute('ssrc');
+            let isUserSource = true;
+            let sourceStr = '';
 
             $(source)
                 .find('>parameter')
@@ -711,13 +716,29 @@ SDP.prototype.jingle2media = function(content) {
                     let value = parameter.getAttribute('value');
 
                     value = SDPUtil.filterSpecialChars(value);
-                    sdp += `a=ssrc:${ssrc} ${name}`;
+                    sourceStr += `a=ssrc:${ssrc} ${name}`;
+
                     if (value && value.length) {
-                        sdp += `:${value}`;
+                        sourceStr += `:${value}`;
                     }
-                    sdp += '\r\n';
+
+                    sourceStr += '\r\n';
+
+                    if (value?.includes('mixedmslabel')) {
+                        isUserSource = false;
+                    }
                 });
+
+            if (isUserSource) {
+                userSources += sourceStr;
+            } else {
+                nonUserSources += sourceStr;
+            }
         });
+
+    // The sdp-interop package is relying the mixedmslabel m line to be the first one in order to set the direction
+    // to sendrecv.
+    sdp += nonUserSources + userSources;
 
     return sdp;
 };


### PR DESCRIPTION
The issue was caused by incorrect ordering of the mixedmslabel mline.
sdp-interop is expecting that this mline was the first one but in
reality we were placing it last. This was causing the direction of a
user related m line to be sendrecv instead of sendonly. In certain
situation this issue was causing 2 MediaStreamTracks associated with a
single MediaStream/participant.