### PR TITLE
fix(presence) Change the default videoType assumed in presence to camera.

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -6,6 +6,7 @@ import { $iq, $msg, $pres, Strophe } from 'strophe.js';
 
 import * as JitsiTranscriptionStatus from '../../JitsiTranscriptionStatus';
 import * as MediaType from '../../service/RTC/MediaType';
+import VideoType from '../../service/RTC/VideoType';
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
 import GlobalOnErrorHandler from '../util/GlobalOnErrorHandler';
 import Listenable from '../util/Listenable';
@@ -1618,7 +1619,7 @@ export default class ChatRoom extends Listenable {
         }
         const data = {
             muted: true, // muted by default
-            videoType: undefined // no video type by default
+            videoType: VideoType.CAMERA // 'camera' by default
         };
         let mutedNode = null;
 


### PR DESCRIPTION
The client doesn't add videoType to presence if the videoType is CAMERA since it is the default type.
Fixes https://github.com/jitsi/lib-jitsi-meet/issues/1649