### PR TITLE
feat(multi-stream-support) Add track streaming status

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1613,6 +1613,14 @@ JitsiConference.prototype.getLastN = function() {
 };
 
 /**
+ * Obtains the forwarded sources list in this conference.
+ * @return {Array<string>|null}
+ */
+JitsiConference.prototype.getForwardedSources = function() {
+    return this.rtc.getForwardedSources();
+};
+
+/**
  * Selects a new value for "lastN". The requested amount of videos are going
  * to be delivered after the value is in effect. Set to -1 for unlimited or
  * all available videos.

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2136,8 +2136,7 @@ JitsiConference.prototype.onRemoteTrackRemoved = function(removedTrack) {
                 // considered equal the result of splice can be ignored.
                 participant._tracks.splice(i, 1);
 
-                this.eventEmitter.emit(
-                    JitsiConferenceEvents.TRACK_REMOVED, removedTrack);
+                this.eventEmitter.emit(JitsiConferenceEvents.TRACK_REMOVED, removedTrack);
 
                 if (this.transcriber) {
                     this.transcriber.removeTrack(removedTrack);

--- a/JitsiConferenceEvents.spec.ts
+++ b/JitsiConferenceEvents.spec.ts
@@ -28,6 +28,7 @@ describe( "/JitsiConferenceEvents members", () => {
         KICKED,
         PARTICIPANT_KICKED,
         LAST_N_ENDPOINTS_CHANGED,
+        FORWARDED_SOURCES_CHANGED,
         LOCK_STATE_CHANGED,
         SERVER_REGION_CHANGED,
         _MEDIA_SESSION_STARTED,
@@ -104,6 +105,7 @@ describe( "/JitsiConferenceEvents members", () => {
         expect( KICKED ).toBe( 'conference.kicked' );
         expect( PARTICIPANT_KICKED ).toBe( 'conference.participant_kicked' );
         expect( LAST_N_ENDPOINTS_CHANGED ).toBe( 'conference.lastNEndpointsChanged' );
+        expect( FORWARDED_SOURCES_CHANGED ).toBe( 'conference.forwardedSourcesChanged' );
         expect( LOCK_STATE_CHANGED ).toBe( 'conference.lock_state_changed' );
         expect( SERVER_REGION_CHANGED ).toBe( 'conference.server_region_changed' );
         expect( _MEDIA_SESSION_STARTED ).toBe( 'conference.media_session.started' );
@@ -176,6 +178,7 @@ describe( "/JitsiConferenceEvents members", () => {
             expect( JitsiConferenceEvents.KICKED ).toBe( 'conference.kicked' );
             expect( JitsiConferenceEvents.PARTICIPANT_KICKED ).toBe( 'conference.participant_kicked' );
             expect( JitsiConferenceEvents.LAST_N_ENDPOINTS_CHANGED ).toBe( 'conference.lastNEndpointsChanged' );
+            expect( JitsiConferenceEvents.FORWARDED_SOURCES_CHANGED ).toBe( 'conference.forwardedSourcesChanged' );
             expect( JitsiConferenceEvents.LOCK_STATE_CHANGED ).toBe( 'conference.lock_state_changed' );
             expect( JitsiConferenceEvents.SERVER_REGION_CHANGED ).toBe( 'conference.server_region_changed' );
             expect( JitsiConferenceEvents._MEDIA_SESSION_STARTED ).toBe( 'conference.media_session.started' );

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -154,6 +154,16 @@ export enum JitsiConferenceEvents {
     LAST_N_ENDPOINTS_CHANGED = 'conference.lastNEndpointsChanged',
 
     /**
+     * The forwarded sources set is changed.
+     *
+     * @param {Array<string>|null} leavingForwardedSources the sourceNames of all the tracks which are leaving forwarded
+     * sources
+     * @param {Array<string>|null} enteringForwardedSources the sourceNames of all the tracks which are entering forwarded
+     * sources
+     */
+    FORWARDED_SOURCES_CHANGED = 'conference.forwardedSourcesChanged',
+
+    /**
      * Indicates that the room has been locked or unlocked.
      */
     LOCK_STATE_CHANGED = 'conference.lock_state_changed',

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -491,6 +491,7 @@ export const JVB121_STATUS = JitsiConferenceEvents.JVB121_STATUS;
 export const KICKED = JitsiConferenceEvents.KICKED;
 export const PARTICIPANT_KICKED = JitsiConferenceEvents.PARTICIPANT_KICKED;
 export const LAST_N_ENDPOINTS_CHANGED = JitsiConferenceEvents.LAST_N_ENDPOINTS_CHANGED;
