### PR TITLE
fix(tpc) disable ulpfec on chrome 97

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2825,7 +2825,7 @@ TraceablePeerConnection.prototype._createOfferOrAnswer = function(
             }
 
             // Disable ulpfec on Google Chrome 96 or higher because
-            // https://bugs.chromium.org/p/chromium/issues/detail?id=982793
+            // https://bugs.chromium.org/p/chromium/issues/detail?id=1276427
             if (browser.isChromiumBased() && (browser.isVersionEqualTo('96') || browser.isVersionGreaterThan('96'))) {
                 capabilities = capabilities
                     .filter(caps => caps.mimeType.toLowerCase() !== `${MediaType.VIDEO}/${CodecMimeType.ULPFEC}`);

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2824,9 +2824,9 @@ TraceablePeerConnection.prototype._createOfferOrAnswer = function(
                     .filter(caps => caps.mimeType.toLowerCase() !== `${MediaType.VIDEO}/${mimeType}`);
             }
 
-            // Disable ulpfec on Google Chrome 96 because
+            // Disable ulpfec on Google Chrome 96 or higher because
             // https://bugs.chromium.org/p/chromium/issues/detail?id=982793
-            if (browser.isChromiumBased() && browser.isVersionEqualTo('96')) {
+            if (browser.isChromiumBased() && (browser.isVersionEqualTo('96') || browser.isVersionGreaterThan('96'))) {
                 capabilities = capabilities
                     .filter(caps => caps.mimeType.toLowerCase() !== `${MediaType.VIDEO}/${CodecMimeType.ULPFEC}`);
             }

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2826,7 +2826,7 @@ TraceablePeerConnection.prototype._createOfferOrAnswer = function(
 
             // Disable ulpfec on Google Chrome 96 or higher because
             // https://bugs.chromium.org/p/chromium/issues/detail?id=1276427
-            if (browser.isChromiumBased() && (browser.isVersionEqualTo('96') || browser.isVersionGreaterThan('96'))) {
+            if (browser.isChromiumBased() && browser.isVersionGreaterThan('95')) {
                 capabilities = capabilities
                     .filter(caps => caps.mimeType.toLowerCase() !== `${MediaType.VIDEO}/${CodecMimeType.ULPFEC}`);
             }


### PR DESCRIPTION
The issue currently affects browsers based on Chromium 96.0.4664.110 including Brave, Chrome, Edge & Opera and Google Chrome 97.0.4692.56