### PR TITLE
fix(xmpp): disable RTX on Firefox

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -211,7 +211,7 @@ export default class XMPP extends Listenable {
 
         // Disable RTX on Firefox because we prefer simulcast over RTX
         // https://bugzilla.mozilla.org/show_bug.cgi?id=1738504
-        if (!(this.options.disableRtx || (browser.isFirefox()))) {
+        if (!(this.options.disableRtx || browser.isFirefox())) {
             this.caps.addFeature('urn:ietf:rfc:4588');
         }
         if (this.options.enableOpusRed === true && browser.supportsAudioRed()) {

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -209,9 +209,9 @@ export default class XMPP extends Listenable {
         this.caps.addFeature('urn:xmpp:jingle:apps:rtp:video');
         this.caps.addFeature('http://jitsi.org/json-encoded-sources');
 
-        // Disable RTX on Firefox 83 and older versions because of
-        // https://bugzilla.mozilla.org/show_bug.cgi?id=1668028
-        if (!(this.options.disableRtx || (browser.isFirefox() && browser.isVersionLessThan(94)))) {
+        // Disable RTX on Firefox because we prefer simulcast over RTX
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1738504
+        if (!(this.options.disableRtx || (browser.isFirefox()))) {
             this.caps.addFeature('urn:ietf:rfc:4588');
         }
         if (this.options.enableOpusRed === true && browser.supportsAudioRed()) {


### PR DESCRIPTION
The combination of simulcast and RTX causes bad video quality on
Firefox. Turning RTX off until Firefox can handle the combination
better.
