### PR TITLE
fix(avmoderation,breakout-rooms) dispose handlers when leaving

### DIFF
--- a/modules/xmpp/AVModeration.js
+++ b/modules/xmpp/AVModeration.js
@@ -29,7 +29,15 @@ export default class AVModeration {
         this._whitelistAudio = [];
         this._whitelistVideo = [];
 
-        this._xmpp.addListener(XMPPEvents.AV_MODERATION_RECEIVED, this._onMessage.bind(this));
+        this._onMessage = this._onMessage.bind(this);
+        this._xmpp.addListener(XMPPEvents.AV_MODERATION_RECEIVED, this._onMessage);
+    }
+
+    /**
+     * Stops listening for events.
+     */
+    dispose() {
+        this._xmpp.removeListener(XMPPEvents.AV_MODERATION_RECEIVED, this._onMessage);
     }
 
     /**

--- a/modules/xmpp/BreakoutRooms.js
+++ b/modules/xmpp/BreakoutRooms.js
@@ -29,9 +29,17 @@ export default class BreakoutRooms {
     constructor(room) {
         this.room = room;
 
-        this.room.xmpp.addListener(XMPPEvents.BREAKOUT_ROOMS_EVENT, this._handleMessages.bind(this));
+        this._handleMessages = this._handleMessages.bind(this);
+        this.room.xmpp.addListener(XMPPEvents.BREAKOUT_ROOMS_EVENT, this._handleMessages);
 
         this._rooms = {};
+    }
+
+    /**
+     * Stops listening for events.
+     */
+    dispose() {
+        this.room.xmpp.removeListener(XMPPEvents.BREAKOUT_ROOMS_EVENT, this._handleMessages);
     }
 
     /**

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1849,6 +1849,9 @@ export default class ChatRoom extends Listenable {
      * rejected.
      */
     leave() {
+        this.avModeration.dispose();
+        this.breakoutRooms.dispose();
+
         const promises = [];
 
         this.lobby?.lobbyRoom && promises.push(this.lobby.leave());


### PR DESCRIPTION
Both of this features listen for events in the XMPP connection. Thus, if we join
another meeting over the same connection we might still receive some events on
the old event handler.

Stop listening for events from the components as soon as the leave operation is
triggered.