### PR TITLE
Fix connection stats

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1101,8 +1101,8 @@ JitsiConference.prototype.addTrack = function(track) {
         if (FeatureFlags.isMultiStreamSupportEnabled() && mediaType === MediaType.VIDEO) {
             const addTrackPromises = [];
 
-            this.p2pJingleSession && addTrackPromises.push(this.p2pJingleSession.addTrack(track));
-            this.jvbJingleSession && addTrackPromises.push(this.jvbJingleSession.addTrack(track));
+            this.p2pJingleSession && addTrackPromises.push(this.p2pJingleSession.addTracks([ track ]));
+            this.jvbJingleSession && addTrackPromises.push(this.jvbJingleSession.addTracks([ track ]));
 
             return Promise.all(addTrackPromises)
                 .then(() => {

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -430,7 +430,9 @@ JitsiConference.prototype._init = function(options = {}) {
     this.receiveVideoController = new ReceiveVideoController(this, this.rtc);
     this.sendVideoController = new SendVideoController(this, this.rtc);
 
-    this.participantConnectionStatus
+    // Do not initialize ParticipantConnectionStatusHandler when source-name signaling is enabled.
+    if (!FeatureFlags.isSourceNameSignalingEnabled()) {
+        this.participantConnectionStatus
         = new ParticipantConnectionStatusHandler(
             this.rtc,
             this,
@@ -441,7 +443,8 @@ JitsiConference.prototype._init = function(options = {}) {
                 rtcMuteTimeout: config._peerConnStatusRtcMuteTimeout,
                 outOfLastNTimeout: config._peerConnStatusOutOfLastNTimeout
             });
-    this.participantConnectionStatus.init();
+        this.participantConnectionStatus.init();
+    }
 
     // Add the ability to enable callStats only on a percentage of users based on config.js settings.
     let enableCallStats = true;

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1961,6 +1961,17 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
             .then(transceiver => {
                 oldTrack && this.localTracks.delete(oldTrack.rtcId);
                 newTrack && this.localTracks.set(newTrack.rtcId, newTrack);
+
+                // Update the local SSRC cache for the case when one track gets replaced with another and no
+                // renegotiation is triggered as a result of this.
+                if (oldTrack && newTrack) {
+                    const oldTrackSSRC = this.localSSRCs.get(oldTrack.rtcId);
+
+                    if (oldTrackSSRC) {
+                        this.localSSRCs.delete(oldTrack.rtcId);
+                        this.localSSRCs.set(newTrack.rtcId, oldTrackSSRC);
+                    }
+                }
                 const mediaActive = mediaType === MediaType.AUDIO
                     ? this.audioTransferActive
                     : this.videoTransferActive;

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1944,7 +1944,11 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
     // Jicofo before the mute state is sent over presence. Therefore, trigger a renegotiation in this case. If we
     // rely on "negotiationneeded" fired by the browser to signal new ssrcs, the mute state in presence will be sent
     // before the source signaling which is undesirable.
-    const negotiationNeeded = Boolean(!oldTrack || !this.localTracks.has(oldTrack?.rtcId));
+    // Send the presence before signaling for a new screenshare source. This is needed for multi-stream support since
+    // videoType needs to be availble at remote track creation time so that a fake tile for screenshare can be added.
+    // FIXME - This check needs to be removed when the client switches to the bridge based signaling for tracks.
+    const isNewTrackScreenshare = !oldTrack && newTrack?.getVideoType() === VideoType.DESKTOP;
+    const negotiationNeeded = !isNewTrackScreenshare && Boolean(!oldTrack || !this.localTracks.has(oldTrack?.rtcId));
 
     if (this._usesUnifiedPlan) {
         logger.debug(`${this} TPC.replaceTrack using unified plan`);

--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -210,7 +210,7 @@ export default class LocalSdpMunger {
                     const trackId = streamAndTrackIDs[1];
 
                     // eslint-disable-next-line max-depth
-                    if (FeatureFlags.isMultiStreamSupportEnabled() && mediaType === MediaType.VIDEO) {
+                    if (FeatureFlags.isSourceNameSignalingEnabled()) {
 
                         // eslint-disable-next-line max-depth
                         if (streamId === '-' || !streamId) {
@@ -367,7 +367,13 @@ export default class LocalSdpMunger {
         for (const source of sources) {
             const nameExists = mediaSection.ssrcs.find(ssrc => ssrc.id === source && ssrc.attribute === 'name');
             const msid = mediaSection.ssrcs.find(ssrc => ssrc.id === source && ssrc.attribute === 'msid')?.value;
-            const trackIndex = msid ? msid.split('-')[2] : null;
+            let trackIndex;
+
+            if (msid) {
+                const streamId = msid.split(' ')[0];
+
+                trackIndex = streamId.split('-')[2];
+            }
 
             if (!nameExists) {
                 // Inject source names as a=ssrc:3124985624 name:endpointA-v0

--- a/types/auto/modules/xmpp/JingleSessionPC.d.ts
+++ b/types/auto/modules/xmpp/JingleSessionPC.d.ts
@@ -459,11 +459,11 @@ export default class JingleSessionPC extends JingleSession {
      * Adds a new track to the peerconnection. This method needs to be called only when a secondary JitsiLocalTrack is
      * being added to the peerconnection for the first time.
      *
-     * @param {JitsiLocalTrack} localTrack track to be added to the peer connection.
+     * @param {Array<JitsiLocalTrack>} localTracks - Tracks to be added to the peer connection.
      * @returns {Promise<void>} that resolves when the track is successfully added to the peerconnection, rejected
      * otherwise.
      */
-    addTrack(localTrack: any): Promise<void>;
+    addTracks(localTracks?: Array<any>): Promise<void>;
     /**
      * Replaces <tt>oldTrack</tt> with <tt>newTrack</tt> and performs a single
      * offer/answer cycle after both operations are done. Either


### PR DESCRIPTION
fix(TPC) Update the local SSRC cache when a track is replace with another.
Fixes an issue where the local stats are not emitted in Unified plan after a track replace.

fix(multi-stream) Add video tracks sequentially.
If there are more than one video track at pc creation time, add them sequentially to avoid renegotiation loop.

fix(TPC) Send presence before signaling for SS tracks.
This is needed for the track to be identified as a desktop track on the remote peer when the JitsiRemoteTrack is created.
Fixes https://github.com/jitsi/lib-jitsi-meet/issues/1649.

fix(multi-stream) Do not emit ParticipantConnectionStatus updates when source-name signaling is enabled.