### PR TITLE
fix(browserCapabilities) bump minimum chrome version to 88

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -4,7 +4,7 @@ import { getLogger } from '@jitsi/logger';
 const logger = getLogger(__filename);
 
 /* Minimum required Chrome / Chromium version. This applies also to derivatives. */
-const MIN_REQUIRED_CHROME_VERSION = 80;
+const MIN_REQUIRED_CHROME_VERSION = 88;
 const MIN_REQUIRED_SAFARI_VERSION = 14;
 const MIN_REQUIRED_IOS_VERSION = 14;
 

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -4,7 +4,7 @@ import { getLogger } from '@jitsi/logger';
 const logger = getLogger(__filename);
 
 /* Minimum required Chrome / Chromium version. This applies also to derivatives. */
-const MIN_REQUIRED_CHROME_VERSION = 72;
+const MIN_REQUIRED_CHROME_VERSION = 80;
 const MIN_REQUIRED_SAFARI_VERSION = 14;
 const MIN_REQUIRED_IOS_VERSION = 14;
 


### PR DESCRIPTION
This is the target chrome version in webpack babel

https://github.com/jitsi/lib-jitsi-meet/blob/3b38ab37f2bd2777d9ac56ee006840d412aac83e/webpack-shared-config.js#L47