### PR TITLE
fix: add required events dependency for browser environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "async": "0.9.0",
         "base64-js": "1.3.1",
         "current-executing-script": "0.1.3",
+        "events": "3.3.0",
         "lodash.clonedeep": "4.5.0",
         "lodash.debounce": "4.0.8",
         "lodash.isequal": "4.5.0",
@@ -3665,7 +3666,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -9874,8 +9874,7 @@
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "execa": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "async": "0.9.0",
     "base64-js": "1.3.1",
     "current-executing-script": "0.1.3",
+    "events": "3.3.0",
     "lodash.clonedeep": "4.5.0",
     "lodash.debounce": "4.0.8",
     "lodash.isequal": "4.5.0",


### PR DESCRIPTION
Currently lib-jitsi-meet imports `events` but it's not defined in the package.json. The IDE thinks it imports the built-in module of node.js but webpack actually resolves it as the `events` package which is installed as a dependency of webpack itself. This PR clarifies which module is actually imported.