### PR TITLE
fix(rtc): fix sending video type on unmute

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1128,7 +1128,7 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
 
     // Send the video type message to the bridge if the track is not removed/added to the pc as part of
     // the mute/unmute operation. This currently happens only on Firefox.
-    if (track.isVideoTrack() && !browser.doesVideoMuteByStreamRemove()) {
+    if (track.isVideoTrack() && (!track.isMuted() || (track.isMuted() && !browser.doesVideoMuteByStreamRemove()))) {
         this._sendBridgeVideoTypeMessage(track);
     }
 


### PR DESCRIPTION
When initially adding a muted desktop track to the conference, the video type was not being sent to the video bridge when subsequently unmuting, thus the stream was not being forwarded to clients as the video type was set to NONE.

This fixes the logic that when the track is unmuted the BridgeVideoType is sent, otherwise when muted it checks if the stream is muted by removing it from the PC, similar to how it was done before.