### PR TITLE
feat(ScreenObtainer): add support for tab capture on Electron

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -164,7 +164,7 @@ const ScreenObtainer = {
                             audio: audioConstraints,
                             video: {
                                 mandatory: {
-                                    chromeMediaSource: 'desktop',
+                                    chromeMediaSource: streamType === 'tab' ? 'tab' : 'desktop',
                                     chromeMediaSourceId: streamId,
                                     minFrameRate: desktopSharingFrameRate?.min ?? SS_DEFAULT_FRAME_RATE,
                                     maxFrameRate: desktopSharingFrameRate?.max ?? SS_DEFAULT_FRAME_RATE,


### PR DESCRIPTION
With https://github.com/electron/electron/pull/31204 being merged into Electron and released with Electron 17.x.x, Electron can now capture individual WebContents (Tabs). This change allows the standard flow to support tab capture