### PR TITLE
fix(build) patch transpile exclude regex for windows

### DIFF
--- a/webpack-shared-config.js
+++ b/webpack-shared-config.js
@@ -29,12 +29,11 @@ module.exports = (minimize, analyzeBundle) => {
             }, {
                 // Transpile ES2015 (aka ES6) to ES5.
 
-                exclude: [
+                include: [
                     new RegExp(
-                        `${__dirname}/node_modules/(?!@jitsi/js-utils)`
-                            .replace(/\//g, path.sep)
-                            .replace(/\\/g, '\\$&')
-                    )
+                        path.join(__dirname, '(?!node_modules)').replace(/\\/g, '\\$&')
+                    ),
+                    path.join(__dirname, 'node_modules', '@jitsi', 'js-utils')
                 ],
                 loader: 'babel-loader',
                 options: {

--- a/webpack-shared-config.js
+++ b/webpack-shared-config.js
@@ -30,7 +30,11 @@ module.exports = (minimize, analyzeBundle) => {
                 // Transpile ES2015 (aka ES6) to ES5.
 
                 exclude: [
-                    new RegExp(`${__dirname}/node_modules/(?!@jitsi/js-utils)`)
+                    new RegExp(
+                        `${__dirname}/node_modules/(?!@jitsi/js-utils)`
+                            .replace(/\//g, path.sep)
+                            .replace(/\\/g, '\\$&')
+                    )
                 ],
                 loader: 'babel-loader',
                 options: {


### PR DESCRIPTION
on windows replaces slashes with backslashes and then escapes them for the regex to be valid

related to #1951 and #1956