### PR TITLE
fix: p2p reject reason

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2157,7 +2157,7 @@ JitsiConference.prototype._onIncomingCallP2P = function(
         rejectReason = {
             reason: 'decline',
             reasonDescription: 'P2P disabled',
-            errorMsg: 'P2P mode disabled in the configuration'
+            errorMsg: 'P2P mode disabled in the configuration or browser unsupported'
         };
     } else if (this.p2pJingleSession) {
         // Reject incoming P2P call (already in progress)


### PR DESCRIPTION
Additionally I was wondering if it is still a problem to have a P2P connections between Chrome, Firefox and Safari?