### PR TITLE
fix: Set affiliation.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1721,7 +1721,7 @@ JitsiConference.prototype.grantOwner = function(id) {
     if (!participant) {
         return;
     }
-    this.room.setAffiliation(participant.getJid(), 'owner');
+    this.room.setAffiliation(participant.getConnectionJid(), 'owner');
 };
 
 /**
@@ -1737,10 +1737,9 @@ JitsiConference.prototype.revokeOwner = function(id) {
     if (isMyself) {
         this.room.setAffiliation(this.room.myroomjid, role);
     } else if (participant) {
-        this.room.setAffiliation(participant.getJid(), role);
+        this.room.setAffiliation(participant.getConnectionJid(), role);
     }
 };
-
 
 /**
  * Kick participant from this conference.
@@ -1844,6 +1843,7 @@ JitsiConference.prototype.onMemberJoined = function(
     const participant
         = new JitsiParticipant(jid, this, nick, isHidden, statsID, status, identity);
 
+    participant.setConnectionJid(fullJid);
     participant.setRole(role);
     participant.setBotType(botType);
     participant.setFeatures(features);

--- a/JitsiParticipant.js
+++ b/JitsiParticipant.js
@@ -327,4 +327,21 @@ export default class JitsiParticipant {
     setBotType(newBotType) {
         this._botType = newBotType;
     }
+
+    /**
+     * Returns the connection jid for the participant.
+     *
+     * @returns {string|undefined} - The connection jid of the participant.
+     */
+    getConnectionJid() {
+        return this._connectionJid;
+    }
+
+    /**
+     * Sets the connection jid for the participant.
+     * @param {String} newJid - The connection jid to set.
+     */
+    setConnectionJid(newJid) {
+        this._connectionJid = newJid;
+    }
 }

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1230,7 +1230,7 @@ export default class ChatRoom extends Listenable {
         .c('query', { xmlns: 'http://jabber.org/protocol/muc#admin' })
         .c('item', {
             affiliation,
-            nick: Strophe.getResourceFromJid(jid)
+            jid: Strophe.getBareJidFromJid(jid)
         })
         .c('reason').t(`Your affiliation has been changed to '${affiliation}'.`)
         .up().up().up();
@@ -1376,7 +1376,7 @@ export default class ChatRoom extends Listenable {
                             xmlns: 'http://jabber.org/protocol/muc#admin' })
                         .c('item', {
                             'affiliation': 'member',
-                            'jid': m.jid
+                            'jid': Strophe.getBareJidFromJid(m.jid)
                         }).up().up());
                 }
             });

--- a/types/auto/JitsiParticipant.d.ts
+++ b/types/auto/JitsiParticipant.d.ts
@@ -203,5 +203,17 @@ export default class JitsiParticipant {
      */
     setBotType(newBotType: string): void;
     _botType: string;
+    /**
+     * Returns the connection jid for the participant.
+     *
+     * @returns {string|undefined} - The connection jid of the participant.
+     */
+    getConnectionJid(): string | undefined;
+    /**
+     * Sets the connection jid for the participant.
+     * @param {String} newJid - The connection jid to set.
+     */
+    setConnectionJid(newJid: string): void;
+    _connectionJid: string;
 }
 import { MediaType } from "./service/RTC/MediaType";


### PR DESCRIPTION
XEP-0045:
Affiliations are granted, revoked, and maintained based on the user’s bare JID, not the nick as with roles.