### PR TITLE
fix(qualitycontrol) SenderVideoConstraintsV2 changed to SenderSourceConstraints

### DIFF
--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -376,21 +376,21 @@ export default class BridgeChannel {
                 }
                 break;
             }
-            case 'SenderVideoConstraintsV2': {
+            case 'SenderSourceConstraints': {
                 if (FeatureFlags.isSourceNameSignalingEnabled()) {
-                    const { sourceName, idealHeight } = obj;
+                    const { sourceName, maxHeight } = obj;
 
-                    if (typeof sourceName === 'string' && typeof idealHeight === 'number') {
+                    if (typeof sourceName === 'string' && typeof maxHeight === 'number') {
                         // eslint-disable-next-line object-property-newline
-                        logger.info(`SenderVideoConstraintsV2: ${JSON.stringify({ sourceName, idealHeight })}`);
+                        logger.info(`SenderSourceConstraints: ${JSON.stringify({ sourceName, maxHeight })}`);
                         emitter.emit(
                             RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED, {
                                 sourceName,
-                                idealHeight
+                                maxHeight
                             }
                         );
                     } else {
-                        logger.error(`Invalid SenderVideoConstraintsV2: ${JSON.stringify(obj)}`);
+                        logger.error(`Invalid SenderSourceConstraints: ${JSON.stringify(obj)}`);
                     }
                 }
                 break;

--- a/modules/qualitycontrol/SendVideoController.js
+++ b/modules/qualitycontrol/SendVideoController.js
@@ -90,16 +90,16 @@ export default class SendVideoController {
      */
     _onSenderConstraintsReceived(videoConstraints) {
         if (FeatureFlags.isSourceNameSignalingEnabled()) {
-            const { idealHeight, sourceName } = videoConstraints;
+            const { maxHeight, sourceName } = videoConstraints;
             const localVideoTracks = this._conference.getLocalVideoTracks() ?? [];
 
             for (const track of localVideoTracks) {
                 // Propagate the sender constraint only if it has changed.
                 if (track.getSourceName() === sourceName
                     && (!this._sourceSenderConstraints.has(sourceName)
-                    || this._sourceSenderConstraints.get(sourceName) !== idealHeight)) {
-                    this._sourceSenderConstraints.set(sourceName, idealHeight);
-                    logger.debug(`Sender constraints for source:${sourceName} changed to idealHeight:${idealHeight}`);
+                    || this._sourceSenderConstraints.get(sourceName) !== maxHeight)) {
+                    this._sourceSenderConstraints.set(sourceName, maxHeight);
+                    logger.debug(`Sender constraints for source:${sourceName} changed to maxHeight:${maxHeight}`);
                     this._propagateSendMaxFrameHeight(sourceName);
                 }
             }


### PR DESCRIPTION
The colibri class name for the source name sender constraints changed from SenderVideoConstraintsV2 to SenderSourceConstraints.
The new format is {colibriClass: 'SenderSourceConstraints', sourceName: 'b6746083-v0', maxHeight: 180}