+export const FORWARDED_SOURCES_CHANGED = JitsiConferenceEvents.FORWARDED_SOURCES_CHANGED;
 export const LOCK_STATE_CHANGED = JitsiConferenceEvents.LOCK_STATE_CHANGED;
 export const SERVER_REGION_CHANGED = JitsiConferenceEvents.SERVER_REGION_CHANGED;
 export const _MEDIA_SESSION_STARTED = JitsiConferenceEvents._MEDIA_SESSION_STARTED;

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -156,9 +156,9 @@ export enum JitsiConferenceEvents {
     /**
      * The forwarded sources set is changed.
      *
-     * @param {Array<string>|null} leavingForwardedSources the sourceNames of all the tracks which are leaving forwarded
+     * @param {Array<string>} leavingForwardedSources the sourceNames of all the tracks which are leaving forwarded
      * sources
-     * @param {Array<string>|null} enteringForwardedSources the sourceNames of all the tracks which are entering forwarded
+     * @param {Array<string>} enteringForwardedSources the sourceNames of all the tracks which are entering forwarded
      * sources
      */
     FORWARDED_SOURCES_CHANGED = 'conference.forwardedSourcesChanged',

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -16,6 +16,7 @@ import browser from './modules/browser';
 import NetworkInfo from './modules/connectivity/NetworkInfo';
 import { ParticipantConnectionStatus }
     from './modules/connectivity/ParticipantConnectionStatus';
+import { TrackStreamingStatusMap } from './modules/connectivity/TrackStreamingStatus';
 import getActiveAudioDevice from './modules/detection/ActiveDeviceDetector';
 import * as DetectionEvents from './modules/detection/DetectionEvents';
 import TrackVADEmitter from './modules/detection/TrackVADEmitter';
@@ -119,7 +120,8 @@ export default _mergeNamespaceAndModule({
         participantConnectionStatus: ParticipantConnectionStatus,
         recording: recordingConstants,
         sipVideoGW: VideoSIPGWConstants,
-        transcriptionStatus: JitsiTranscriptionStatus
+        transcriptionStatus: JitsiTranscriptionStatus,
+        trackStreamingStatus: TrackStreamingStatusMap
     },
     events: {
         conference: JitsiConferenceEvents,

--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -16,7 +16,7 @@ import browser from './modules/browser';
 import NetworkInfo from './modules/connectivity/NetworkInfo';
 import { ParticipantConnectionStatus }
     from './modules/connectivity/ParticipantConnectionStatus';
-import { TrackStreamingStatusMap } from './modules/connectivity/TrackStreamingStatus';
+import { TrackStreamingStatus } from './modules/connectivity/TrackStreamingStatus';
 import getActiveAudioDevice from './modules/detection/ActiveDeviceDetector';
 import * as DetectionEvents from './modules/detection/DetectionEvents';
 import TrackVADEmitter from './modules/detection/TrackVADEmitter';
@@ -121,7 +121,7 @@ export default _mergeNamespaceAndModule({
         recording: recordingConstants,
         sipVideoGW: VideoSIPGWConstants,
         transcriptionStatus: JitsiTranscriptionStatus,
-        trackStreamingStatus: TrackStreamingStatusMap
+        trackStreamingStatus: TrackStreamingStatus
     },
     events: {
         conference: JitsiConferenceEvents,

--- a/JitsiTrackEvents.js
+++ b/JitsiTrackEvents.js
@@ -43,3 +43,16 @@ export const NO_DATA_FROM_SOURCE = 'track.no_data_from_source';
  * the microphone that is currently selected.
  */
 export const NO_AUDIO_INPUT = 'track.no_audio_input';
+
+/**
+ * Event fired when we detect local problem with the video track.
+ * First argument is the sourceName of the track and the second is a string indicating if the connection is currently
+ * - active - the connection is active.
+ * - inactive - the connection is inactive, was intentionally interrupted by the bridge because of low BWE or because
+ *   of the endpoint falling out of last N.
+ * - interrupted - a network problem occurred.
+ * - restoring - the connection was inactive and is restoring now.
+ *
+ * The current status value can be obtained by calling JitsiRemoteTrack.getTrackStreamingStatus().
+ */
+export const TRACK_STREAMING_STATUS_CHANGED = 'track.streaming_status_changed';

--- a/JitsiTrackEvents.js
+++ b/JitsiTrackEvents.js
@@ -45,7 +45,7 @@ export const NO_DATA_FROM_SOURCE = 'track.no_data_from_source';
 export const NO_AUDIO_INPUT = 'track.no_audio_input';
 
 /**
- * Event fired when we detect local problem with the video track.
+ * Event fired whenever video track's streaming changes.
  * First argument is the sourceName of the track and the second is a string indicating if the connection is currently
  * - active - the connection is active.
  * - inactive - the connection is inactive, was intentionally interrupted by the bridge because of low BWE or because

--- a/JitsiTrackEvents.spec.ts
+++ b/JitsiTrackEvents.spec.ts
@@ -8,6 +8,7 @@ describe( "/JitsiTrackEvents members", () => {
         TRACK_AUDIO_LEVEL_CHANGED,
         TRACK_AUDIO_OUTPUT_CHANGED,
         TRACK_MUTE_CHANGED,
+        TRACK_STREAMING_STATUS_CHANGED,
         TRACK_VIDEOTYPE_CHANGED,
         NO_DATA_FROM_SOURCE,
         NO_AUDIO_INPUT,
@@ -28,6 +29,7 @@ describe( "/JitsiTrackEvents members", () => {
             expect( JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED ).toBe( 'track.audioLevelsChanged' );
             expect( JitsiTrackEvents.TRACK_AUDIO_OUTPUT_CHANGED ).toBe( 'track.audioOutputChanged' );
             expect( JitsiTrackEvents.TRACK_MUTE_CHANGED ).toBe( 'track.trackMuteChanged' );
+            expect( JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED ).toBe( 'track.streaming_status_changed' );
             expect( JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED ).toBe( 'track.videoTypeChanged' );
             expect( JitsiTrackEvents.NO_DATA_FROM_SOURCE ).toBe( 'track.no_data_from_source' );
             expect( JitsiTrackEvents.NO_AUDIO_INPUT ).toBe( 'track.no_audio_input' );

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -359,11 +359,25 @@ export default class BridgeChannel {
                 break;
             }
             case 'LastNEndpointsChangeEvent': {
-                // The new/latest list of last-n endpoint IDs (i.e. endpoints for which the bridge is sending video).
-                const lastNEndpoints = obj.lastNEndpoints;
+                if (!FeatureFlags.isSourceNameSignalingEnabled()) {
+                    // The new/latest list of last-n endpoint IDs (i.e. endpoints for which the bridge is sending
+                    // video).
+                    const lastNEndpoints = obj.lastNEndpoints;
 
-                logger.info(`New forwarded endpoints: ${lastNEndpoints}`);
-                emitter.emit(RTCEvents.LASTN_ENDPOINT_CHANGED, lastNEndpoints);
+                    logger.info(`New forwarded endpoints: ${lastNEndpoints}`);
+                    emitter.emit(RTCEvents.LASTN_ENDPOINT_CHANGED, lastNEndpoints);
+                }
+
+                break;
+            }
+            case 'ForwardedSources': {
+                if (FeatureFlags.isSourceNameSignalingEnabled()) {
+                    // The new/latest list of forwarded sources
+                    const forwardedSources = obj.forwardedSources;
+
+                    logger.info(`New forwarded sources: ${forwardedSources}`);
+                    emitter.emit(RTCEvents.FORWARDED_SOURCES_CHANGED, forwardedSources);
+                }
 
                 break;
             }

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -593,6 +593,14 @@ export default class RTC extends Listenable {
     }
 
     /**
+     * Get forwarded sources list.
+     * @returns {Array<string>|null}
+     */
+    getForwardedSources() {
+        return this._forwardedSources;
+    }
+
+    /**
      * Get local video track.
      * @returns {JitsiLocalTrack|undefined}
      */

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -127,6 +127,15 @@ export default class RTC extends Listenable {
         this._lastNEndpoints = null;
 
         /**
+         * Defines the forwarded sources list. It can be null or an array once initialised with a channel forwarded
+         * sources event.
+         *
+         * @type {Array<string>|null}
+         * @private
+         */
+        this._forwardedSources = null;
+
+        /**
          * The number representing the maximum video height the local client
          * should receive from the bridge.
          *
@@ -145,6 +154,9 @@ export default class RTC extends Listenable {
 
         // The last N change listener.
         this._lastNChangeListener = this._onLastNChanged.bind(this);
+
+        // The forwarded sources change listener.
+        this._forwardedSourcesChangeListener = this._onForwardedSourcesChanged.bind(this);
 
         this._onDeviceListChanged = this._onDeviceListChanged.bind(this);
         this._updateAudioOutputForAudioTracks
@@ -277,6 +289,11 @@ export default class RTC extends Listenable {
 
         // Add Last N change listener.
         this.addListener(RTCEvents.LASTN_ENDPOINT_CHANGED, this._lastNChangeListener);
+
+        if (FeatureFlags.isSourceNameSignalingEnabled()) {
+            // Add forwarded sources change listener.
+            this.addListener(RTCEvents.FORWARDED_SOURCES_CHANGED, this._forwardedSourcesChangeListener);
+        }
     }
 
     /**
@@ -313,6 +330,31 @@ export default class RTC extends Listenable {
             JitsiConferenceEvents.LAST_N_ENDPOINTS_CHANGED,
             leavingLastNEndpoints,
             enteringLastNEndpoints);
+    }
+
+    /**
+     * Receives events when forwarded sources had changed.
+     *
+     * @param {array} forwardedSources The new forwarded sources.
+     * @private
+     */
+    _onForwardedSourcesChanged(forwardedSources = []) {
+        const oldForwardedSources = this._forwardedSources || [];
+        let leavingForwardedSources = [];
+        let enteringForwardedSources = [];
+
+        this._forwardedSources = forwardedSources;
+
+        leavingForwardedSources = oldForwardedSources.filter(sourceName => !this.isInForwardedSources(sourceName));
+
+        enteringForwardedSources = forwardedSources.filter(
+            sourceName => oldForwardedSources.indexOf(sourceName) === -1);
+
+        this.conference.eventEmitter.emit(
+            JitsiConferenceEvents.FORWARDED_SOURCES_CHANGED,
+            leavingForwardedSources,
+            enteringForwardedSources,
+            Date.now());
     }
 
     /**
@@ -925,6 +967,18 @@ export default class RTC extends Listenable {
     isInLastN(id) {
         return !this._lastNEndpoints // lastNEndpoints not initialised yet.
             || this._lastNEndpoints.indexOf(id) > -1;
+    }
+
+    /**
+     * Indicates if the source name is currently included in the forwarded sources.
+     *
+     * @param {string} sourceName The source name that we check for forwarded sources.
+     * @returns {boolean} true if the source name is in the forwarded sources or if we don't have bridge channel
+     * support, otherwise we return false.
+     */
+    isInForwardedSources(sourceName) {
+        return !this._forwardedSources // forwardedSources not initialised yet.
+            || this._forwardedSources.indexOf(sourceName) > -1;
     }
 
     /**

--- a/modules/connectivity/TrackStreamingStatus.ts
+++ b/modules/connectivity/TrackStreamingStatus.ts
@@ -1,0 +1,651 @@
+import { getLogger } from '@jitsi/logger';
+
+import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
+import * as JitsiTrackEvents from '../../JitsiTrackEvents';
+import RTCEvents from '../../service/RTC/RTCEvents';
+import { createTrackStreamingStatusEvent } from '../../service/statistics/AnalyticsEvents';
+import JitsiConference from '../../types/hand-crafted/JitsiConference';
+import JitsiRemoteTrack from '../../types/hand-crafted/modules/RTC/JitsiRemoteTrack';
+import RTC from '../../types/hand-crafted/modules/RTC/RTC';
+import browser from '../browser';
+import Statistics from '../statistics/statistics';
+
+/** Track streaming statuses. */
+type TrackStreamingStatus = 'active' | 'inactive' | 'interrupted' | 'restoring';
+interface TrackStreamingStatusMapType {
+    [key: string]: TrackStreamingStatus
+}
+
+type VideoType = 'camera' | 'desktop';
+type StreamingStatusMap = {
+    videoType?: VideoType,
+    startedMs?: number,
+    p2p?: boolean,
+    streamingStatus?: string,
+    value?: number
+};
+
+const logger = getLogger(__filename);
+
+/**
+ * Default value of 500 milliseconds for {@link TrackStreamingStatusImpl.outOfForwardedSourcesTimeout}.
+ */
+const DEFAULT_NOT_IN_FORWARDED_SOURCES_TIMEOUT = 500;
+
+/**
+ * Default value of 2500 milliseconds for {@link TrackStreamingStatusImpl.p2pRtcMuteTimeout}.
+ */
+const DEFAULT_P2P_RTC_MUTE_TIMEOUT = 2500;
+
+/**
+ * Default value of 10000 milliseconds for {@link TrackStreamingStatusImpl.rtcMuteTimeout}.
+ */
+const DEFAULT_RTC_MUTE_TIMEOUT = 10000;
+
+/**
+ * The time to wait a track to be restored. Track which was out of forwarded sources should be inactive and when
+ * entering forwarded sources it becomes restoring and when data is received from bridge it will become active, but if
+ * no data is received for some time we set status of that track streaming to interrupted.
+ */
+const DEFAULT_RESTORING_TIMEOUT = 10000;
+
+export const TrackStreamingStatusMap: TrackStreamingStatusMapType = {
+    /**
+     * Status indicating that streaming is currently active.
+     */
+    ACTIVE: 'active',
+
+    /**
+     * Status indicating that streaming is currently inactive.
+     * Inactive means the streaming was stopped on purpose from the bridge, like exiting forwarded sources or
+     * adaptivity decided to drop video because of not enough bandwidth.
+     */
+    INACTIVE: 'inactive',
+
+    /**
+     * Status indicating that streaming is currently interrupted.
+     */
+    INTERRUPTED: 'interrupted',
+
+    /**
+     * Status indicating that streaming is currently restoring.
+     */
+    RESTORING: 'restoring'
+};
+
+/**
+ * Class is responsible for emitting JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED events.
+ */
+export class TrackStreamingStatusImpl {
+    rtc: RTC;
+    conference: JitsiConference;
+    track: JitsiRemoteTrack;
+
+    /**  This holds the timeout callback ID scheduled using window.setTimeout. */
+    trackTimer: number | null;
+
+    /**
+     * If video track frozen detection through RTC mute event is supported, we wait some time until video track is
+     * considered frozen. But because when the track falls out of forwarded sources it is expected for the video to
+     * freeze this timeout must be significantly reduced in "out of forwarded sources" case.
+     *
+     * Basically this value is used instead of {@link rtcMuteTimeout} when track is not in forwarded sources.
+     */
+    outOfForwardedSourcesTimeout: number;
+
+    /**
+     * How long we are going to wait for the corresponding signaling mute event after the RTC video track muted
+     * event is fired on the Media stream, before the connection interrupted is fired. The default value is
+     * {@link DEFAULT_P2P_RTC_MUTE_TIMEOUT}.
+     */
+    p2pRtcMuteTimeout: number;
+
+    /**
+     * How long we're going to wait after the RTC video track muted event for the corresponding signalling mute
+     * event, before the connection interrupted is fired. The default value is {@link DEFAULT_RTC_MUTE_TIMEOUT}.
+     *
+     * @returns amount of time in milliseconds
+     */
+    rtcMuteTimeout: number;
+
+    /**
+     * This holds a timestamp indicating  when remote video track was RTC muted. The purpose of storing the
+     * timestamp is to avoid the transition to disconnected status in case of legitimate video mute operation where
+     * the signalling video muted event can arrive shortly after RTC muted event.
+     *
+     * The timestamp is measured in milliseconds obtained with <tt>Date.now()</tt>.
+     *
+     * FIXME merge this logic with NO_DATA_FROM_SOURCE event implemented in JitsiLocalTrack by extending the event
+     * to the remote track and allowing to set different timeout for local and remote tracks.
+     */
+    rtcMutedTimestamp: number | null;
+
+    /** This holds the restoring timeout callback ID scheduled using window.setTimeout. */
+    restoringTimer: ReturnType<typeof setTimeout> | null;
+
+    /**
+     * This holds the current streaming status (along with all the internal events that happen while in that
+     * state).
+     *
+     * The goal is to send this information to the analytics backend for post-mortem analysis.
+     */
+    streamingStatusMap: StreamingStatusMap;
+
+    _onP2PStatus: () => void;
+    _onUserLeft: () => void;
+    _onTrackRtcMuted: () => void;
+    _onTrackRtcUnmuted: () => void;
+    _onSignallingMuteChanged: () => void;
+    _onTrackVideoTypeChanged: () => void;
+    _onLastNValueChanged: () => void;
+    _onForwardedSourcesChanged: () => void;
+
+    /* eslint-disable max-params*/
+    /**
+     * Calculates the new {@link TrackStreamingStatus} based on the values given for some specific remote track. It is
+     * assumed that the conference is currently in the JVB mode (in contrary to the P2P mode)
+     * @param isInForwardedSources - indicates whether the track is in the forwarded sources set. When set to
+     * false it means that JVB is not sending any video for the track.
+     * @param isRestoringTimedout - if true it means that the track has been outside of forwarded sources too
+     * long to be considered {@link TrackStreamingStatusMap.RESTORING}.
+     * @param isVideoMuted - true if the track is video muted and we should not expect to receive any video.
+     * @param isVideoTrackFrozen - if the current browser support video frozen detection then it will be set to
+     * true when the video track is frozen. If the current browser does not support frozen detection the it's always
+     * false.
+     * @return {TrackStreamingStatus} the new streaming status for the track for whom the values above were provided.
+     * @private
+     */
+    static _getNewStateForJvbMode(
+            isInForwardedSources: boolean,
+            isRestoringTimedout: boolean,
+            isVideoMuted: boolean,
+            isVideoTrackFrozen: boolean): TrackStreamingStatus {
+
+        // We are currently not checking the endpoint connection status received from the JVB.
+        if (isVideoMuted) {
+            // If the connection is active according to JVB and the track is video muted there is no way for the
+            // connection to be inactive, because the detection logic below only makes sense for video.
+            return TrackStreamingStatusMap.ACTIVE;
+        }
+
+        // Logic when isVideoTrackFrozen is supported
+        if (browser.supportsVideoMuteOnConnInterrupted()) {
+            if (!isVideoTrackFrozen) {
+                // If the video is playing we're good
+                return TrackStreamingStatusMap.ACTIVE;
+            } else if (isInForwardedSources) {
+                return isRestoringTimedout ? TrackStreamingStatusMap.INTERRUPTED : TrackStreamingStatusMap.RESTORING;
+            }
+
+            return TrackStreamingStatusMap.INACTIVE;
+        }
+
+        // Because this browser is incapable of detecting frozen video we must rely on the forwarded sources value
+        return isInForwardedSources ? TrackStreamingStatusMap.ACTIVE : TrackStreamingStatusMap.INACTIVE;
+    }
+
+    /* eslint-enable max-params*/
+
+    /**
+     * In P2P mode we don't care about any values coming from the JVB and the streaming status can be only active or
+     * interrupted.
+     * @param isVideoMuted - true if video muted
+     * @param isVideoTrackFrozen - true if the video track for the remote track is currently frozen. If the
+     * current browser does not support video frozen detection then it's always false.
+     * @return {TrackStreamingStatus}
+     * @private
+     */
+    static _getNewStateForP2PMode(isVideoMuted: boolean, isVideoTrackFrozen: boolean): TrackStreamingStatus {
+        if (!browser.supportsVideoMuteOnConnInterrupted()) {
+            // There's no way to detect problems in P2P when there's no video track frozen detection...
+            return TrackStreamingStatusMap.ACTIVE;
+        }
+
+        return isVideoMuted || !isVideoTrackFrozen
+            ? TrackStreamingStatusMap.ACTIVE : TrackStreamingStatusMap.INTERRUPTED;
+    }
+
+    /**
+     * Creates new instance of <tt>TrackStreamingStatus</tt>.
+     *
+     * @constructor
+     * @param rtc - the RTC service instance
+     * @param conference - parent conference instance
+     * @param {Object} options
+     * @param {number} [options.p2pRtcMuteTimeout=2500] custom value for
+     * {@link TrackStreamingStatusImpl.p2pRtcMuteTimeout}.
+     * @param {number} [options.rtcMuteTimeout=2000] custom value for
+     * {@link TrackStreamingStatusImpl.rtcMuteTimeout}.
+     * @param {number} [options.outOfForwardedSourcesTimeout=500] custom value for
+     * {@link TrackStreamingStatusImpl.outOfForwardedSourcesTimeout}.
+     */
+    constructor(rtc: RTC, conference: JitsiConference, track: JitsiRemoteTrack, options: {
+        outOfForwardedSourcesTimeout: number,
+        p2pRtcMuteTimeout: number,
+        rtcMuteTimeout: number
+    }) {
+        this.rtc = rtc;
+        this.conference = conference;
+        this.track = track;
+
+        this.restoringTimer = null;
+        this.rtcMutedTimestamp = null;
+        this.streamingStatusMap = {};
+        this.trackTimer = null;
+
+        this.outOfForwardedSourcesTimeout = typeof options.outOfForwardedSourcesTimeout === 'number'
+            ? options.outOfForwardedSourcesTimeout : DEFAULT_NOT_IN_FORWARDED_SOURCES_TIMEOUT;
+
+        this.p2pRtcMuteTimeout = typeof options.p2pRtcMuteTimeout === 'number'
+            ? options.p2pRtcMuteTimeout : DEFAULT_P2P_RTC_MUTE_TIMEOUT;
+
+        this.rtcMuteTimeout = typeof options.rtcMuteTimeout === 'number'
+            ? options.rtcMuteTimeout : DEFAULT_RTC_MUTE_TIMEOUT;
+        logger.info(`RtcMuteTimeout set to: ${this.rtcMuteTimeout}`);
+    }
+
+    /**
+     * Gets the video frozen timeout for given source name.
+     * @return how long are we going to wait since RTC video muted even, before a video track is considered
+     * frozen.
+     * @private
+     */
+    _getVideoFrozenTimeout(): number {
+        const sourceName = this.track.getSourceName();
+
+        return this.rtc.isInForwardedSources(sourceName)
+            ? this.rtcMuteTimeout
+            : this.conference.isP2PActive() ? this.p2pRtcMuteTimeout : this.outOfForwardedSourcesTimeout;
+    }
+
+    /**
+     * Initializes <tt>TrackStreamingStatus</tt> and bind required event listeners.
+     */
+    init(): void {
+        // Handles P2P status changes
+        this._onP2PStatus = this.figureOutStreamingStatus.bind(this);
+        this.conference.on(JitsiConferenceEvents.P2P_STATUS, this._onP2PStatus);
+
+        // Used to send analytics events for the participant that left the call.
+        this._onUserLeft = this.onUserLeft.bind(this);
+        this.conference.on(JitsiConferenceEvents.USER_LEFT, this._onUserLeft);
+
+        // On some browsers MediaStreamTrack trigger "onmute"/"onunmute" events for video type tracks when they stop
+        // receiving data which is often a sign that remote user is having connectivity issues.
+        if (browser.supportsVideoMuteOnConnInterrupted()) {
+
+            this._onTrackRtcMuted = this.onTrackRtcMuted.bind(this);
+            this.rtc.addListener(RTCEvents.REMOTE_TRACK_MUTE, this._onTrackRtcMuted);
+
+            this._onTrackRtcUnmuted = this.onTrackRtcUnmuted.bind(this);
+            this.rtc.addListener(RTCEvents.REMOTE_TRACK_UNMUTE, this._onTrackRtcUnmuted);
+
+            // Listened which will be bound to JitsiRemoteTrack to listen for signalling mute/unmute events.
+            this._onSignallingMuteChanged = this.onSignallingMuteChanged.bind(this);
+            this.track.on(JitsiTrackEvents.TRACK_MUTE_CHANGED, this._onSignallingMuteChanged);
+
+            // Used to send an analytics event when the video type changes.
+            this._onTrackVideoTypeChanged = this.onTrackVideoTypeChanged.bind(this);
+            this.track.on(JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED, this._onTrackVideoTypeChanged);
+        }
+
+        this._onForwardedSourcesChanged = this.onForwardedSourcesChanged.bind(this);
+        this.conference.on(JitsiConferenceEvents.FORWARDED_SOURCES_CHANGED, this._onForwardedSourcesChanged);
+
+        this._onLastNValueChanged = this.figureOutStreamingStatus.bind(this);
+        this.rtc.on(RTCEvents.LASTN_VALUE_CHANGED, this._onLastNValueChanged);
+    }
+
+    /**
+     * Removes all event listeners and disposes of all resources held by this instance.
+     */
+    dispose(): void {
+        if (browser.supportsVideoMuteOnConnInterrupted()) {
+            this.rtc.removeListener(RTCEvents.REMOTE_TRACK_MUTE, this._onTrackRtcMuted);
+            this.rtc.removeListener(RTCEvents.REMOTE_TRACK_UNMUTE, this._onTrackRtcUnmuted);
+
+            this.track.off(JitsiTrackEvents.TRACK_MUTE_CHANGED, this._onSignallingMuteChanged);
+        }
+
+        this.conference.off(JitsiConferenceEvents.FORWARDED_SOURCES_CHANGED, this._onForwardedSourcesChanged);
+        this.conference.off(JitsiConferenceEvents.P2P_STATUS, this._onP2PStatus);
+        this.conference.off(JitsiConferenceEvents.USER_LEFT, this._onUserLeft);
+        this.rtc.removeListener(RTCEvents.LASTN_VALUE_CHANGED, this._onLastNValueChanged);
+
+        this.clearTimeout();
+        this.clearRtcMutedTimestamp();
+        this.maybeSendTrackStreamingStatusEvent(Date.now());
+        this.figureOutStreamingStatus();
+    }
+
+    /**
+     * Changes streaming status.
+     * @param newStatus
+     */
+    _changeStreamingStatus(newStatus: TrackStreamingStatus): void {
+        if (this.track.getTrackStreamingStatus() !== newStatus) {
+
+            const sourceName = this.track.getSourceName();
+
+            this.track.setTrackStreamingStatus(newStatus);
+
+            logger.debug(`Emit track streaming status(${Date.now()}) ${sourceName}: ${newStatus}`);
+
+            // Log the event on CallStats
+            Statistics.sendLog(
+                JSON.stringify({
+                    id: 'track.streaming.status',
+                    track: sourceName,
+                    status: newStatus
+                }));
+
+            this.track.emit(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED, newStatus);
+        }
+    }
+
+    /**
+     * Reset the postponed "streaming interrupted" event which was previously scheduled as a timeout on RTC 'onmute'
+     * event.
+     */
+    clearTimeout(): void {
+        if (this.trackTimer) {
+            window.clearTimeout(this.trackTimer);
+            this.trackTimer = null;
+        }
+    }
+
+    /**
+     * Clears the timestamp of the RTC muted event for remote video track.
+     */
+    clearRtcMutedTimestamp(): void {
+        this.rtcMutedTimestamp = null;
+    }
+
+    /**
+     * Checks if track is considered frozen.
+     * @return <tt>true</tt> if the video has frozen or <tt>false</tt> when it's either not considered frozen
+     * (yet) or if freeze detection is not supported by the current browser.
+     *
+     * FIXME merge this logic with NO_DATA_FROM_SOURCE event implemented in JitsiLocalTrack by extending the event to
+     *       the remote track and allowing to set different timeout for local and remote tracks.
+     */
+    isVideoTrackFrozen(): boolean {
+        if (!browser.supportsVideoMuteOnConnInterrupted()) {
+            return false;
+        }
+
+        const isVideoRTCMuted = this.track.isWebRTCTrackMuted();
+        const rtcMutedTimestamp = this.rtcMutedTimestamp;
+        const timeout = this._getVideoFrozenTimeout();
+
+        return isVideoRTCMuted && typeof rtcMutedTimestamp === 'number' && (Date.now() - rtcMutedTimestamp) >= timeout;
+    }
+
+    /**
+     * Figures out (and updates) the current streaming status for the track identified by the source name.
+     */
+    figureOutStreamingStatus(): void {
+        const sourceName = this.track.getSourceName();
+        const inP2PMode = this.conference.isP2PActive();
+        const isRestoringTimedOut = this._isRestoringTimedout();
+        const audioOnlyMode = this.conference.getLastN() === 0;
+
+        // NOTE Overriding videoMuted to true for audioOnlyMode should disable any detection based on video playback or
+        // forwarded sources.
+        const isVideoMuted = this.track.isVideoMuted() || audioOnlyMode;
+        const isVideoTrackFrozen = this.isVideoTrackFrozen();
+        const isInForwardedSources = this.rtc.isInForwardedSources(sourceName);
+
+        const newState
+            = inP2PMode
+                ? TrackStreamingStatusImpl._getNewStateForP2PMode(
+                    isVideoMuted,
+                    isVideoTrackFrozen)
+                : TrackStreamingStatusImpl._getNewStateForJvbMode(
+                    isInForwardedSources,
+                    isRestoringTimedOut,
+                    isVideoMuted,
+                    isVideoTrackFrozen);
+
+        // if the new state is not restoring clear timers and timestamps that we use to track the restoring state
+        if (newState !== TrackStreamingStatusMap.RESTORING) {
+            this._clearRestoringTimer();
+        }
+
+        logger.debug(
+            `Figure out conn status for ${sourceName}, is video muted: ${
+                isVideoMuted} video track frozen: ${
+                isVideoTrackFrozen} p2p mode: ${
+                inP2PMode} is in forwarded sources: ${
+                isInForwardedSources} currentStatus => newStatus: ${
+                this.track.getTrackStreamingStatus()} => ${newState}`);
+
+        const oldStreamingStatus = this.streamingStatusMap || {};
+
+        // Send an analytics event (guard on either the p2p flag or the streaming status has changed since the last
+        // time this code block run).
+        if (!('p2p' in oldStreamingStatus)
+            || !('streamingStatus' in oldStreamingStatus)
+            || oldStreamingStatus.p2p !== inP2PMode
+            || oldStreamingStatus.streamingStatus !== newState) {
+
+            const nowMs = Date.now();
+
+            this.maybeSendTrackStreamingStatusEvent(nowMs);
+
+            this.streamingStatusMap = {
+                ...oldStreamingStatus,
+                streamingStatus: newState,
+                p2p: inP2PMode,
+                startedMs: nowMs
+            };
+
+            // sometimes (always?) we're late to hook the TRACK_VIDEOTYPE_CHANGED event and the video type is not in
+            // oldStreamingStatus.
+            if (!('videoType' in this.streamingStatusMap)) {
+                this.streamingStatusMap.videoType = this.track.getVideoType();
+            }
+        }
+        this._changeStreamingStatus(newState);
+    }
+
+    /**
+     * Computes the duration of the current streaming status for the track (i.e. 15 seconds in the INTERRUPTED state)
+     * and sends a track streaming status event.
+     * @param nowMs - The current time (in millis).
+     */
+    maybeSendTrackStreamingStatusEvent(nowMs: number): void {
+        const trackStreamingStatus = this.streamingStatusMap;
+
+        if (trackStreamingStatus
+            && 'startedMs' in trackStreamingStatus
+            && 'videoType' in trackStreamingStatus
+            && 'streamingStatus' in trackStreamingStatus
+            && 'p2p' in trackStreamingStatus) {
+            trackStreamingStatus.value = nowMs - trackStreamingStatus.startedMs;
+            Statistics.sendAnalytics(createTrackStreamingStatusEvent(trackStreamingStatus));
+        }
+    }
+
+    /**
+     * On change in forwarded sources set check all leaving and entering track to change their corresponding statuses.
+     *
+     * @param leavingForwardedSources - The array of sourceName leaving forwarded sources.
+     * @param enteringForwardedSources - The array of sourceName entering forwarded sources.
+     * @param timestamp - The time in millis
+     * @private
+     */
+    onForwardedSourcesChanged(
+            leavingForwardedSources: string[] = [],
+            enteringForwardedSources: string[] = [],
+            timestamp: number): void {
+
+        const sourceName = this.track.getSourceName();
+
+        logger.debug(`Fowarded sources changed leaving=${leavingForwardedSources}, entering=${
+            enteringForwardedSources} at ${timestamp}`);
+
+        // If the browser doesn't fire the mute/onmute events when the remote peer stops/starts sending media,
+        // calculate the streaming status for all the tracks since it won't get triggered automatically on the track
+        // that has started/stopped receiving media.
+        if (!browser.supportsVideoMuteOnConnInterrupted()) {
+            this.figureOutStreamingStatus();
+        }
+
+        if (leavingForwardedSources.includes(sourceName)) {
+            this.track.clearEnteredForwardedSourcesTimestamp();
+            this._clearRestoringTimer();
+            browser.supportsVideoMuteOnConnInterrupted() && this.figureOutStreamingStatus();
+        }
+
+        if (enteringForwardedSources.includes(sourceName)) {
+            // store the timestamp this track is entering forwarded sources
+            this.track.setEnteredForwardedSourcesTimestamp(timestamp);
+            browser.supportsVideoMuteOnConnInterrupted() && this.figureOutStreamingStatus();
+        }
+    }
+
+    /**
+     * Clears the restoring timer for video track and the timestamp for entering forwarded sources.
+     */
+    _clearRestoringTimer(): void {
+        const rTimer = this.restoringTimer;
+
+        if (rTimer) {
+            clearTimeout(rTimer);
+            this.restoringTimer = null;
+        }
+    }
+
+    /**
+     * Checks whether a track had stayed enough in restoring state, compares current time and the time the track
+     * entered in forwarded sources. If it hasn't timedout and there is no timer added, add new timer in order to give
+     * it more time to become active or mark it as interrupted on next check.
+     *
+     * @returns <tt>true</tt> if the track was in restoring state more than the timeout
+     * ({@link DEFAULT_RESTORING_TIMEOUT}.) in order to set its status to interrupted.
+     * @private
+     */
+    _isRestoringTimedout(): boolean {
+        const enteredForwardedSourcesTimestamp = this.track.getEnteredForwardedSourcesTimestamp();
+
+        if (enteredForwardedSourcesTimestamp
+            && (Date.now() - enteredForwardedSourcesTimestamp) >= DEFAULT_RESTORING_TIMEOUT) {
+            return true;
+        }
+
+        // still haven't reached timeout, if there is no timer scheduled, schedule one so we can track the restoring
+        // state and change it after reaching the timeout
+        const rTimer = this.restoringTimer;
+
+        if (!rTimer) {
+            this.restoringTimer = setTimeout(() => this.figureOutStreamingStatus(), DEFAULT_RESTORING_TIMEOUT);
+        }
+
+        return false;
+    }
+
+    /** Checks whether a track is the current track. */
+    _isCurrentTrack(track: JitsiRemoteTrack): boolean {
+        return track.getSourceName() === this.track.getSourceName();
+    }
+
+    /**
+     * Sends a last/final track streaming status event for the track of the user that left the conference.
+     * @param id - The id of the participant that left the conference.
+     */
+    onUserLeft(id: string): void {
+        if (this.track.getParticipantId() === id) {
+            this.maybeSendTrackStreamingStatusEvent(Date.now());
+            this.streamingStatusMap = {};
+        }
+    }
+
+    /**
+     * Handles RTC 'onmute' event for the video track.
+     *
+     * @param track - The video track for which 'onmute' event will be processed.
+     */
+    onTrackRtcMuted(track: JitsiRemoteTrack): void {
+        if (!this._isCurrentTrack(track)) {
+            return;
+        }
+
+        const sourceName = track.getSourceName();
+
+        logger.debug(`Detector track RTC muted: ${sourceName}`, Date.now());
+
+        this.rtcMutedTimestamp = Date.now();
+        if (!track.isVideoMuted()) {
+            // If the user is not muted according to the signalling we'll give it some time, before the streaming
+            // interrupted event is triggered.
+            this.clearTimeout();
+
+            // The timeout is reduced when track is not in the forwarded sources
+            const timeout = this._getVideoFrozenTimeout();
+
+            this.trackTimer = window.setTimeout(() => {
+                logger.debug(`Set RTC mute timeout for: ${sourceName} of ${timeout} ms`);
+                this.clearTimeout();
+                this.figureOutStreamingStatus();
+            }, timeout);
+        }
+    }
+
+    /**
+     * Handles RTC 'onunmute' event for the video track.
+     *
+     * @param track - The video track for which 'onunmute' event will be processed.
+     */
+    onTrackRtcUnmuted(track: JitsiRemoteTrack): void {
+        if (!this._isCurrentTrack(track)) {
+            return;
+        }
+
+        const sourceName = this.track.getSourceName();
+
+        logger.debug(`Detector track RTC unmuted: ${sourceName}`, Date.now());
+
+        this.clearTimeout();
+        this.clearRtcMutedTimestamp();
+
+        this.figureOutStreamingStatus();
+    }
+
+    /**
+     * Here the signalling "mute"/"unmute" events are processed.
+     *
+     * @param track - The remote video track for which the signalling mute/unmute event will be
+     * processed.
+     */
+    onSignallingMuteChanged(track: JitsiRemoteTrack): void {
+        if (!this._isCurrentTrack(track)) {
+            return;
+        }
+
+        const sourceName = this.track.getSourceName();
+
+        logger.debug(`Detector on track signalling mute changed: ${sourceName}`, track.isMuted());
+
+        this.figureOutStreamingStatus();
+    }
+
+    /**
+     * Sends a track streaming status event as a result of the video type changing.
+     * @deprecated this will go away with full multiple streams support
+     * @param type - The video type.
+     */
+    onTrackVideoTypeChanged(type: VideoType): void {
+        const nowMs = Date.now();
+
+        this.maybeSendTrackStreamingStatusEvent(nowMs);
+
+        this.streamingStatusMap = {
+            ...this.streamingStatusMap || {},
+            videoType: type,
+            startedMs: nowMs
+        };
+    }
+}
+
+export default TrackStreamingStatusImpl;

--- a/service/RTC/RTCEvents.js
+++ b/service/RTC/RTCEvents.js
@@ -12,6 +12,7 @@ const RTCEvents = {
     ENDPOINT_CONN_STATUS_CHANGED: 'rtc.endpoint_conn_status_changed',
     DOMINANT_SPEAKER_CHANGED: 'rtc.dominant_speaker_changed',
     LASTN_ENDPOINT_CHANGED: 'rtc.lastn_endpoint_changed',
+    FORWARDED_SOURCES_CHANGED: 'rtc.forwarded_sources_changed',
 
     /**
      * Event emitted when the user granted/blocked a permission for the camera / mic.

--- a/service/RTC/RTCEvents.spec.ts
+++ b/service/RTC/RTCEvents.spec.ts
@@ -10,6 +10,7 @@ describe( "/service/RTC/RTCEvents members", () => {
         ENDPOINT_CONN_STATUS_CHANGED,
         DOMINANT_SPEAKER_CHANGED,
         LASTN_ENDPOINT_CHANGED,
+        FORWARDED_SOURCES_CHANGED,
         PERMISSIONS_CHANGED,
         SENDER_VIDEO_CONSTRAINTS_CHANGED,
         LASTN_VALUE_CHANGED,
@@ -41,6 +42,7 @@ describe( "/service/RTC/RTCEvents members", () => {
         expect( ENDPOINT_CONN_STATUS_CHANGED ).toBe( 'rtc.endpoint_conn_status_changed' );
         expect( DOMINANT_SPEAKER_CHANGED ).toBe( 'rtc.dominant_speaker_changed' );
         expect( LASTN_ENDPOINT_CHANGED ).toBe( 'rtc.lastn_endpoint_changed' );
+        expect( FORWARDED_SOURCES_CHANGED ).toBe( 'rtc.forwarded_sources_changed' );
         expect( PERMISSIONS_CHANGED ).toBe( 'rtc.permissions_changed' );
         expect( SENDER_VIDEO_CONSTRAINTS_CHANGED ).toBe( 'rtc.sender_video_constraints_changed' );
         expect( LASTN_VALUE_CHANGED ).toBe( 'rtc.lastn_value_changed' );

--- a/service/statistics/AnalyticsEvents.js
+++ b/service/statistics/AnalyticsEvents.js
@@ -372,6 +372,23 @@ export const createParticipantConnectionStatusEvent = function(attributes = {}) 
 };
 
 /**
+ * Creates an event related to remote track streaming status changes.
+ *
+ * @param attributes the attributes to attach to the event.
+ * @returns {{type: string, source: string, name: string}}
+ */
+export const createTrackStreamingStatusEvent = function(attributes = {}) {
+    const action = 'duration';
+
+    return {
+        type: TYPE_OPERATIONAL,
+        source: 'track.streaming.status',
+        action,
+        attributes
+    };
+};
+
+/**
  * Creates an event for a Jingle-related event.
  * @param action the action of the event
  * @param attributes attributes to add to the event.

--- a/service/statistics/AnalyticsEvents.spec.ts
+++ b/service/statistics/AnalyticsEvents.spec.ts
@@ -35,6 +35,7 @@ describe( "/service/statistics/AnalyticsEvents members", () => {
         createFocusLeftEvent,
         createGetUserMediaEvent,
         createParticipantConnectionStatusEvent,
+        createTrackStreamingStatusEvent,
         createJingleEvent,
         createNoDataFromSourceEvent,
         createP2PEvent,
@@ -81,6 +82,7 @@ describe( "/service/statistics/AnalyticsEvents members", () => {
         expect( typeof ( createFocusLeftEvent ) ).toBe( 'function' );
         expect( typeof ( createGetUserMediaEvent ) ).toBe( 'function' );
         expect( typeof ( createParticipantConnectionStatusEvent ) ).toBe( 'function' );
+        expect( typeof ( createTrackStreamingStatusEvent ) ).toBe( 'function' );
         expect( typeof ( createJingleEvent ) ).toBe( 'function' );
         expect( typeof ( createNoDataFromSourceEvent ) ).toBe( 'function' );
         expect( typeof ( createP2PEvent ) ).toBe( 'function' );

--- a/types/auto/JitsiConference.d.ts
+++ b/types/auto/JitsiConference.d.ts
@@ -535,6 +535,11 @@ declare class JitsiConference {
      */
     getLastN(): number;
     /**
+     * Obtains the forwarded sources list in this conference.
+     * @return {Array<string>|null}
+     */
+    getForwardedSources(): Array<string> | null;
+    /**
      * Selects a new value for "lastN". The requested amount of videos are going
      * to be delivered after the value is in effect. Set to -1 for unlimited or
      * all available videos.

--- a/types/auto/JitsiConferenceEvents.d.ts
+++ b/types/auto/JitsiConferenceEvents.d.ts
@@ -129,6 +129,15 @@ export declare enum JitsiConferenceEvents {
      */
     LAST_N_ENDPOINTS_CHANGED = "conference.lastNEndpointsChanged",
     /**
+     * The forwarded sources set is changed.
+     *
+     * @param {Array<string>|null} leavingForwardedSources the sourceNames of all the tracks which are leaving forwarded
+     * sources
+     * @param {Array<string>|null} enteringForwardedSources the sourceNames of all the tracks which are entering forwarded
+     * sources
+     */
+    FORWARDED_SOURCES_CHANGED = "conference.forwardedSourcesChanged",
+    /**
      * Indicates that the room has been locked or unlocked.
      */
     LOCK_STATE_CHANGED = "conference.lock_state_changed",
@@ -408,6 +417,7 @@ export declare const JVB121_STATUS = JitsiConferenceEvents.JVB121_STATUS;
 export declare const KICKED = JitsiConferenceEvents.KICKED;
 export declare const PARTICIPANT_KICKED = JitsiConferenceEvents.PARTICIPANT_KICKED;
 export declare const LAST_N_ENDPOINTS_CHANGED = JitsiConferenceEvents.LAST_N_ENDPOINTS_CHANGED;
+export declare const FORWARDED_SOURCES_CHANGED = JitsiConferenceEvents.FORWARDED_SOURCES_CHANGED;
 export declare const LOCK_STATE_CHANGED = JitsiConferenceEvents.LOCK_STATE_CHANGED;
 export declare const SERVER_REGION_CHANGED = JitsiConferenceEvents.SERVER_REGION_CHANGED;
 export declare const _MEDIA_SESSION_STARTED = JitsiConferenceEvents._MEDIA_SESSION_STARTED;

--- a/types/auto/JitsiConferenceEvents.d.ts
+++ b/types/auto/JitsiConferenceEvents.d.ts
@@ -131,9 +131,9 @@ export declare enum JitsiConferenceEvents {
     /**
      * The forwarded sources set is changed.
      *
-     * @param {Array<string>|null} leavingForwardedSources the sourceNames of all the tracks which are leaving forwarded
+     * @param {Array<string>} leavingForwardedSources the sourceNames of all the tracks which are leaving forwarded
      * sources
-     * @param {Array<string>|null} enteringForwardedSources the sourceNames of all the tracks which are entering forwarded
+     * @param {Array<string>} enteringForwardedSources the sourceNames of all the tracks which are entering forwarded
      * sources
      */
     FORWARDED_SOURCES_CHANGED = "conference.forwardedSourcesChanged",

--- a/types/auto/JitsiTrackEvents.d.ts
+++ b/types/auto/JitsiTrackEvents.d.ts
@@ -37,3 +37,15 @@ export const NO_DATA_FROM_SOURCE: "track.no_data_from_source";
  * the microphone that is currently selected.
  */
 export const NO_AUDIO_INPUT: "track.no_audio_input";
+/**
+ * Event fired when we detect local problem with the video track.
+ * First argument is the sourceName of the track and the second is a string indicating if the connection is currently
+ * - active - the connection is active.
+ * - inactive - the connection is inactive, was intentionally interrupted by the bridge because of low BWE or because
+ *   of the endpoint falling out of last N.
+ * - interrupted - a network problem occurred.
+ * - restoring - the connection was inactive and is restoring now.
+ *
+ * The current status value can be obtained by calling JitsiRemoteTrack.getTrackStreamingStatus().
+ */
+export const TRACK_STREAMING_STATUS_CHANGED: "track.streaming_status_changed";

--- a/types/auto/JitsiTrackEvents.d.ts
+++ b/types/auto/JitsiTrackEvents.d.ts
@@ -38,7 +38,7 @@ export const NO_DATA_FROM_SOURCE: "track.no_data_from_source";
  */
 export const NO_AUDIO_INPUT: "track.no_audio_input";
 /**
- * Event fired when we detect local problem with the video track.
+ * Event fired whenever video track's streaming changes.
  * First argument is the sourceName of the track and the second is a string indicating if the connection is currently
  * - active - the connection is active.
  * - inactive - the connection is inactive, was intentionally interrupted by the bridge because of low BWE or because

--- a/types/auto/modules/RTC/JitsiRemoteTrack.d.ts
+++ b/types/auto/modules/RTC/JitsiRemoteTrack.d.ts
@@ -88,10 +88,6 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      */
     isMuted(): boolean | any | any;
     /**
-     * @returns {Boolean} Whether this is a muted video track.
-     */
-    isVideoMuted(): boolean;
-    /**
      * Returns the participant id which owns the track.
      *
      * @returns {string} the id of the participants. It corresponds to the
@@ -134,40 +130,44 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      */
     _getStatus(): string;
     /**
-     * Disposes trackStreamingStatusImpl and clears trackStreamingStatus
+     * Initializes trackStreamingStatusImpl.
      */
-    disposeTrackStreamingStatus(): void;
+    _initTrackStreamingStatus(): void;
+    /**
+     * Disposes trackStreamingStatusImpl and clears trackStreamingStatus.
+     */
+    _disposeTrackStreamingStatus(): void;
     /**
      * Updates track's streaming status.
      *
-     * @param {string} state the current track streaming state. {@link TrackStreamingStatusMap}.
+     * @param {string} state the current track streaming state. {@link TrackStreamingStatus}.
      */
-    setTrackStreamingStatus(status: any): void;
+    _setTrackStreamingStatus(status: any): void;
     /**
      * Returns track's streaming status.
      *
      * @returns {string} the streaming status <tt>TrackStreamingStatus</tt> of the track. Returns null
      * if trackStreamingStatusImpl hasn't been initialized.
      *
-     * {@link TrackStreamingStatusMap}.
+     * {@link TrackStreamingStatus}.
      */
     getTrackStreamingStatus(): string;
     /**
      * Clears the timestamp of when the track entered forwarded sources.
      */
-    clearEnteredForwardedSourcesTimestamp(): void;
+    _clearEnteredForwardedSourcesTimestamp(): void;
     /**
      * Updates the timestamp of when the track entered forwarded sources.
      *
      * @param {number} timestamp the time in millis
      */
-    setEnteredForwardedSourcesTimestamp(timestamp: number): void;
+    _setEnteredForwardedSourcesTimestamp(timestamp: number): void;
     /**
      * Returns the timestamp of when the track entered forwarded sources.
      *
      * @returns {number} the time in millis
      */
-    getEnteredForwardedSourcesTimestamp(): number;
+    _getEnteredForwardedSourcesTimestamp(): number;
 }
 import JitsiTrack from "./JitsiTrack";
 import TrackStreamingStatusImpl from "../connectivity/TrackStreamingStatus";

--- a/types/auto/modules/RTC/JitsiRemoteTrack.d.ts
+++ b/types/auto/modules/RTC/JitsiRemoteTrack.d.ts
@@ -28,6 +28,15 @@ export default class JitsiRemoteTrack extends JitsiTrack {
     muted: boolean;
     isP2P: boolean;
     _sourceName: string;
+    _trackStreamingStatus: any;
+    _trackStreamingStatusImpl: TrackStreamingStatusImpl;
+    /**
+     * This holds the timestamp indicating when remote video track entered forwarded sources set. Track entering
+     * forwardedSources will have streaming status restoring and when we start receiving video will become active,
+     * but if video is not received for certain time {@link DEFAULT_RESTORING_TIMEOUT} that track streaming status
+     * will become interrupted.
+     */
+    _enteredForwardedSourcesTimestamp: number;
     hasBeenMuted: boolean;
     _containerHandlers: {};
     /**
@@ -36,6 +45,21 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      * @returns {void}
      */
     _bindTrackHandlers(): void;
+    /**
+     * Overrides addEventListener method to init TrackStreamingStatus instance when there are listeners for the
+     * {@link JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED} event.
+     *
+     * @param {string} event - event name
+     * @param {function} handler - event handler
+     */
+    _addEventListener(event: string, handler: Function): void;
+    /**
+     * Overrides removeEventListener method to dispose TrackStreamingStatus instance.
+     *
+     * @param {string} event - event name
+     * @param {function} handler - event handler
+     */
+    _removeEventListener(event: string, handler: Function): void;
     /**
      * Callback invoked when the track is muted. Emits an event notifying
      * listeners of the mute event.
@@ -63,6 +87,10 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      * muted and <tt>false</tt> otherwise.
      */
     isMuted(): boolean | any | any;
+    /**
+     * @returns {Boolean} Whether this is a muted video track.
+     */
+    isVideoMuted(): boolean;
     /**
      * Returns the participant id which owns the track.
      *
@@ -105,5 +133,41 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      * @returns {string}
      */
     _getStatus(): string;
+    /**
+     * Disposes trackStreamingStatusImpl and clears trackStreamingStatus
+     */
+    disposeTrackStreamingStatus(): void;
+    /**
+     * Updates track's streaming status.
+     *
+     * @param {string} state the current track streaming state. {@link TrackStreamingStatusMap}.
+     */
+    setTrackStreamingStatus(status: any): void;
+    /**
+     * Returns track's streaming status.
+     *
+     * @returns {string} the streaming status <tt>TrackStreamingStatus</tt> of the track. Returns null
+     * if trackStreamingStatusImpl hasn't been initialized.
+     *
+     * {@link TrackStreamingStatusMap}.
+     */
+    getTrackStreamingStatus(): string;
+    /**
+     * Clears the timestamp of when the track entered forwarded sources.
+     */
+    clearEnteredForwardedSourcesTimestamp(): void;
+    /**
+     * Updates the timestamp of when the track entered forwarded sources.
+     *
+     * @param {number} timestamp the time in millis
+     */
+    setEnteredForwardedSourcesTimestamp(timestamp: number): void;
+    /**
+     * Returns the timestamp of when the track entered forwarded sources.
+     *
+     * @returns {number} the time in millis
+     */
+    getEnteredForwardedSourcesTimestamp(): number;
 }
 import JitsiTrack from "./JitsiTrack";
+import TrackStreamingStatusImpl from "../connectivity/TrackStreamingStatus";

--- a/types/auto/modules/RTC/RTC.d.ts
+++ b/types/auto/modules/RTC/RTC.d.ts
@@ -185,6 +185,14 @@ export default class RTC extends Listenable {
      */
     private _lastNEndpoints;
     /**
+     * Defines the forwarded sources list. It can be null or an array once initialised with a channel forwarded
+     * sources event.
+     *
+     * @type {Array<string>|null}
+     * @private
+     */
+    private _forwardedSources;
+    /**
      * The number representing the maximum video height the local client
      * should receive from the bridge.
      *
@@ -200,6 +208,7 @@ export default class RTC extends Listenable {
      */
     private _selectedEndpoints;
     _lastNChangeListener: any;
+    _forwardedSourcesChangeListener: any;
     /**
      * Callback invoked when the list of known audio and video devices has
      * been updated. Attempts to update the known available audio output
@@ -247,6 +256,13 @@ export default class RTC extends Listenable {
      * @private
      */
     private _onLastNChanged;
+    /**
+     * Receives events when forwarded sources had changed.
+     *
+     * @param {array} forwardedSources The new forwarded sources.
+     * @private
+     */
+    private _onForwardedSourcesChanged;
     /**
      * Should be called when current media session ends and after the
      * PeerConnection has been closed using PeerConnection.close() method.
@@ -432,6 +448,14 @@ export default class RTC extends Listenable {
      * don't have bridge channel support, otherwise we return false.
      */
     isInLastN(id: string): boolean;
+    /**
+     * Indicates if the source name is currently included in the forwarded sources.
+     *
+     * @param {string} sourceName The source name that we check for forwarded sources.
+     * @returns {boolean} true if the source name is in the forwarded sources or if we don't have bridge channel
+     * support, otherwise we return false.
+     */
+    isInForwardedSources(sourceName: string): boolean;
 }
 import Listenable from "../util/Listenable";
 import TraceablePeerConnection from "./TraceablePeerConnection";

--- a/types/auto/modules/RTC/RTC.d.ts
+++ b/types/auto/modules/RTC/RTC.d.ts
@@ -357,6 +357,11 @@ export default class RTC extends Listenable {
      */
     addLocalTrack(track: any): void;
     /**
+     * Get forwarded sources list.
+     * @returns {Array<string>|null}
+     */
+    getForwardedSources(): Array<string> | null;
+    /**
      * Get local video track.
      * @returns {JitsiLocalTrack|undefined}
      */

--- a/types/auto/modules/connectivity/TrackStreamingStatus.d.ts
+++ b/types/auto/modules/connectivity/TrackStreamingStatus.d.ts
@@ -1,12 +1,28 @@
 import JitsiConference from '../../types/hand-crafted/JitsiConference';
 import JitsiRemoteTrack from '../../types/hand-crafted/modules/RTC/JitsiRemoteTrack';
 import RTC from '../../types/hand-crafted/modules/RTC/RTC';
+import { VideoType } from '../../types/hand-crafted/service/RTC/VideoType';
 /** Track streaming statuses. */
-declare type TrackStreamingStatus = 'active' | 'inactive' | 'interrupted' | 'restoring';
-interface TrackStreamingStatusMapType {
-    [key: string]: TrackStreamingStatus;
+export declare enum TrackStreamingStatus {
+    /**
+     * Status indicating that streaming is currently active.
+     */
+    ACTIVE = "active",
+    /**
+     * Status indicating that streaming is currently inactive.
+     * Inactive means the streaming was stopped on purpose from the bridge, like exiting forwarded sources or
+     * adaptivity decided to drop video because of not enough bandwidth.
+     */
+    INACTIVE = "inactive",
+    /**
+     * Status indicating that streaming is currently interrupted.
+     */
+    INTERRUPTED = "interrupted",
+    /**
+     * Status indicating that streaming is currently restoring.
+     */
+    RESTORING = "restoring"
 }
-declare type VideoType = 'camera' | 'desktop';
 declare type StreamingStatusMap = {
     videoType?: VideoType;
     startedMs?: number;
@@ -14,7 +30,6 @@ declare type StreamingStatusMap = {
     streamingStatus?: string;
     value?: number;
 };
-export declare const TrackStreamingStatusMap: TrackStreamingStatusMapType;
 /**
  * Class is responsible for emitting JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED events.
  */
@@ -79,7 +94,7 @@ export declare class TrackStreamingStatusImpl {
      * @param isInForwardedSources - indicates whether the track is in the forwarded sources set. When set to
      * false it means that JVB is not sending any video for the track.
      * @param isRestoringTimedout - if true it means that the track has been outside of forwarded sources too
-     * long to be considered {@link TrackStreamingStatusMap.RESTORING}.
+     * long to be considered {@link TrackStreamingStatus.RESTORING}.
      * @param isVideoMuted - true if the track is video muted and we should not expect to receive any video.
      * @param isVideoTrackFrozen - if the current browser support video frozen detection then it will be set to
      * true when the video track is frozen. If the current browser does not support frozen detection the it's always

--- a/types/auto/modules/connectivity/TrackStreamingStatus.d.ts
+++ b/types/auto/modules/connectivity/TrackStreamingStatus.d.ts
@@ -1,0 +1,224 @@
+import JitsiConference from '../../types/hand-crafted/JitsiConference';
+import JitsiRemoteTrack from '../../types/hand-crafted/modules/RTC/JitsiRemoteTrack';
+import RTC from '../../types/hand-crafted/modules/RTC/RTC';
+/** Track streaming statuses. */
+declare type TrackStreamingStatus = 'active' | 'inactive' | 'interrupted' | 'restoring';
+interface TrackStreamingStatusMapType {
+    [key: string]: TrackStreamingStatus;
+}
+declare type VideoType = 'camera' | 'desktop';
+declare type StreamingStatusMap = {
+    videoType?: VideoType;
+    startedMs?: number;
+    p2p?: boolean;
+    streamingStatus?: string;
+    value?: number;
+};
+export declare const TrackStreamingStatusMap: TrackStreamingStatusMapType;
+/**
+ * Class is responsible for emitting JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED events.
+ */
+export declare class TrackStreamingStatusImpl {
+    rtc: RTC;
+    conference: JitsiConference;
+    track: JitsiRemoteTrack;
+    /**  This holds the timeout callback ID scheduled using window.setTimeout. */
+    trackTimer: number | null;
+    /**
+     * If video track frozen detection through RTC mute event is supported, we wait some time until video track is
+     * considered frozen. But because when the track falls out of forwarded sources it is expected for the video to
+     * freeze this timeout must be significantly reduced in "out of forwarded sources" case.
+     *
+     * Basically this value is used instead of {@link rtcMuteTimeout} when track is not in forwarded sources.
+     */
+    outOfForwardedSourcesTimeout: number;
+    /**
+     * How long we are going to wait for the corresponding signaling mute event after the RTC video track muted
+     * event is fired on the Media stream, before the connection interrupted is fired. The default value is
+     * {@link DEFAULT_P2P_RTC_MUTE_TIMEOUT}.
+     */
+    p2pRtcMuteTimeout: number;
+    /**
+     * How long we're going to wait after the RTC video track muted event for the corresponding signalling mute
+     * event, before the connection interrupted is fired. The default value is {@link DEFAULT_RTC_MUTE_TIMEOUT}.
+     *
+     * @returns amount of time in milliseconds
+     */
+    rtcMuteTimeout: number;
+    /**
+     * This holds a timestamp indicating  when remote video track was RTC muted. The purpose of storing the
+     * timestamp is to avoid the transition to disconnected status in case of legitimate video mute operation where
+     * the signalling video muted event can arrive shortly after RTC muted event.
+     *
+     * The timestamp is measured in milliseconds obtained with <tt>Date.now()</tt>.
+     *
+     * FIXME merge this logic with NO_DATA_FROM_SOURCE event implemented in JitsiLocalTrack by extending the event
+     * to the remote track and allowing to set different timeout for local and remote tracks.
+     */
+    rtcMutedTimestamp: number | null;
+    /** This holds the restoring timeout callback ID scheduled using window.setTimeout. */
+    restoringTimer: ReturnType<typeof setTimeout> | null;
+    /**
+     * This holds the current streaming status (along with all the internal events that happen while in that
+     * state).
+     *
+     * The goal is to send this information to the analytics backend for post-mortem analysis.
+     */
+    streamingStatusMap: StreamingStatusMap;
+    _onP2PStatus: () => void;
+    _onUserLeft: () => void;
+    _onTrackRtcMuted: () => void;
+    _onTrackRtcUnmuted: () => void;
+    _onSignallingMuteChanged: () => void;
+    _onTrackVideoTypeChanged: () => void;
+    _onLastNValueChanged: () => void;
+    _onForwardedSourcesChanged: () => void;
+    /**
+     * Calculates the new {@link TrackStreamingStatus} based on the values given for some specific remote track. It is
+     * assumed that the conference is currently in the JVB mode (in contrary to the P2P mode)
+     * @param isInForwardedSources - indicates whether the track is in the forwarded sources set. When set to
+     * false it means that JVB is not sending any video for the track.
+     * @param isRestoringTimedout - if true it means that the track has been outside of forwarded sources too
+     * long to be considered {@link TrackStreamingStatusMap.RESTORING}.
+     * @param isVideoMuted - true if the track is video muted and we should not expect to receive any video.
+     * @param isVideoTrackFrozen - if the current browser support video frozen detection then it will be set to
+     * true when the video track is frozen. If the current browser does not support frozen detection the it's always
+     * false.
+     * @return {TrackStreamingStatus} the new streaming status for the track for whom the values above were provided.
+     * @private
+     */
+    static _getNewStateForJvbMode(isInForwardedSources: boolean, isRestoringTimedout: boolean, isVideoMuted: boolean, isVideoTrackFrozen: boolean): TrackStreamingStatus;
+    /**
+     * In P2P mode we don't care about any values coming from the JVB and the streaming status can be only active or
+     * interrupted.
+     * @param isVideoMuted - true if video muted
+     * @param isVideoTrackFrozen - true if the video track for the remote track is currently frozen. If the
+     * current browser does not support video frozen detection then it's always false.
+     * @return {TrackStreamingStatus}
+     * @private
+     */
+    static _getNewStateForP2PMode(isVideoMuted: boolean, isVideoTrackFrozen: boolean): TrackStreamingStatus;
+    /**
+     * Creates new instance of <tt>TrackStreamingStatus</tt>.
+     *
+     * @constructor
+     * @param rtc - the RTC service instance
+     * @param conference - parent conference instance
+     * @param {Object} options
+     * @param {number} [options.p2pRtcMuteTimeout=2500] custom value for
+     * {@link TrackStreamingStatusImpl.p2pRtcMuteTimeout}.
+     * @param {number} [options.rtcMuteTimeout=2000] custom value for
+     * {@link TrackStreamingStatusImpl.rtcMuteTimeout}.
+     * @param {number} [options.outOfForwardedSourcesTimeout=500] custom value for
+     * {@link TrackStreamingStatusImpl.outOfForwardedSourcesTimeout}.
+     */
+    constructor(rtc: RTC, conference: JitsiConference, track: JitsiRemoteTrack, options: {
+        outOfForwardedSourcesTimeout: number;
+        p2pRtcMuteTimeout: number;
+        rtcMuteTimeout: number;
+    });
+    /**
+     * Gets the video frozen timeout for given source name.
+     * @return how long are we going to wait since RTC video muted even, before a video track is considered
+     * frozen.
+     * @private
+     */
+    _getVideoFrozenTimeout(): number;
+    /**
+     * Initializes <tt>TrackStreamingStatus</tt> and bind required event listeners.
+     */
+    init(): void;
+    /**
+     * Removes all event listeners and disposes of all resources held by this instance.
+     */
+    dispose(): void;
+    /**
+     * Changes streaming status.
+     * @param newStatus
+     */
+    _changeStreamingStatus(newStatus: TrackStreamingStatus): void;
+    /**
+     * Reset the postponed "streaming interrupted" event which was previously scheduled as a timeout on RTC 'onmute'
+     * event.
+     */
+    clearTimeout(): void;
+    /**
+     * Clears the timestamp of the RTC muted event for remote video track.
+     */
+    clearRtcMutedTimestamp(): void;
+    /**
+     * Checks if track is considered frozen.
+     * @return <tt>true</tt> if the video has frozen or <tt>false</tt> when it's either not considered frozen
+     * (yet) or if freeze detection is not supported by the current browser.
+     *
+     * FIXME merge this logic with NO_DATA_FROM_SOURCE event implemented in JitsiLocalTrack by extending the event to
+     *       the remote track and allowing to set different timeout for local and remote tracks.
+     */
+    isVideoTrackFrozen(): boolean;
+    /**
+     * Figures out (and updates) the current streaming status for the track identified by the source name.
+     */
+    figureOutStreamingStatus(): void;
+    /**
+     * Computes the duration of the current streaming status for the track (i.e. 15 seconds in the INTERRUPTED state)
+     * and sends a track streaming status event.
+     * @param nowMs - The current time (in millis).
+     */
+    maybeSendTrackStreamingStatusEvent(nowMs: number): void;
+    /**
+     * On change in forwarded sources set check all leaving and entering track to change their corresponding statuses.
+     *
+     * @param leavingForwardedSources - The array of sourceName leaving forwarded sources.
+     * @param enteringForwardedSources - The array of sourceName entering forwarded sources.
+     * @param timestamp - The time in millis
+     * @private
+     */
+    onForwardedSourcesChanged(leavingForwardedSources: string[], enteringForwardedSources: string[], timestamp: number): void;
+    /**
+     * Clears the restoring timer for video track and the timestamp for entering forwarded sources.
+     */
+    _clearRestoringTimer(): void;
+    /**
+     * Checks whether a track had stayed enough in restoring state, compares current time and the time the track
+     * entered in forwarded sources. If it hasn't timedout and there is no timer added, add new timer in order to give
+     * it more time to become active or mark it as interrupted on next check.
+     *
+     * @returns <tt>true</tt> if the track was in restoring state more than the timeout
+     * ({@link DEFAULT_RESTORING_TIMEOUT}.) in order to set its status to interrupted.
+     * @private
+     */
+    _isRestoringTimedout(): boolean;
+    /** Checks whether a track is the current track. */
+    _isCurrentTrack(track: JitsiRemoteTrack): boolean;
+    /**
+     * Sends a last/final track streaming status event for the track of the user that left the conference.
+     * @param id - The id of the participant that left the conference.
+     */
+    onUserLeft(id: string): void;
+    /**
+     * Handles RTC 'onmute' event for the video track.
+     *
+     * @param track - The video track for which 'onmute' event will be processed.
+     */
+    onTrackRtcMuted(track: JitsiRemoteTrack): void;
+    /**
+     * Handles RTC 'onunmute' event for the video track.
+     *
+     * @param track - The video track for which 'onunmute' event will be processed.
+     */
+    onTrackRtcUnmuted(track: JitsiRemoteTrack): void;
+    /**
+     * Here the signalling "mute"/"unmute" events are processed.
+     *
+     * @param track - The remote video track for which the signalling mute/unmute event will be
+     * processed.
+     */
+    onSignallingMuteChanged(track: JitsiRemoteTrack): void;
+    /**
+     * Sends a track streaming status event as a result of the video type changing.
+     * @deprecated this will go away with full multiple streams support
+     * @param type - The video type.
+     */
+    onTrackVideoTypeChanged(type: VideoType): void;
+}
+export default TrackStreamingStatusImpl;

--- a/types/auto/service/RTC/RTCEvents.d.ts
+++ b/types/auto/service/RTC/RTCEvents.d.ts
@@ -4,6 +4,7 @@ export const DATA_CHANNEL_OPEN: string;
 export const ENDPOINT_CONN_STATUS_CHANGED: string;
 export const DOMINANT_SPEAKER_CHANGED: string;
 export const LASTN_ENDPOINT_CHANGED: string;
+export const FORWARDED_SOURCES_CHANGED: string;
 export const PERMISSIONS_CHANGED: string;
 export const SENDER_VIDEO_CONSTRAINTS_CHANGED: string;
 export const LASTN_VALUE_CHANGED: string;

--- a/types/auto/service/statistics/AnalyticsEvents.d.ts
+++ b/types/auto/service/statistics/AnalyticsEvents.d.ts
@@ -275,6 +275,11 @@ export function createParticipantConnectionStatusEvent(attributes?: {}): {
     source: string;
     name: string;
 };
+export function createTrackStreamingStatusEvent(attributes?: {}): {
+    type: string;
+    source: string;
+    name: string;
+};
 export function createJingleEvent(action: any, attributes?: {}): {
     type: string;
     action: any;

--- a/types/hand-crafted/JitsiConference.d.ts
+++ b/types/hand-crafted/JitsiConference.d.ts
@@ -10,6 +10,8 @@ import JitsiVideoSIPGWSession from './modules/videosipgw/JitsiVideoSIPGWSession'
 import TraceablePeerConnection from './modules/RTC/TraceablePeerConnection';
 import { MediaType } from './service/RTC/MediaType';
 
+type JitsiConferenceEventsType = `${JitsiConferenceEvents}`
+
 export default class JitsiConference {
   constructor( options: {
     name: string;
@@ -42,10 +44,10 @@ export default class JitsiConference {
   getLocalAudioTrack: () => JitsiLocalTrack | null;
   getLocalVideoTrack: () => JitsiLocalTrack | null;
   getPerformanceStats: () => unknown | null; // TODO:
-  on: ( eventId: JitsiConferenceEvents, handler: () => unknown ) => void; // TODO:
-  off: ( eventId: JitsiConferenceEvents, handler: () => unknown ) => void; // TODO:
-  addEventListener: ( eventId: JitsiConferenceEvents, handler: () => unknown ) => void; // TODO:
-  removeEventListener: ( eventId: JitsiConferenceEvents, handler: () => unknown ) => void; // TODO:
+  on: ( eventId: JitsiConferenceEvents | JitsiConferenceEventsType, handler: (...args: any[]) => unknown ) => void; // TODO:
+  off: ( eventId: JitsiConferenceEvents | JitsiConferenceEventsType, handler: (...args: any[]) => unknown ) => void; // TODO:
+  addEventListener: ( eventId: JitsiConferenceEvents | JitsiConferenceEventsType, handler: (...args: any[]) => unknown ) => void; // TODO:
+  removeEventListener: ( eventId: JitsiConferenceEvents | JitsiConferenceEventsType, handler: (...args: any[]) => unknown ) => void; // TODO:
   addCommandListener: ( command: string, handler: () => unknown ) => void; // TODO:
   removeCommandListener: ( command: string, handler: () => unknown ) => void; // TODO:
   // sendTextMessage: (message: string, elementName: string) => void; // obsolete

--- a/types/hand-crafted/JitsiConference.d.ts
+++ b/types/hand-crafted/JitsiConference.d.ts
@@ -1,4 +1,4 @@
-import { JitsiConferenceEvents } from './JitsiConferenceEvents';
+import { JitsiConferenceEvents } from '../../JitsiConferenceEvents';
 import JitsiConnection from './JitsiConnection';
 import JitsiTrackError from './JitsiTrackError';
 import JitsiParticipant from './JitsiParticipant';
@@ -9,8 +9,6 @@ import Transcriber from './modules/transcription/transcriber';
 import JitsiVideoSIPGWSession from './modules/videosipgw/JitsiVideoSIPGWSession';
 import TraceablePeerConnection from './modules/RTC/TraceablePeerConnection';
 import { MediaType } from './service/RTC/MediaType';
-
-type JitsiConferenceEventsType = `${JitsiConferenceEvents}`
 
 export default class JitsiConference {
   constructor( options: {
@@ -44,10 +42,10 @@ export default class JitsiConference {
   getLocalAudioTrack: () => JitsiLocalTrack | null;
   getLocalVideoTrack: () => JitsiLocalTrack | null;
   getPerformanceStats: () => unknown | null; // TODO:
-  on: ( eventId: JitsiConferenceEvents | JitsiConferenceEventsType, handler: (...args: any[]) => unknown ) => void; // TODO:
-  off: ( eventId: JitsiConferenceEvents | JitsiConferenceEventsType, handler: (...args: any[]) => unknown ) => void; // TODO:
-  addEventListener: ( eventId: JitsiConferenceEvents | JitsiConferenceEventsType, handler: (...args: any[]) => unknown ) => void; // TODO:
-  removeEventListener: ( eventId: JitsiConferenceEvents | JitsiConferenceEventsType, handler: (...args: any[]) => unknown ) => void; // TODO:
+  on: ( eventId: JitsiConferenceEvents, handler: (...args: any[]) => unknown ) => void; // TODO:
+  off: ( eventId: JitsiConferenceEvents, handler: (...args: any[]) => unknown ) => void; // TODO:
+  addEventListener: ( eventId: JitsiConferenceEvents, handler: (...args: any[]) => unknown ) => void; // TODO:
+  removeEventListener: ( eventId: JitsiConferenceEvents, handler: (...args: any[]) => unknown ) => void; // TODO:
   addCommandListener: ( command: string, handler: () => unknown ) => void; // TODO:
   removeCommandListener: ( command: string, handler: () => unknown ) => void; // TODO:
   // sendTextMessage: (message: string, elementName: string) => void; // obsolete

--- a/types/hand-crafted/JitsiConferenceEvents.d.ts
+++ b/types/hand-crafted/JitsiConferenceEvents.d.ts
@@ -21,6 +21,7 @@ export enum JitsiConferenceEvents {
   KICKED = 'conference.kicked',
   PARTICIPANT_KICKED = 'conference.participant_kicked',
   LAST_N_ENDPOINTS_CHANGED = 'conference.lastNEndpointsChanged',
+  FORWARDED_SOURCES_CHANGED = 'conference.forwardedSourcesChanged',
   LOCK_STATE_CHANGED = 'conference.lock_state_changed',
   SERVER_REGION_CHANGED = 'conference.server_region_changed',
   _MEDIA_SESSION_STARTED = 'conference.media_session.started',

--- a/types/hand-crafted/modules/RTC/JitsiRemoteTrack.d.ts
+++ b/types/hand-crafted/modules/RTC/JitsiRemoteTrack.d.ts
@@ -12,11 +12,10 @@ export default class JitsiRemoteTrack extends JitsiTrack {
   toString: () => string;
   getSourceName: () => string;
   getTrackStreamingStatus: () => string;
-  setTrackStreamingStatus: (newStatus: string) => void;
-  clearEnteredForwardedSourcesTimestamp: () => void;
-  setEnteredForwardedSourcesTimestamp: (timestamp: number) => void;
-  getEnteredForwardedSourcesTimestamp: () => number | null;
-  isVideoMuted: () => boolean;
+  _setTrackStreamingStatus: (newStatus: string) => void;
+  _clearEnteredForwardedSourcesTimestamp: () => void;
+  _setEnteredForwardedSourcesTimestamp: (timestamp: number) => void;
+  _getEnteredForwardedSourcesTimestamp: () => number | null;
 
   containerEvents: [ 'abort', 'canplay', 'canplaythrough', 'emptied', 'ended', 'error', 'loadeddata',
     'loadedmetadata', 'loadstart', 'pause', 'play', 'playing', 'ratechange', 'stalled', 'suspend',

--- a/types/hand-crafted/modules/RTC/JitsiRemoteTrack.d.ts
+++ b/types/hand-crafted/modules/RTC/JitsiRemoteTrack.d.ts
@@ -10,6 +10,13 @@ export default class JitsiRemoteTrack extends JitsiTrack {
   isLocal: () => false;
   getSSRC: () => number;
   toString: () => string;
+  getSourceName: () => string;
+  getTrackStreamingStatus: () => string;
+  setTrackStreamingStatus: (newStatus: string) => void;
+  clearEnteredForwardedSourcesTimestamp: () => void;
+  setEnteredForwardedSourcesTimestamp: (timestamp: number) => void;
+  getEnteredForwardedSourcesTimestamp: () => number | null;
+  isVideoMuted: () => boolean;
 
   containerEvents: [ 'abort', 'canplay', 'canplaythrough', 'emptied', 'ended', 'error', 'loadeddata',
     'loadedmetadata', 'loadstart', 'pause', 'play', 'playing', 'ratechange', 'stalled', 'suspend',

--- a/types/hand-crafted/modules/RTC/JitsiTrack.d.ts
+++ b/types/hand-crafted/modules/RTC/JitsiTrack.d.ts
@@ -1,9 +1,10 @@
+import EventEmitter from 'events';
 import JitsiConference from '../../JitsiConference';
 import { MediaType } from '../../service/RTC/MediaType';
 import { VideoType } from '../../service/RTC/VideoType';
 import TraceablePeerConnection from './TraceablePeerConnection';
 
-export default class JitsiTrack {
+export default class JitsiTrack extends EventEmitter {
   constructor( conference: JitsiConference, stream: unknown, track: unknown, streamInactiveHandler: unknown, trackMediaType: unknown, videoType: unknown ); // TODO:
   disposed: boolean;
   getVideoType: () => VideoType;

--- a/types/hand-crafted/modules/RTC/RTC.d.ts
+++ b/types/hand-crafted/modules/RTC/RTC.d.ts
@@ -46,6 +46,7 @@ export default class RTC extends Listenable {
   sendChannelMessage: ( to: string, payload: unknown ) => void; // TODO:
   setLastN: ( value: number ) => void;
   isInLastN: ( id: string ) => boolean;
+  isInForwardedSources: ( sourceName: string ) => boolean;
   setNewReceiverVideoConstraints: ( constraints: unknown ) => void; // TODO:
   setVideoType: ( videoType: string ) => void;
   setVideoMute: ( value: unknown ) => Promise<unknown>; // TODO:

--- a/types/hand-crafted/modules/util/Listenable.d.ts
+++ b/types/hand-crafted/modules/util/Listenable.d.ts
@@ -4,4 +4,6 @@ export default class Listenable {
   constructor( eventEmitter?: EventEmitter<unknown> ); // TODO:
   addListener: ( eventName: string, listener: () => unknown ) => () => unknown; // TODO: returns remote listener func
   removeListener: ( eventName: string, listener: () => unknown ) => void;
+  on: (eventName: string, listener: (...args: any[]) => unknown) => unknown; // TODO: returns remote listener func
+  off: (eventName: string, listener: (...args: any[]) => unknown) => void;
 }


### PR DESCRIPTION
This change allow us handle the streaming status of each individual track when the feature flag is enabled. The emitted streaming status is mostly used for the connection indicator in the UI. 

Related jitsi-meet PR: https://github.com/jitsi/jitsi-meet/pull/10934 

Todo/Follow up item:
- Look into moving some of the `TrackStreamingStatus#onForwardedSourcesChanged` logic out into `RTC#_onForwardedSourcesChanged`. The reason being is that since TrackStreamingStatus is only initialized when a track is rendered, there is a corner case where we are not capturing the timestamp of when it entered forwarded sources.
- Add specs, this can be part of another PR.
