### PR TITLE
fix(JingleSessionPC) Do not force track removal at pc level on user leave.

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1720,7 +1720,7 @@ export default class JingleSessionPC extends JingleSession {
     }
 
     /**
-     * Handles the deletion of the remote tracks and SSRCs associated with a remote endpoint.
+     * Handles the deletion of SSRCs associated with a remote user from the remote description when the user leaves.
      *
      * @param {string} id Endpoint id of the participant that has left the call.
      * @returns {void}
@@ -1730,7 +1730,6 @@ export default class JingleSessionPC extends JingleSession {
             const removeSsrcInfo = this.peerconnection.getRemoteSourceInfoByParticipant(id);
 
             if (removeSsrcInfo.length) {
-                this.peerconnection.removeRemoteTracks(id);
                 const oldLocalSdp = new SDP(this.peerconnection.localDescription.sdp);
                 const newRemoteSdp = this._processRemoteRemoveSource(removeSsrcInfo);
 

--- a/types/auto/modules/xmpp/JingleSessionPC.d.ts
+++ b/types/auto/modules/xmpp/JingleSessionPC.d.ts
@@ -393,7 +393,7 @@ export default class JingleSessionPC extends JingleSession {
      */
     removeRemoteStream(elem: any): void;
     /**
-     * Handles the deletion of the remote tracks and SSRCs associated with a remote endpoint.
+     * Handles the deletion of SSRCs associated with a remote user from the remote description when the user leaves.
      *
      * @param {string} id Endpoint id of the participant that has left the call.
      * @returns {void}


### PR DESCRIPTION
When a user leaves, the ssrcs associated with the ep are removed from the remote description and a renegotiation is forced. The browser then fires 'removetrack' event on the associated MediaStream when sRD is called with ssrcs removed. Therefore, there is no need to explicitly delete the tracks at the TPC level. This also prevents the 'Removed track not found for stream' events from showing up in the browser console log.