### PR TITLE
fix(RTC) skip DtlsTransport init if getSenders is missing

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2289,7 +2289,7 @@ TraceablePeerConnection.prototype._mungeOpus = function(description) {
  */
 TraceablePeerConnection.prototype._initializeDtlsTransport = function() {
     // We are assuming here that we only have one bundled transport here
-    if (this._dtlsTransport) {
+    if (!this.peerconnection.getSenders || this._dtlsTransport) {
         return;
     }
 


### PR DESCRIPTION
PR #1850 might cause problems if a client doesn't have support for getSenders() yet, like our mobile client. So this PR checks first if getSenders() is supported.