### PR TITLE
fix(presence) Parse peer presence in legacy format correctly.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -952,9 +952,7 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track, tr
     logger.info(`${this} creating remote track[endpoint=${ownerEndpointId},ssrc=${trackSsrc},`
         + `type=${mediaType},sourceName=${sourceName}]`);
 
-    const peerMediaInfo = FeatureFlags.isSourceNameSignalingEnabled()
-        ? this.signalingLayer.getPeerSourceInfo(ownerEndpointId, sourceName)
-        : this.signalingLayer.getPeerMediaInfo(ownerEndpointId, mediaType);
+    const peerMediaInfo = this.signalingLayer.getPeerMediaInfo(ownerEndpointId, mediaType, sourceName);
 
     if (!peerMediaInfo) {
         GlobalOnErrorHandler.callErrorHandler(

--- a/modules/xmpp/SignalingLayerImpl.js
+++ b/modules/xmpp/SignalingLayerImpl.js
@@ -296,23 +296,26 @@ export default class SignalingLayerImpl extends SignalingLayer {
     /**
      * @inheritDoc
      */
-    getPeerMediaInfo(owner, mediaType) {
+    getPeerMediaInfo(owner, mediaType, sourceName) {
         const legacyGetPeerMediaInfo = () => {
             if (this.chatRoom) {
                 return this.chatRoom.getMediaPresenceInfo(owner, mediaType);
             }
             logger.error('Requested peer media info, before room was set');
         };
+        const lastPresence = this.chatRoom.getLastPresence(owner);
+
+        if (!lastPresence) {
+            throw new Error(`getPeerMediaInfo - no presence stored for: ${owner}`);
+        }
 
         if (FeatureFlags.isSourceNameSignalingEnabled()) {
-            const lastPresence = this.chatRoom.getLastPresence(owner);
-
-            if (!lastPresence) {
-                throw new Error(`getPeerMediaInfo - no presence stored for: ${owner}`);
-            }
-
             if (!this._doesEndpointSendNewSourceInfo(owner)) {
                 return legacyGetPeerMediaInfo();
+            }
+
+            if (sourceName) {
+                return this.getPeerSourceInfo(owner, sourceName);
             }
 
             /**


### PR DESCRIPTION
When source-name signaling is enabled, get correct peermedia info when the peer sends presence in the legacy format. This fixes an issue where Jigasi users cannot be heard by endpoints that have source-name signaling enabled.