### PR TITLE
fix(TPC) Do not force renegotiations for p2p.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1980,8 +1980,8 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
                     ? Promise.resolve()
                     : this.tpcUtils.setEncodings(newTrack);
 
-                // Renegotiate only in the case of P2P. We rely on 'negotiationeeded' to be fired for JVB.
-                return configureEncodingsPromise.then(() => this.isP2P || negotiationNeeded);
+                // Force renegotiation only when the source is added for the first time.
+                return configureEncodingsPromise.then(() => negotiationNeeded);
             });
     }
 


### PR DESCRIPTION
Chrome doesn't render media when the SSRC is added back to the m-line after removing it because of source-remove->source-add from peer. Avoid renegotiations so that these source removes and adds are not sent to the peer after the track is replaced.