### PR TITLE
fix(e2ee): fix loading web worker when using a relative path inside a blob for the E2EE context

### DIFF
--- a/modules/e2ee/E2EEContext.js
+++ b/modules/e2ee/E2EEContext.js
@@ -37,14 +37,22 @@ export default class E2EEcontext {
             baseUrl = `${ljm.src.substring(0, idx)}/`;
         }
 
-        // Initialize the E2EE worker. In order to avoid CORS issues, start the worker and have it
-        // synchronously load the JS.
         const workerUrl = `${baseUrl}lib-jitsi-meet.e2ee-worker.js`;
-        const workerBlob
-            = new Blob([ `importScripts("${workerUrl}");` ], { type: 'application/javascript' });
-        const blobUrl = window.URL.createObjectURL(workerBlob);
+        
+        if (baseUrl && baseUrl.length > 0) {
+            // Initialize the E2EE worker. In order to avoid CORS issues, start the worker and have it
+            // synchronously load the JS.
+            const workerBlob
+                = new Blob([ `importScripts("${workerUrl}");` ], { type: 'application/javascript' });
+            const blobUrl = window.URL.createObjectURL(workerBlob);
 
-        this._worker = new Worker(blobUrl, { name: 'E2EE Worker' });
+            this._worker = new Worker(blobUrl, { name: 'E2EE Worker' });
+        } else {
+            // If there is no baseUrl then we create the worker in a normal way
+            // as you cant load scripts inside blobs from relative paths.
+            // See: https://www.html5rocks.com/en/tutorials/workers/basics/#toc-inlineworkers-loadingscripts
+            this._worker = new Worker(workerUrl, { name: 'E2EE Worker' });
+        }
 
         this._worker.onerror = e => logger.error(e);
 

--- a/modules/e2ee/E2EEContext.js
+++ b/modules/e2ee/E2EEContext.js
@@ -37,22 +37,20 @@ export default class E2EEcontext {
             baseUrl = `${ljm.src.substring(0, idx)}/`;
         }
 
-        const workerUrl = `${baseUrl}lib-jitsi-meet.e2ee-worker.js`;
+        let workerUrl = `${baseUrl}lib-jitsi-meet.e2ee-worker.js`;
 
+        // If there is no baseUrl then we create the worker in a normal way
+        // as you cant load scripts inside blobs from relative paths.
+        // See: https://www.html5rocks.com/en/tutorials/workers/basics/#toc-inlineworkers-loadingscripts
         if (baseUrl && baseUrl.length > 0) {
             // Initialize the E2EE worker. In order to avoid CORS issues, start the worker and have it
             // synchronously load the JS.
             const workerBlob
                 = new Blob([ `importScripts("${workerUrl}");` ], { type: 'application/javascript' });
-            const blobUrl = window.URL.createObjectURL(workerBlob);
-
-            this._worker = new Worker(blobUrl, { name: 'E2EE Worker' });
-        } else {
-            // If there is no baseUrl then we create the worker in a normal way
-            // as you cant load scripts inside blobs from relative paths.
-            // See: https://www.html5rocks.com/en/tutorials/workers/basics/#toc-inlineworkers-loadingscripts
-            this._worker = new Worker(workerUrl, { name: 'E2EE Worker' });
+            workerUrl = window.URL.createObjectURL(workerBlob);
         }
+
+        this._worker = new Worker(workerUrl, { name: 'E2EE Worker' });
 
         this._worker.onerror = e => logger.error(e);
 

--- a/modules/e2ee/E2EEContext.js
+++ b/modules/e2ee/E2EEContext.js
@@ -38,7 +38,7 @@ export default class E2EEcontext {
         }
 
         const workerUrl = `${baseUrl}lib-jitsi-meet.e2ee-worker.js`;
-        
+
         if (baseUrl && baseUrl.length > 0) {
             // Initialize the E2EE worker. In order to avoid CORS issues, start the worker and have it
             // synchronously load the JS.

--- a/modules/e2ee/E2EEContext.js
+++ b/modules/e2ee/E2EEContext.js
@@ -42,7 +42,7 @@ export default class E2EEcontext {
         // If there is no baseUrl then we create the worker in a normal way
         // as you cant load scripts inside blobs from relative paths.
         // See: https://www.html5rocks.com/en/tutorials/workers/basics/#toc-inlineworkers-loadingscripts
-        if (baseUrl && baseUrl.length > 0) {
+        if (baseUrl && baseUrl !== '/') {
             // Initialize the E2EE worker. In order to avoid CORS issues, start the worker and have it
             // synchronously load the JS.
             const workerBlob

--- a/modules/e2ee/E2EEContext.js
+++ b/modules/e2ee/E2EEContext.js
@@ -47,6 +47,7 @@ export default class E2EEcontext {
             // synchronously load the JS.
             const workerBlob
                 = new Blob([ `importScripts("${workerUrl}");` ], { type: 'application/javascript' });
+
             workerUrl = window.URL.createObjectURL(workerBlob);
         }
 


### PR DESCRIPTION
When loading a web worker inside a blob using importScripts you cannot use a relative path because of CORS issues as it resolves to a blob: path.

Please see: https://www.html5rocks.com/en/tutorials/workers/basics/#toc-inlineworkers-loadingscripts