### PR TITLE
feat: Adjust setReceiverConstraints to use new format

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -146,9 +146,7 @@ export default _mergeNamespaceAndModule({
         Statistics.init(options);
 
         // Configure the feature flags.
-        FeatureFlags.init({
-            sourceNameSignaling: options.sourceNameSignaling
-        });
+        FeatureFlags.init(options.flags);
 
         // Initialize global window.connectionTimes
         // FIXME do not use 'window'

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -146,7 +146,7 @@ export default _mergeNamespaceAndModule({
         Statistics.init(options);
 
         // Configure the feature flags.
-        FeatureFlags.init(options.flags);
+        FeatureFlags.init(options.flags || { });
 
         // Initialize global window.connectionTimes
         // FIXME do not use 'window'

--- a/modules/qualitycontrol/ReceiveVideoController.js
+++ b/modules/qualitycontrol/ReceiveVideoController.js
@@ -308,11 +308,11 @@ export class ReceiveVideoController {
         }
 
         const isEndpointsFormat = Object.keys(constraints).includes('onStageEndpoints', 'selectedEndpoints');
-        const isSourceNamesFormat = Object.keys(constraints).includes('prioritizedSources', 'selectedSources');
+        const isSourcesFormat = Object.keys(constraints).includes('onStageSources', 'selectedSources');
 
-        if (!FeatureFlags.isSourceNameSignalingEnabled() && isSourceNamesFormat) {
+        if (!FeatureFlags.isSourceNameSignalingEnabled() && isSourcesFormat) {
             throw new Error(
-                '"prioritizedSources" and "selectedSources" are not supported when sourceNameSignaling is disabled.'
+                '"onStageSources" and "selectedSources" are not supported when sourceNameSignaling is disabled.'
             );
         }
 

--- a/modules/qualitycontrol/ReceiveVideoController.js
+++ b/modules/qualitycontrol/ReceiveVideoController.js
@@ -316,10 +316,11 @@ export class ReceiveVideoController {
             );
         }
 
-        if (isEndpointsFormat && isSourceNamesFormat) {
-            throw new Error('Cannot mix constraints format.');
+        if (FeatureFlags.isSourceNameSignalingEnabled() && isEndpointsFormat) {
+            throw new Error(
+                '"onStageEndpoints" and "selectedEndpoints" are not supported when sourceNameSignaling is enabled.'
+            );
         }
-
         const constraintsChanged = this._receiverVideoConstraints.updateReceiverVideoConstraints(constraints);
 
         if (constraintsChanged) {

--- a/modules/qualitycontrol/ReceiveVideoController.spec.js
+++ b/modules/qualitycontrol/ReceiveVideoController.spec.js
@@ -57,9 +57,9 @@ describe('ReceiveVideoController', () => {
         receiveVideoController = new ReceiveVideoController(conference, rtc);
     });
 
-    describe('when isSourceNameSignalingEnabled is enabled', () => {
+    describe('when sourceNameSignaling is enabled', () => {
         beforeEach(() => {
-            spyOn(FeatureFlags, 'isSourceNameSignalingEnabled').and.returnValue(true);
+            FeatureFlags.init({ sourceNameSignaling: true });
         });
 
         it('should call setNewReceiverVideoConstraints with the source names format.', () => {
@@ -90,9 +90,9 @@ describe('ReceiveVideoController', () => {
         });
     });
 
-    describe('when isSourceNameSignalingEnabled is disabled', () => {
+    describe('when sourceNameSignaling is disabled', () => {
         beforeEach(() => {
-            spyOn(FeatureFlags, 'isSourceNameSignalingEnabled').and.returnValue(false);
+            FeatureFlags.init({ sourceNameSignaling: false });
         });
 
         it('should call setNewReceiverVideoConstraints with the endpoints format.', () => {

--- a/modules/qualitycontrol/ReceiveVideoController.spec.js
+++ b/modules/qualitycontrol/ReceiveVideoController.spec.js
@@ -1,0 +1,125 @@
+import FeatureFlags from '../flags/FeatureFlags';
+import Listenable from '../util/Listenable';
+
+import { ReceiveVideoController } from './ReceiveVideoController';
+
+// JSDocs disabled for Mock classes to avoid duplication - check on the original classes for info.
+/* eslint-disable require-jsdoc */
+/**
+ * Mock conference for the purpose of this test file.
+ */
+class MockConference extends Listenable {
+    /**
+     * A constructor...
+     */
+    constructor() {
+        super();
+        this.options = {
+            config: {}
+        };
+
+        this.activeMediaSession = undefined;
+        this.mediaSessions = [];
+    }
+
+    _getMediaSessions() {
+        return this.mediaSessions;
+    }
+}
+
+/**
+ * Mock {@link RTC} - add things as needed, but only things useful for all tests.
+ */
+export class MockRTC extends Listenable {
+    /**
+     * constructor
+     */
+    /* eslint-disable no-useless-constructor */
+    constructor() {
+        super();
+    }
+
+    // eslint-disable-next-line no-empty-function
+    setNewReceiverVideoConstraints() {
+
+    }
+}
+
+/* eslint-enable require-jsdoc */
+describe('ReceiveVideoController', () => {
+    let conference;
+    let rtc;
+    let receiveVideoController;
+
+    beforeEach(() => {
+        conference = new MockConference();
+        rtc = new MockRTC();
+        receiveVideoController = new ReceiveVideoController(conference, rtc);
+    });
+
+    describe('when isSourceNameSignalingEnabled is enabled', () => {
+        beforeEach(() => {
+            spyOn(FeatureFlags, 'isSourceNameSignalingEnabled').and.returnValue(true);
+        });
+
+        it('should call setNewReceiverVideoConstraints with the source names format.', () => {
+            const rtcSpy = spyOn(rtc, 'setNewReceiverVideoConstraints');
+            const constraints = {
+                prioritizedSources: [ 'A_camera_1', 'B_screen_2', 'C_camera_1' ],
+                selectedSources: [ 'A_camera_1' ]
+            };
+
+            receiveVideoController.setReceiverConstraints(constraints);
+            expect(rtcSpy).toHaveBeenCalledWith(constraints);
+        });
+
+        it('should not allow the endpoints format.', () => {
+            const constraints = {
+                onStageEndpoints: [ 'A', 'B', 'C' ],
+                selectedEndpoints: [ 'A' ]
+            };
+
+            try {
+                receiveVideoController.setReceiverConstraints(constraints);
+                fail();
+            } catch (error) {
+                expect(error).toEqual(new Error(
+                    '"onStageEndpoints" and "selectedEndpoints" are not supported when sourceNameSignaling is enabled.'
+                ));
+            }
+        });
+    });
+
+    describe('when isSourceNameSignalingEnabled is disabled', () => {
+        beforeEach(() => {
+            spyOn(FeatureFlags, 'isSourceNameSignalingEnabled').and.returnValue(false);
+        });
+
+        it('should call setNewReceiverVideoConstraints with the endpoints format.', () => {
+            const rtcSpy = spyOn(rtc, 'setNewReceiverVideoConstraints');
+            const constraints = {
+                onStageEndpoints: [ 'A', 'B', 'C' ],
+                selectedEndpoints: [ 'A' ]
+            };
+
+            receiveVideoController.setReceiverConstraints(constraints);
+            expect(rtcSpy).toHaveBeenCalledWith(constraints);
+        });
+
+        it('should not allow the source names format.', () => {
+            const constraints = {
+                prioritizedSources: [ 'A_camera_1', 'B_screen_2', 'C_camera_1' ],
+                selectedSources: [ 'A_camera_1' ]
+            };
+
+            try {
+                receiveVideoController.setReceiverConstraints(constraints);
+                fail();
+            } catch (error) {
+                expect(error).toEqual(new Error(
+                    '"prioritizedSources" and "selectedSources" are not supported when sourceNameSignaling is disabled.'
+                ));
+            }
+        });
+    });
+});

--- a/modules/qualitycontrol/ReceiveVideoController.spec.js
+++ b/modules/qualitycontrol/ReceiveVideoController.spec.js
@@ -65,7 +65,7 @@ describe('ReceiveVideoController', () => {
         it('should call setNewReceiverVideoConstraints with the source names format.', () => {
             const rtcSpy = spyOn(rtc, 'setNewReceiverVideoConstraints');
             const constraints = {
-                prioritizedSources: [ 'A_camera_1', 'B_screen_2', 'C_camera_1' ],
+                onStageSources: [ 'A_camera_1', 'B_screen_2', 'C_camera_1' ],
                 selectedSources: [ 'A_camera_1' ]
             };
 
@@ -108,7 +108,7 @@ describe('ReceiveVideoController', () => {
 
         it('should not allow the source names format.', () => {
             const constraints = {
-                prioritizedSources: [ 'A_camera_1', 'B_screen_2', 'C_camera_1' ],
+                onStageSources: [ 'A_camera_1', 'B_screen_2', 'C_camera_1' ],
                 selectedSources: [ 'A_camera_1' ]
             };
 
@@ -117,7 +117,7 @@ describe('ReceiveVideoController', () => {
                 fail();
             } catch (error) {
                 expect(error).toEqual(new Error(
-                    '"prioritizedSources" and "selectedSources" are not supported when sourceNameSignaling is disabled.'
+                    '"onStageSources" and "selectedSources" are not supported when sourceNameSignaling is disabled.'
                 ));
             }
         });


### PR DESCRIPTION
Update the video receiver constraints to start using the new sources format when the 1sourceNameSignaling` feature flag is enabled.

Related PR: https://github.com/jitsi/jitsi-meet/pull/10527 