### PR TITLE
Fix msid munging

### DIFF
--- a/modules/sdp/LocalSdpMunger.spec.js
+++ b/modules/sdp/LocalSdpMunger.spec.js
@@ -163,3 +163,41 @@ describe('DoNotTransformSdpForPlanB', () => {
         });
     });
 });
+
+describe('Transform msids for source-name signaling', () => {
+    const tpc = new MockPeerConnection('1', false);
+    const localEndpointId = 'sRdpsdg';
+
+    FeatureFlags.init({ });
+    const localSdpMunger = new LocalSdpMunger(tpc, localEndpointId);
+    let audioMsidLine, audioMsid, videoMsidLine, videoMsid;
+    const transformStreamIdentifiers = () => {
+        const sdpStr = transform.write(SampleSdpStrings.simulcastRtxSdp);
+        const desc = new RTCSessionDescription({
+            type: 'offer',
+            sdp: sdpStr
+        });
+        const transformedDesc = localSdpMunger.transformStreamIdentifiers(desc);
+        const newSdp = transform.parse(transformedDesc.sdp);
+
+        audioMsidLine = getSsrcLines(newSdp, 'audio').find(ssrc => ssrc.attribute === 'msid')?.value;
+        audioMsid = audioMsidLine.split(' ')[0];
+        videoMsidLine = getSsrcLines(newSdp, 'video').find(ssrc => ssrc.attribute === 'msid')?.value;
+        videoMsid = videoMsidLine.split(' ')[0];
+    };
+
+    it('should not transform', () => {
+        transformStreamIdentifiers();
+
+        expect(audioMsid).toBe('dcbb0236-cea5-402e-9e9a-595c65ffcc2a-1');
+        expect(videoMsid).toBe('0836cc8e-a7bb-47e9-affb-0599414bc56d-1');
+    });
+
+    it('should transform', () => {
+        FeatureFlags.init({ sourceNameSignaling: true });
+        transformStreamIdentifiers();
+
+        expect(audioMsid).toBe('sRdpsdg-audio-0-1');
+        expect(videoMsid).toBe('sRdpsdg-video-0-1');
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",
-        "@jitsi/sdp-interop": "https://git@github.com/jitsi/sdp-interop#dbd765c99e50a7f18bea75d0b6fb07dc58691076",
+        "@jitsi/sdp-interop": "https://git@github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
         "@jitsi/sdp-simulcast": "0.4.0",
         "async": "0.9.0",
         "base64-js": "1.3.1",
@@ -1993,8 +1993,8 @@
     },
     "node_modules/@jitsi/sdp-interop": {
       "version": "1.0.5",
-      "resolved": "git+https://git@github.com/jitsi/sdp-interop.git#dbd765c99e50a7f18bea75d0b6fb07dc58691076",
-      "integrity": "sha512-4nqEqJWyRFjHM/riI0DQRNx+mgx277iK0r5LhwVAHDZDBYbLN54vYcfZ6JepcmygQiixa8jet/gLJnikdH9wzQ==",
+      "resolved": "git+https://git@github.com/jitsi/sdp-interop.git#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
+      "integrity": "sha512-80u69QNTBArnCd1CGbTTrl/8AsZOOMF82dQhrgXBQAnrimdpomX1fMZ82ZkxyWyYvRMPG167u43Tp8y1g2DLNA==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "4.5.0",
@@ -8279,9 +8279,9 @@
       "integrity": "sha512-QZE0NpI/GKRdZK0vhuyFYWr4XkCz4slihkSfy6RTszjj/YEHZKIV7yGJo6Hbs3kYI2h5v7apoy+h2WCOMumPJw=="
     },
     "@jitsi/sdp-interop": {
-      "version": "git+https://git@github.com/jitsi/sdp-interop.git#dbd765c99e50a7f18bea75d0b6fb07dc58691076",
-      "integrity": "sha512-4nqEqJWyRFjHM/riI0DQRNx+mgx277iK0r5LhwVAHDZDBYbLN54vYcfZ6JepcmygQiixa8jet/gLJnikdH9wzQ==",
-      "from": "@jitsi/sdp-interop@https://git@github.com/jitsi/sdp-interop#dbd765c99e50a7f18bea75d0b6fb07dc58691076",
+      "version": "git+https://git@github.com/jitsi/sdp-interop.git#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
+      "integrity": "sha512-80u69QNTBArnCd1CGbTTrl/8AsZOOMF82dQhrgXBQAnrimdpomX1fMZ82ZkxyWyYvRMPG167u43Tp8y1g2DLNA==",
+      "from": "@jitsi/sdp-interop@https://git@github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
       "requires": {
         "lodash.clonedeep": "4.5.0",
         "sdp-transform": "2.14.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@jitsi/js-utils": "2.0.0",
     "@jitsi/logger": "2.0.0",
-    "@jitsi/sdp-interop": "https://git@github.com/jitsi/sdp-interop#dbd765c99e50a7f18bea75d0b6fb07dc58691076",
+    "@jitsi/sdp-interop": "https://git@github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
     "@jitsi/sdp-simulcast": "0.4.0",
     "async": "0.9.0",
     "base64-js": "1.3.1",

--- a/types/auto/modules/sdp/LocalSdpMunger.d.ts
+++ b/types/auto/modules/sdp/LocalSdpMunger.d.ts
@@ -16,6 +16,8 @@ export default class LocalSdpMunger {
     constructor(tpc: any, localEndpointId: string);
     tpc: any;
     localEndpointId: string;
+    audioSourcesToMsidMap: Map<any, any>;
+    videoSourcesToMsidMap: Map<any, any>;
     /**
      * Makes sure that muted local video tracks associated with the parent
      * {@link TraceablePeerConnection} are described in the local SDP. It's done


### PR DESCRIPTION
fix(SDP) Always modify the streamId part of msid when source-name signaling enabled.
Do this even if the browser provides a non '-' string for streamId since we rely on this to generate the source name.

fix(multi-stream) Update the <ssrc, source-name> map for p2p as well.

Update sdp-interop@latest