### PR TITLE
feat: Refactor updating presence for audio/video mute and video type.

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1557,22 +1557,6 @@ export default class ChatRoom extends Listenable {
      *
      * @param mute
      */
-    setVideoMute(mute) {
-        this.sendVideoInfoPresence(mute);
-    }
-
-    /**
-     *
-     * @param mute
-     */
-    setAudioMute(mute) {
-        this.sendAudioInfoPresence(mute);
-    }
-
-    /**
-     *
-     * @param mute
-     */
     addAudioInfoToPresence(mute) {
         const audioMutedTagName = 'audiomuted';
 
@@ -1592,15 +1576,6 @@ export default class ChatRoom extends Listenable {
      *
      * @param mute
      */
-    sendAudioInfoPresence(mute) {
-        // FIXME resend presence on CONNECTED
-        this.addAudioInfoToPresence(mute) && this.sendPresence();
-    }
-
-    /**
-     *
-     * @param mute
-     */
     addVideoInfoToPresence(mute) {
         const videoMutedTagName = 'videomuted';
 
@@ -1614,14 +1589,6 @@ export default class ChatRoom extends Listenable {
             {
                 value: mute.toString()
             });
-    }
-
-    /**
-     *
-     * @param mute
-     */
-    sendVideoInfoPresence(mute) {
-        this.addVideoInfoToPresence(mute) && this.sendPresence();
     }
 
     /**


### PR DESCRIPTION
This brings few changes and fixes. Thew initial presence will always mis audioMuted and videoMuted value, those will be added on session accept. All updates to presence are done on sessionAccept, on source-add or source-remove and the only one not signalled when camera track is replaced by video track and vice versa.
This change brings more presence updates when number of participants are below startAudioMuted/startVideoMuted, but when participants are above those numbers we get less presence update. This is important for big meetings.
Fixes wrong videoMuted state, as replace track and mute are both executed in promise, sometimes the replace-track one finishes first and when the mute one is resolved there is no conference object in the track to be able to update the presence (hitting this when we pass the startAudioMuted threshold).