### PR TITLE
fix(breakout-rooms) send whole payload on update event

### DIFF
--- a/modules/xmpp/BreakoutRooms.js
+++ b/modules/xmpp/BreakoutRooms.js
@@ -164,7 +164,7 @@ export default class BreakoutRooms {
             break;
         case BREAKOUT_ROOM_EVENTS.UPDATE: {
             this._rooms = payload.rooms;
-            this.room.eventEmitter.emit(XMPPEvents.BREAKOUT_ROOMS_UPDATED, payload.rooms);
+            this.room.eventEmitter.emit(XMPPEvents.BREAKOUT_ROOMS_UPDATED, payload);
             break;
         }
         }


### PR DESCRIPTION
This is necessary when adding new properties to the payload.