### PR TITLE
fix(JingleSessionPC) Do not recycle m-lines when sources leave and join.

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1868,8 +1868,6 @@ export default class JingleSessionPC extends JingleSession {
                     const mid = remoteSdp.media.findIndex(mLine => mLine.includes(line));
 
                     if (mid > -1) {
-                        const mediaType = SDPUtil.parseMLine(remoteSdp.media[mid].split('\r\n')[0])?.media;
-
                         if (this.isP2P) {
                             // Do not remove ssrcs from m-line in p2p mode. If the ssrc is removed and added back to
                             // the same m-line (on source-add), Chrome/Safari do not render the media even if it is
@@ -1879,6 +1877,7 @@ export default class JingleSessionPC extends JingleSession {
                             // fire the "removetrack" event on the associated MediaStream. Also, the current direction
                             // of the transceiver for p2p will depend on whether a local sources is added or not. It
                             // will be 'sendrecv' if the local source is present, 'sendonly' otherwise.
+                            const mediaType = SDPUtil.parseMLine(remoteSdp.media[mid].split('\r\n')[0])?.media;
                             const desiredDirection = this.peerconnection.getDesiredMediaDirection(mediaType, false);
 
                             [ MediaDirection.SENDRECV, MediaDirection.SENDONLY ].forEach(direction => {
@@ -1886,14 +1885,10 @@ export default class JingleSessionPC extends JingleSession {
                                     .replace(`a=${direction}`, `a=${desiredDirection}`);
                             });
                         } else {
-                            // Change the port to 0 to reject the m-line associated with the source. The rejected
-                            // m-lines are recycled when new ssrcs need to be added to the remote description.
-                            const port = SDPUtil.parseMLine(remoteSdp.media[mid].split('\r\n')[0])?.port;
-
+                            // Jvb connections will have direction set to 'sendonly' for the remote sources.
                             remoteSdp.media[mid] = remoteSdp.media[mid].replace(`${line}\r\n`, '');
-                            remoteSdp.media[mid] = remoteSdp.media[mid].replace(
-                                `m=${mediaType} ${port}`,
-                                `m=${mediaType} 0`);
+                            remoteSdp.media[mid] = remoteSdp.media[mid]
+                                .replace(`a=${MediaDirection.SENDONLY}`, `a=${MediaDirection.INACTIVE}`);
                         }
                     }
                 });


### PR DESCRIPTION
Recycling the m-line by rejecting it and then re-using is causing issues where sometimes the track addition fails. When a new ssrc is added to an m-line that was rejected and port is changed back to the default port, sometimes the remote sdp returned by browser wouldn't contain the newly added ssrcs and the track addition fails as a result.
Error: No SSRC lines found in remote SDP for remote stream[msid=854882f8-audio-1,type=audio]
    at Ca._remoteTrackAdded (https://web-cdn.jitsi.net/meetjitsi_5885.2601/libs/lib-jitsi-meet.min.js?v=5885.2601:2:439103)
    at Ca._usesUnifiedPlan.onTrack (https://web-cdn.jitsi.net/meetjitsi_5885.2601/libs/lib-jitsi-meet.min.js?v=5885.2601:2:432207)
    at RTCPeerConnection.r (https://web-cdn.jitsi.net/meetjitsi_5885.2601/libs/lib-jitsi-meet.min.js?v=5885.2601:2:680736)
.