### PR TITLE
fix(JingleSessionPC) fix "echo" on mobile

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1517,9 +1517,10 @@ export default class JingleSessionPC extends JingleSession {
             // RN doesn't support RTCRtpSenders yet, aggresive layer suspension on RN is implemented
             // by changing the media direction in the SDP. This is applicable to jvb sessions only.
             if (!this.isP2P && browser.isReactNative() && typeof maxFrameHeight !== 'undefined') {
-                const videoActive = maxFrameHeight > 0;
+                const audioActive = this.peerconnection.audioTransferActive;
+                const videoActive = this.peerconnection.videoTransferActive && maxFrameHeight > 0;
 
-                return this.setMediaTransferActive(true, videoActive);
+                return this.setMediaTransferActive(audioActive, videoActive);
             }
 
             const jitsiLocalTrack = sourceName


### PR DESCRIPTION
This patch removes aggressive layer suspension on RN. The way it was
implemented it would start sending media to the JVB even while in P2P.

I tried to look for a way around it, but I could not find a "is media
active in this Jingle session PC?" flag, so I chose the shortest path to
the fix and yanked the (mis)feature altogether. This will start to work
once we have transceivers.