### PR TITLE
fix(sdp): update data channel to RFC format

### DIFF
--- a/modules/sdp/SDPUtil.js
+++ b/modules/sdp/SDPUtil.js
@@ -112,6 +112,9 @@ const SDPUtil = {
 
         return [ sctpPort, protocol, streamCount ];// SCTP port
     },
+    parseSCTPPort(line) {
+        return line.substring(12);
+    },
     buildRTPMap(el) {
         let line
             = `a=rtpmap:${el.getAttribute('id')} ${el.getAttribute('name')}/${

--- a/modules/sdp/SampleSdpStrings.js
+++ b/modules/sdp/SampleSdpStrings.js
@@ -37,7 +37,7 @@ const baseAudioMLineSdp = ''
 
 // A basic sdp application mline
 const baseDataMLineSdp = ''
-+ 'm=application 9 DTLS/SCTP 5000\r\n'
++ 'm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n'
 + 'c=IN IP4 0.0.0.0\r\n'
 + 'b=AS:30\r\n'
 + 'a=setup:passive\r\n'
@@ -45,7 +45,8 @@ const baseDataMLineSdp = ''
 + 'a=ice-ufrag:adPg\r\n'
 + 'a=ice-pwd:Xsr05Mq8S7CR44DAnusZE26F\r\n'
 + 'a=fingerprint:sha-256 6A:39:DE:11:24:AD:2E:4E:63:D6:69:D3:85:05:53:C7:3C:38:A4:B7:91:74:C0:91:44:FC:94:63:7F:01:AB:A9\r\n'
-+ 'a=sctpmap:5000 webrtc-datachannel 1024\r\n';
++ 'a=sctp-port:5000\r\n'
++ 'a=max-message-size:262144\r\n';
 
 // A basic sdp video mline with a single stream
 const plainVideoMLineSdp = ''
@@ -257,17 +258,7 @@ const flexFecVideoMLineSdp = ''
 + 'a=ssrc:116623191 cname:mT86hcsCZwQBPh6R\r\n'
 + 'a=ssrc:116623191 msid:a2548ae2-32e8-4b09-89bc-b11f3e49ac5a b3e3d760-6b1b-48bd-8519-9d6261311d28\r\n'
 + 'a=ssrc:116623191 mslabel:a2548ae2-32e8-4b09-89bc-b11f3e49ac5a\r\n'
-+ 'a=ssrc:116623191 label:b3e3d760-6b1b-48bd-8519-9d6261311d28\r\n'
-+ 'm=application 9 DTLS/SCTP 5000\r\n'
-+ 'c=IN IP4 0.0.0.0\r\n'
-+ 'b=AS:30\r\n'
-+ 'a=ice-ufrag:aLBh\r\n'
-+ 'a=ice-pwd:7IeqrWG5ryCW2X47Lso8XYdK\r\n'
-+ 'a=ice-options:trickle\r\n'
-+ 'a=fingerprint:sha-256 78:3C:F9:96:85:FB:20:25:F8:2F:AB:37:8B:8B:17:29:EF:54:7B:7C:17:2E:90:02:8A:A1:8F:A7:F9:C5:F2:90\r\n'
-+ 'a=setup:active\r\n'
-+ 'a=mid:data\r\n'
-+ 'a=sctpmap:5000 webrtc-datachannel 1024\r\n';
++ 'a=ssrc:116623191 label:b3e3d760-6b1b-48bd-8519-9d6261311d28\r\n';
 
 const recvOnlyAudioMline = ''
 + 'm=audio 54405 RTP/SAVPF 111 103 104 126\r\n'


### PR DESCRIPTION
This PR switches to generating sctp-port based SDP.
It also adds support for parsing sctp-port, but can handle
fallback to old-style sctpmap as well.
Fixes: #1778 