### PR TITLE
fix(rn,JingleSessionPC) remove aggressive layer suspension in RN

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1514,15 +1514,6 @@ export default class JingleSessionPC extends JingleSession {
         if (this._assertNotEnded()) {
             logger.info(`${this} setSenderVideoConstraint: ${maxFrameHeight}, sourceName: ${sourceName}`);
 
-            // RN doesn't support RTCRtpSenders yet, aggresive layer suspension on RN is implemented
-            // by changing the media direction in the SDP. This is applicable to jvb sessions only.
-            if (!this.isP2P && browser.isReactNative() && typeof maxFrameHeight !== 'undefined') {
-                const audioActive = this.peerconnection.audioTransferActive;
-                const videoActive = this.peerconnection.videoTransferActive && maxFrameHeight > 0;
-
-                return this.setMediaTransferActive(audioActive, videoActive);
-            }
-
             const jitsiLocalTrack = sourceName
                 ? this.rtc.getLocalVideoTracks().find(track => track.getSourceName() === sourceName)
                 : this.rtc.getLocalVideoTrack();


### PR DESCRIPTION
It's possible we get sender constraint messages while operations to
change the direction in the JVB session are in progress so we currently
have no predictable way to properly suspend video without races.

Since this will be solved when we move to transceivers, this is a
compromise we are making.