### PR TITLE
fix: Add private message handler for breakout_rooms

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -463,7 +463,8 @@ export default class XMPP extends Listenable {
 
         if (this.avModerationComponentAddress
             || this.speakerStatsComponentAddress
-            || this.conferenceDurationComponentAddress) {
+            || this.conferenceDurationComponentAddress
+            || this.breakoutRoomsComponentAddress) {
             this.connection.addHandler(this._onPrivateMessage.bind(this), null, 'message', null, null);
         }
     }


### PR DESCRIPTION
Add the _onPrivateMessage handler when breakout_rooms is found in disco info.

I think this is a bug.  If only breakout_rooms rooms is enabled then, the _onPrivateMessage handler never gets called for breakout room messages.  