### PR TITLE
fix(BridgeChannel): re-send constraints and videoType message after every re-connect

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -195,10 +195,7 @@ export default class RTC extends Listenable {
         RTCUtils.removeListener(RTCEvents.DEVICE_LIST_CHANGED, this._onDeviceListChanged);
 
         if (this._channelOpenListener) {
-            this.removeListener(
-                RTCEvents.DATA_CHANNEL_OPEN,
-                this._channelOpenListener
-            );
+            this.removeListener(RTCEvents.DATA_CHANNEL_OPEN, this._channelOpenListener);
         }
     }
 
@@ -281,9 +278,6 @@ export default class RTC extends Listenable {
                     logError(error, 'VideoTypeMessage', this._videoType);
                 }
             }
-
-            this.removeListener(RTCEvents.DATA_CHANNEL_OPEN, this._channelOpenListener);
-            this._channelOpenListener = null;
         };
         this.addListener(RTCEvents.DATA_CHANNEL_OPEN, this._channelOpenListener);
 

--- a/types/auto/modules/RTC/RTC.d.ts
+++ b/types/auto/modules/RTC/RTC.d.ts
@@ -249,7 +249,7 @@ export default class RTC extends Listenable {
      * @param {string} [wsUrl] WebSocket URL.
      */
     initializeBridgeChannel(peerconnection?: RTCPeerConnection, wsUrl?: string): void;
-    _channelOpenListener: any;
+    _channelOpenListener: () => void;
     /**
      * Receives events when Last N had changed.
      * @param {array} lastNEndpoints The new Last N endpoints.


### PR DESCRIPTION
This fixes an issue where the receiver constraints and video type messages are sent on the bridge channel only the first time the ws conn gets re-established.