### PR TITLE
fix(conference) Disable p2p between eps running in different SDP modes.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2169,10 +2169,22 @@ JitsiConference.prototype.onRemoteTrackRemoved = function(removedTrack) {
  * Handles an incoming call event for the P2P jingle session.
  */
 JitsiConference.prototype._onIncomingCallP2P = function(jingleSession, jingleOffer) {
-
     let rejectReason;
+    const usesUnifiedPlan = browser.supportsUnifiedPlan()
+        && (!browser.isChromiumBased() || (this.options.config.enableUnifiedOnChrome ?? true));
+    const contentName = jingleOffer.find('>content').attr('name');
+    const peerUsesUnifiedPlan = contentName === '0' || contentName === '1';
 
-    if ((!this.isP2PEnabled() && !this.isP2PTestModeEnabled()) || browser.isFirefox() || browser.isWebKitBased()) {
+    // Reject P2P between endpoints that are not running in the same mode w.r.t to SDPs (plan-b and unified plan).
+    if (usesUnifiedPlan !== peerUsesUnifiedPlan) {
+        rejectReason = {
+            reason: 'decline',
+            reasonDescription: 'P2P disabled',
+            errorMsg: 'P2P across two endpoints in different SDP modes is disabled'
+        };
+    } else if ((!this.isP2PEnabled() && !this.isP2PTestModeEnabled())
+        || browser.isFirefox()
+        || browser.isWebKitBased()) {
         rejectReason = {
             reason: 'decline',
             reasonDescription: 'P2P disabled',

--- a/modules/sdp/LocalSdpMunger.spec.js
+++ b/modules/sdp/LocalSdpMunger.spec.js
@@ -168,9 +168,8 @@ describe('Transform msids for source-name signaling', () => {
     const tpc = new MockPeerConnection('1', false);
     const localEndpointId = 'sRdpsdg';
 
-    FeatureFlags.init({ });
     const localSdpMunger = new LocalSdpMunger(tpc, localEndpointId);
-    let audioMsidLine, audioMsid, videoMsidLine, videoMsid;
+    let audioMsid, audioMsidLine, videoMsid, videoMsidLine;
     const transformStreamIdentifiers = () => {
         const sdpStr = transform.write(SampleSdpStrings.simulcastRtxSdp);
         const desc = new RTCSessionDescription({
@@ -187,6 +186,7 @@ describe('Transform msids for source-name signaling', () => {
     };
 
     it('should not transform', () => {
+        FeatureFlags.init({ sourceNameSignaling: false });
         transformStreamIdentifiers();
 
         expect(audioMsid).toBe('dcbb0236-cea5-402e-9e9a-595c65ffcc2a-1');


### PR DESCRIPTION
Disable p2p between endpoints that are not running in the same SDP mode. The source-add/source-remove handlers assume the mids to follow the same pattern on both self and peer but the mids generated in plan-b mode are different from unified plan mode. Fixes https://github.com/jitsi/jitsi-meet/issues/11100.