### PR TITLE
fix(xmpp): use RTX with Firefox from 96 on only

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -323,6 +323,17 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
+     * Check if the browser supports the RTP RTX feature (and it is usable).
+     *
+     * @returns {boolean}
+     */
+    supportsRTX() {
+        // Disable RTX on Firefox up to 96 because we prefer simulcast over RTX
+        // see https://bugzilla.mozilla.org/show_bug.cgi?id=1738504
+        return !(this.isFirefox() && this.isVersionLessThan('96'));
+    }
+
+    /**
      * Returns the version of a Chromium based browser.
      *
      * @returns {Number}

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -209,9 +209,7 @@ export default class XMPP extends Listenable {
         this.caps.addFeature('urn:xmpp:jingle:apps:rtp:video');
         this.caps.addFeature('http://jitsi.org/json-encoded-sources');
 
-        // Disable RTX on Firefox 83 and older versions because of
-        // https://bugzilla.mozilla.org/show_bug.cgi?id=1668028
-        if (!(this.options.disableRtx || (browser.isFirefox() && browser.isVersionLessThan(94)))) {
+        if (!(this.options.disableRtx || !browser.supportsRTX())) {
             this.caps.addFeature('urn:ietf:rfc:4588');
         }
         if (this.options.enableOpusRed === true && browser.supportsAudioRed()) {


### PR DESCRIPTION
RTX in combination with simulcast on Firefox results in bad video quality
therefore we only enable it for version >= 96.