### PR TITLE
fix(TPC): Select 1 as the default scale factor for p2p.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2498,10 +2498,12 @@ TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeig
 
     // For p2p and cases and where simulcast is explicitly disabled.
     } else if (frameHeight > 0) {
+        let scaleFactor = HD_SCALE_FACTOR;
+
         // Do not scale down encodings for desktop tracks for non-simulcast case.
-        const scaleFactor = videoType === VideoType.DESKTOP || localVideoTrack.resolution <= frameHeight
-            ? HD_SCALE_FACTOR
-            : Math.floor(localVideoTrack.resolution / frameHeight);
+        if (videoType === VideoType.CAMERA && localVideoTrack.resolution > frameHeight) {
+            scaleFactor = Math.floor(localVideoTrack.resolution / frameHeight);
+        }
 
         parameters.encodings[0].active = true;
         parameters.encodings[0].scaleResolutionDownBy = scaleFactor;


### PR DESCRIPTION
This fixes an issue where a user is not able to unmute their video if the MediaStreamTrack associated with the camera stream returns a null value for the track height.