### PR TITLE
End-to-end ping updates

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -407,7 +407,7 @@ JitsiConference.prototype._init = function(options = {}) {
     this.room.addListener(XMPPEvents.SOURCE_ADD_ERROR, this._removeLocalSourceOnReject);
     this.room.addListener(XMPPEvents.SOURCE_REMOVE, this._updateRoomPresence);
 
-    if (config.e2eping.enabled === true) {
+    if (config.e2eping && config.e2eping.enabled === true) {
         this.e2eping = new E2ePing(
             this,
             config,

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -407,17 +407,21 @@ JitsiConference.prototype._init = function(options = {}) {
     this.room.addListener(XMPPEvents.SOURCE_ADD_ERROR, this._removeLocalSourceOnReject);
     this.room.addListener(XMPPEvents.SOURCE_REMOVE, this._updateRoomPresence);
 
-    this.e2eping = new E2ePing(
-        this,
-        config,
-        (message, to) => {
-            try {
-                this.sendMessage(
-                    message, to, true /* sendThroughVideobridge */);
-            } catch (error) {
-                logger.warn('Failed to send E2E ping request or response.', error && error.msg);
-            }
-        });
+    if (config.e2eping.enabled === true) {
+        this.e2eping = new E2ePing(
+            this,
+            config,
+            (message, to) => {
+                try {
+                    this.sendMessage(
+                        message, to, true /* sendThroughVideobridge */);
+                } catch (error) {
+                    logger.warn(
+                        'Failed to send E2E ping request or response.',
+                         error && error.msg);
+                }
+            });
+    }
 
     if (!this.rtc) {
         this.rtc = new RTC(this, options);

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -407,18 +407,15 @@ JitsiConference.prototype._init = function(options = {}) {
     this.room.addListener(XMPPEvents.SOURCE_ADD_ERROR, this._removeLocalSourceOnReject);
     this.room.addListener(XMPPEvents.SOURCE_REMOVE, this._updateRoomPresence);
 
-    if (config.e2eping && config.e2eping.enabled === true) {
+    if (config.e2eping?.enabled) {
         this.e2eping = new E2ePing(
             this,
             config,
             (message, to) => {
                 try {
-                    this.sendMessage(
-                        message, to, true /* sendThroughVideobridge */);
+                    this.sendMessage(message, to, true /* sendThroughVideobridge */);
                 } catch (error) {
-                    logger.warn(
-                        'Failed to send E2E ping request or response.',
-                         error && error.msg);
+                    logger.warn('Failed to send E2E ping request or response.', error && error.msg);
                 }
             });
     }

--- a/modules/e2eping/e2eping.js
+++ b/modules/e2eping/e2eping.js
@@ -238,9 +238,6 @@ export default class E2ePing {
             + `maxMessagesPerSecond=${this.maxMessagesPerSecond}.`);
 
         this.participantJoined = this.participantJoined.bind(this);
-        conference.on(
-            JitsiConferenceEvents.USER_JOINED,
-            this.participantJoined);
 
         this.participantLeft = this.participantLeft.bind(this);
         conference.on(
@@ -256,6 +253,18 @@ export default class E2ePing {
         conference.on(
             JitsiConferenceEvents.DATA_CHANNEL_OPENED,
             this.dataChannelOpened);
+
+        this.conferenceJoined = this.conferenceJoined.bind(this);
+        conference.on(JitsiConferenceEvents.CONFERENCE_JOINED, this.conferenceJoined);
+    }
+
+    /**
+     * Delay processing USER_JOINED events until the MUC is fully joined,
+     * otherwise the apparent conference size will be wrong.
+     */
+    conferenceJoined() {
+        this.conference.getParticipants().forEach(p => this.participantJoined(p.getId(), p));
+        this.conference.on(JitsiConferenceEvents.USER_JOINED, this.participantJoined);
     }
 
     /**

--- a/modules/e2eping/e2eping.js
+++ b/modules/e2eping/e2eping.js
@@ -1,9 +1,6 @@
 import { getLogger } from '@jitsi/logger';
 
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
-import * as E2ePingEvents
-    from '../../service/e2eping/E2ePingEvents';
-import Statistics from '../statistics/statistics';
 
 const logger = getLogger(__filename);
 
@@ -112,12 +109,10 @@ class ParticipantWrapper {
      * @type {*}
      */
     maybeLogRttAndStop() {
-        const now = window.performance.now();
-
         // The RTT we'll report is the minimum RTT measured
         let rtt = Infinity;
         let request, requestId;
-        let numRequestsWithResponses = 0
+        let numRequestsWithResponses = 0;
 
         for (requestId in this.requests) {
             if (this.requests.hasOwnProperty(requestId)) {
@@ -130,10 +125,10 @@ class ParticipantWrapper {
             }
         }
 
-        if (numRequestsWithResponses >= e2eping.numRequests) {
+        if (numRequestsWithResponses >= this.e2eping.numRequests) {
             console.log(`Measured RTT=${rtt} ms to participant ${this.id} (in
-                region ${this.participant.getProperty('region')}`));
-            clearIntervals()
+                region ${this.participant.getProperty('region')}`);
+            this.clearIntervals();
         }
     }
 }
@@ -269,7 +264,7 @@ export default class E2ePing {
         // We don't need to send e2eping in both directions for a pair of
         // endpoints. Force only one direction with just string comparison of
         // the IDs.
-        if (conference.myUserId() > id) {
+        if (this.conference.myUserId() > id) {
             console.log(`Starting e2eping for participant ${id}`);
             this.participants[id] = new ParticipantWrapper(participant, this);
         }

--- a/modules/e2eping/e2eping.js
+++ b/modules/e2eping/e2eping.js
@@ -103,12 +103,9 @@ class ParticipantWrapper {
         const totalSeconds
             = totalMessages / this.e2eping.maxMessagesPerSecond;
 
-        // Randomize between .9 and 1.1
-        const r = 1 - ((Math.random() - 0.5) * 0.2);
-        const delayBetweenMessages
-            = Math.max(
-                r * 1000 * (totalSeconds / this.e2eping.numRequests),
-                1000);
+        // Randomize between .5 and 1.5
+        const r = 1.5 - Math.random();
+        const delayBetweenMessages = r * Math.max(1000 * (totalSeconds / this.e2eping.numRequests), 1000);
 
         return delayBetweenMessages;
     }

--- a/modules/e2eping/e2eping.js
+++ b/modules/e2eping/e2eping.js
@@ -266,7 +266,13 @@ export default class E2ePing {
             delete this.participants[id];
         }
 
-        this.participants[id] = new ParticipantWrapper(participant, this);
+        // We don't need to send e2eping in both directions for a pair of
+        // endpoints. Force only one direction with just string comparison of
+        // the IDs.
+        if (conference.myUserId() > id) {
+            console.log(`Starting e2eping for participant ${id}`);
+            this.participants[id] = new ParticipantWrapper(participant, this);
+        }
     }
 
     /**

--- a/modules/e2eping/e2eping.js
+++ b/modules/e2eping/e2eping.js
@@ -93,8 +93,7 @@ class ParticipantWrapper {
         const conferenceSize = this.e2eping.conference.getParticipants().length;
         const endpointPairs = conferenceSize * (conferenceSize - 1) / 2;
         const totalMessages = endpointPairs * this.e2eping.numRequests;
-        const totalSeconds
-            = totalMessages / this.e2eping.maxMessagesPerSecond;
+        const totalSeconds = totalMessages / this.e2eping.maxMessagesPerSecond;
 
         // Randomize between .5 and 1.5
         const r = 1.5 - Math.random();
@@ -159,15 +158,13 @@ class ParticipantWrapper {
         }
 
         if (numRequestsWithResponses >= this.e2eping.numRequests) {
-            logger.info(`Measured RTT=${rtt} ms to participant ${this.id} (in `
-                + `region ${this.participant.getProperty('region')})`);
+            logger.info(`Measured RTT=${rtt} ms to ${this.id} (in ${this.participant.getProperty('region')})`);
             this.stop();
 
             return;
         } else if (totalNumRequests > 2 * this.e2eping.numRequests) {
-            logger.info(`Stopping e2eping for ${this.id} because we've sent `
-                + `${totalNumRequests} with only ${numRequestsWithResponses} `
-                + 'responses.');
+            logger.info(`Stopping e2eping for ${this.id} because we sent ${totalNumRequests} with only `
+                + `${numRequestsWithResponses} responses.`);
             this.stop();
 
             return;
@@ -218,26 +215,20 @@ export default class E2ePing {
                 this.maxConferenceSize = options.e2eping.maxConferenceSize;
             }
             if (typeof options.e2eping.maxMessagesPerSecond === 'number') {
-                this.maxMessagesPerSecond
-                    = options.e2eping.maxMessagesPerSecond;
+                this.maxMessagesPerSecond = options.e2eping.maxMessagesPerSecond;
             }
         }
         logger.info(
-            `Initializing e2e ping with numRequests=${this.numRequests}, `
-            + `maxConferenceSize=${this.maxConferenceSize}, `
+            `Initializing e2e ping with numRequests=${this.numRequests}, maxConferenceSize=${this.maxConferenceSize}, `
             + `maxMessagesPerSecond=${this.maxMessagesPerSecond}.`);
 
         this.participantJoined = this.participantJoined.bind(this);
 
         this.participantLeft = this.participantLeft.bind(this);
-        conference.on(
-            JitsiConferenceEvents.USER_LEFT,
-            this.participantLeft);
+        conference.on(JitsiConferenceEvents.USER_LEFT, this.participantLeft);
 
         this.messageReceived = this.messageReceived.bind(this);
-        conference.on(
-            JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED,
-            this.messageReceived);
+        conference.on(JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED, this.messageReceived);
 
         this.conferenceJoined = this.conferenceJoined.bind(this);
         conference.on(JitsiConferenceEvents.CONFERENCE_JOINED, this.conferenceJoined);
@@ -277,8 +268,7 @@ export default class E2ePing {
      */
     participantJoined(id, participant) {
         if (this.participants[id]) {
-            logger.info(
-                `Participant wrapper already exists for ${id}. Clearing.`);
+            logger.info(`Participant wrapper already exists for ${id}. Clearing.`);
             this.participants[id].stop();
         }
 
@@ -333,8 +323,7 @@ export default class E2ePing {
 
             this.sendMessage(response, participantId);
         } else {
-            logger.info(
-                `Received an invalid e2e ping request from ${participantId}.`);
+            logger.info(`Received an invalid e2e ping request from ${participantId}.`);
         }
     }
 
@@ -358,15 +347,9 @@ export default class E2ePing {
     stop() {
         logger.info('Stopping e2eping');
 
-        this.conference.off(
-            JitsiConferenceEvents.USER_JOINED,
-            this.participantJoined);
-        this.conference.off(
-            JitsiConferenceEvents.USER_LEFT,
-            this.participantLeft);
-        this.conference.off(
-            JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED,
-            this.messageReceived);
+        this.conference.off(JitsiConferenceEvents.USER_JOINED, this.participantJoined);
+        this.conference.off(JitsiConferenceEvents.USER_LEFT, this.participantLeft);
+        this.conference.off(JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED, this.messageReceived);
 
         for (const id in this.participants) {
             if (this.participants.hasOwnProperty(id)) {

--- a/modules/e2eping/e2eping.js
+++ b/modules/e2eping/e2eping.js
@@ -25,7 +25,7 @@ const DEFAULT_NUM_REQUESTS = 5;
  * The maximum number of messages per second to aim for. This is for the entire
  * conference, with the assumption that all endpoints join at once.
  */
-const DEFAULT_MAX_MESSAGES_PER_SECOND = 300;
+const DEFAULT_MAX_MESSAGES_PER_SECOND = 250;
 
 /**
  * The conference size beyond which e2e pings will be disabled.

--- a/modules/e2eping/e2eping.js
+++ b/modules/e2eping/e2eping.js
@@ -79,7 +79,6 @@ class ParticipantWrapper {
      * Stop pinging this participant, canceling a scheduled ping, if any.
      */
     stop() {
-        logger.info(`Stopping e2eping for ${this.id}`);
         if (this.timeout) {
             window.clearTimeout(this.timeout);
         }

--- a/types/auto/modules/e2eping/e2eping.d.ts
+++ b/types/auto/modules/e2eping/e2eping.d.ts
@@ -24,9 +24,9 @@ export default class E2ePing {
     eventEmitter: any;
     sendMessage: Function;
     pingIntervalMs: any;
-    analyticsIntervalMs: any;
     participants: {};
     isDataChannelOpen: boolean;
+    numRequests: any;
     /**
      * Handles a participant joining the conference. Starts to send ping
      * requests to the participant.

--- a/types/auto/modules/e2eping/e2eping.d.ts
+++ b/types/auto/modules/e2eping/e2eping.d.ts
@@ -26,6 +26,8 @@ export default class E2ePing {
     participants: {};
     isDataChannelOpen: boolean;
     numRequests: any;
+    maxConferenceSize: any;
+    maxMessagesPerSecond: any;
     /**
      * Handles a participant joining the conference. Starts to send ping
      * requests to the participant.

--- a/types/auto/modules/e2eping/e2eping.d.ts
+++ b/types/auto/modules/e2eping/e2eping.d.ts
@@ -24,7 +24,6 @@ export default class E2ePing {
     eventEmitter: any;
     sendMessage: Function;
     participants: {};
-    isDataChannelOpen: boolean;
     numRequests: any;
     maxConferenceSize: any;
     maxMessagesPerSecond: any;
@@ -49,11 +48,6 @@ export default class E2ePing {
      * @param payload - The payload of the message.
      */
     messageReceived(participant: any, payload: any): void;
-    /**
-     * Notifies this instance that the communications channel has been opened
-     * and it can now send messages via sendMessage.
-     */
-    dataChannelOpened(): void;
     /**
      * Delay processing USER_JOINED events until the MUC is fully joined,
      * otherwise the apparent conference size will be wrong.

--- a/types/auto/modules/e2eping/e2eping.d.ts
+++ b/types/auto/modules/e2eping/e2eping.d.ts
@@ -23,7 +23,6 @@ export default class E2ePing {
     conference: any;
     eventEmitter: any;
     sendMessage: Function;
-    pingIntervalMs: any;
     participants: {};
     isDataChannelOpen: boolean;
     numRequests: any;
@@ -53,6 +52,10 @@ export default class E2ePing {
      * and it can now send messages via sendMessage.
      */
     dataChannelOpened(): void;
+    /**
+     * Remove a participant without calling "stop".
+     */
+    removeParticipant(id: any): void;
     /**
      * Handles a ping request coming from another participant.
      *

--- a/types/auto/modules/e2eping/e2eping.d.ts
+++ b/types/auto/modules/e2eping/e2eping.d.ts
@@ -55,6 +55,11 @@ export default class E2ePing {
      */
     dataChannelOpened(): void;
     /**
+     * Delay processing USER_JOINED events until the MUC is fully joined,
+     * otherwise the apparent conference size will be wrong.
+     */
+    conferenceJoined(): void;
+    /**
      * Remove a participant without calling "stop".
      */
     removeParticipant(id: any): void;


### PR DESCRIPTION
- Do not send analytics periodically.
- Stop sending e2eping after 5 responses.
- Only send e2eping in one direction in a pair of endpoints.
- Fix syntax, lint errors.
- squash: Cleanup logs, stop pings if we don't get responses.
- Use a timeout instead of interval.
- feat: Space out e2e pings based on conference size.
