### PR TITLE
fix(TPC) change the tranceiver dir to recvonly when track is removed.

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -625,7 +625,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
      */
     _sendMuteStatus(mute) {
         if (this.conference) {
-            this.conference._setTrackMuteStatus(this, mute);
+            this.conference._setTrackMuteStatus(this, mute) && this.conference.room.sendPresence();
         }
     }
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1991,6 +1991,7 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
 
     if (this._usesUnifiedPlan) {
         logger.debug(`${this} TPC.replaceTrack using unified plan`);
+        const mediaType = newTrack?.getType() ?? oldTrack?.getType();
         const stream = newTrack?.getOriginalStream();
         const promise = newTrack && !stream
 
@@ -1998,14 +1999,12 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
             // The track will be replaced again on the peerconnection when the user unmutes.
             ? Promise.resolve()
             : this.tpcUtils.replaceTrack(oldTrack, newTrack);
+        const transceiver = this.tpcUtils.findTransceiver(mediaType, oldTrack);
 
         return promise
             .then(() => {
                 oldTrack && this.localTracks.delete(oldTrack.rtcId);
                 newTrack && this.localTracks.set(newTrack.rtcId, newTrack);
-
-                const mediaType = newTrack?.getType() ?? oldTrack?.getType();
-                const transceiver = this.tpcUtils.findTransceiver(mediaType, oldTrack);
 
                 if (transceiver) {
                     // Set the transceiver direction.


### PR DESCRIPTION
This fixes occasional failures of MuteTest.MuteAfterJoinCanShareAndUnmute torture test and also the case on Safari where user stopping the screenshare doesn't stop showing the screensharing indication on the thumbnail.
Its applicable to other browsers as well.