### PR TITLE
fix(JitsiConference) squelch bogus p2p session end error

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3593,13 +3593,12 @@ JitsiConference.prototype._stopP2PSession = function(options = {}) {
             // crash the responder would stay in P2P mode until ICE fails which
             // could take up to 20 seconds.
             //
-            // NOTE lack of 'reason' is considered as graceful session terminate
+            // NOTE: whilst this is an error callback,  'success' as a reason is
+            // considered as graceful session terminate
             // where both initiator and responder terminate their sessions
             // simultaneously.
-            if (reason) {
-                logger.error(
-                    'An error occurred while trying to terminate'
-                        + ' P2P Jingle session', error);
+            if (reason !== 'success') {
+                logger.error('An error occurred while trying to terminate P2P Jingle session', error);
             }
         }, {
             reason,


### PR DESCRIPTION
After the refactor in
https://github.com/jitsi/lib-jitsi-meet/commit/5a4232f9083fd1ef49c89fb164afdd9aff23dcaa
the succesful terminating reason is expressed by the 'success' value in the
`reason`parameter, rather than having it undefined.

Ref: https://github.com/jitsi/lib-jitsi-meet/issues/1793#issuecomment-989913626