### PR TITLE
feat(build) remove export from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "scripts": {
     "build": "npm run build:webpack && npm run build:tsc",
-    "build:webpack": "LIB_JITSI_MEET_COMMIT_HASH=$(git rev-parse --short HEAD 2>/dev/null) webpack",
+    "build:webpack": "webpack",
     "build:tsc": "tsc --build --clean && tsc",
     "gen-types": "tsc --declaration --declarationDir types/auto --emitDeclarationOnly",
     "lint": "eslint .",

--- a/webpack-shared-config.js
+++ b/webpack-shared-config.js
@@ -33,7 +33,7 @@ module.exports = (minimize, analyzeBundle) => {
                     replace: commitHash,
                     search: '{#COMMIT_HASH#}'
                 },
-                test: path.join(__dirname, 'JitsiMeetJS.js')
+                test: path.join(__dirname, 'JitsiMeetJS.ts')
             }, {
                 // Transpile ES2015 (aka ES6) to ES5.
 

--- a/webpack-shared-config.js
+++ b/webpack-shared-config.js
@@ -1,10 +1,16 @@
 /* global __dirname */
 
+const { execSync } = require('child_process');
 const path = require('path');
 const process = require('process');
 const { ProvidePlugin } = require('webpack');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
+const devNull = process.platform === 'win32' ? 'nul' : '/dev/null';
+const commitHash = process.env.LIB_JITSI_MEET_COMMIT_HASH
+    || execSync(`git rev-parse --short HEAD 2>${devNull} || echo development`)
+        .toString()
+        .trim();
 
 module.exports = (minimize, analyzeBundle) => {
     return {
@@ -24,8 +30,7 @@ module.exports = (minimize, analyzeBundle) => {
                 loader: 'string-replace-loader',
                 options: {
                     flags: 'g',
-                    replace:
-                        process.env.LIB_JITSI_MEET_COMMIT_HASH || 'development',
+                    replace: commitHash,
                     search: '{#COMMIT_HASH#}'
                 },
                 test: path.join(__dirname, 'JitsiMeetJS.js')


### PR DESCRIPTION
this moves the determination of the git commit to webpack-shared-config

LIB_JITSI_MEET_COMMIT_HASH is still kept for backward compatibility

related to #1951 and #1952