### PR TITLE
fix: recover from reservation error

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3007,6 +3007,19 @@ JitsiConference.prototype._onIceConnectionRestored = function(session) {
 };
 
 /**
+ * Handles {@link XMPPEvents.RESERVATION_ERROR} event. This happens when focus
+ * returns error due to reservation rejection.
+ *
+ * @private
+ */
+JitsiConference.prototype._onReservationFailure = function(roomJid) {
+    // on reservation error, room creation by focus would have failed
+    // but emuc still caches chatRoom object and isRoomCreated checks
+    // would be wrong. Expunge chatRoom from cache.
+    this.xmpp.expungeRoom(roomJid);
+};
+
+/**
  * Accept incoming P2P Jingle call.
  * @param {JingleSessionPC} jingleSession the session instance
  * @param {jQuery} jingleOffer a jQuery selector pointing to 'jingle' IQ element

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -232,6 +232,11 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
         JitsiConferenceEvents.CONFERENCE_FAILED,
         JitsiConferenceErrors.RESERVATION_ERROR);
 
+    chatRoom.addListener(XMPPEvents.RESERVATION_ERROR,
+        () => {
+            conference._onReservationFailure(chatRoom.roomjid);
+        });
+
     this.chatRoomForwarder.forward(XMPPEvents.GRACEFUL_SHUTDOWN,
         JitsiConferenceEvents.CONFERENCE_FAILED,
         JitsiConferenceErrors.GRACEFUL_SHUTDOWN);

--- a/modules/xmpp/strophe.emuc.js
+++ b/modules/xmpp/strophe.emuc.js
@@ -70,6 +70,18 @@ export default class MucConnectionPlugin extends ConnectionPluginListenable {
     }
 
     /**
+     * Removes room from cache, to be used in the event that the ChatRoom
+     * creation failed and should no longer return true for isRoomCreated check.
+     *
+     * @param {string} roomJid - The JID of the room.
+     */
+    expungeRoom(roomJid) {
+        if (roomJid && roomJid in this.rooms) {
+            delete this.rooms[roomJid];
+        }
+    }
+
+    /**
      *  Check if a room with the passed JID is already created.
      *
      * @param {string} roomJid - The JID of the room.

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -665,6 +665,16 @@ export default class XMPP extends Listenable {
     }
 
     /**
+     * Removes room from emuc cache, to be used in the event that the ChatRoom
+     * creation failed.
+     *
+     * @param {string} roomJid - The JID of the room.
+     */
+    expungeRoom(roomJid) {
+        this.connection.emuc.expungeRoom(roomJid);
+    }
+
+    /**
      * Returns the room JID based on the passed room name and domain.
      *
      * @param {string} roomName - The room name.


### PR DESCRIPTION
Ref: https://community.jitsi.org/t/ux-when-reservation-fails/110095/9?u=shawn

Right now, users are not able to retry join after focus returns reservation-error; strophe emuc plugin caches room object and no longer allows re-creation because it thinks room already created.

This fix adds a listener for reservation errors and expunges room object from emuc cache.

**Update:** This issue is also present for `XMPPEvents.ROOM_MAX_USERS_ERROR`. When max users reached, user sees error and can no longer retry join.