### PR TITLE
fix(presence) Only apply default videoType on video tracks

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1627,7 +1627,7 @@ export default class ChatRoom extends Listenable {
         }
         const data = {
             muted: true, // muted by default
-            videoType: VideoType.CAMERA // 'camera' by default
+            videoType: mediaType === MediaType.VIDEO ? VideoType.CAMERA : undefined // 'camera' by default
         };
         let mutedNode = null;
 


### PR DESCRIPTION
This changes the chat room presence to only include videoType value on video tracks.