### PR TITLE
Fix p2p multistream

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -454,7 +454,7 @@ export class TPCUtils {
             if (active) {
                 // The first transceiver is for the local track and only this one can be set to 'sendrecv'.
                 // When multi-stream is enabled, there can be multiple transceivers with outbound streams.
-                if ((idx === 0 && localTracks.length) || FeatureFlags.isMultiStreamSupportEnabled()) {
+                if (idx < localTracks.length) {
                     transceiver.direction = MediaDirection.SENDRECV;
                 } else {
                     transceiver.direction = MediaDirection.RECVONLY;

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -298,6 +298,7 @@ export class TPCUtils {
             // that the highest resolution stream is available always. Safari is an exception here since it does not
             // send the desktop stream at all if only the high resolution stream is enabled.
             if (this.pc.isSharingLowFpsScreen()
+                && localVideoTrack.getVideoType() === VideoType.DESKTOP
                 && this.pc.usesUnifiedPlan()
                 && !browser.isWebKitBased()
                 && this.localStreamEncodingsConfig[idx].scaleResolutionDownBy !== HD_SCALE_FACTOR) {
@@ -451,8 +452,9 @@ export class TPCUtils {
         logger.info(`${this.pc} ${active ? 'Enabling' : 'Suspending'} ${mediaType} media transfer.`);
         transceivers.forEach((transceiver, idx) => {
             if (active) {
-                // The first transceiver is for the local track and only this one can be set to 'sendrecv'
-                if (idx === 0 && localTracks.length) {
+                // The first transceiver is for the local track and only this one can be set to 'sendrecv'.
+                // When multi-stream is enabled, there can be multiple transceivers with outbound streams.
+                if ((idx === 0 && localTracks.length) || FeatureFlags.isMultiStreamSupportEnabled()) {
                     transceiver.direction = MediaDirection.SENDRECV;
                 } else {
                     transceiver.direction = MediaDirection.RECVONLY;

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1977,7 +1977,9 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
     // Send the presence before signaling for a new screenshare source. This is needed for multi-stream support since
     // videoType needs to be availble at remote track creation time so that a fake tile for screenshare can be added.
     // FIXME - This check needs to be removed when the client switches to the bridge based signaling for tracks.
-    const isNewTrackScreenshare = !oldTrack && newTrack?.getVideoType() === VideoType.DESKTOP;
+    const isNewTrackScreenshare = !oldTrack
+        && newTrack?.getVideoType() === VideoType.DESKTOP
+        && FeatureFlags.isMultiStreamSupportEnabled();
     const negotiationNeeded = !isNewTrackScreenshare && Boolean(!oldTrack || !this.localTracks.has(oldTrack?.rtcId));
 
     if (this._usesUnifiedPlan) {
@@ -2015,6 +2017,8 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
                 // this connection again.
                 if (transceiver && mediaActive) {
                     transceiver.direction = newTrack ? MediaDirection.SENDRECV : MediaDirection.RECVONLY;
+                } else if (transceiver) {
+                    transceiver.direction = MediaDirection.INACTIVE;
                 }
 
                 // Avoid configuring the encodings on Chromium/Safari until simulcast is configured

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1697,6 +1697,8 @@ export default class JingleSessionPC extends JingleSession {
                 });
             });
 
+            let midFound = false;
+
             /* eslint-enable no-invalid-this */
             currentRemoteSdp.media.forEach((media, i2) => {
                 if (!SDPUtil.findLine(media, `a=mid:${name}`)) {
@@ -1706,7 +1708,14 @@ export default class JingleSessionPC extends JingleSession {
                     addSsrcInfo[i2] = '';
                 }
                 addSsrcInfo[i2] += lines;
+                midFound = true;
             });
+
+            // In p2p unified mode with multi-stream enabled, the new sources will have content name that doesn't exist
+            // in the current remote description. Add a new m-line for this newly signaled source.
+            if (!midFound && this.isP2P && FeatureFlags.isSourceNameSignalingEnabled()) {
+                addSsrcInfo[name] = lines;
+            }
         });
 
         return addSsrcInfo;
@@ -1929,8 +1938,17 @@ export default class JingleSessionPC extends JingleSession {
      *  in removeSsrcInfo
      */
     _processRemoteAddSource(addSsrcInfo) {
-        const remoteSdp = new SDP(this.peerconnection.remoteDescription.sdp);
+        let remoteSdp = new SDP(this.peerconnection.remoteDescription.sdp);
 
+        // Add a new m-line in the remote description if the source info for a secondary video source is recceived from
+        // the remote p2p peer when multi-stream support is enabled.
+        if (addSsrcInfo.length > remoteSdp.media.length
+            && FeatureFlags.isSourceNameSignalingEnabled()
+            && this.isP2P
+            && this.usesUnifiedPlan) {
+            remoteSdp.addMlineForNewLocalSource(MediaType.VIDEO);
+            remoteSdp = new SDP(remoteSdp.raw);
+        }
         addSsrcInfo.forEach((lines, idx) => {
             remoteSdp.media[idx] += lines;
 
@@ -2640,12 +2658,12 @@ export default class JingleSessionPC extends JingleSession {
         // context a common object for one run of ssrc update (source-add and source-remove) so we can match them if we
         // need to
         const ctx = {};
+        const removedSsrcInfo = getSignaledSourceInfo(sdpDiffer);
 
-        if (removedAnySSRCs) {
-            const sourceInfo = getSignaledSourceInfo(sdpDiffer);
-
+        if (removedAnySSRCs && removedSsrcInfo.ssrcs.length) {
             // Log only the SSRCs instead of the full IQ.
-            logger.info(`${this} Sending source-remove for ${sourceInfo.mediaType} ssrcs=${sourceInfo.ssrcs}`);
+            logger.info(`${this} Sending source-remove for ${removedSsrcInfo.mediaType}`
+                + ` ssrcs=${removedSsrcInfo.ssrcs}`);
             this.connection.sendIQ(
                 remove,
                 () => {
@@ -2670,19 +2688,18 @@ export default class JingleSessionPC extends JingleSession {
             );
 
         const containsNewSSRCs = sdpDiffer.toJingle(add);
+        const addedSsrcInfo = getSignaledSourceInfo(sdpDiffer);
 
-        if (containsNewSSRCs) {
-            const sourceInfo = getSignaledSourceInfo(sdpDiffer);
-
+        if (containsNewSSRCs && addedSsrcInfo.ssrcs.length) {
             // Log only the SSRCs instead of the full IQ.
-            logger.info(`${this} Sending source-add for ${sourceInfo.mediaType} ssrcs=${sourceInfo.ssrcs}`);
+            logger.info(`${this} Sending source-add for ${addedSsrcInfo.mediaType} ssrcs=${addedSsrcInfo.ssrcs}`);
             this.connection.sendIQ(
                 add,
                 () => {
                     this.room.eventEmitter.emit(XMPPEvents.SOURCE_ADD, this, ctx);
                 },
                 this.newJingleErrorHandler(add, error => {
-                    this.room.eventEmitter.emit(XMPPEvents.SOURCE_ADD_ERROR, this, error, sourceInfo.mediaType, ctx);
+                    this.room.eventEmitter.emit(XMPPEvents.SOURCE_ADD_ERROR, this, error, addedSsrcInfo.mediaType, ctx);
                 }),
                 IQ_TIMEOUT);
         }

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -2653,14 +2653,15 @@ export default class JingleSessionPC extends JingleSession {
                 sid: this.sid
             }
             );
-        const removedAnySSRCs = sdpDiffer.toJingle(remove);
+
+        sdpDiffer.toJingle(remove);
 
         // context a common object for one run of ssrc update (source-add and source-remove) so we can match them if we
         // need to
         const ctx = {};
         const removedSsrcInfo = getSignaledSourceInfo(sdpDiffer);
 
-        if (removedAnySSRCs && removedSsrcInfo.ssrcs.length) {
+        if (removedSsrcInfo.ssrcs.length) {
             // Log only the SSRCs instead of the full IQ.
             logger.info(`${this} Sending source-remove for ${removedSsrcInfo.mediaType}`
                 + ` ssrcs=${removedSsrcInfo.ssrcs}`);
@@ -2687,10 +2688,10 @@ export default class JingleSessionPC extends JingleSession {
             }
             );
 
-        const containsNewSSRCs = sdpDiffer.toJingle(add);
+        sdpDiffer.toJingle(add);
         const addedSsrcInfo = getSignaledSourceInfo(sdpDiffer);
 
-        if (containsNewSSRCs && addedSsrcInfo.ssrcs.length) {
+        if (addedSsrcInfo.ssrcs.length) {
             // Log only the SSRCs instead of the full IQ.
             logger.info(`${this} Sending source-add for ${addedSsrcInfo.mediaType} ssrcs=${addedSsrcInfo.ssrcs}`);
             this.connection.sendIQ(


### PR DESCRIPTION
fix(multi-stream) add new m-line when remote adds a second video source in p2p.
A new m-line needs to be added in the remote description when a new secondary video source is signaled by the peer.

fix(TPC) Suppress lower layers only for screenshare tracks.
With multi-stream support enabled, an extra check for videoType for local track is needed to dtermine if the lower layers need to be suppressed.

fix(TPC) Mark the direction inactive on inactive media connection.
If a new secondary video source is added on the jvb connection while p2p is active, make sure the direction is set to inactive on the jvb connection, so that no media is being sent out on the jvb connection.