### PR TITLE
fix(tpc) extend ulpfec workaround to all versions

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2824,9 +2824,9 @@ TraceablePeerConnection.prototype._createOfferOrAnswer = function(
                     .filter(caps => caps.mimeType.toLowerCase() !== `${MediaType.VIDEO}/${mimeType}`);
             }
 
-            // Disable ulpfec on Google Chrome 96 or higher because
+            // Disable ulpfec on Google Chrome and derivatives because
             // https://bugs.chromium.org/p/chromium/issues/detail?id=1276427
-            if (browser.isChromiumBased() && browser.isVersionGreaterThan('95')) {
+            if (browser.isChromiumBased()) {
                 capabilities = capabilities
                     .filter(caps => caps.mimeType.toLowerCase() !== `${MediaType.VIDEO}/${CodecMimeType.ULPFEC}`);
             }


### PR DESCRIPTION
So, I've been doing more testing.

It seems that the BrowserDetection lib returns `undefined` on calling browser.isVersionGreaterThan('95') for Edge. There is also a problem with Opera - workaround not working - but I have not dug deeper there.

Internally the Bowser dependency identifies Edge and Opera by their real names, however Jitsi identifies Edge as `chrome`, and for Opera - my theory is - , the version scheme has differences.

These mismatches lead to problems on `this._bowser.satisfies` at `_checkCondition` function (@jitsi/js-utils).

Workaround is making the statement much more simple and more broad.