### PR TITLE
Fix reneg on unmute

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1988,7 +1988,9 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
     }
 
     // If a track is being added to the peerconnection for the first time, we want the source signaling to be sent to
-    // Jicofo before the mute state is sent over presence. Therefore, trigger a renegotiation in this case.
+    // Jicofo before the mute state is sent over presence. Therefore, trigger a renegotiation in this case. If we
+    // rely on "negotiationneeded" fired by the browser to signal new ssrcs, the mute state in presence will be sent
+    // before the source signaling which is undesirable.
     const negotiationNeeded = Boolean(!oldTrack || !this.localTracks.has(oldTrack?.rtcId));
 
     if (this._usesUnifiedPlan) {

--- a/modules/xmpp/SignalingLayerImpl.js
+++ b/modules/xmpp/SignalingLayerImpl.js
@@ -343,8 +343,10 @@ export default class SignalingLayerImpl extends SignalingLayer {
 
         // Now signaling layer instance is shared between different JingleSessionPC instances, so although very unlikely
         // an SSRC conflict could potentially occur. Log a message to make debugging easier.
-        if (this.ssrcOwners.has(ssrc)) {
-            logger.error(`SSRC owner re-assigned from ${this.ssrcOwners.get(ssrc)} to ${endpointId}`);
+        const existingOwner = this.ssrcOwners.get(ssrc);
+
+        if (existingOwner && existingOwner !== endpointId) {
+            logger.error(`SSRC owner re-assigned from ${existingOwner} to ${endpointId}`);
         }
         this.ssrcOwners.set(ssrc, endpointId);
     }


### PR DESCRIPTION
This ensures that the source signaling is sent before the mute state is sent in presence. Jicofo relies on mute state from presence to check if the sender limit has been reached.
