### PR TITLE
Tests to monitor regressions in the TypeScript conversion

### DIFF
--- a/JitsiConferenceErrors.spec.ts
+++ b/JitsiConferenceErrors.spec.ts
@@ -1,0 +1,80 @@
+import * as exported from "./JitsiConferenceErrors";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/JitsiConferenceErrors members", () => {
+    const {
+        AUTHENTICATION_REQUIRED,
+        CHAT_ERROR,
+        SETTINGS_ERROR,
+        CONFERENCE_DESTROYED,
+        CONFERENCE_MAX_USERS,
+        CONNECTION_ERROR,
+        CONFERENCE_RESTARTED,
+        NOT_ALLOWED_ERROR,
+        MEMBERS_ONLY_ERROR,
+        CONFERENCE_ACCESS_DENIED,
+        FOCUS_DISCONNECTED,
+        FOCUS_LEFT,
+        GRACEFUL_SHUTDOWN,
+        ICE_FAILED,
+        INCOMPATIBLE_SERVER_VERSIONS,
+        OFFER_ANSWER_FAILED,
+        PASSWORD_NOT_SUPPORTED,
+        PASSWORD_REQUIRED,
+        RESERVATION_ERROR,
+        VIDEOBRIDGE_NOT_AVAILABLE,
+        JitsiConferenceErrors,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( AUTHENTICATION_REQUIRED ).toBe( 'conference.authenticationRequired' );
+        expect( CHAT_ERROR ).toBe( 'conference.chatError' );
+        expect( SETTINGS_ERROR ).toBe( 'conference.settingsError' );
+        expect( CONFERENCE_DESTROYED ).toBe( 'conference.destroyed' );
+        expect( CONFERENCE_MAX_USERS ).toBe( 'conference.max_users' );
+        expect( CONNECTION_ERROR ).toBe( 'conference.connectionError' );
+        expect( CONFERENCE_RESTARTED ).toBe( 'conference.restarted' );
+        expect( NOT_ALLOWED_ERROR ).toBe( 'conference.connectionError.notAllowed' );
+        expect( MEMBERS_ONLY_ERROR ).toBe( 'conference.connectionError.membersOnly' );
+        expect( CONFERENCE_ACCESS_DENIED ).toBe( 'conference.connectionError.accessDenied' );
+        expect( FOCUS_DISCONNECTED ).toBe( 'conference.focusDisconnected' );
+        expect( FOCUS_LEFT ).toBe( 'conference.focusLeft' );
+        expect( GRACEFUL_SHUTDOWN ).toBe( 'conference.gracefulShutdown' );
+        expect( ICE_FAILED ).toBe( 'conference.iceFailed' );
+        expect( INCOMPATIBLE_SERVER_VERSIONS ).toBe( 'conference.incompatible_server_versions' );
+        expect( OFFER_ANSWER_FAILED ).toBe( 'conference.offerAnswerFailed' );
+        expect( PASSWORD_NOT_SUPPORTED ).toBe( 'conference.passwordNotSupported' );
+        expect( PASSWORD_REQUIRED ).toBe( 'conference.passwordRequired' );
+        expect( RESERVATION_ERROR ).toBe( 'conference.reservationError' );
+        expect( VIDEOBRIDGE_NOT_AVAILABLE ).toBe( 'conference.videobridgeNotAvailable' );
+        if ( JitsiConferenceErrors ) {
+            expect( JitsiConferenceErrors.AUTHENTICATION_REQUIRED ).toBe( 'conference.authenticationRequired' );
+            expect( JitsiConferenceErrors.CHAT_ERROR ).toBe( 'conference.chatError' );
+            expect( JitsiConferenceErrors.SETTINGS_ERROR ).toBe( 'conference.settingsError' );
+            expect( JitsiConferenceErrors.CONFERENCE_DESTROYED ).toBe( 'conference.destroyed' );
+            expect( JitsiConferenceErrors.CONFERENCE_MAX_USERS ).toBe( 'conference.max_users' );
+            expect( JitsiConferenceErrors.CONNECTION_ERROR ).toBe( 'conference.connectionError' );
+            expect( JitsiConferenceErrors.CONFERENCE_RESTARTED ).toBe( 'conference.restarted' );
+            expect( JitsiConferenceErrors.NOT_ALLOWED_ERROR ).toBe( 'conference.connectionError.notAllowed' );
+            expect( JitsiConferenceErrors.MEMBERS_ONLY_ERROR ).toBe( 'conference.connectionError.membersOnly' );
+            expect( JitsiConferenceErrors.CONFERENCE_ACCESS_DENIED ).toBe( 'conference.connectionError.accessDenied' );
+            expect( JitsiConferenceErrors.FOCUS_DISCONNECTED ).toBe( 'conference.focusDisconnected' );
+            expect( JitsiConferenceErrors.FOCUS_LEFT ).toBe( 'conference.focusLeft' );
+            expect( JitsiConferenceErrors.GRACEFUL_SHUTDOWN ).toBe( 'conference.gracefulShutdown' );
+            expect( JitsiConferenceErrors.ICE_FAILED ).toBe( 'conference.iceFailed' );
+            expect( JitsiConferenceErrors.INCOMPATIBLE_SERVER_VERSIONS ).toBe( 'conference.incompatible_server_versions' );
+            expect( JitsiConferenceErrors.OFFER_ANSWER_FAILED ).toBe( 'conference.offerAnswerFailed' );
+            expect( JitsiConferenceErrors.PASSWORD_NOT_SUPPORTED ).toBe( 'conference.passwordNotSupported' );
+            expect( JitsiConferenceErrors.PASSWORD_REQUIRED ).toBe( 'conference.passwordRequired' );
+            expect( JitsiConferenceErrors.RESERVATION_ERROR ).toBe( 'conference.reservationError' );
+            expect( JitsiConferenceErrors.VIDEOBRIDGE_NOT_AVAILABLE ).toBe( 'conference.videobridgeNotAvailable' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/JitsiConferenceEvents.spec.ts
+++ b/JitsiConferenceEvents.spec.ts
@@ -1,0 +1,233 @@
+import * as exported from "./JitsiConferenceEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/JitsiConferenceEvents members", () => {
+    const {
+        AUDIO_INPUT_STATE_CHANGE,
+        AUDIO_UNMUTE_PERMISSIONS_CHANGED,
+        AUTH_STATUS_CHANGED,
+        BEFORE_STATISTICS_DISPOSED,
+        CONFERENCE_ERROR,
+        CONFERENCE_FAILED,
+        CONFERENCE_JOIN_IN_PROGRESS,
+        CONFERENCE_JOINED,
+        CONFERENCE_LEFT,
+        CONFERENCE_UNIQUE_ID_SET,
+        CONNECTION_ESTABLISHED,
+        CONNECTION_INTERRUPTED,
+        CONNECTION_RESTORED,
+        DATA_CHANNEL_OPENED,
+        DISPLAY_NAME_CHANGED,
+        DOMINANT_SPEAKER_CHANGED,
+        CONFERENCE_CREATED_TIMESTAMP,
+        DTMF_SUPPORT_CHANGED,
+        ENDPOINT_MESSAGE_RECEIVED,
+        ENDPOINT_STATS_RECEIVED,
+        JVB121_STATUS,
+        KICKED,
+        PARTICIPANT_KICKED,
+        LAST_N_ENDPOINTS_CHANGED,
+        LOCK_STATE_CHANGED,
+        SERVER_REGION_CHANGED,
+        _MEDIA_SESSION_STARTED,
+        _MEDIA_SESSION_ACTIVE_CHANGED,
+        MEMBERS_ONLY_CHANGED,
+        MESSAGE_RECEIVED,
+        NO_AUDIO_INPUT,
+        NOISY_MIC,
+        NON_PARTICIPANT_MESSAGE_RECEIVED,
+        PRIVATE_MESSAGE_RECEIVED,
+        PARTICIPANT_CONN_STATUS_CHANGED,
+        PARTCIPANT_FEATURES_CHANGED,
+        PARTICIPANT_PROPERTY_CHANGED,
+        P2P_STATUS,
+        PHONE_NUMBER_CHANGED,
+        PROPERTIES_CHANGED,
+        RECORDER_STATE_CHANGED,
+        VIDEO_SIP_GW_AVAILABILITY_CHANGED,
+        VIDEO_SIP_GW_SESSION_STATE_CHANGED,
+        START_MUTED_POLICY_CHANGED,
+        STARTED_MUTED,
+        SUBJECT_CHANGED,
+        SUSPEND_DETECTED,
+        TALK_WHILE_MUTED,
+        TRACK_ADDED,
+        TRACK_AUDIO_LEVEL_CHANGED,
+        TRACK_MUTE_CHANGED,
+        TRACK_REMOVED,
+        TRACK_UNMUTE_REJECTED,
+        TRANSCRIPTION_STATUS_CHANGED,
+        USER_JOINED,
+        USER_LEFT,
+        USER_ROLE_CHANGED,
+        USER_STATUS_CHANGED,
+        VIDEO_UNMUTE_PERMISSIONS_CHANGED,
+        BOT_TYPE_CHANGED,
+        LOBBY_USER_JOINED,
+        LOBBY_USER_UPDATED,
+        LOBBY_USER_LEFT,
+        AV_MODERATION_APPROVED,
+        AV_MODERATION_REJECTED,
+        AV_MODERATION_CHANGED,
+        AV_MODERATION_PARTICIPANT_APPROVED,
+        AV_MODERATION_PARTICIPANT_REJECTED,
+        FACIAL_EXPRESSION_ADDED,
+        BREAKOUT_ROOMS_MOVE_TO_ROOM,
+        BREAKOUT_ROOMS_UPDATED,
+        JitsiConferenceEvents,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( AUDIO_INPUT_STATE_CHANGE ).toBe( 'conference.audio_input_state_changed' );
+        expect( AUDIO_UNMUTE_PERMISSIONS_CHANGED ).toBe( 'conference.audio_unmute_permissions_changed' );
+        expect( AUTH_STATUS_CHANGED ).toBe( 'conference.auth_status_changed' );
+        expect( BEFORE_STATISTICS_DISPOSED ).toBe( 'conference.beforeStatisticsDisposed' );
+        expect( CONFERENCE_ERROR ).toBe( 'conference.error' );
+        expect( CONFERENCE_FAILED ).toBe( 'conference.failed' );
+        expect( CONFERENCE_JOIN_IN_PROGRESS ).toBe( 'conference.join_in_progress' );
+        expect( CONFERENCE_JOINED ).toBe( 'conference.joined' );
+        expect( CONFERENCE_LEFT ).toBe( 'conference.left' );
+        expect( CONFERENCE_UNIQUE_ID_SET ).toBe( 'conference.unique_id_set' );
+        expect( CONNECTION_ESTABLISHED ).toBe( 'conference.connectionEstablished' );
+        expect( CONNECTION_INTERRUPTED ).toBe( 'conference.connectionInterrupted' );
+        expect( CONNECTION_RESTORED ).toBe( 'conference.connectionRestored' );
+        expect( DATA_CHANNEL_OPENED ).toBe( 'conference.dataChannelOpened' );
+        expect( DISPLAY_NAME_CHANGED ).toBe( 'conference.displayNameChanged' );
+        expect( DOMINANT_SPEAKER_CHANGED ).toBe( 'conference.dominantSpeaker' );
+        expect( CONFERENCE_CREATED_TIMESTAMP ).toBe( 'conference.createdTimestamp' );
+        expect( DTMF_SUPPORT_CHANGED ).toBe( 'conference.dtmfSupportChanged' );
+        expect( ENDPOINT_MESSAGE_RECEIVED ).toBe( 'conference.endpoint_message_received' );
+        expect( ENDPOINT_STATS_RECEIVED ).toBe( 'conference.endpoint_stats_received' );
+        expect( JVB121_STATUS ).toBe( 'conference.jvb121Status' );
+        expect( KICKED ).toBe( 'conference.kicked' );
+        expect( PARTICIPANT_KICKED ).toBe( 'conference.participant_kicked' );
+        expect( LAST_N_ENDPOINTS_CHANGED ).toBe( 'conference.lastNEndpointsChanged' );
+        expect( LOCK_STATE_CHANGED ).toBe( 'conference.lock_state_changed' );
+        expect( SERVER_REGION_CHANGED ).toBe( 'conference.server_region_changed' );
+        expect( _MEDIA_SESSION_STARTED ).toBe( 'conference.media_session.started' );
+        expect( _MEDIA_SESSION_ACTIVE_CHANGED ).toBe( 'conference.media_session.active_changed' );
+        expect( MEMBERS_ONLY_CHANGED ).toBe( 'conference.membersOnlyChanged' );
+        expect( MESSAGE_RECEIVED ).toBe( 'conference.messageReceived' );
+        expect( NO_AUDIO_INPUT ).toBe( 'conference.no_audio_input' );
+        expect( NOISY_MIC ).toBe( 'conference.noisy_mic' );
+        expect( NON_PARTICIPANT_MESSAGE_RECEIVED ).toBe( 'conference.non_participant_message_received' );
+        expect( PRIVATE_MESSAGE_RECEIVED ).toBe( 'conference.privateMessageReceived' );
+        expect( PARTICIPANT_CONN_STATUS_CHANGED ).toBe( 'conference.participant_conn_status_changed' );
+        expect( PARTCIPANT_FEATURES_CHANGED ).toBe( 'conference.partcipant_features_changed' );
+        expect( PARTICIPANT_PROPERTY_CHANGED ).toBe( 'conference.participant_property_changed' );
+        expect( P2P_STATUS ).toBe( 'conference.p2pStatus' );
+        expect( PHONE_NUMBER_CHANGED ).toBe( 'conference.phoneNumberChanged' );
+        expect( PROPERTIES_CHANGED ).toBe( 'conference.propertiesChanged' );
+        expect( RECORDER_STATE_CHANGED ).toBe( 'conference.recorderStateChanged' );
+        expect( VIDEO_SIP_GW_AVAILABILITY_CHANGED ).toBe( 'conference.videoSIPGWAvailabilityChanged' );
+        expect( VIDEO_SIP_GW_SESSION_STATE_CHANGED ).toBe( 'conference.videoSIPGWSessionStateChanged' );
+        expect( START_MUTED_POLICY_CHANGED ).toBe( 'conference.start_muted_policy_changed' );
+        expect( STARTED_MUTED ).toBe( 'conference.started_muted' );
+        expect( SUBJECT_CHANGED ).toBe( 'conference.subjectChanged' );
+        expect( SUSPEND_DETECTED ).toBe( 'conference.suspendDetected' );
+        expect( TALK_WHILE_MUTED ).toBe( 'conference.talk_while_muted' );
+        expect( TRACK_ADDED ).toBe( 'conference.trackAdded' );
+        expect( TRACK_AUDIO_LEVEL_CHANGED ).toBe( 'conference.audioLevelsChanged' );
+        expect( TRACK_MUTE_CHANGED ).toBe( 'conference.trackMuteChanged' );
+        expect( TRACK_REMOVED ).toBe( 'conference.trackRemoved' );
+        expect( TRACK_UNMUTE_REJECTED ).toBe( 'conference.trackUnmuteRejected' );
+        expect( TRANSCRIPTION_STATUS_CHANGED ).toBe( 'conference.transcriptionStatusChanged' );
+        expect( USER_JOINED ).toBe( 'conference.userJoined' );
+        expect( USER_LEFT ).toBe( 'conference.userLeft' );
+        expect( USER_ROLE_CHANGED ).toBe( 'conference.roleChanged' );
+        expect( USER_STATUS_CHANGED ).toBe( 'conference.statusChanged' );
+        expect( VIDEO_UNMUTE_PERMISSIONS_CHANGED ).toBe( 'conference.video_unmute_permissions_changed' );
+        expect( BOT_TYPE_CHANGED ).toBe( 'conference.bot_type_changed' );
+        expect( LOBBY_USER_JOINED ).toBe( 'conference.lobby.userJoined' );
+        expect( LOBBY_USER_UPDATED ).toBe( 'conference.lobby.userUpdated' );
+        expect( LOBBY_USER_LEFT ).toBe( 'conference.lobby.userLeft' );
+        expect( AV_MODERATION_APPROVED ).toBe( 'conference.av_moderation.approved' );
+        expect( AV_MODERATION_REJECTED ).toBe( 'conference.av_moderation.rejected' );
+        expect( AV_MODERATION_CHANGED ).toBe( 'conference.av_moderation.changed' );
+        expect( AV_MODERATION_PARTICIPANT_APPROVED ).toBe( 'conference.av_moderation.participant.approved' );
+        expect( AV_MODERATION_PARTICIPANT_REJECTED ).toBe( 'conference.av_moderation.participant.rejected' );
+        expect( FACIAL_EXPRESSION_ADDED ).toBe( 'conference.facial_expression.added' );
+        expect( BREAKOUT_ROOMS_MOVE_TO_ROOM ).toBe( 'conference.breakout-rooms.move-to-room' );
+        expect( BREAKOUT_ROOMS_UPDATED ).toBe( 'conference.breakout-rooms.updated' );
+        if ( JitsiConferenceEvents ) {
+            expect( JitsiConferenceEvents.AUDIO_INPUT_STATE_CHANGE ).toBe( 'conference.audio_input_state_changed' );
+            expect( JitsiConferenceEvents.AUDIO_UNMUTE_PERMISSIONS_CHANGED ).toBe( 'conference.audio_unmute_permissions_changed' );
+            expect( JitsiConferenceEvents.AUTH_STATUS_CHANGED ).toBe( 'conference.auth_status_changed' );
+            expect( JitsiConferenceEvents.BEFORE_STATISTICS_DISPOSED ).toBe( 'conference.beforeStatisticsDisposed' );
+            expect( JitsiConferenceEvents.CONFERENCE_ERROR ).toBe( 'conference.error' );
+            expect( JitsiConferenceEvents.CONFERENCE_FAILED ).toBe( 'conference.failed' );
+            expect( JitsiConferenceEvents.CONFERENCE_JOIN_IN_PROGRESS ).toBe( 'conference.join_in_progress' );
+            expect( JitsiConferenceEvents.CONFERENCE_JOINED ).toBe( 'conference.joined' );
+            expect( JitsiConferenceEvents.CONFERENCE_LEFT ).toBe( 'conference.left' );
+            expect( JitsiConferenceEvents.CONFERENCE_UNIQUE_ID_SET ).toBe( 'conference.unique_id_set' );
+            expect( JitsiConferenceEvents.CONNECTION_ESTABLISHED ).toBe( 'conference.connectionEstablished' );
+            expect( JitsiConferenceEvents.CONNECTION_INTERRUPTED ).toBe( 'conference.connectionInterrupted' );
+            expect( JitsiConferenceEvents.CONNECTION_RESTORED ).toBe( 'conference.connectionRestored' );
+            expect( JitsiConferenceEvents.DATA_CHANNEL_OPENED ).toBe( 'conference.dataChannelOpened' );
+            expect( JitsiConferenceEvents.DISPLAY_NAME_CHANGED ).toBe( 'conference.displayNameChanged' );
+            expect( JitsiConferenceEvents.DOMINANT_SPEAKER_CHANGED ).toBe( 'conference.dominantSpeaker' );
+            expect( JitsiConferenceEvents.CONFERENCE_CREATED_TIMESTAMP ).toBe( 'conference.createdTimestamp' );
+            expect( JitsiConferenceEvents.DTMF_SUPPORT_CHANGED ).toBe( 'conference.dtmfSupportChanged' );
+            expect( JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED ).toBe( 'conference.endpoint_message_received' );
+            expect( JitsiConferenceEvents.ENDPOINT_STATS_RECEIVED ).toBe( 'conference.endpoint_stats_received' );
+            expect( JitsiConferenceEvents.JVB121_STATUS ).toBe( 'conference.jvb121Status' );
+            expect( JitsiConferenceEvents.KICKED ).toBe( 'conference.kicked' );
+            expect( JitsiConferenceEvents.PARTICIPANT_KICKED ).toBe( 'conference.participant_kicked' );
+            expect( JitsiConferenceEvents.LAST_N_ENDPOINTS_CHANGED ).toBe( 'conference.lastNEndpointsChanged' );
+            expect( JitsiConferenceEvents.LOCK_STATE_CHANGED ).toBe( 'conference.lock_state_changed' );
+            expect( JitsiConferenceEvents.SERVER_REGION_CHANGED ).toBe( 'conference.server_region_changed' );
+            expect( JitsiConferenceEvents._MEDIA_SESSION_STARTED ).toBe( 'conference.media_session.started' );
+            expect( JitsiConferenceEvents._MEDIA_SESSION_ACTIVE_CHANGED ).toBe( 'conference.media_session.active_changed' );
+            expect( JitsiConferenceEvents.MEMBERS_ONLY_CHANGED ).toBe( 'conference.membersOnlyChanged' );
+            expect( JitsiConferenceEvents.MESSAGE_RECEIVED ).toBe( 'conference.messageReceived' );
+            expect( JitsiConferenceEvents.NO_AUDIO_INPUT ).toBe( 'conference.no_audio_input' );
+            expect( JitsiConferenceEvents.NOISY_MIC ).toBe( 'conference.noisy_mic' );
+            expect( JitsiConferenceEvents.NON_PARTICIPANT_MESSAGE_RECEIVED ).toBe( 'conference.non_participant_message_received' );
+            expect( JitsiConferenceEvents.PRIVATE_MESSAGE_RECEIVED ).toBe( 'conference.privateMessageReceived' );
+            expect( JitsiConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED ).toBe( 'conference.participant_conn_status_changed' );
+            expect( JitsiConferenceEvents.PARTCIPANT_FEATURES_CHANGED ).toBe( 'conference.partcipant_features_changed' );
+            expect( JitsiConferenceEvents.PARTICIPANT_PROPERTY_CHANGED ).toBe( 'conference.participant_property_changed' );
+            expect( JitsiConferenceEvents.P2P_STATUS ).toBe( 'conference.p2pStatus' );
+            expect( JitsiConferenceEvents.PHONE_NUMBER_CHANGED ).toBe( 'conference.phoneNumberChanged' );
+            expect( JitsiConferenceEvents.PROPERTIES_CHANGED ).toBe( 'conference.propertiesChanged' );
+            expect( JitsiConferenceEvents.RECORDER_STATE_CHANGED ).toBe( 'conference.recorderStateChanged' );
+            expect( JitsiConferenceEvents.VIDEO_SIP_GW_AVAILABILITY_CHANGED ).toBe( 'conference.videoSIPGWAvailabilityChanged' );
+            expect( JitsiConferenceEvents.VIDEO_SIP_GW_SESSION_STATE_CHANGED ).toBe( 'conference.videoSIPGWSessionStateChanged' );
+            expect( JitsiConferenceEvents.START_MUTED_POLICY_CHANGED ).toBe( 'conference.start_muted_policy_changed' );
+            expect( JitsiConferenceEvents.STARTED_MUTED ).toBe( 'conference.started_muted' );
+            expect( JitsiConferenceEvents.SUBJECT_CHANGED ).toBe( 'conference.subjectChanged' );
+            expect( JitsiConferenceEvents.SUSPEND_DETECTED ).toBe( 'conference.suspendDetected' );
+            expect( JitsiConferenceEvents.TALK_WHILE_MUTED ).toBe( 'conference.talk_while_muted' );
+            expect( JitsiConferenceEvents.TRACK_ADDED ).toBe( 'conference.trackAdded' );
+            expect( JitsiConferenceEvents.TRACK_AUDIO_LEVEL_CHANGED ).toBe( 'conference.audioLevelsChanged' );
+            expect( JitsiConferenceEvents.TRACK_MUTE_CHANGED ).toBe( 'conference.trackMuteChanged' );
+            expect( JitsiConferenceEvents.TRACK_REMOVED ).toBe( 'conference.trackRemoved' );
+            expect( JitsiConferenceEvents.TRACK_UNMUTE_REJECTED ).toBe( 'conference.trackUnmuteRejected' );
+            expect( JitsiConferenceEvents.TRANSCRIPTION_STATUS_CHANGED ).toBe( 'conference.transcriptionStatusChanged' );
+            expect( JitsiConferenceEvents.USER_JOINED ).toBe( 'conference.userJoined' );
+            expect( JitsiConferenceEvents.USER_LEFT ).toBe( 'conference.userLeft' );
+            expect( JitsiConferenceEvents.USER_ROLE_CHANGED ).toBe( 'conference.roleChanged' );
+            expect( JitsiConferenceEvents.USER_STATUS_CHANGED ).toBe( 'conference.statusChanged' );
+            expect( JitsiConferenceEvents.VIDEO_UNMUTE_PERMISSIONS_CHANGED ).toBe( 'conference.video_unmute_permissions_changed' );
+            expect( JitsiConferenceEvents.BOT_TYPE_CHANGED ).toBe( 'conference.bot_type_changed' );
+            expect( JitsiConferenceEvents.LOBBY_USER_JOINED ).toBe( 'conference.lobby.userJoined' );
+            expect( JitsiConferenceEvents.LOBBY_USER_UPDATED ).toBe( 'conference.lobby.userUpdated' );
+            expect( JitsiConferenceEvents.LOBBY_USER_LEFT ).toBe( 'conference.lobby.userLeft' );
+            expect( JitsiConferenceEvents.AV_MODERATION_APPROVED ).toBe( 'conference.av_moderation.approved' );
+            expect( JitsiConferenceEvents.AV_MODERATION_REJECTED ).toBe( 'conference.av_moderation.rejected' );
+            expect( JitsiConferenceEvents.AV_MODERATION_CHANGED ).toBe( 'conference.av_moderation.changed' );
+            expect( JitsiConferenceEvents.AV_MODERATION_PARTICIPANT_APPROVED ).toBe( 'conference.av_moderation.participant.approved' );
+            expect( JitsiConferenceEvents.AV_MODERATION_PARTICIPANT_REJECTED ).toBe( 'conference.av_moderation.participant.rejected' );
+            expect( JitsiConferenceEvents.FACIAL_EXPRESSION_ADDED ).toBe( 'conference.facial_expression.added' );
+            expect( JitsiConferenceEvents.BREAKOUT_ROOMS_MOVE_TO_ROOM ).toBe( 'conference.breakout-rooms.move-to-room' );
+            expect( JitsiConferenceEvents.BREAKOUT_ROOMS_UPDATED ).toBe( 'conference.breakout-rooms.updated' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/JitsiConnectionErrors.spec.ts
+++ b/JitsiConnectionErrors.spec.ts
@@ -1,0 +1,32 @@
+import * as exported from "./JitsiConnectionErrors";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/JitsiConnectionErrors members", () => {
+    const {
+        CONNECTION_DROPPED_ERROR,
+        OTHER_ERROR,
+        PASSWORD_REQUIRED,
+        SERVER_ERROR,
+        JitsiConnectionErrors,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( CONNECTION_DROPPED_ERROR ).toBe( 'connection.droppedError' );
+        expect( OTHER_ERROR ).toBe( 'connection.otherError' );
+        expect( PASSWORD_REQUIRED ).toBe( 'connection.passwordRequired' );
+        expect( SERVER_ERROR ).toBe( 'connection.serverError' );
+        if ( JitsiConnectionErrors ) {
+            expect( JitsiConnectionErrors.CONNECTION_DROPPED_ERROR ).toBe( 'connection.droppedError' );
+            expect( JitsiConnectionErrors.OTHER_ERROR ).toBe( 'connection.otherError' );
+            expect( JitsiConnectionErrors.PASSWORD_REQUIRED ).toBe( 'connection.passwordRequired' );
+            expect( JitsiConnectionErrors.SERVER_ERROR ).toBe( 'connection.serverError' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/JitsiConnectionEvents.spec.ts
+++ b/JitsiConnectionEvents.spec.ts
@@ -1,0 +1,35 @@
+import * as exported from "./JitsiConnectionEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/JitsiConnectionEvents members", () => {
+    const {
+        CONNECTION_DISCONNECTED,
+        CONNECTION_ESTABLISHED,
+        CONNECTION_FAILED,
+        WRONG_STATE,
+        DISPLAY_NAME_REQUIRED,
+        JitsiConnectionEvents,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( CONNECTION_DISCONNECTED ).toBe( 'connection.connectionDisconnected' );
+        expect( CONNECTION_ESTABLISHED ).toBe( 'connection.connectionEstablished' );
+        expect( CONNECTION_FAILED ).toBe( 'connection.connectionFailed' );
+        expect( WRONG_STATE ).toBe( 'connection.wrongState' );
+        expect( DISPLAY_NAME_REQUIRED ).toBe( 'connection.display_name_required' );
+        if ( JitsiConnectionEvents ) {
+            expect( JitsiConnectionEvents.CONNECTION_DISCONNECTED ).toBe( 'connection.connectionDisconnected' );
+            expect( JitsiConnectionEvents.CONNECTION_ESTABLISHED ).toBe( 'connection.connectionEstablished' );
+            expect( JitsiConnectionEvents.CONNECTION_FAILED ).toBe( 'connection.connectionFailed' );
+            expect( JitsiConnectionEvents.WRONG_STATE ).toBe( 'connection.wrongState' );
+            expect( JitsiConnectionEvents.DISPLAY_NAME_REQUIRED ).toBe( 'connection.display_name_required' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/JitsiMediaDevicesEvents.spec.ts
+++ b/JitsiMediaDevicesEvents.spec.ts
@@ -1,0 +1,32 @@
+import * as exported from "./JitsiMediaDevicesEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/JitsiMediaDevicesEvents members", () => {
+    const {
+        DEVICE_LIST_CHANGED,
+        PERMISSIONS_CHANGED,
+        PERMISSION_PROMPT_IS_SHOWN,
+        SLOW_GET_USER_MEDIA,
+        JitsiMediaDevicesEvents,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( DEVICE_LIST_CHANGED ).toBe( 'mediaDevices.devicechange' );
+        expect( PERMISSIONS_CHANGED ).toBe( 'rtc.permissions_changed' );
+        expect( PERMISSION_PROMPT_IS_SHOWN ).toBe( 'mediaDevices.permissionPromptIsShown' );
+        expect( SLOW_GET_USER_MEDIA ).toBe( 'mediaDevices.slowGetUserMedia' );
+        if ( JitsiMediaDevicesEvents ) {
+            expect( JitsiMediaDevicesEvents.DEVICE_LIST_CHANGED ).toBe( 'mediaDevices.devicechange' );
+            expect( JitsiMediaDevicesEvents.PERMISSIONS_CHANGED ).toBe( 'rtc.permissions_changed' );
+            expect( JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN ).toBe( 'mediaDevices.permissionPromptIsShown' );
+            expect( JitsiMediaDevicesEvents.SLOW_GET_USER_MEDIA ).toBe( 'mediaDevices.slowGetUserMedia' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/JitsiTrackErrors.spec.ts
+++ b/JitsiTrackErrors.spec.ts
@@ -1,0 +1,56 @@
+import * as exported from "./JitsiTrackErrors";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/JitsiTrackErrors members", () => {
+    const {
+        CONSTRAINT_FAILED,
+        ELECTRON_DESKTOP_PICKER_ERROR,
+        ELECTRON_DESKTOP_PICKER_NOT_FOUND,
+        GENERAL,
+        NOT_FOUND,
+        PERMISSION_DENIED,
+        SCREENSHARING_GENERIC_ERROR,
+        SCREENSHARING_USER_CANCELED,
+        TIMEOUT,
+        TRACK_IS_DISPOSED,
+        TRACK_NO_STREAM_FOUND,
+        UNSUPPORTED_RESOLUTION,
+        JitsiTrackErrors,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( CONSTRAINT_FAILED ).toBe( 'gum.constraint_failed' );
+        expect( ELECTRON_DESKTOP_PICKER_ERROR ).toBe( 'gum.electron_desktop_picker_error' );
+        expect( ELECTRON_DESKTOP_PICKER_NOT_FOUND ).toBe( 'gum.electron_desktop_picker_not_found' );
+        expect( GENERAL ).toBe( 'gum.general' );
+        expect( NOT_FOUND ).toBe( 'gum.not_found' );
+        expect( PERMISSION_DENIED ).toBe( 'gum.permission_denied' );
+        expect( SCREENSHARING_GENERIC_ERROR ).toBe( 'gum.screensharing_generic_error' );
+        expect( SCREENSHARING_USER_CANCELED ).toBe( 'gum.screensharing_user_canceled' );
+        expect( TIMEOUT ).toBe( 'gum.timeout' );
+        expect( TRACK_IS_DISPOSED ).toBe( 'track.track_is_disposed' );
+        expect( TRACK_NO_STREAM_FOUND ).toBe( 'track.no_stream_found' );
+        expect( UNSUPPORTED_RESOLUTION ).toBe( 'gum.unsupported_resolution' );
+        if ( JitsiTrackErrors ) {
+            expect( JitsiTrackErrors.CONSTRAINT_FAILED ).toBe( 'gum.constraint_failed' );
+            expect( JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_ERROR ).toBe( 'gum.electron_desktop_picker_error' );
+            expect( JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_NOT_FOUND ).toBe( 'gum.electron_desktop_picker_not_found' );
+            expect( JitsiTrackErrors.GENERAL ).toBe( 'gum.general' );
+            expect( JitsiTrackErrors.NOT_FOUND ).toBe( 'gum.not_found' );
+            expect( JitsiTrackErrors.PERMISSION_DENIED ).toBe( 'gum.permission_denied' );
+            expect( JitsiTrackErrors.SCREENSHARING_GENERIC_ERROR ).toBe( 'gum.screensharing_generic_error' );
+            expect( JitsiTrackErrors.SCREENSHARING_USER_CANCELED ).toBe( 'gum.screensharing_user_canceled' );
+            expect( JitsiTrackErrors.TIMEOUT ).toBe( 'gum.timeout' );
+            expect( JitsiTrackErrors.TRACK_IS_DISPOSED ).toBe( 'track.track_is_disposed' );
+            expect( JitsiTrackErrors.TRACK_NO_STREAM_FOUND ).toBe( 'track.no_stream_found' );
+            expect( JitsiTrackErrors.UNSUPPORTED_RESOLUTION ).toBe( 'gum.unsupported_resolution' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/JitsiTrackEvents.spec.ts
+++ b/JitsiTrackEvents.spec.ts
@@ -1,0 +1,41 @@
+import * as exported from "./JitsiTrackEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/JitsiTrackEvents members", () => {
+    const {
+        LOCAL_TRACK_STOPPED,
+        TRACK_AUDIO_LEVEL_CHANGED,
+        TRACK_AUDIO_OUTPUT_CHANGED,
+        TRACK_MUTE_CHANGED,
+        TRACK_VIDEOTYPE_CHANGED,
+        NO_DATA_FROM_SOURCE,
+        NO_AUDIO_INPUT,
+        JitsiTrackEvents,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( LOCAL_TRACK_STOPPED ).toBe( 'track.stopped' );
+        expect( TRACK_AUDIO_LEVEL_CHANGED ).toBe( 'track.audioLevelsChanged' );
+        expect( TRACK_AUDIO_OUTPUT_CHANGED ).toBe( 'track.audioOutputChanged' );
+        expect( TRACK_MUTE_CHANGED ).toBe( 'track.trackMuteChanged' );
+        expect( TRACK_VIDEOTYPE_CHANGED ).toBe( 'track.videoTypeChanged' );
+        expect( NO_DATA_FROM_SOURCE ).toBe( 'track.no_data_from_source' );
+        expect( NO_AUDIO_INPUT ).toBe( 'track.no_audio_input' );
+        if ( JitsiTrackEvents ) {
+            expect( JitsiTrackEvents.LOCAL_TRACK_STOPPED ).toBe( 'track.stopped' );
+            expect( JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED ).toBe( 'track.audioLevelsChanged' );
+            expect( JitsiTrackEvents.TRACK_AUDIO_OUTPUT_CHANGED ).toBe( 'track.audioOutputChanged' );
+            expect( JitsiTrackEvents.TRACK_MUTE_CHANGED ).toBe( 'track.trackMuteChanged' );
+            expect( JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED ).toBe( 'track.videoTypeChanged' );
+            expect( JitsiTrackEvents.NO_DATA_FROM_SOURCE ).toBe( 'track.no_data_from_source' );
+            expect( JitsiTrackEvents.NO_AUDIO_INPUT ).toBe( 'track.no_audio_input' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/JitsiTranscriptionStatus.spec.ts
+++ b/JitsiTranscriptionStatus.spec.ts
@@ -1,0 +1,26 @@
+import * as exported from "./JitsiTranscriptionStatus";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/JitsiTranscriptionStatus members", () => {
+    const {
+        ON,
+        OFF,
+        JitsiTranscriptionStatus,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( ON ).toBe( 'on' );
+        expect( OFF ).toBe( 'off' );
+        if ( JitsiTranscriptionStatus ) {
+            expect( JitsiTranscriptionStatus.ON ).toBe( 'on' );
+            expect( JitsiTranscriptionStatus.OFF ).toBe( 'off' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,10 @@ module.exports = function(config) {
         files: [
             'https://code.jquery.com/jquery-3.5.1.min.js',
             'node_modules/core-js/index.js',
-            './modules/**/*.spec.js'
+            './modules/**/*.spec.js',
+            './modules/**/*.spec.ts',
+            './service/**/*.spec.ts',
+            './*.spec.ts'
         ],
 
         // list of files to exclude
@@ -28,7 +31,8 @@ module.exports = function(config) {
         //  https://npmjs.org/browse/keyword/karma-preprocessor
         preprocessors: {
             'node_modules/core-js/**': [ 'webpack' ],
-            './**/*.spec.js': [ 'webpack', 'sourcemap' ]
+            './**/*.spec.js': [ 'webpack', 'sourcemap' ],
+            './**/*.spec.ts': [ 'webpack', 'sourcemap' ]
         },
 
         // test results reporter to use

--- a/modules/detection/DetectionEvents.spec.ts
+++ b/modules/detection/DetectionEvents.spec.ts
@@ -1,0 +1,41 @@
+import * as exported from "./DetectionEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/modules/detection/DetectionEvents members", () => {
+    const {
+        DETECTOR_STATE_CHANGE,
+        AUDIO_INPUT_STATE_CHANGE,
+        NO_AUDIO_INPUT,
+        VAD_NOISY_DEVICE,
+        VAD_REPORT_PUBLISHED,
+        VAD_SCORE_PUBLISHED,
+        VAD_TALK_WHILE_MUTED,
+        DetectionEvents,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( DETECTOR_STATE_CHANGE ).toBe( 'detector_state_change' );
+        expect( AUDIO_INPUT_STATE_CHANGE ).toBe( 'audio_input_state_changed' );
+        expect( NO_AUDIO_INPUT ).toBe( 'no_audio_input_detected' );
+        expect( VAD_NOISY_DEVICE ).toBe( 'detection.vad_noise_device' );
+        expect( VAD_REPORT_PUBLISHED ).toBe( 'vad-report-published' );
+        expect( VAD_SCORE_PUBLISHED ).toBe( 'detection.vad_score_published' );
+        expect( VAD_TALK_WHILE_MUTED ).toBe( 'detection.vad_talk_while_muted' );
+        if ( DetectionEvents ) {
+            expect( DetectionEvents.DETECTOR_STATE_CHANGE ).toBe( 'detector_state_change' );
+            expect( DetectionEvents.AUDIO_INPUT_STATE_CHANGE ).toBe( 'audio_input_state_changed' );
+            expect( DetectionEvents.NO_AUDIO_INPUT ).toBe( 'no_audio_input_detected' );
+            expect( DetectionEvents.VAD_NOISY_DEVICE ).toBe( 'detection.vad_noise_device' );
+            expect( DetectionEvents.VAD_REPORT_PUBLISHED ).toBe( 'vad-report-published' );
+            expect( DetectionEvents.VAD_SCORE_PUBLISHED ).toBe( 'detection.vad_score_published' );
+            expect( DetectionEvents.VAD_TALK_WHILE_MUTED ).toBe( 'detection.vad_talk_while_muted' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/modules/proxyconnection/constants.spec.ts
+++ b/modules/proxyconnection/constants.spec.ts
@@ -1,0 +1,29 @@
+import { ACTIONS } from "./constants";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "modules/proxyconnection/constants members", () => {
+    const {
+        ACCEPT,
+        CONNECTION_ERROR,
+        INITIATE,
+        TERMINATE,
+        TRANSPORT_INFO,
+        UNAVAILABLE,
+        ...others
+    } = ACTIONS as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( ACCEPT ).toBe( 'session-accept' );
+        expect( CONNECTION_ERROR ).toBe( 'connection-error-encountered' );
+        expect( INITIATE ).toBe( 'session-initiate' );
+        expect( TERMINATE ).toBe( 'session-terminate' );
+        expect( TRANSPORT_INFO ).toBe( 'transport-info' );
+        expect( UNAVAILABLE ).toBe( 'unavailable' );
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/modules/videosipgw/VideoSIPGWConstants.spec.ts
+++ b/modules/videosipgw/VideoSIPGWConstants.spec.ts
@@ -1,0 +1,52 @@
+import * as exported from "./VideoSIPGWConstants";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/modules/videosipgw/VideoSIPGWConstants members", () => {
+    const {
+        STATUS_AVAILABLE,
+        STATUS_UNDEFINED,
+        STATUS_BUSY,
+        STATE_ON,
+        STATE_OFF,
+        STATE_PENDING,
+        STATE_RETRYING,
+        STATE_FAILED,
+        ERROR_NO_CONNECTION,
+        ERROR_SESSION_EXISTS,
+        VideoSIPGWStatusConstants,
+        VideoSIPGWStateConstants,
+        VideoSIPGWErrorConstants,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( STATUS_AVAILABLE ).toBe( 'available' );
+        expect( STATUS_UNDEFINED ).toBe( 'undefined' );
+        expect( STATUS_BUSY ).toBe( 'busy' );
+        expect( STATE_ON ).toBe( 'on' );
+        expect( STATE_OFF ).toBe( 'off' );
+        expect( STATE_PENDING ).toBe( 'pending' );
+        expect( STATE_RETRYING ).toBe( 'retrying' );
+        expect( STATE_FAILED ).toBe( 'failed' );
+        expect( ERROR_NO_CONNECTION ).toBe( 'error_no_connection' );
+        expect( ERROR_SESSION_EXISTS ).toBe( 'error_session_already_exists' );
+        if ( VideoSIPGWStatusConstants ) {
+            expect( VideoSIPGWStatusConstants.STATUS_AVAILABLE ).toBe( 'available' );
+            expect( VideoSIPGWStatusConstants.STATUS_UNDEFINED ).toBe( 'undefined' );
+            expect( VideoSIPGWStatusConstants.STATUS_BUSY ).toBe( 'busy' );
+            expect( VideoSIPGWStateConstants.STATE_ON ).toBe( 'on' );
+            expect( VideoSIPGWStateConstants.STATE_OFF ).toBe( 'off' );
+            expect( VideoSIPGWStateConstants.STATE_PENDING ).toBe( 'pending' );
+            expect( VideoSIPGWStateConstants.STATE_RETRYING ).toBe( 'retrying' );
+            expect( VideoSIPGWStateConstants.STATE_FAILED ).toBe( 'failed' );
+            expect( VideoSIPGWErrorConstants.ERROR_NO_CONNECTION ).toBe( 'error_no_connection' );
+            expect( VideoSIPGWErrorConstants.ERROR_SESSION_EXISTS ).toBe( 'error_session_already_exists' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/modules/xmpp/JingleSessionState.spec.ts
+++ b/modules/xmpp/JingleSessionState.spec.ts
@@ -1,0 +1,29 @@
+import * as exported from "./JingleSessionState";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/modules/xmpp/JingleSessionState members", () => {
+    const {
+        PENDING,
+        ACTIVE,
+        ENDED,
+        JingleSessionState,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( PENDING ).toBe( 'pending' );
+        expect( ACTIVE ).toBe( 'active' );
+        expect( ENDED ).toBe( 'ended' );
+        if ( JingleSessionState ) {
+            expect( JingleSessionState.PENDING ).toBe( 'pending' );
+            expect( JingleSessionState.ACTIVE ).toBe( 'active' );
+            expect( JingleSessionState.ENDED ).toBe( 'ended' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/modules/xmpp/MediaSessionEvents.spec.ts
+++ b/modules/xmpp/MediaSessionEvents.spec.ts
@@ -1,0 +1,23 @@
+import { default as exported } from "./MediaSessionEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/modules/xmpp/MediaSessionEvents members", () => {
+    const {
+        REMOTE_VIDEO_CONSTRAINTS_CHANGED,
+        MediaSessionEvents,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( REMOTE_VIDEO_CONSTRAINTS_CHANGED ).toBe( 'media_session.REMOTE_VIDEO_CONSTRAINTS_CHANGED' );
+        if ( MediaSessionEvents ) {
+            expect( MediaSessionEvents.REMOTE_VIDEO_CONSTRAINTS_CHANGED ).toBe( 'media_session.REMOTE_VIDEO_CONSTRAINTS_CHANGED' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-env": "7.16.0",
     "@babel/preset-typescript": "7.16.7",
     "@jitsi/eslint-config": "4.0.0",
+    "@types/jasmine": "^3.10.3",
     "@types/sdp-transform": "2.4.5",
     "babel-loader": "8.2.3",
     "core-js": "3.19.1",

--- a/service/RTC/BridgeVideoType.spec.ts
+++ b/service/RTC/BridgeVideoType.spec.ts
@@ -1,0 +1,32 @@
+import * as exported from "./BridgeVideoType";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/RTC/BridgeVideoType members", () => {
+    const {
+        CAMERA,
+        DESKTOP,
+        DESKTOP_HIGH_FPS,
+        NONE,
+        BridgeVideoType,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( CAMERA ).toBe( 'camera' );
+        expect( DESKTOP ).toBe( 'desktop' );
+        expect( DESKTOP_HIGH_FPS ).toBe( 'desktop_high_fps' );
+        expect( NONE ).toBe( 'none' );
+        if ( BridgeVideoType ) {
+            expect( BridgeVideoType.CAMERA ).toBe( 'camera' );
+            expect( BridgeVideoType.DESKTOP ).toBe( 'desktop' );
+            expect( BridgeVideoType.DESKTOP_HIGH_FPS ).toBe( 'desktop_high_fps' );
+            expect( BridgeVideoType.NONE ).toBe( 'none' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/RTC/CameraFacingMode.spec.ts
+++ b/service/RTC/CameraFacingMode.spec.ts
@@ -1,0 +1,26 @@
+import * as exported from "./CameraFacingMode";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/RTC/CameraFacingMode members", () => {
+    const {
+        ENVIRONMENT,
+        USER,
+        CameraFacingMode,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( ENVIRONMENT ).toBe( 'environment' );
+        expect( USER ).toBe( 'user' );
+        if ( CameraFacingMode ) {
+            expect( CameraFacingMode.ENVIRONMENT ).toBe( 'environment' );
+            expect( CameraFacingMode.USER ).toBe( 'user' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/RTC/CodecMimeType.spec.ts
+++ b/service/RTC/CodecMimeType.spec.ts
@@ -1,0 +1,35 @@
+import * as exported from "./CodecMimeType";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/RTC/CodecMimeType members", () => {
+    const {
+        H264,
+        OPUS,
+        ULPFEC,
+        VP8,
+        VP9,
+        CodecMimeType,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( H264 ).toBe( 'h264' );
+        expect( OPUS ).toBe( 'opus' );
+        expect( ULPFEC ).toBe( 'ulpfec' );
+        expect( VP8 ).toBe( 'vp8' );
+        expect( VP9 ).toBe( 'vp9' );
+        if ( CodecMimeType ) {
+            expect( CodecMimeType.H264 ).toBe( 'h264' );
+            expect( CodecMimeType.OPUS ).toBe( 'opus' );
+            expect( CodecMimeType.ULPFEC ).toBe( 'ulpfec' );
+            expect( CodecMimeType.VP8 ).toBe( 'vp8' );
+            expect( CodecMimeType.VP9 ).toBe( 'vp9' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/RTC/MediaDirection.spec.ts
+++ b/service/RTC/MediaDirection.spec.ts
@@ -1,0 +1,32 @@
+import * as exported from "./MediaDirection";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/RTC/MediaDirection members", () => {
+    const {
+        INACTIVE,
+        RECVONLY,
+        SENDONLY,
+        SENDRECV,
+        MediaDirection,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( INACTIVE ).toBe( 'inactive' );
+        expect( RECVONLY ).toBe( 'recvonly' );
+        expect( SENDONLY ).toBe( 'sendonly' );
+        expect( SENDRECV ).toBe( 'sendrecv' );
+        if ( MediaDirection ) {
+            expect( MediaDirection.INACTIVE ).toBe( 'inactive' );
+            expect( MediaDirection.RECVONLY ).toBe( 'recvonly' );
+            expect( MediaDirection.SENDONLY ).toBe( 'sendonly' );
+            expect( MediaDirection.SENDRECV ).toBe( 'sendrecv' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/RTC/MediaType.spec.ts
+++ b/service/RTC/MediaType.spec.ts
@@ -1,0 +1,29 @@
+import * as exported from "./MediaType";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/RTC/MediaType members", () => {
+    const {
+        AUDIO,
+        PRESENTER,
+        VIDEO,
+        MediaType,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( AUDIO ).toBe( 'audio' );
+        expect( PRESENTER ).toBe( 'presenter' );
+        expect( VIDEO ).toBe( 'video' );
+        if ( MediaType ) {
+            expect( MediaType.AUDIO ).toBe( 'audio' );
+            expect( MediaType.PRESENTER ).toBe( 'presenter' );
+            expect( MediaType.VIDEO ).toBe( 'video' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/RTC/RTCEvents.spec.ts
+++ b/service/RTC/RTCEvents.spec.ts
@@ -1,0 +1,98 @@
+import * as exported from "./RTCEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/RTC/RTCEvents members", () => {
+    const {
+        CREATE_ANSWER_FAILED,
+        CREATE_OFFER_FAILED,
+        DATA_CHANNEL_OPEN,
+        ENDPOINT_CONN_STATUS_CHANGED,
+        DOMINANT_SPEAKER_CHANGED,
+        LASTN_ENDPOINT_CHANGED,
+        PERMISSIONS_CHANGED,
+        SENDER_VIDEO_CONSTRAINTS_CHANGED,
+        LASTN_VALUE_CHANGED,
+        LOCAL_TRACK_SSRC_UPDATED,
+        LOCAL_TRACK_MAX_ENABLED_RESOLUTION_CHANGED,
+        TRACK_ATTACHED,
+        REMOTE_TRACK_ADDED,
+        REMOTE_TRACK_MUTE,
+        REMOTE_TRACK_REMOVED,
+        REMOTE_TRACK_UNMUTE,
+        SET_LOCAL_DESCRIPTION_FAILED,
+        SET_REMOTE_DESCRIPTION_FAILED,
+        AUDIO_OUTPUT_DEVICE_CHANGED,
+        DEVICE_LIST_CHANGED,
+        DEVICE_LIST_WILL_CHANGE,
+        DEVICE_LIST_AVAILABLE,
+        ENDPOINT_MESSAGE_RECEIVED,
+        ENDPOINT_STATS_RECEIVED,
+        LOCAL_UFRAG_CHANGED,
+        REMOTE_UFRAG_CHANGED,
+        RTCEvents,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( CREATE_ANSWER_FAILED ).toBe( 'rtc.create_answer_failed' );
+        expect( CREATE_OFFER_FAILED ).toBe( 'rtc.create_offer_failed' );
+        expect( DATA_CHANNEL_OPEN ).toBe( 'rtc.data_channel_open' );
+        expect( ENDPOINT_CONN_STATUS_CHANGED ).toBe( 'rtc.endpoint_conn_status_changed' );
+        expect( DOMINANT_SPEAKER_CHANGED ).toBe( 'rtc.dominant_speaker_changed' );
+        expect( LASTN_ENDPOINT_CHANGED ).toBe( 'rtc.lastn_endpoint_changed' );
+        expect( PERMISSIONS_CHANGED ).toBe( 'rtc.permissions_changed' );
+        expect( SENDER_VIDEO_CONSTRAINTS_CHANGED ).toBe( 'rtc.sender_video_constraints_changed' );
+        expect( LASTN_VALUE_CHANGED ).toBe( 'rtc.lastn_value_changed' );
+        expect( LOCAL_TRACK_SSRC_UPDATED ).toBe( 'rtc.local_track_ssrc_updated' );
+        expect( LOCAL_TRACK_MAX_ENABLED_RESOLUTION_CHANGED ).toBe( 'rtc.local_track_max_enabled_resolution_changed' );
+        expect( TRACK_ATTACHED ).toBe( 'rtc.track_attached' );
+        expect( REMOTE_TRACK_ADDED ).toBe( 'rtc.remote_track_added' );
+        expect( REMOTE_TRACK_MUTE ).toBe( 'rtc.remote_track_mute' );
+        expect( REMOTE_TRACK_REMOVED ).toBe( 'rtc.remote_track_removed' );
+        expect( REMOTE_TRACK_UNMUTE ).toBe( 'rtc.remote_track_unmute' );
+        expect( SET_LOCAL_DESCRIPTION_FAILED ).toBe( 'rtc.set_local_description_failed' );
+        expect( SET_REMOTE_DESCRIPTION_FAILED ).toBe( 'rtc.set_remote_description_failed' );
+        expect( AUDIO_OUTPUT_DEVICE_CHANGED ).toBe( 'rtc.audio_output_device_changed' );
+        expect( DEVICE_LIST_CHANGED ).toBe( 'rtc.device_list_changed' );
+        expect( DEVICE_LIST_WILL_CHANGE ).toBe( 'rtc.device_list_will_change' );
+        expect( DEVICE_LIST_AVAILABLE ).toBe( 'rtc.device_list_available' );
+        expect( ENDPOINT_MESSAGE_RECEIVED ).toBe( 'rtc.endpoint_message_received' );
+        expect( ENDPOINT_STATS_RECEIVED ).toBe( 'rtc.endpoint_stats_received' );
+        expect( LOCAL_UFRAG_CHANGED ).toBe( 'rtc.local_ufrag_changed' );
+        expect( REMOTE_UFRAG_CHANGED ).toBe( 'rtc.remote_ufrag_changed' );
+        if ( RTCEvents ) {
+            expect( RTCEvents.CREATE_ANSWER_FAILED ).toBe( 'rtc.create_answer_failed' );
+            expect( RTCEvents.CREATE_OFFER_FAILED ).toBe( 'rtc.create_offer_failed' );
+            expect( RTCEvents.DATA_CHANNEL_OPEN ).toBe( 'rtc.data_channel_open' );
+            expect( RTCEvents.ENDPOINT_CONN_STATUS_CHANGED ).toBe( 'rtc.endpoint_conn_status_changed' );
+            expect( RTCEvents.DOMINANT_SPEAKER_CHANGED ).toBe( 'rtc.dominant_speaker_changed' );
+            expect( RTCEvents.LASTN_ENDPOINT_CHANGED ).toBe( 'rtc.lastn_endpoint_changed' );
+            expect( RTCEvents.PERMISSIONS_CHANGED ).toBe( 'rtc.permissions_changed' );
+            expect( RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED ).toBe( 'rtc.sender_video_constraints_changed' );
+            expect( RTCEvents.LASTN_VALUE_CHANGED ).toBe( 'rtc.lastn_value_changed' );
+            expect( RTCEvents.LOCAL_TRACK_SSRC_UPDATED ).toBe( 'rtc.local_track_ssrc_updated' );
+            expect( RTCEvents.LOCAL_TRACK_MAX_ENABLED_RESOLUTION_CHANGED ).toBe( 'rtc.local_track_max_enabled_resolution_changed' );
+            expect( RTCEvents.TRACK_ATTACHED ).toBe( 'rtc.track_attached' );
+            expect( RTCEvents.REMOTE_TRACK_ADDED ).toBe( 'rtc.remote_track_added' );
+            expect( RTCEvents.REMOTE_TRACK_MUTE ).toBe( 'rtc.remote_track_mute' );
+            expect( RTCEvents.REMOTE_TRACK_REMOVED ).toBe( 'rtc.remote_track_removed' );
+            expect( RTCEvents.REMOTE_TRACK_UNMUTE ).toBe( 'rtc.remote_track_unmute' );
+            expect( RTCEvents.SET_LOCAL_DESCRIPTION_FAILED ).toBe( 'rtc.set_local_description_failed' );
+            expect( RTCEvents.SET_REMOTE_DESCRIPTION_FAILED ).toBe( 'rtc.set_remote_description_failed' );
+            expect( RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED ).toBe( 'rtc.audio_output_device_changed' );
+            expect( RTCEvents.DEVICE_LIST_CHANGED ).toBe( 'rtc.device_list_changed' );
+            expect( RTCEvents.DEVICE_LIST_WILL_CHANGE ).toBe( 'rtc.device_list_will_change' );
+            expect( RTCEvents.DEVICE_LIST_AVAILABLE ).toBe( 'rtc.device_list_available' );
+            expect( RTCEvents.ENDPOINT_MESSAGE_RECEIVED ).toBe( 'rtc.endpoint_message_received' );
+            expect( RTCEvents.ENDPOINT_STATS_RECEIVED ).toBe( 'rtc.endpoint_stats_received' );
+            expect( RTCEvents.LOCAL_UFRAG_CHANGED ).toBe( 'rtc.local_ufrag_changed' );
+            expect( RTCEvents.REMOTE_UFRAG_CHANGED ).toBe( 'rtc.remote_ufrag_changed' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/RTC/Resolutions.spec.ts
+++ b/service/RTC/Resolutions.spec.ts
@@ -1,0 +1,43 @@
+import * as exported from "./Resolutions";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/RTC/Resolutions members", () => {
+    const {
+        '2160': R2160,
+        '4k': R4k,
+        '1080': R1080,
+        fullhd,
+        '720': R720,
+        hd,
+        '540': R540,
+        qhd,
+        '480': R480,
+        vga,
+        '360': R360,
+        '240': R240,
+        '180': R180,
+        ...others
+    } = exported as any;
+
+    it( "known members", () => {
+        expect( R2160 ).toEqual( { width: 3840, height: 2160 } );
+        expect( R4k ).toEqual( { width: 3840, height: 2160 } );
+        expect( R1080 ).toEqual( { width: 1920, height: 1080 } );
+        expect( fullhd ).toEqual( { width: 1920, height: 1080 } );
+        expect( R720 ).toEqual( { width: 1280, height: 720 } );
+        expect( hd ).toEqual( { width: 1280, height: 720 } );
+        expect( R540 ).toEqual( { width: 960, height: 540 } );
+        expect( qhd ).toEqual( { width: 960, height: 540 } );
+        expect( R480 ).toEqual( { width: 640, height: 480 } );
+        expect( vga ).toEqual( { width: 640, height: 480 } );
+        expect( R360 ).toEqual( { width: 640, height: 360 } );
+        expect( R240 ).toEqual( { width: 320, height: 240 } );
+        expect( R180 ).toEqual( { width: 320, height: 180 } );
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/RTC/SignalingEvents.spec.ts
+++ b/service/RTC/SignalingEvents.spec.ts
@@ -1,0 +1,26 @@
+import * as exported from "./SignalingEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/RTC/SignalingEvents members", () => {
+    const {
+        PEER_MUTED_CHANGED,
+        PEER_VIDEO_TYPE_CHANGED,
+        SignalingEvents,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( PEER_MUTED_CHANGED ).toBe( 'signaling.peerMuted' );
+        expect( PEER_VIDEO_TYPE_CHANGED ).toBe( 'signaling.peerVideoType' );
+        if ( SignalingEvents ) {
+            expect( SignalingEvents.PEER_MUTED_CHANGED ).toBe( 'signaling.peerMuted' );
+            expect( SignalingEvents.PEER_VIDEO_TYPE_CHANGED ).toBe( 'signaling.peerVideoType' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/RTC/StreamEventTypes.spec.ts
+++ b/service/RTC/StreamEventTypes.spec.ts
@@ -1,0 +1,38 @@
+import * as exported from "./StreamEventTypes";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/RTC/StreamEventTypes members", () => {
+    const {
+        EVENT_TYPE_LOCAL_CREATED,
+        EVENT_TYPE_LOCAL_CHANGED,
+        EVENT_TYPE_LOCAL_ENDED,
+        EVENT_TYPE_REMOTE_CREATED,
+        EVENT_TYPE_REMOTE_ENDED,
+        TRACK_MUTE_CHANGED,
+        StreamEventTypes,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( EVENT_TYPE_LOCAL_CREATED ).toBe( 'stream.local_created' );
+        expect( EVENT_TYPE_LOCAL_CHANGED ).toBe( 'stream.local_changed' );
+        expect( EVENT_TYPE_LOCAL_ENDED ).toBe( 'stream.local_ended' );
+        expect( EVENT_TYPE_REMOTE_CREATED ).toBe( 'stream.remote_created' );
+        expect( EVENT_TYPE_REMOTE_ENDED ).toBe( 'stream.remote_ended' );
+        expect( TRACK_MUTE_CHANGED ).toBe( 'rtc.track_mute_changed' );
+        if ( StreamEventTypes ) {
+            expect( StreamEventTypes.EVENT_TYPE_LOCAL_CREATED ).toBe( 'stream.local_created' );
+            expect( StreamEventTypes.EVENT_TYPE_LOCAL_CHANGED ).toBe( 'stream.local_changed' );
+            expect( StreamEventTypes.EVENT_TYPE_LOCAL_ENDED ).toBe( 'stream.local_ended' );
+            expect( StreamEventTypes.EVENT_TYPE_REMOTE_CREATED ).toBe( 'stream.remote_created' );
+            expect( StreamEventTypes.EVENT_TYPE_REMOTE_ENDED ).toBe( 'stream.remote_ended' );
+            expect( StreamEventTypes.TRACK_MUTE_CHANGED ).toBe( 'rtc.track_mute_changed' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/RTC/VideoType.spec.ts
+++ b/service/RTC/VideoType.spec.ts
@@ -1,0 +1,26 @@
+import * as exported from "./VideoType";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/RTC/VideoType members", () => {
+    const {
+        CAMERA,
+        DESKTOP,
+        VideoType,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( CAMERA ).toBe( 'camera' );
+        expect( DESKTOP ).toBe( 'desktop' );
+        if ( VideoType ) {
+            expect( VideoType.CAMERA ).toBe( 'camera' );
+            expect( VideoType.DESKTOP ).toBe( 'desktop' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/authentication/AuthenticationEvents.spec.ts
+++ b/service/authentication/AuthenticationEvents.spec.ts
@@ -1,0 +1,23 @@
+import * as exported from "./AuthenticationEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/authentication/AuthenticationEvents members", () => {
+    const {
+        IDENTITY_UPDATED,
+        AuthenticationEvents,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( IDENTITY_UPDATED ).toBe( 'authentication.identity_updated' );
+        if ( AuthenticationEvents ) {
+            expect( AuthenticationEvents.IDENTITY_UPDATED ).toBe( 'authentication.identity_updated' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/connectivity/ConnectionQualityEvents.spec.ts
+++ b/service/connectivity/ConnectionQualityEvents.spec.ts
@@ -1,0 +1,26 @@
+import * as exported from "./ConnectionQualityEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/connectivity/ConnectionQualityEvents members", () => {
+    const {
+        LOCAL_STATS_UPDATED = 'cq.local_stats_updated',
+        REMOTE_STATS_UPDATED,
+        ConnectionQualityEvents,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( LOCAL_STATS_UPDATED ).toBe( 'cq.local_stats_updated' );
+        expect( REMOTE_STATS_UPDATED ).toBe( 'cq.remote_stats_updated' );
+        if ( ConnectionQualityEvents ) {
+            expect( ConnectionQualityEvents.LOCAL_STATS_UPDATED ).toBe( 'cq.local_stats_updated' );
+            expect( ConnectionQualityEvents.REMOTE_STATS_UPDATED ).toBe( 'cq.remote_stats_updated' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/e2eping/E2ePingEvents.spec.ts
+++ b/service/e2eping/E2ePingEvents.spec.ts
@@ -1,0 +1,23 @@
+import * as exported from "./E2ePingEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/e2eping/E2ePingEvents members", () => {
+    const {
+        E2E_RTT_CHANGED,
+        E2ePingEvents,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( E2E_RTT_CHANGED ).toBe( 'e2eping.e2e_rtt_changed' );
+        if ( E2ePingEvents ) {
+            expect( E2ePingEvents.E2E_RTT_CHANGED ).toBe( 'e2eping.e2e_rtt_changed' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/statistics/AnalyticsEvents.spec.ts
+++ b/service/statistics/AnalyticsEvents.spec.ts
@@ -1,0 +1,100 @@
+import * as exported from "./AnalyticsEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/statistics/AnalyticsEvents members", () => {
+    const {
+        TYPE_OPERATIONAL,
+        TYPE_PAGE,
+        TYPE_TRACK,
+        TYPE_UI,
+        ACTION_JINGLE_RESTART,
+        ACTION_JINGLE_SA_TIMEOUT,
+        ACTION_JINGLE_SI_RECEIVED,
+        ACTION_JINGLE_SI_TIMEOUT,
+        ACTION_JINGLE_TERMINATE,
+        ACTION_JINGLE_TR_RECEIVED,
+        ACTION_JINGLE_TR_SUCCESS,
+        ACTION_P2P_DECLINED,
+        ACTION_P2P_ESTABLISHED,
+        ACTION_P2P_FAILED,
+        ACTION_P2P_SWITCH_TO_JVB,
+        AVAILABLE_DEVICE,
+        CONNECTION_DISCONNECTED,
+        FEEDBACK,
+        ICE_DURATION,
+        ICE_ESTABLISHMENT_DURATION_DIFF,
+        ICE_STATE_CHANGED,
+        NO_BYTES_SENT,
+        TRACK_UNMUTED,
+        createBridgeDownEvent,
+        createConnectionFailedEvent,
+        createConferenceEvent,
+        createConnectionStageReachedEvent,
+        createE2eRttEvent,
+        createFocusLeftEvent,
+        createGetUserMediaEvent,
+        createParticipantConnectionStatusEvent,
+        createJingleEvent,
+        createNoDataFromSourceEvent,
+        createP2PEvent,
+        createRemotelyMutedEvent,
+        createRtpStatsEvent,
+        createRttByRegionEvent,
+        createTransportStatsEvent,
+        createAudioOutputProblemEvent,
+        createBridgeChannelClosedEvent,
+        createTtfmEvent,
+        /*AnalyticsEvents,*/
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( TYPE_OPERATIONAL ).toBe( 'operational' );
+        expect( TYPE_PAGE ).toBe( 'page' );
+        expect( TYPE_TRACK ).toBe( 'track' );
+        expect( TYPE_UI ).toBe( 'ui' );
+        expect( ACTION_JINGLE_RESTART ).toBe( 'restart' );
+        expect( ACTION_JINGLE_SA_TIMEOUT ).toBe( 'session-accept.timeout' );
+        expect( ACTION_JINGLE_SI_RECEIVED ).toBe( 'session-initiate.received' );
+        expect( ACTION_JINGLE_SI_TIMEOUT ).toBe( 'session-initiate.timeout' );
+        expect( ACTION_JINGLE_TERMINATE ).toBe( 'terminate' );
+        expect( ACTION_JINGLE_TR_RECEIVED ).toBe( 'transport-replace.received' );
+        expect( ACTION_JINGLE_TR_SUCCESS ).toBe( 'transport-replace.success' );
+        expect( ACTION_P2P_DECLINED ).toBe( 'decline' );
+        expect( ACTION_P2P_ESTABLISHED ).toBe( 'established' );
+        expect( ACTION_P2P_FAILED ).toBe( 'failed' );
+        expect( ACTION_P2P_SWITCH_TO_JVB ).toBe( 'switch.to.jvb' );
+        expect( AVAILABLE_DEVICE ).toBe( 'available.device' );
+        expect( CONNECTION_DISCONNECTED ).toBe( 'connection.disconnected' );
+        expect( FEEDBACK ).toBe( 'feedback' );
+        expect( ICE_DURATION ).toBe( 'ice.duration' );
+        expect( ICE_ESTABLISHMENT_DURATION_DIFF ).toBe( 'ice.establishment.duration.diff' );
+        expect( ICE_STATE_CHANGED ).toBe( 'ice.state.changed' );
+        expect( NO_BYTES_SENT ).toBe( 'track.no-bytes-sent' );
+        expect( TRACK_UNMUTED ).toBe( 'track.unmuted' );
+        expect( typeof ( createBridgeDownEvent ) ).toBe( 'function' );
+        expect( typeof ( createConnectionFailedEvent ) ).toBe( 'function' );
+        expect( typeof ( createConferenceEvent ) ).toBe( 'function' );
+        expect( typeof ( createConnectionStageReachedEvent ) ).toBe( 'function' );
+        expect( typeof ( createE2eRttEvent ) ).toBe( 'function' );
+        expect( typeof ( createFocusLeftEvent ) ).toBe( 'function' );
+        expect( typeof ( createGetUserMediaEvent ) ).toBe( 'function' );
+        expect( typeof ( createParticipantConnectionStatusEvent ) ).toBe( 'function' );
+        expect( typeof ( createJingleEvent ) ).toBe( 'function' );
+        expect( typeof ( createNoDataFromSourceEvent ) ).toBe( 'function' );
+        expect( typeof ( createP2PEvent ) ).toBe( 'function' );
+        expect( typeof ( createRemotelyMutedEvent ) ).toBe( 'function' );
+        expect( typeof ( createRtpStatsEvent ) ).toBe( 'function' );
+        expect( typeof ( createRttByRegionEvent ) ).toBe( 'function' );
+        expect( typeof ( createTransportStatsEvent ) ).toBe( 'function' );
+        expect( typeof ( createAudioOutputProblemEvent ) ).toBe( 'function' );
+        expect( typeof ( createBridgeChannelClosedEvent ) ).toBe( 'function' );
+        expect( typeof ( createTtfmEvent ) ).toBe( 'function' );
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/statistics/Events.spec.ts
+++ b/service/statistics/Events.spec.ts
@@ -1,0 +1,35 @@
+import * as exported from "./Events";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/statistics/Events members", () => {
+    const {
+        AUDIO_LEVEL,
+        BEFORE_DISPOSED,
+        BYTE_SENT_STATS,
+        CONNECTION_STATS,
+        LONG_TASKS_STATS,
+        Events,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( AUDIO_LEVEL ).toBe( 'statistics.audioLevel' );
+        expect( BEFORE_DISPOSED ).toBe( 'statistics.before_disposed' );
+        expect( BYTE_SENT_STATS ).toBe( 'statistics.byte_sent_stats' );
+        expect( CONNECTION_STATS ).toBe( 'statistics.connectionstats' );
+        expect( LONG_TASKS_STATS ).toBe( 'statistics.long_tasks_stats' );
+        if ( Events ) {
+            expect( Events.AUDIO_LEVEL ).toBe( 'statistics.audioLevel' );
+            expect( Events.BEFORE_DISPOSED ).toBe( 'statistics.before_disposed' );
+            expect( Events.BYTE_SENT_STATS ).toBe( 'statistics.byte_sent_stats' );
+            expect( Events.CONNECTION_STATS ).toBe( 'statistics.connectionstats' );
+            expect( Events.LONG_TASKS_STATS ).toBe( 'statistics.long_tasks_stats' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/statistics/constants.spec.ts
+++ b/service/statistics/constants.spec.ts
@@ -1,0 +1,23 @@
+import * as exported from "./constants";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/statistics/constants members", () => {
+    const {
+        LOCAL_JID,
+        Constants,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+
+    it( "known members", () => {
+        expect( LOCAL_JID ).toBe( 'local' );
+        if ( Constants ) {
+            expect( Constants.LOCAL_JID ).toBe( 'local' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/xmpp/XMPPEvents.spec.ts
+++ b/service/xmpp/XMPPEvents.spec.ts
@@ -1,0 +1,304 @@
+import * as exported from "./XMPPEvents";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/xmpp/XMPPEvents members", () => {
+    const {
+        ADD_ICE_CANDIDATE_FAILED,
+        AUDIO_MUTED_BY_FOCUS,
+        VIDEO_MUTED_BY_FOCUS,
+        AUTHENTICATION_REQUIRED,
+        BRIDGE_DOWN,
+        CALL_ACCEPTED,
+        CALL_INCOMING,
+        CALL_ENDED,
+        CHAT_ERROR_RECEIVED,
+        SETTINGS_ERROR_RECEIVED,
+        CONFERENCE_PROPERTIES_CHANGED,
+        CONNECTION_ESTABLISHED,
+        CONNECTION_FAILED,
+        CONNECTION_INTERRUPTED,
+        CONNECTION_RESTORED,
+        CONNECTION_ICE_FAILED,
+        CONNECTION_RESTARTED,
+        CONNECTION_STATUS_CHANGED,
+        DISPLAY_NAME_CHANGED,
+        EMUC_ROOM_ADDED,
+        EMUC_ROOM_REMOVED,
+        ETHERPAD,
+        FOCUS_DISCONNECTED,
+        FOCUS_LEFT,
+        GRACEFUL_SHUTDOWN,
+        ICE_RESTARTING,
+        ICE_RESTART_SUCCESS,
+        KICKED,
+        LOCAL_ROLE_CHANGED,
+        MEETING_ID_SET,
+        MESSAGE_RECEIVED,
+        INVITE_MESSAGE_RECEIVED,
+        PRIVATE_MESSAGE_RECEIVED,
+        MUC_MEMBER_BOT_TYPE_CHANGED,
+        MUC_DESTROYED,
+        MUC_JOIN_IN_PROGRESS,
+        MUC_JOINED,
+        MUC_MEMBER_JOINED,
+        MUC_MEMBER_LEFT,
+        MUC_LOBBY_MEMBER_JOINED,
+        MUC_LOBBY_MEMBER_UPDATED,
+        MUC_LOBBY_MEMBER_LEFT,
+        MUC_DENIED_ACCESS,
+        MUC_LEFT,
+        MUC_ROLE_CHANGED,
+        MUC_LOCK_CHANGED,
+        MUC_MEMBERS_ONLY_CHANGED,
+        PARTICIPANT_AUDIO_MUTED,
+        PARTICIPANT_VIDEO_MUTED,
+        PARTICIPANT_VIDEO_TYPE_CHANGED,
+        PARTICIPANT_FEATURES_CHANGED,
+        PASSWORD_REQUIRED,
+        PHONE_NUMBER_CHANGED,
+        PRESENCE_RECEIVED,
+        PRESENCE_STATUS,
+        PROMPT_FOR_LOGIN,
+        READY_TO_JOIN,
+        RECORDER_STATE_CHANGED,
+        REMOTE_STATS,
+        RENEGOTIATION_FAILED,
+        RESERVATION_ERROR,
+        ROOM_CONNECT_ERROR,
+        ROOM_CONNECT_NOT_ALLOWED_ERROR,
+        ROOM_JOIN_ERROR,
+        ROOM_CONNECT_MEMBERS_ONLY_ERROR,
+        ROOM_MAX_USERS_ERROR,
+        SENDING_CHAT_MESSAGE,
+        SENDING_PRIVATE_CHAT_MESSAGE,
+        SESSION_ACCEPT,
+        SESSION_ACCEPT_ERROR,
+        SESSION_ACCEPT_TIMEOUT,
+        SOURCE_ADD,
+        SOURCE_ADD_ERROR,
+        SOURCE_REMOVE,
+        SOURCE_REMOVE_ERROR,
+        SPEAKER_STATS_RECEIVED,
+        CONFERENCE_TIMESTAMP_RECEIVED,
+        AV_MODERATION_APPROVED,
+        AV_MODERATION_REJECTED,
+        AV_MODERATION_RECEIVED,
+        AV_MODERATION_CHANGED,
+        AV_MODERATION_PARTICIPANT_APPROVED,
+        AV_MODERATION_PARTICIPANT_REJECTED,
+        BREAKOUT_ROOMS_MOVE_TO_ROOM,
+        BREAKOUT_ROOMS_EVENT,
+        BREAKOUT_ROOMS_UPDATED,
+        START_MUTED_FROM_FOCUS,
+        SUBJECT_CHANGED,
+        SUSPEND_DETECTED,
+        TRANSCRIPTION_STATUS_CHANGED,
+        TRANSPORT_INFO,
+        VIDEO_SIP_GW_AVAILABILITY_CHANGED,
+        VIDEO_SIP_GW_SESSION_STATE_CHANGED,
+        ICE_CONNECTION_STATE_CHANGED,
+        JSON_MESSAGE_RECEIVED,
+        XMPPEvents,
+        ...others
+    } = exported as any; // TODO: remove cast after typescript conversion
+    it( "known members", () => {
+        expect( ADD_ICE_CANDIDATE_FAILED ).toBe( 'xmpp.add_ice_candidate_failed' );
+        expect( AUDIO_MUTED_BY_FOCUS ).toBe( 'xmpp.audio_muted_by_focus' );
+        expect( VIDEO_MUTED_BY_FOCUS ).toBe( 'xmpp.video_muted_by_focus' );
+        expect( AUTHENTICATION_REQUIRED ).toBe( 'xmpp.authentication_required' );
+        expect( BRIDGE_DOWN ).toBe( 'xmpp.bridge_down' );
+        expect( CALL_ACCEPTED ).toBe( 'xmpp.callaccepted.jingle' );
+        expect( CALL_INCOMING ).toBe( 'xmpp.callincoming.jingle' );
+        expect( CALL_ENDED ).toBe( 'xmpp.callended.jingle' );
+        expect( CHAT_ERROR_RECEIVED ).toBe( 'xmpp.chat_error_received' );
+        expect( SETTINGS_ERROR_RECEIVED ).toBe( 'xmpp.settings_error_received' );
+        expect( CONFERENCE_PROPERTIES_CHANGED ).toBe( 'xmpp.conference_properties_changed' );
+        expect( CONNECTION_ESTABLISHED ).toBe( 'xmpp.connection.connected' );
+        expect( CONNECTION_FAILED ).toBe( 'xmpp.connection.failed' );
+        expect( CONNECTION_INTERRUPTED ).toBe( 'xmpp.connection.interrupted' );
+        expect( CONNECTION_RESTORED ).toBe( 'xmpp.connection.restored' );
+        expect( CONNECTION_ICE_FAILED ).toBe( 'xmpp.connection.ice.failed' );
+        expect( CONNECTION_RESTARTED ).toBe( 'xmpp.connection.restart' );
+        expect( CONNECTION_STATUS_CHANGED ).toBe( 'xmpp.connection.status.changed' );
+        expect( DISPLAY_NAME_CHANGED ).toBe( 'xmpp.display_name_changed' );
+        expect( EMUC_ROOM_ADDED ).toBe( 'xmpp.emuc_room_added' );
+        expect( EMUC_ROOM_REMOVED ).toBe( 'xmpp.emuc_room_removed' );
+        expect( ETHERPAD ).toBe( 'xmpp.etherpad' );
+        expect( FOCUS_DISCONNECTED ).toBe( 'xmpp.focus_disconnected' );
+        expect( FOCUS_LEFT ).toBe( 'xmpp.focus_left' );
+        expect( GRACEFUL_SHUTDOWN ).toBe( 'xmpp.graceful_shutdown' );
+        expect( ICE_RESTARTING ).toBe( 'rtc.ice_restarting' );
+        expect( ICE_RESTART_SUCCESS ).toBe( 'rtc.ice_restart_success' );
+        expect( KICKED ).toBe( 'xmpp.kicked' );
+        expect( LOCAL_ROLE_CHANGED ).toBe( 'xmpp.localrole_changed' );
+        expect( MEETING_ID_SET ).toBe( 'xmpp.meeting_id_set' );
+        expect( MESSAGE_RECEIVED ).toBe( 'xmpp.message_received' );
+        expect( INVITE_MESSAGE_RECEIVED ).toBe( 'xmpp.invite_message_received' );
+        expect( PRIVATE_MESSAGE_RECEIVED ).toBe( 'xmpp.private_message_received' );
+        expect( MUC_MEMBER_BOT_TYPE_CHANGED ).toBe( 'xmpp.muc_member_bot_type_changed' );
+        expect( MUC_DESTROYED ).toBe( 'xmpp.muc_destroyed' );
+        expect( MUC_JOIN_IN_PROGRESS ).toBe( 'xmpp.muc_join_in_progress' );
+        expect( MUC_JOINED ).toBe( 'xmpp.muc_joined' );
+        expect( MUC_MEMBER_JOINED ).toBe( 'xmpp.muc_member_joined' );
+        expect( MUC_MEMBER_LEFT ).toBe( 'xmpp.muc_member_left' );
+        expect( MUC_LOBBY_MEMBER_JOINED ).toBe( 'xmpp.muc_lobby_member_joined' );
+        expect( MUC_LOBBY_MEMBER_UPDATED ).toBe( 'xmpp.muc_lobby_member_updated' );
+        expect( MUC_LOBBY_MEMBER_LEFT ).toBe( 'xmpp.muc_lobby_member_left' );
+        expect( MUC_DENIED_ACCESS ).toBe( 'xmpp.muc_denied access' );
+        expect( MUC_LEFT ).toBe( 'xmpp.muc_left' );
+        expect( MUC_ROLE_CHANGED ).toBe( 'xmpp.muc_role_changed' );
+        expect( MUC_LOCK_CHANGED ).toBe( 'xmpp.muc_lock_changed' );
+        expect( MUC_MEMBERS_ONLY_CHANGED ).toBe( 'xmpp.muc_members_only_changed' );
+        expect( PARTICIPANT_AUDIO_MUTED ).toBe( 'xmpp.audio_muted' );
+        expect( PARTICIPANT_VIDEO_MUTED ).toBe( 'xmpp.video_muted' );
+        expect( PARTICIPANT_VIDEO_TYPE_CHANGED ).toBe( 'xmpp.video_type' );
+        expect( PARTICIPANT_FEATURES_CHANGED ).toBe( 'xmpp.participant_features_changed' );
+        expect( PASSWORD_REQUIRED ).toBe( 'xmpp.password_required' );
+        expect( PHONE_NUMBER_CHANGED ).toBe( 'conference.phoneNumberChanged' );
+        expect( PRESENCE_RECEIVED ).toBe( 'xmpp.presence_received' );
+        expect( PRESENCE_STATUS ).toBe( 'xmpp.presence_status' );
+        expect( PROMPT_FOR_LOGIN ).toBe( 'xmpp.prompt_for_login' );
+        expect( READY_TO_JOIN ).toBe( 'xmpp.ready_to_join' );
+        expect( RECORDER_STATE_CHANGED ).toBe( 'xmpp.recorderStateChanged' );
+        expect( REMOTE_STATS ).toBe( 'xmpp.remote_stats' );
+        expect( RENEGOTIATION_FAILED ).toBe( 'xmpp.renegotiation_failed' );
+        expect( RESERVATION_ERROR ).toBe( 'xmpp.room_reservation_error' );
+        expect( ROOM_CONNECT_ERROR ).toBe( 'xmpp.room_connect_error' );
+        expect( ROOM_CONNECT_NOT_ALLOWED_ERROR ).toBe( 'xmpp.room_connect_error.not_allowed' );
+        expect( ROOM_JOIN_ERROR ).toBe( 'xmpp.room_join_error' );
+        expect( ROOM_CONNECT_MEMBERS_ONLY_ERROR ).toBe( 'xmpp.room_connect_error.members_only' );
+        expect( ROOM_MAX_USERS_ERROR ).toBe( 'xmpp.room_max_users_error' );
+        expect( SENDING_CHAT_MESSAGE ).toBe( 'xmpp.sending_chat_message' );
+        expect( SENDING_PRIVATE_CHAT_MESSAGE ).toBe( 'xmpp.sending_private_chat_message' );
+        expect( SESSION_ACCEPT ).toBe( 'xmpp.session_accept' );
+        expect( SESSION_ACCEPT_ERROR ).toBe( 'xmpp.session_accept_error' );
+        expect( SESSION_ACCEPT_TIMEOUT ).toBe( 'xmpp.session_accept_timeout' );
+        expect( SOURCE_ADD ).toBe( 'xmpp.source_add' );
+        expect( SOURCE_ADD_ERROR ).toBe( 'xmpp.source_add_error' );
+        expect( SOURCE_REMOVE ).toBe( 'xmpp.source_remove' );
+        expect( SOURCE_REMOVE_ERROR ).toBe( 'xmpp.source_remove_error' );
+        expect( SPEAKER_STATS_RECEIVED ).toBe( 'xmpp.speaker_stats_received' );
+        expect( CONFERENCE_TIMESTAMP_RECEIVED ).toBe( 'xmpp.conference_timestamp_received' );
+        expect( AV_MODERATION_APPROVED ).toBe( 'xmpp.av_moderation.approved' );
+        expect( AV_MODERATION_REJECTED ).toBe( 'xmpp.av_moderation.rejected' );
+        expect( AV_MODERATION_RECEIVED ).toBe( 'xmpp.av_moderation.received' );
+        expect( AV_MODERATION_CHANGED ).toBe( 'xmpp.av_moderation.changed' );
+        expect( AV_MODERATION_PARTICIPANT_APPROVED ).toBe( 'xmpp.av_moderation.participant.approved' );
+        expect( AV_MODERATION_PARTICIPANT_REJECTED ).toBe( 'xmpp.av_moderation.participant.rejected' );
+        expect( BREAKOUT_ROOMS_MOVE_TO_ROOM ).toBe( 'xmpp.breakout-rooms.move-to-room' );
+        expect( BREAKOUT_ROOMS_EVENT ).toBe( 'xmpp.breakout-rooms.event' );
+        expect( BREAKOUT_ROOMS_UPDATED ).toBe( 'xmpp.breakout-rooms.updated' );
+        expect( START_MUTED_FROM_FOCUS ).toBe( 'xmpp.start_muted_from_focus' );
+        expect( SUBJECT_CHANGED ).toBe( 'xmpp.subject_changed' );
+        expect( SUSPEND_DETECTED ).toBe( 'xmpp.suspend_detected' );
+        expect( TRANSCRIPTION_STATUS_CHANGED ).toBe( 'xmpp.transcription_status_changed' );
+        expect( TRANSPORT_INFO ).toBe( 'xmpp.transportinfo.jingle' );
+        expect( VIDEO_SIP_GW_AVAILABILITY_CHANGED ).toBe( 'xmpp.videoSIPGWAvailabilityChanged' );
+        expect( VIDEO_SIP_GW_SESSION_STATE_CHANGED ).toBe( 'xmpp.videoSIPGWSessionStateChanged' );
+        expect( ICE_CONNECTION_STATE_CHANGED ).toBe( 'xmpp.ice_connection_state_changed' );
+        expect( JSON_MESSAGE_RECEIVED ).toBe( 'xmmp.json_message_received' );
+        if ( XMPPEvents ) {
+            expect( XMPPEvents.ADD_ICE_CANDIDATE_FAILED ).toBe( 'xmpp.add_ice_candidate_failed' );
+            expect( XMPPEvents.AUDIO_MUTED_BY_FOCUS ).toBe( 'xmpp.audio_muted_by_focus' );
+            expect( XMPPEvents.VIDEO_MUTED_BY_FOCUS ).toBe( 'xmpp.video_muted_by_focus' );
+            expect( XMPPEvents.AUTHENTICATION_REQUIRED ).toBe( 'xmpp.authentication_required' );
+            expect( XMPPEvents.BRIDGE_DOWN ).toBe( 'xmpp.bridge_down' );
+            expect( XMPPEvents.CALL_ACCEPTED ).toBe( 'xmpp.callaccepted.jingle' );
+            expect( XMPPEvents.CALL_INCOMING ).toBe( 'xmpp.callincoming.jingle' );
+            expect( XMPPEvents.CALL_ENDED ).toBe( 'xmpp.callended.jingle' );
+            expect( XMPPEvents.CHAT_ERROR_RECEIVED ).toBe( 'xmpp.chat_error_received' );
+            expect( XMPPEvents.SETTINGS_ERROR_RECEIVED ).toBe( 'xmpp.settings_error_received' );
+            expect( XMPPEvents.CONFERENCE_PROPERTIES_CHANGED ).toBe( 'xmpp.conference_properties_changed' );
+            expect( XMPPEvents.CONNECTION_ESTABLISHED ).toBe( 'xmpp.connection.connected' );
+            expect( XMPPEvents.CONNECTION_FAILED ).toBe( 'xmpp.connection.failed' );
+            expect( XMPPEvents.CONNECTION_INTERRUPTED ).toBe( 'xmpp.connection.interrupted' );
+            expect( XMPPEvents.CONNECTION_RESTORED ).toBe( 'xmpp.connection.restored' );
+            expect( XMPPEvents.CONNECTION_ICE_FAILED ).toBe( 'xmpp.connection.ice.failed' );
+            expect( XMPPEvents.CONNECTION_RESTARTED ).toBe( 'xmpp.connection.restart' );
+            expect( XMPPEvents.CONNECTION_STATUS_CHANGED ).toBe( 'xmpp.connection.status.changed' );
+            expect( XMPPEvents.DISPLAY_NAME_CHANGED ).toBe( 'xmpp.display_name_changed' );
+            expect( XMPPEvents.EMUC_ROOM_ADDED ).toBe( 'xmpp.emuc_room_added' );
+            expect( XMPPEvents.EMUC_ROOM_REMOVED ).toBe( 'xmpp.emuc_room_removed' );
+            expect( XMPPEvents.ETHERPAD ).toBe( 'xmpp.etherpad' );
+            expect( XMPPEvents.FOCUS_DISCONNECTED ).toBe( 'xmpp.focus_disconnected' );
+            expect( XMPPEvents.FOCUS_LEFT ).toBe( 'xmpp.focus_left' );
+            expect( XMPPEvents.GRACEFUL_SHUTDOWN ).toBe( 'xmpp.graceful_shutdown' );
+            expect( XMPPEvents.ICE_RESTARTING ).toBe( 'rtc.ice_restarting' );
+            expect( XMPPEvents.ICE_RESTART_SUCCESS ).toBe( 'rtc.ice_restart_success' );
+            expect( XMPPEvents.KICKED ).toBe( 'xmpp.kicked' );
+            expect( XMPPEvents.LOCAL_ROLE_CHANGED ).toBe( 'xmpp.localrole_changed' );
+            expect( XMPPEvents.MEETING_ID_SET ).toBe( 'xmpp.meeting_id_set' );
+            expect( XMPPEvents.MESSAGE_RECEIVED ).toBe( 'xmpp.message_received' );
+            expect( XMPPEvents.INVITE_MESSAGE_RECEIVED ).toBe( 'xmpp.invite_message_received' );
+            expect( XMPPEvents.PRIVATE_MESSAGE_RECEIVED ).toBe( 'xmpp.private_message_received' );
+            expect( XMPPEvents.MUC_MEMBER_BOT_TYPE_CHANGED ).toBe( 'xmpp.muc_member_bot_type_changed' );
+            expect( XMPPEvents.MUC_DESTROYED ).toBe( 'xmpp.muc_destroyed' );
+            expect( XMPPEvents.MUC_JOIN_IN_PROGRESS ).toBe( 'xmpp.muc_join_in_progress' );
+            expect( XMPPEvents.MUC_JOINED ).toBe( 'xmpp.muc_joined' );
+            expect( XMPPEvents.MUC_MEMBER_JOINED ).toBe( 'xmpp.muc_member_joined' );
+            expect( XMPPEvents.MUC_MEMBER_LEFT ).toBe( 'xmpp.muc_member_left' );
+            expect( XMPPEvents.MUC_LOBBY_MEMBER_JOINED ).toBe( 'xmpp.muc_lobby_member_joined' );
+            expect( XMPPEvents.MUC_LOBBY_MEMBER_UPDATED ).toBe( 'xmpp.muc_lobby_member_updated' );
+            expect( XMPPEvents.MUC_LOBBY_MEMBER_LEFT ).toBe( 'xmpp.muc_lobby_member_left' );
+            expect( XMPPEvents.MUC_DENIED_ACCESS ).toBe( 'xmpp.muc_denied access' );
+            expect( XMPPEvents.MUC_LEFT ).toBe( 'xmpp.muc_left' );
+            expect( XMPPEvents.MUC_ROLE_CHANGED ).toBe( 'xmpp.muc_role_changed' );
+            expect( XMPPEvents.MUC_LOCK_CHANGED ).toBe( 'xmpp.muc_lock_changed' );
+            expect( XMPPEvents.MUC_MEMBERS_ONLY_CHANGED ).toBe( 'xmpp.muc_members_only_changed' );
+            expect( XMPPEvents.PARTICIPANT_AUDIO_MUTED ).toBe( 'xmpp.audio_muted' );
+            expect( XMPPEvents.PARTICIPANT_VIDEO_MUTED ).toBe( 'xmpp.video_muted' );
+            expect( XMPPEvents.PARTICIPANT_VIDEO_TYPE_CHANGED ).toBe( 'xmpp.video_type' );
+            expect( XMPPEvents.PARTICIPANT_FEATURES_CHANGED ).toBe( 'xmpp.participant_features_changed' );
+            expect( XMPPEvents.PASSWORD_REQUIRED ).toBe( 'xmpp.password_required' );
+            expect( XMPPEvents.PHONE_NUMBER_CHANGED ).toBe( 'conference.phoneNumberChanged' );
+            expect( XMPPEvents.PRESENCE_RECEIVED ).toBe( 'xmpp.presence_received' );
+            expect( XMPPEvents.PRESENCE_STATUS ).toBe( 'xmpp.presence_status' );
+            expect( XMPPEvents.PROMPT_FOR_LOGIN ).toBe( 'xmpp.prompt_for_login' );
+            expect( XMPPEvents.READY_TO_JOIN ).toBe( 'xmpp.ready_to_join' );
+            expect( XMPPEvents.RECORDER_STATE_CHANGED ).toBe( 'xmpp.recorderStateChanged' );
+            expect( XMPPEvents.REMOTE_STATS ).toBe( 'xmpp.remote_stats' );
+            expect( XMPPEvents.RENEGOTIATION_FAILED ).toBe( 'xmpp.renegotiation_failed' );
+            expect( XMPPEvents.RESERVATION_ERROR ).toBe( 'xmpp.room_reservation_error' );
+            expect( XMPPEvents.ROOM_CONNECT_ERROR ).toBe( 'xmpp.room_connect_error' );
+            expect( XMPPEvents.ROOM_CONNECT_NOT_ALLOWED_ERROR ).toBe( 'xmpp.room_connect_error.not_allowed' );
+            expect( XMPPEvents.ROOM_JOIN_ERROR ).toBe( 'xmpp.room_join_error' );
+            expect( XMPPEvents.ROOM_CONNECT_MEMBERS_ONLY_ERROR ).toBe( 'xmpp.room_connect_error.members_only' );
+            expect( XMPPEvents.ROOM_MAX_USERS_ERROR ).toBe( 'xmpp.room_max_users_error' );
+            expect( XMPPEvents.SENDING_CHAT_MESSAGE ).toBe( 'xmpp.sending_chat_message' );
+            expect( XMPPEvents.SENDING_PRIVATE_CHAT_MESSAGE ).toBe( 'xmpp.sending_private_chat_message' );
+            expect( XMPPEvents.SESSION_ACCEPT ).toBe( 'xmpp.session_accept' );
+            expect( XMPPEvents.SESSION_ACCEPT_ERROR ).toBe( 'xmpp.session_accept_error' );
+            expect( XMPPEvents.SESSION_ACCEPT_TIMEOUT ).toBe( 'xmpp.session_accept_timeout' );
+            expect( XMPPEvents.SOURCE_ADD ).toBe( 'xmpp.source_add' );
+            expect( XMPPEvents.SOURCE_ADD_ERROR ).toBe( 'xmpp.source_add_error' );
+            expect( XMPPEvents.SOURCE_REMOVE ).toBe( 'xmpp.source_remove' );
+            expect( XMPPEvents.SOURCE_REMOVE_ERROR ).toBe( 'xmpp.source_remove_error' );
+            expect( XMPPEvents.SPEAKER_STATS_RECEIVED ).toBe( 'xmpp.speaker_stats_received' );
+            expect( XMPPEvents.CONFERENCE_TIMESTAMP_RECEIVED ).toBe( 'xmpp.conference_timestamp_received' );
+            expect( XMPPEvents.AV_MODERATION_APPROVED ).toBe( 'xmpp.av_moderation.approved' );
+            expect( XMPPEvents.AV_MODERATION_REJECTED ).toBe( 'xmpp.av_moderation.rejected' );
+            expect( XMPPEvents.AV_MODERATION_RECEIVED ).toBe( 'xmpp.av_moderation.received' );
+            expect( XMPPEvents.AV_MODERATION_CHANGED ).toBe( 'xmpp.av_moderation.changed' );
+            expect( XMPPEvents.AV_MODERATION_PARTICIPANT_APPROVED ).toBe( 'xmpp.av_moderation.participant.approved' );
+            expect( XMPPEvents.AV_MODERATION_PARTICIPANT_REJECTED ).toBe( 'xmpp.av_moderation.participant.rejected' );
+            expect( XMPPEvents.BREAKOUT_ROOMS_MOVE_TO_ROOM ).toBe( 'xmpp.breakout-rooms.move-to-room' );
+            expect( XMPPEvents.BREAKOUT_ROOMS_EVENT ).toBe( 'xmpp.breakout-rooms.event' );
+            expect( XMPPEvents.BREAKOUT_ROOMS_UPDATED ).toBe( 'xmpp.breakout-rooms.updated' );
+            expect( XMPPEvents.START_MUTED_FROM_FOCUS ).toBe( 'xmpp.start_muted_from_focus' );
+            expect( XMPPEvents.SUBJECT_CHANGED ).toBe( 'xmpp.subject_changed' );
+            expect( XMPPEvents.SUSPEND_DETECTED ).toBe( 'xmpp.suspend_detected' );
+            expect( XMPPEvents.TRANSCRIPTION_STATUS_CHANGED ).toBe( 'xmpp.transcription_status_changed' );
+            expect( XMPPEvents.TRANSPORT_INFO ).toBe( 'xmpp.transportinfo.jingle' );
+            expect( XMPPEvents.VIDEO_SIP_GW_AVAILABILITY_CHANGED ).toBe( 'xmpp.videoSIPGWAvailabilityChanged' );
+            expect( XMPPEvents.VIDEO_SIP_GW_SESSION_STATE_CHANGED ).toBe( 'xmpp.videoSIPGWSessionStateChanged' );
+            expect( XMPPEvents.ICE_CONNECTION_STATE_CHANGED ).toBe( 'xmpp.ice_connection_state_changed' );
+            expect( XMPPEvents.JSON_MESSAGE_RECEIVED ).toBe( 'xmmp.json_message_received' );
+        }
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "doc",
     "dist",
     "**/*.spec.js",
+    "**/*.spec.ts",
     "*.conf*.js",
     "webpack*.js",
     "lib-jitsi-meet.*.js",


### PR DESCRIPTION
These are the brittle tests across the files that contain simple constant style exports.

The aim here is to ensure that when the TypeScript versions are merged that we have a baseline and that we can ensure no regressions.

Note that the tests are setup look for additional members and to fail if they appear - this would indicate a change that needs the test updating (hence they are brittle). You may also spot that I've done these with knowledge of the TypeScript versions that I have tucked away.

Please note the inclusion of @types/jasmine to keep TypeScript / VSCode happy and the updates to both tsconfig.json and karma.conf.js to include the .ts tests