### PR TITLE
Fix presence

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -923,8 +923,9 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track, tr
     logger.info(`${this} creating remote track[endpoint=${ownerEndpointId},ssrc=${trackSsrc},`
         + `type=${mediaType},sourceName=${sourceName}]`);
 
-    const peerMediaInfo
-        = this.signalingLayer.getPeerMediaInfo(ownerEndpointId, mediaType);
+    const peerMediaInfo = FeatureFlags.isSourceNameSignalingEnabled()
+        ? this.signalingLayer.getPeerSourceInfo(ownerEndpointId, sourceName)
+        : this.signalingLayer.getPeerMediaInfo(ownerEndpointId, mediaType);
 
     if (!peerMediaInfo) {
         GlobalOnErrorHandler.callErrorHandler(

--- a/modules/xmpp/SignalingLayerImpl.js
+++ b/modules/xmpp/SignalingLayerImpl.js
@@ -351,7 +351,14 @@ export default class SignalingLayerImpl extends SignalingLayer {
      * @inheritDoc
      */
     getPeerSourceInfo(owner, sourceName) {
-        return this._remoteSourceState[owner] ? this._remoteSourceState[owner][sourceName] : undefined;
+        const mediaInfo = {
+            muted: true, // muted by default
+            videoType: VideoType.CAMERA // 'camera' by default
+        };
+
+        return this._remoteSourceState[owner]
+            ? this._remoteSourceState[owner][sourceName] ?? mediaInfo
+            : undefined;
     }
 
     /**

--- a/modules/xmpp/SignalingLayerImpl.spec.js
+++ b/modules/xmpp/SignalingLayerImpl.spec.js
@@ -398,19 +398,5 @@ describe('SignalingLayerImpl', () => {
 
             expect(signalingLayer.getPeerSourceInfo(endpointId, '12345678-v0')).toBeUndefined();
         });
-        it('when it\'s no longer in the presence', () => {
-            chatRoom.mockSourceInfoPresence(endpointId, {
-                '12345678-v0': { muted: false }
-            });
-
-            expect(signalingLayer.getPeerSourceInfo(endpointId, '12345678-v0')).toBeDefined();
-
-            chatRoom.mockSourceInfoPresence(endpointId, {
-                '12345678-v1': { muted: false }
-            });
-
-            expect(signalingLayer.getPeerSourceInfo(endpointId, '12345678-v0')).toBeUndefined();
-            expect(signalingLayer.getPeerSourceInfo(endpointId, '12345678-v1')).toBeDefined();
-        });
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",
-        "@jitsi/sdp-interop": "https://git@github.com/jitsi/sdp-interop#3707993863eb6c5b6d66c4a025e9dba193775bfb",
+        "@jitsi/sdp-interop": "https://git@github.com/jitsi/sdp-interop#dbd765c99e50a7f18bea75d0b6fb07dc58691076",
         "@jitsi/sdp-simulcast": "0.4.0",
         "async": "0.9.0",
         "base64-js": "1.3.1",
@@ -1993,8 +1993,8 @@
     },
     "node_modules/@jitsi/sdp-interop": {
       "version": "1.0.5",
-      "resolved": "git+https://git@github.com/jitsi/sdp-interop.git#3707993863eb6c5b6d66c4a025e9dba193775bfb",
-      "integrity": "sha512-gqp3Pne45vlrLUyBgfTCw58zMflNripWb2Eaj0mF++U5uk2oRoo1/GBZu2C6Z42ExHfHfhFUFR3N8/Ss2LwnVw==",
+      "resolved": "git+https://git@github.com/jitsi/sdp-interop.git#dbd765c99e50a7f18bea75d0b6fb07dc58691076",
+      "integrity": "sha512-4nqEqJWyRFjHM/riI0DQRNx+mgx277iK0r5LhwVAHDZDBYbLN54vYcfZ6JepcmygQiixa8jet/gLJnikdH9wzQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "4.5.0",
@@ -8279,9 +8279,9 @@
       "integrity": "sha512-QZE0NpI/GKRdZK0vhuyFYWr4XkCz4slihkSfy6RTszjj/YEHZKIV7yGJo6Hbs3kYI2h5v7apoy+h2WCOMumPJw=="
     },
     "@jitsi/sdp-interop": {
-      "version": "git+https://git@github.com/jitsi/sdp-interop.git#3707993863eb6c5b6d66c4a025e9dba193775bfb",
-      "integrity": "sha512-gqp3Pne45vlrLUyBgfTCw58zMflNripWb2Eaj0mF++U5uk2oRoo1/GBZu2C6Z42ExHfHfhFUFR3N8/Ss2LwnVw==",
-      "from": "@jitsi/sdp-interop@https://git@github.com/jitsi/sdp-interop#3707993863eb6c5b6d66c4a025e9dba193775bfb",
+      "version": "git+https://git@github.com/jitsi/sdp-interop.git#dbd765c99e50a7f18bea75d0b6fb07dc58691076",
+      "integrity": "sha512-4nqEqJWyRFjHM/riI0DQRNx+mgx277iK0r5LhwVAHDZDBYbLN54vYcfZ6JepcmygQiixa8jet/gLJnikdH9wzQ==",
+      "from": "@jitsi/sdp-interop@https://git@github.com/jitsi/sdp-interop#dbd765c99e50a7f18bea75d0b6fb07dc58691076",
       "requires": {
         "lodash.clonedeep": "4.5.0",
         "sdp-transform": "2.14.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@jitsi/js-utils": "2.0.0",
     "@jitsi/logger": "2.0.0",
-    "@jitsi/sdp-interop": "https://git@github.com/jitsi/sdp-interop#3707993863eb6c5b6d66c4a025e9dba193775bfb",
+    "@jitsi/sdp-interop": "https://git@github.com/jitsi/sdp-interop#dbd765c99e50a7f18bea75d0b6fb07dc58691076",
     "@jitsi/sdp-simulcast": "0.4.0",
     "async": "0.9.0",
     "base64-js": "1.3.1",


### PR DESCRIPTION
fix(multi-stream) Reject m-lines associated with removed sources.
We do not want the client to re-use the inactive transceivers that are associated with m-lines for removed remote tracks. Rejecting a m-line on source-remove clears it from the list of available transceivers.

fix(multi-stream) Add default presence for camera tracks in source-name signaling.
Also switch to using signalingLayer.getPeerSourceInfo during remote track creation when source-name signaling is used