### PR TITLE
fix: Drop unused region info from presence.

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -167,16 +167,6 @@ export default class ChatRoom extends Listenable {
             });
         }
 
-        if (options.deploymentInfo && options.deploymentInfo.userRegion) {
-            this.presMap.nodes.push({
-                'tagName': 'region',
-                'attributes': {
-                    id: options.deploymentInfo.userRegion,
-                    xmlns: 'http://jitsi.org/jitsi-meet'
-                }
-            });
-        }
-
         this.presenceUpdateTime = Date.now();
     }
 


### PR DESCRIPTION
We set the region using a custom extension https://github.com/jitsi/jitsi-xmpp-extensions/blob/master/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/RegionPacketExtension.java in ChatRoom.initPresenceMap, and we use that in jicofo.