### PR TITLE
feat(lobby): challenge-response messaging

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3942,6 +3942,63 @@ JitsiConference.prototype.joinLobby = function(displayName, email) {
 };
 
 /**
+ * Gets the local id for a participant in a lobby room.
+ * Returns undefined when current participant is not in the lobby room.
+ * This is used for lobby room private chat messages.
+ *
+ * @returns {string}
+ */
+JitsiConference.prototype.myLobbyUserId = function() {
+    if (this.room) {
+        return this.room.getLobby().getLocalId();
+    }
+};
+
+/**
+ * Sends a message to a lobby room.
+ * When id is specified it sends a private message.
+ * Otherwise it sends the message to all moderators.
+ * @param {message} Object The message to send
+ * @param {string} id The participant id.
+ *
+ * @returns {void}
+ */
+JitsiConference.prototype.sendLobbyMessage = function(message, id) {
+    if (this.room) {
+        if (id) {
+            return this.room.getLobby().sendPrivateMessage(id, message);
+        }
+
+        return this.room.getLobby().sendMessage(message);
+    }
+};
+
+/**
+ * Adds a message listener to the lobby room
+ * @param {Function} listener The listener function,
+ * called when a new message is received in the lobby room.
+ *
+ * @returns {Function} Handler returned to be able to remove it later.
+ */
+JitsiConference.prototype.addLobbyMessageListener = function(listener) {
+    if (this.room) {
+        return this.room.getLobby().addMessageListener(listener);
+    }
+};
+
+/**
+ * Removes a message handler from the lobby room
+ * @param {Function} handler The handler function  to remove.
+ *
+ * @returns {void}
+ */
+JitsiConference.prototype.removeLobbyMessageHandler = function(handler) {
+    if (this.room) {
+        return this.room.getLobby().removeMessageHandler(handler);
+    }
+};
+
+/**
  * Denies an occupant in the lobby room access to the conference.
  * @param {string} id The participant id.
  */

--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -83,6 +83,74 @@ export default class Lobby {
     }
 
     /**
+     * Broadcast a message to all participants in the lobby room
+     * @param {Object} message The message to send
+     *
+     * @returns {void}
+     */
+    sendMessage(message) {
+        if (this.lobbyRoom) {
+            this.lobbyRoom.sendMessage(JSON.stringify(message), 'json-message');
+        }
+    }
+
+    /**
+     * Sends a private message to a participant in a lobby room.
+     * @param {string} id The message to send
+     * @param {Object} message The message to send
+     *
+     * @returns {void}
+     */
+    sendPrivateMessage(id, message) {
+        if (this.lobbyRoom) {
+            this.lobbyRoom.sendPrivateMessage(id, JSON.stringify(message), 'json-message');
+        }
+    }
+
+    /**
+     * Gets the local id for a participant in a lobby room.
+     * This is used for lobby room private chat messages.
+     *
+     * @returns {string}
+     */
+    getLocalId() {
+        if (this.lobbyRoom) {
+            return Strophe.getResourceFromJid(this.lobbyRoom.myroomjid);
+        }
+    }
+
+    /**
+     * Adds a message listener to the lobby room.
+     * @param {Function} listener The listener function,
+     * called when a new message is received in the lobby room.
+     *
+     * @returns {Function} Handler returned to be able to remove it later.
+     */
+    addMessageListener(listener) {
+        if (this.lobbyRoom) {
+            const handler = (participantId, message) => {
+                listener(message, Strophe.getResourceFromJid(participantId));
+            };
+
+            this.lobbyRoom.on(XMPPEvents.JSON_MESSAGE_RECEIVED, handler);
+
+            return handler;
+        }
+    }
+
+    /**
+     * Remove a message handler from the lobby room.
+     * @param {Function} handler The handler function to remove.
+     *
+     * @returns {void}
+     */
+    removeMessageHandler(handler) {
+        if (this.lobbyRoom) {
+            this.lobbyRoom.off(XMPPEvents.JSON_MESSAGE_RECEIVED, handler);
+        }
+    }
+
+    /**
      * Leaves the lobby room.
      *
      * @returns {Promise}


### PR DESCRIPTION
Better moderation capabilities in locked down rooms: challenge/response in lobby [#9714](https://github.com/jitsi/jitsi-meet/issues/9714)
Messaging methods in lobby room
getLocalId to get the local room id from jid
setMessageListener to listen for messages in lobby room

Reviewed-by: Fecri Kaan Ulubey f.kaan93@gmail.com