### PR TITLE
fix(JitsiConference) clear auto-p2p timeout on leave

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -657,6 +657,7 @@ JitsiConference.prototype.leave = async function() {
 
     this._delayedIceFailed && this._delayedIceFailed.cancel();
 
+    this._maybeClearDeferredStartP2P();
     this._maybeClearSITimeout();
 
     // Close both JVb and P2P JingleSessions


### PR DESCRIPTION
In a custom application using lib-jitsi-meet I am encountering this error sometimes after conference has been left.

![image](https://user-images.githubusercontent.com/416945/147852260-155f1435-dd47-467d-9ba6-63b6e2fb51f1.png)

This has to do with a timeout not being cleared AFAIK