### PR TITLE
chore(build) remove unneeded code

### DIFF
--- a/webpack-shared-config.js
+++ b/webpack-shared-config.js
@@ -29,9 +29,6 @@ module.exports = (minimize, analyzeBundle) => {
             }, {
                 // Transpile ES2015 (aka ES6) to ES5.
 
-                exclude: [
-                    new RegExp(`${__dirname}/node_modules/(?!@jitsi/js-utils)`)
-                ],
                 loader: 'babel-loader',
                 options: {
                     presets: [


### PR DESCRIPTION
There is no need to treat js-utils differently, since it's now declared
as a module in package.json

Ref: https://github.com/jitsi/lib-jitsi-meet/pull/1957