### PR TITLE
fix: Missed "cname" attribute in SDP jingle

### DIFF
--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -205,6 +205,7 @@ SDP.prototype.toJingle = function(elem, thecreator) {
 
                 for (const [ availableSsrc, ssrcParameters ] of ssrcMap) {
                     const sourceName = SDPUtil.parseSourceNameLine(ssrcParameters);
+                    const { msid, cname } = SDPUtil.parseSsrcAttributes(ssrcParameters);
 
                     elem.c('source', {
                         ssrc: availableSsrc,
@@ -212,13 +213,19 @@ SDP.prototype.toJingle = function(elem, thecreator) {
                         xmlns: 'urn:xmpp:jingle:apps:rtp:ssma:0'
                     });
 
-                    const msid = SDPUtil.parseMSIDAttribute(ssrcParameters);
-
                     // eslint-disable-next-line max-depth
                     if (msid) {
                         elem.c('parameter');
                         elem.attrs({ name: 'msid' });
                         elem.attrs({ value: msid });
+                        elem.up();
+                    }
+
+                    // eslint-disable-next-line max-depth
+                    if (cname) {
+                        elem.c('parameter');
+                        elem.attrs({ name: 'cname' });
+                        elem.attrs({ value: cname });
                         elem.up();
                     }
 

--- a/modules/sdp/SDPDiffer.js
+++ b/modules/sdp/SDPDiffer.js
@@ -171,6 +171,7 @@ SDPDiffer.prototype.toJingle = function(modify) {
             const mediaSsrc = media.ssrcs[ssrcNum];
             const ssrcLines = mediaSsrc.lines;
             const sourceName = SDPUtil.parseSourceNameLine(ssrcLines);
+            const { msid, cname } = SDPUtil.parseSsrcAttributes(ssrcLines);
 
             modify.c('source', { xmlns: 'urn:xmpp:jingle:apps:rtp:ssma:0' });
             modify.attrs({
@@ -178,13 +179,17 @@ SDPDiffer.prototype.toJingle = function(modify) {
                 ssrc: mediaSsrc.ssrc
             });
 
-            // Only MSID attribute is sent
-            const msid = SDPUtil.parseMSIDAttribute(ssrcLines);
-
             if (msid) {
                 modify.c('parameter');
                 modify.attrs({ name: 'msid' });
                 modify.attrs({ value: msid });
+                modify.up();
+            }
+
+            if (cname) {
+                modify.c('parameter');
+                modify.attrs({ name: 'cname' });
+                modify.attrs({ value: cname });
                 modify.up();
             }
 

--- a/modules/sdp/SDPUtil.js
+++ b/modules/sdp/SDPUtil.js
@@ -48,21 +48,33 @@ const SDPUtil = {
     },
 
     /**
+     * Returns an object with parsed attributes from the given array of SSRC attribute lines.
+     *
+     * @param {string[]} ssrcLines - an array of lines similar to 'a:213123 msid:stream-id track-id'.
+     * @returns {Object.<string, string>} - an object with parsed attributes
+     */
+    parseSsrcAttributes(ssrcLines) {
+        const attributes = {};
+
+        ssrcLines.forEach(line => {
+            const { key, value } = line.match(/a=ssrc:\w+\s+(?<key>\w+):(?<value>.*)/)?.groups ?? {};
+
+            if (key && value) {
+                attributes[key] = SDPUtil.filterSpecialChars(value);
+            }
+        });
+
+        return attributes;
+    },
+
+    /**
      * Finds the MSID attribute in the given array of SSRC attribute lines and returns the value.
      *
      * @param {string[]} ssrcLines - an array of lines similar to 'a:213123 msid:stream-id track-id'.
      * @returns {undefined|string}
      */
     parseMSIDAttribute(ssrcLines) {
-        const msidLine = ssrcLines.find(line => line.indexOf(' msid:') > 0);
-
-        if (!msidLine) {
-            return undefined;
-        }
-
-        const v = msidLine.substring(msidLine.indexOf(' msid:') + 6 /* the length of ' msid:' */);
-
-        return SDPUtil.filterSpecialChars(v);
+        return SDPUtil.parseSsrcAttributes(ssrcLines).msid;
     },
     parseMLine(line) {
         const data = {};


### PR DESCRIPTION
Added `cname` attribute to SDP jingle.

The missed `cname` causes receiving PeerConnection's track without a media stream in not-latest Chromium-based browsers.