### PR TITLE
use path.join in webpack-shared.config

### DIFF
--- a/webpack-shared-config.js
+++ b/webpack-shared-config.js
@@ -1,5 +1,6 @@
 /* global __dirname */
 
+const path = require('path');
 const process = require('process');
 const { ProvidePlugin } = require('webpack');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
@@ -24,7 +25,7 @@ module.exports = (minimize, analyzeBundle) => {
                         process.env.LIB_JITSI_MEET_COMMIT_HASH || 'development',
                     search: '{#COMMIT_HASH#}'
                 },
-                test: `${__dirname}/JitsiMeetJS.js`
+                test: path.join(__dirname, 'JitsiMeetJS.js')
             }, {
                 // Transpile ES2015 (aka ES6) to ES5.
 


### PR DESCRIPTION
In theory it is good practice to use path.join in webpack config files rather than doing string concatenation - it also happens to make this line cross-environment compatible