### PR TITLE
fix(logging) Log all the ssrcs present in the source signaling.

### DIFF
--- a/modules/xmpp/JingleHelperFunctions.js
+++ b/modules/xmpp/JingleHelperFunctions.js
@@ -157,10 +157,8 @@ export function expandSourcesFromJson(iq, jsonMessageXml) {
             if (videoSources?.length) {
                 for (let i = 0; i < videoSources.length; i++) {
                     videoRtpDescription.appendChild(_createSourceExtension(owner, videoSources[i]));
+                    ssrcs.push(videoSources[i]?.s);
                 }
-
-                // Log only the first video ssrc per endpoint.
-                ssrcs.push(videoSources[0]?.s);
             }
 
             if (videoSsrcGroups?.length) {
@@ -171,8 +169,8 @@ export function expandSourcesFromJson(iq, jsonMessageXml) {
             if (audioSources?.length) {
                 for (let i = 0; i < audioSources.length; i++) {
                     audioRtpDescription.appendChild(_createSourceExtension(owner, audioSources[i]));
+                    ssrcs.push(audioSources[i]?.s);
                 }
-                ssrcs.push(audioSources[0]?.s);
             }
 
             if (audioSsrcGroups?.length) {


### PR DESCRIPTION
Since the order of the ssrcs in the json-encoded message is not guaranteed to be in the correct SIM/FID order, log all the ssrcs.