### PR TITLE
Fix sctp streams

### DIFF
--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -364,6 +364,8 @@ SDP.prototype.transportToJingle = function(mediaindex, elem) {
             number: sctpAttrs, /* SCTP port */
             protocol: 'webrtc-datachannel' /* protocol */
         });
+        // The parser currently requires streams to be present
+        elem.attrs({ streams: 0 });
         elem.up();
     } else if (sctpmap) {
         const sctpAttrs = SDPUtil.parseSCTPMap(sctpmap);
@@ -377,6 +379,8 @@ SDP.prototype.transportToJingle = function(mediaindex, elem) {
         // Optional stream count attribute
         if (sctpAttrs.length > 2) {
             elem.attrs({ streams: sctpAttrs[2] });
+        } else {
+            elem.attrs({ streams: 0 });
         }
         elem.up();
     }

--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -364,6 +364,7 @@ SDP.prototype.transportToJingle = function(mediaindex, elem) {
             number: sctpAttrs, /* SCTP port */
             protocol: 'webrtc-datachannel' /* protocol */
         });
+
         // The parser currently requires streams to be present
         elem.attrs({ streams: 0 });
         elem.up();


### PR DESCRIPTION
This patch fixes an issue introduced in #1779 by always providing a stream count, because for the XMPP parser the stream count is not optional.