### PR TITLE
Compile the typescript prior to running the karma tests to ensure that the auto-generated declarations are up-to-date

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
     "prepack": "npm run build",
-    "test": "karma start karma.conf.js",
+    "test": "tsc && karma start karma.conf.js",
     "test-watch": "karma start karma.conf.js --no-single-run",
     "validate": "npm ls",
     "watch": "webpack --config webpack.config.js --watch --mode development"


### PR DESCRIPTION
I won't be offended if you consider this to be a bit lazy - but as I'm doing lots of work within karma it makes sense for me to auto-update the typescript definition files when I run the tests - as I'm effectively driving the TypeScript conversion via TDD.