### PR TITLE
feat(multi-stream-support) Add the support for multiple local video streams.

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -163,6 +163,9 @@ export default class JitsiLocalTrack extends JitsiTrack {
         // correspond to the id of a matching device from the available device list.
         this._realDeviceId = this.deviceId === '' ? undefined : this.deviceId;
 
+        // The source name that will be signaled for this track.
+        this._sourceName = null;
+
         this._trackMutedTS = 0;
 
         this._onDeviceListWillChange = devices => {
@@ -669,6 +672,15 @@ export default class JitsiLocalTrack extends JitsiTrack {
     }
 
     /**
+     * Returns the source name associated with the jitsi track.
+     *
+     * @returns {string | null} source name
+     */
+    getSourceName() {
+        return this._sourceName;
+    }
+
+    /**
      * Returns if associated MediaStreamTrack is in the 'ended' state
      *
      * @returns {boolean}
@@ -859,6 +871,15 @@ export default class JitsiLocalTrack extends JitsiTrack {
                 logger.error('Failed to switch to the new stream!', error);
                 throw error;
             });
+    }
+
+    /**
+     * Sets the source name to be used for signaling the jitsi track.
+     *
+     * @param {string} name The source name.
+     */
+    setSourceName(name) {
+        this._sourceName = name;
     }
 
     /**

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -339,21 +339,41 @@ export class TPCUtils {
 
     /**
      * Replaces the existing track on a RTCRtpSender with the given track.
+     *
      * @param {JitsiLocalTrack} oldTrack - existing track on the sender that needs to be removed.
      * @param {JitsiLocalTrack} newTrack - new track that needs to be added to the sender.
-     * @returns {Promise<void>} - resolved when done.
+     * @returns {Promise<RTCRtpTransceiver>} - resolved with the associated transceiver when done, rejected otherwise.
      */
     replaceTrack(oldTrack, newTrack) {
         const mediaType = newTrack?.getType() ?? oldTrack?.getType();
-        const transceiver = this.findTransceiver(mediaType, oldTrack);
         const track = newTrack?.getTrack() ?? null;
+        let transceiver;
+
+        // If old track exists, replace the track on the corresponding sender.
+        if (oldTrack) {
+            transceiver = this.pc.peerconnection.getTransceivers()?.find(t => t.sender?.track === oldTrack.getTrack());
+
+        // Find the first recvonly transceiver when a second track of the same media type is being added to the pc. As
+        // part of the track addition, a new m-line was added to the remote description with direction set to recvonly.
+        } else if (this.pc.getLocalTracks(mediaType)?.length && !newTrack?.conference) {
+            transceiver = this.pc.peerconnection.getTransceivers()?.find(
+                t => t.receiver?.track?.kind === mediaType
+                && t.direction === MediaDirection.RECVONLY
+                && t.currentDirection === MediaDirection.INACTIVE);
+
+        // If a track of a given media type is added for the first time, replace the track on the first sender. This
+        // will be called when the user joins the call muted but unmutes during the call.
+        } else {
+            transceiver = this.pc.peerconnection.getTransceivers()?.find(t => t.receiver?.track?.kind === mediaType);
+        }
 
         if (!transceiver) {
             return Promise.reject(new Error('replace track failed'));
         }
         logger.debug(`${this.pc} Replacing ${oldTrack} with ${newTrack}`);
 
-        return transceiver.sender.replaceTrack(track);
+        return transceiver.sender.replaceTrack(track)
+            .then(() => Promise.resolve(transceiver));
     }
 
     /**

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1952,10 +1952,9 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
             // The track will be replaced again on the peerconnection when the user unmutes.
             ? Promise.resolve()
             : this.tpcUtils.replaceTrack(oldTrack, newTrack);
-        const transceiver = this.tpcUtils.findTransceiver(mediaType, oldTrack);
 
         return promise
-            .then(() => {
+            .then(transceiver => {
                 oldTrack && this.localTracks.delete(oldTrack.rtcId);
                 newTrack && this.localTracks.set(newTrack.rtcId, newTrack);
                 const mediaActive = mediaType === MediaType.AUDIO

--- a/modules/flags/FeatureFlags.js
+++ b/modules/flags/FeatureFlags.js
@@ -13,8 +13,19 @@ class FeatureFlags {
      */
     init(flags) {
         this._sourceNameSignaling = Boolean(flags.sourceNameSignaling);
+        this._sendMultipleVideoStreams = Boolean(flags.sendMultipleVideoStreams);
 
-        logger.info(`Source name signaling: ${this._sourceNameSignaling}`);
+        logger.info(`Source name signaling: ${this._sourceNameSignaling},`
+            + ` Send multiple video streams: ${this._sendMultipleVideoStreams}`);
+    }
+
+    /**
+     * Checks if multiple local video streams support is enabled.
+     *
+     * @returns {boolean}
+     */
+    isMultiStreamSupportEnabled() {
+        return this._sourceNameSignaling && this._sendMultipleVideoStreams;
     }
 
     /**

--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -210,14 +210,14 @@ export default class LocalSdpMunger {
                     const trackId = streamAndTrackIDs[1];
 
                     // eslint-disable-next-line max-depth
-                    if (streamId === '-' || !streamId) {
-                        streamId = `${this.localEndpointId}-${mediaType}`;
-                    }
-
-                    // eslint-disable-next-line max-depth
                     if (FeatureFlags.isMultiStreamSupportEnabled()
                         && this.tpc.usesUnifiedPlan()
                         && mediaType === MediaType.VIDEO) {
+
+                        // eslint-disable-next-line max-depth
+                        if (streamId === '-' || !streamId) {
+                            streamId = `${this.localEndpointId}-${mediaType}`;
+                        }
 
                         // eslint-disable-next-line max-depth
                         if (!sourceToMsidMap.has(trackId)) {

--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -182,17 +182,18 @@ export default class LocalSdpMunger {
     }
 
     /**
-     * Modifies 'cname', 'msid', 'label' and 'mslabel' by appending
-     * the id of {@link LocalSdpMunger#tpc} at the end, preceding by a dash
-     * sign.
+     * Modifies 'cname', 'msid', 'label' and 'mslabel' by appending the id of {@link LocalSdpMunger#tpc} at the end,
+     * preceding by a dash sign.
      *
-     * @param {MLineWrap} mediaSection - The media part (audio or video) of the
-     * session description which will be modified in place.
+     * @param {MLineWrap} mediaSection - The media part (audio or video) of the session description which will be
+     * modified in place.
      * @returns {void}
      * @private
      */
     _transformMediaIdentifiers(mediaSection) {
+        const mediaType = mediaSection.mLine?.type;
         const pcId = this.tpc.id;
+        const sourceToMsidMap = new Map();
 
         for (const ssrcLine of mediaSection.ssrcs) {
             switch (ssrcLine.attribute) {
@@ -205,15 +206,29 @@ export default class LocalSdpMunger {
                 if (ssrcLine.value) {
                     const streamAndTrackIDs = ssrcLine.value.split(' ');
 
-                    if (streamAndTrackIDs.length === 2) {
-                        ssrcLine.value
-                            = this._generateMsidAttribute(
-                                mediaSection.mLine?.type,
-                                streamAndTrackIDs[1],
-                                streamAndTrackIDs[0]);
-                    } else {
-                        logger.warn(`Unable to munge local MSID - weird format detected: ${ssrcLine.value}`);
+                    let streamId = streamAndTrackIDs[0];
+                    const trackId = streamAndTrackIDs[1];
+
+                    // eslint-disable-next-line max-depth
+                    if (streamId === '-' || !streamId) {
+                        streamId = `${this.localEndpointId}-${mediaType}`;
                     }
+
+                    // eslint-disable-next-line max-depth
+                    if (FeatureFlags.isMultiStreamSupportEnabled()
+                        && this.tpc.usesUnifiedPlan()
+                        && mediaType === MediaType.VIDEO) {
+
+                        // eslint-disable-next-line max-depth
+                        if (!sourceToMsidMap.has(trackId)) {
+                            streamId = `${streamId}-${sourceToMsidMap.size}`;
+                            sourceToMsidMap.set(trackId, streamId);
+                        }
+                    }
+
+                    ssrcLine.value = this._generateMsidAttribute(mediaType, trackId, sourceToMsidMap.get(trackId));
+                } else {
+                    logger.warn(`Unable to munge local MSID - weird format detected: ${ssrcLine.value}`);
                 }
                 break;
             }
@@ -246,7 +261,7 @@ export default class LocalSdpMunger {
                     .find(ssrc => ssrc.id === source && ssrc.attribute === 'msid');
 
                 if (!msidExists) {
-                    const generatedMsid = this._generateMsidAttribute(mediaSection.mLine?.type, trackId);
+                    const generatedMsid = this._generateMsidAttribute(mediaType, trackId);
 
                     mediaSection.ssrcs.push({
                         id: source,

--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -52,7 +52,8 @@ SDP.prototype.removeTcpCandidates = false;
 SDP.prototype.removeUdpCandidates = false;
 
 /**
- * Adds a new m-line for receiving source of the given media type.
+ * Adds a new m-line to the description so that a new local source can then be attached to the transceiver that gets
+ * added after a reneogtiation cycle.
  *
  * @param {Mediatype} mediaType media type of the new source that is being added.
  */

--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -1,5 +1,8 @@
 /* global $ */
 
+import clonedeep from 'lodash.clonedeep';
+import transform from 'sdp-transform';
+
 import MediaDirection from '../../service/RTC/MediaDirection';
 import browser from '../browser';
 import FeatureFlags from '../flags/FeatureFlags';
@@ -47,6 +50,39 @@ SDP.prototype.removeTcpCandidates = false;
  * @type {boolean}
  */
 SDP.prototype.removeUdpCandidates = false;
+
+/**
+ * Adds a new m-line for receiving source of the given media type.
+ *
+ * @param {Mediatype} mediaType media type of the new source that is being added.
+ */
+SDP.prototype.addMlineForNewLocalSource = function(mediaType) {
+    const mid = this.media.length;
+    const sdp = transform.parse(this.raw);
+    const mline = clonedeep(sdp.media.find(m => m.type === mediaType));
+
+    // Edit media direction, mid and remove the existing ssrc lines in the m-line.
+    mline.mid = mid;
+    mline.direction = MediaDirection.RECVONLY;
+
+    // Remove the ssrcs and source groups.
+    mline.msid = undefined;
+    mline.ssrcs = undefined;
+    mline.ssrcGroups = undefined;
+
+    sdp.media = sdp.media.concat(mline);
+
+    // We regenerate the BUNDLE group (since we added a new m-line)
+    sdp.groups.forEach(group => {
+        if (group.type === 'BUNDLE') {
+            const mids = group.mids.split(' ');
+
+            mids.push(mid);
+            group.mids = mids.join(' ');
+        }
+    });
+    this.raw = transform.write(sdp);
+};
 
 /**
  * Returns map of MediaChannel mapped per channel idx.

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -5,6 +5,7 @@ import { $iq, Strophe } from 'strophe.js';
 
 import * as CodecMimeType from '../../service/RTC/CodecMimeType';
 import MediaDirection from '../../service/RTC/MediaDirection';
+import * as MediaType from '../../service/RTC/MediaType';
 import {
     ICE_DURATION,
     ICE_STATE_CHANGED
@@ -1383,7 +1384,7 @@ export default class JingleSessionPC extends JingleSession {
                     sid: this.sid
                 })
                 .c('content', {
-                    name: 'video',
+                    name: MediaType.VIDEO,
                     senders
                 });
 
@@ -2028,6 +2029,49 @@ export default class JingleSessionPC extends JingleSession {
                         return this.peerconnection.setRemoteDescription(remoteDescription);
                     });
             });
+    }
+
+    /**
+     * Adds a new track to the peerconnection. This method needs to be called only when a secondary JitsiLocalTrack is
+     * being added to the peerconnection for the first time.
+     *
+     * @param {JitsiLocalTrack} localTrack track to be added to the peer connection.
+     * @returns {Promise<void>} that resolves when the track is successfully added to the peerconnection, rejected
+     * otherwise.
+     */
+    addTrack(localTrack) {
+        if (!this.usesUnifiedPlan || localTrack.type !== MediaType.VIDEO) {
+            return Promise.reject(new Error('Multiple tracks of a given media type are not supported'));
+        }
+
+        const workFunction = finishedCallback => {
+            const remoteSdp = new SDP(this.peerconnection.peerconnection.remoteDescription.sdp);
+
+            // Add a new transceiver by adding a new mline in the remote description.
+            remoteSdp.addMlineForNewLocalSource(MediaType.VIDEO);
+            this._renegotiate(remoteSdp.raw)
+                .then(() => finishedCallback(), error => finishedCallback(error));
+        };
+
+        return new Promise((resolve, reject) => {
+            logger.debug(`${this} Queued renegotiation after addTrack`);
+
+            this.modificationQueue.push(
+                workFunction,
+                error => {
+                    if (error) {
+                        logger.error(`${this} renegotiation after addTrack error`, error);
+                        reject(error);
+                    } else {
+                        logger.debug(`${this} renegotiation after addTrack executed - OK`);
+
+                        // Replace the track on the newly generated transceiver.
+                        return this.replaceTrack(null, localTrack)
+                            .then(() => resolve())
+                            .catch(() => reject());
+                    }
+                });
+        });
     }
 
     /**

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -2040,7 +2040,9 @@ export default class JingleSessionPC extends JingleSession {
      * otherwise.
      */
     addTrack(localTrack) {
-        if (!this.usesUnifiedPlan || localTrack.type !== MediaType.VIDEO) {
+        if (!FeatureFlags.isMultiStreamSupportEnabled()
+            || !this.usesUnifiedPlan
+            || localTrack.type !== MediaType.VIDEO) {
             return Promise.reject(new Error('Multiple tracks of a given media type are not supported'));
         }
 

--- a/types/auto/modules/RTC/JitsiLocalTrack.d.ts
+++ b/types/auto/modules/RTC/JitsiLocalTrack.d.ts
@@ -81,6 +81,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
      */
     _testDataSent: boolean;
     _realDeviceId: string;
+    _sourceName: string;
     _trackMutedTS: number;
     _onDeviceListWillChange: (devices: any) => void;
     _onAudioOutputDeviceChanged: any;
@@ -221,6 +222,12 @@ export default class JitsiLocalTrack extends JitsiTrack {
      */
     getParticipantId(): string;
     /**
+     * Returns the source name associated with the jitsi track.
+     *
+     * @returns {string | null} source name
+     */
+    getSourceName(): string | null;
+    /**
      * Returns if associated MediaStreamTrack is in the 'ended' state
      *
      * @returns {boolean}
@@ -269,6 +276,12 @@ export default class JitsiLocalTrack extends JitsiTrack {
      * @returns {Promise}
      */
     setEffect(effect: any): Promise<any>;
+    /**
+     * Sets the source name to be used for signaling the jitsi track.
+     *
+     * @param {string} name The source name.
+     */
+    setSourceName(name: string): void;
     /**
      * Stops the associated MediaStream.
      *

--- a/types/auto/modules/RTC/TPCUtils.d.ts
+++ b/types/auto/modules/RTC/TPCUtils.d.ts
@@ -108,11 +108,12 @@ export class TPCUtils {
     calculateEncodingsBitrates(localVideoTrack: any): Array<number>;
     /**
      * Replaces the existing track on a RTCRtpSender with the given track.
+     *
      * @param {JitsiLocalTrack} oldTrack - existing track on the sender that needs to be removed.
      * @param {JitsiLocalTrack} newTrack - new track that needs to be added to the sender.
-     * @returns {Promise<void>} - resolved when done.
+     * @returns {Promise<RTCRtpTransceiver>} - resolved with the associated transceiver when done, rejected otherwise.
      */
-    replaceTrack(oldTrack: any, newTrack: any): Promise<void>;
+    replaceTrack(oldTrack: any, newTrack: any): Promise<RTCRtpTransceiver>;
     /**
     * Enables/disables audio transmission on the peer connection. When
     * disabled the audio transceiver direction will be set to 'inactive'

--- a/types/auto/modules/flags/FeatureFlags.d.ts
+++ b/types/auto/modules/flags/FeatureFlags.d.ts
@@ -13,8 +13,9 @@ declare class FeatureFlags {
     _sourceNameSignaling: boolean;
     _sendMultipleVideoStreams: boolean;
     /**
+     * Checks if multiple local video streams support is enabled.
      *
-     * @returns
+     * @returns {boolean}
      */
     isMultiStreamSupportEnabled(): boolean;
     /**

--- a/types/auto/modules/flags/FeatureFlags.d.ts
+++ b/types/auto/modules/flags/FeatureFlags.d.ts
@@ -11,6 +11,12 @@ declare class FeatureFlags {
      */
     init(flags: any): void;
     _sourceNameSignaling: boolean;
+    _sendMultipleVideoStreams: boolean;
+    /**
+     *
+     * @returns
+     */
+    isMultiStreamSupportEnabled(): boolean;
     /**
      * Checks if the source name signaling is enabled.
      *

--- a/types/auto/modules/sdp/LocalSdpMunger.d.ts
+++ b/types/auto/modules/sdp/LocalSdpMunger.d.ts
@@ -42,12 +42,11 @@ export default class LocalSdpMunger {
      */
     _generateMsidAttribute(mediaType: string, trackId: string, streamId?: string): string | null;
     /**
-     * Modifies 'cname', 'msid', 'label' and 'mslabel' by appending
-     * the id of {@link LocalSdpMunger#tpc} at the end, preceding by a dash
-     * sign.
+     * Modifies 'cname', 'msid', 'label' and 'mslabel' by appending the id of {@link LocalSdpMunger#tpc} at the end,
+     * preceding by a dash sign.
      *
-     * @param {MLineWrap} mediaSection - The media part (audio or video) of the
-     * session description which will be modified in place.
+     * @param {MLineWrap} mediaSection - The media part (audio or video) of the session description which will be
+     * modified in place.
      * @returns {void}
      * @private
      */

--- a/types/auto/modules/sdp/RtxModifier.d.ts
+++ b/types/auto/modules/sdp/RtxModifier.d.ts
@@ -25,23 +25,24 @@ export default class RtxModifier {
      */
     setSsrcCache(ssrcMapping: Map<any, any>): void;
     /**
-     * Adds RTX ssrcs for any video ssrcs that don't
-     *  already have them.  If the video ssrc has been
-     *  seen before, and already had an RTX ssrc generated,
-     *  the same RTX ssrc will be used again.
+     * Adds RTX ssrcs for any video ssrcs that don't already have them.  If the video ssrc has been seen before, and
+     * already had an RTX ssrc generated, the same RTX ssrc will be used again.
+     *
      * @param {string} sdpStr sdp in raw string format
+     * @returns {string} The modified sdp in raw string format.
      */
     modifyRtxSsrcs(sdpStr: string): string;
     /**
-     * Does the same thing as {@link modifyRtxSsrcs}, but takes the
-     *  {@link MLineWrap} instance wrapping video media as an argument.
+     * Does the same thing as {@link modifyRtxSsrcs}, but takes the {@link MLineWrap} instance wrapping video media as
+     * an argument.
      * @param {MLineWrap} videoMLine
-     * @return {boolean} <tt>true</tt> if the SDP wrapped by
-     *  {@link SdpTransformWrap} has been modified or <tt>false</tt> otherwise.
+     * @return {boolean} <tt>true</tt> if the SDP wrapped by {@link SdpTransformWrap} has been modified or
+     * <tt>false</tt> otherwise.
      */
     modifyRtxSsrcs2(videoMLine: any): boolean;
     /**
-     * Strip all rtx streams from the given sdp
+     * Strip all rtx streams from the given sdp.
+     *
      * @param {string} sdpStr sdp in raw string format
      * @returns {string} sdp string with all rtx streams stripped
      */

--- a/types/auto/modules/sdp/SDP.d.ts
+++ b/types/auto/modules/sdp/SDP.d.ts
@@ -30,7 +30,8 @@ export default class SDP {
      */
     removeUdpCandidates: boolean;
     /**
-     * Adds a new m-line for receiving source of the given media type.
+     * Adds a new m-line to the description so that a new local source can then be attached to the transceiver that gets
+     * added after a reneogtiation cycle.
      *
      * @param {Mediatype} mediaType media type of the new source that is being added.
      */

--- a/types/auto/modules/sdp/SDP.d.ts
+++ b/types/auto/modules/sdp/SDP.d.ts
@@ -30,6 +30,12 @@ export default class SDP {
      */
     removeUdpCandidates: boolean;
     /**
+     * Adds a new m-line for receiving source of the given media type.
+     *
+     * @param {Mediatype} mediaType media type of the new source that is being added.
+     */
+    addMlineForNewLocalSource(mediaType: any): void;
+    /**
      * Returns map of MediaChannel mapped per channel idx.
      */
     getMediaSsrcMap(): {};

--- a/types/auto/modules/xmpp/JingleSessionPC.d.ts
+++ b/types/auto/modules/xmpp/JingleSessionPC.d.ts
@@ -455,6 +455,15 @@ export default class JingleSessionPC extends JingleSession {
      */
     private _initiatorRenegotiate;
     /**
+     * Adds a new track to the peerconnection. This method needs to be called only when a secondary JitsiLocalTrack is
+     * being added to the peerconnection for the first time.
+     *
+     * @param {JitsiLocalTrack} localTrack track to be added to the peer connection.
+     * @returns {Promise<void>} that resolves when the track is successfully added to the peerconnection, rejected
+     * otherwise.
+     */
+    addTrack(localTrack: any): Promise<void>;
+    /**
      * Replaces <tt>oldTrack</tt> with <tt>newTrack</tt> and performs a single
      * offer/answer cycle after both operations are done. Either
      * <tt>oldTrack</tt> or <tt>newTrack</tt> can be null; replacing a valid


### PR DESCRIPTION
This feature is behind 'sendMultipleVideoStreams' config.js flag and is currently supported only on clients running in Unified plan mode.