### PR TITLE
fix(video-quality) Update frame heights in content-modify for p2p.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1123,7 +1123,12 @@ JitsiConference.prototype.addTrack = function(track) {
         return Promise.reject(new Error(`Cannot add second ${mediaType} track to the conference`));
     }
 
-    return this.replaceTrack(null, track);
+    return this.replaceTrack(null, track)
+        .then(() => {
+            if (track.getVideoType() === VideoType.DESKTOP && FeatureFlags.isMultiStreamSupportEnabled()) {
+                this._updateRoomPresence(this.getActiveMediaSession());
+            }
+        });
 };
 
 /**

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1125,6 +1125,9 @@ JitsiConference.prototype.addTrack = function(track) {
 
     return this.replaceTrack(null, track)
         .then(() => {
+            // Presence needs to be sent here for desktop track since we need the presence to reach the remote peer
+            // before signaling so that a fake participant tile is created for screenshare. Otherwise, presence will
+            // only be sent after a session-accept or source-add is ack'ed.
             if (track.getVideoType() === VideoType.DESKTOP && FeatureFlags.isMultiStreamSupportEnabled()) {
                 this._updateRoomPresence(this.getActiveMediaSession());
             }

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1977,7 +1977,8 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
     // FIXME - This check needs to be removed when the client switches to the bridge based signaling for tracks.
     const isNewTrackScreenshare = !oldTrack
         && newTrack?.getVideoType() === VideoType.DESKTOP
-        && FeatureFlags.isMultiStreamSupportEnabled();
+        && FeatureFlags.isMultiStreamSupportEnabled()
+        && !this.isP2P; // negotiationneeded is not fired on p2p peerconnection
     const negotiationNeeded = !isNewTrackScreenshare && Boolean(!oldTrack || !this.localTracks.has(oldTrack?.rtcId));
 
     if (this._usesUnifiedPlan) {

--- a/modules/xmpp/JingleSessionPC.spec.js
+++ b/modules/xmpp/JingleSessionPC.spec.js
@@ -1,5 +1,6 @@
 /* global $, jQuery */
 import { MockRTC } from '../RTC/MockClasses';
+import FeatureFlags from '../flags/FeatureFlags';
 
 import JingleSessionPC from './JingleSessionPC';
 import * as JingleSessionState from './JingleSessionState';
@@ -23,7 +24,25 @@ function createContentModify(senders = 'both', maxFrameHeight) {
     return $(modifyContentsIq).find('>jingle');
 }
 
-describe('JingleSessionPC', () => {
+/**
+ * Creates 'content-modify' Jingle IQ.
+ * @param {string} senders - 'both' or 'none'.
+ * @param {number|undefined} maxFrameHeight - the source constraints.
+ * @returns {jQuery}
+ */
+function createContentModifyForSourceNames() {
+    const modifyContentsIq = jQuery.parseXML(
+        '<jingle action="content-modify" initiator="peer2" sid="sid12345" xmlns="urn:xmpp:jingle:1">'
+        + `<content name="video" senders="both">`
+        + `<source-frame-height maxHeight="180" sourceName="8d519815-v0" xmlns="http://jitsi.org/jitmeet/video"/>`
+        + `<source-frame-height maxHeight="2160" sourceName="8d519815-v1" xmlns="http://jitsi.org/jitmeet/video"/>`
+        + '</content>'
+        + '</jingle>');
+
+    return $(modifyContentsIq).find('>jingle');
+}
+
+describe('JingleSessionPC w/o source-name signaling', () => {
     let jingleSession;
     let connection;
     let rtc;
@@ -62,7 +81,11 @@ describe('JingleSessionPC', () => {
         // connection.connect('jid', undefined, () => { }); */
     });
 
-    describe('send/receive video constraints', () => {
+    describe('send/receive video constraints w/o source-name', () => {
+        beforeEach(() => {
+            FeatureFlags.init({ sourceNameSignaling: false });
+        });
+
         it('sends content-modify with recv frame size', () => {
             const sendIQSpy = spyOn(connection, 'sendIQ').and.callThrough();
 
@@ -117,6 +140,72 @@ describe('JingleSessionPC', () => {
 
                 jingleSession.modifyContents(createContentModify('both', 180));
                 expect(remoteRecvMaxFrameHeight).toBe(180);
+            });
+        });
+    });
+
+    describe('send/receive video constraints w/ source-name', () => {
+        beforeEach(() => {
+            FeatureFlags.init({ sourceNameSignaling: true });
+        });
+
+        it('sends content-modify with recv frame size', () => {
+            const sendIQSpy = spyOn(connection, 'sendIQ').and.callThrough();
+            const sourceConstraints = new Map();
+
+            sourceConstraints.set('8d519815-v0', 180);
+            sourceConstraints.set('8d519815-v1', 2160);
+
+            jingleSession.setReceiverVideoConstraint(null, sourceConstraints);
+
+            expect(jingleSession.getState()).toBe(JingleSessionState.PENDING);
+
+            return new Promise((resolve, reject) => {
+                jingleSession.acceptOffer(
+                    offerIQ,
+                    resolve,
+                    reject,
+                    /* local tracks */ []);
+            }).then(() => {
+                expect(jingleSession.getState()).toBe(JingleSessionState.ACTIVE);
+
+                // FIXME content-modify is sent before session-accept
+                expect(sendIQSpy.calls.count()).toBe(2);
+
+                expect(sendIQSpy.calls.first().args[0].toString()).toBe(
+                    '<iq to="peer2" type="set" xmlns="jabber:client">'
+                    + '<jingle action="content-modify" initiator="peer2" sid="sid12345" xmlns="urn:xmpp:jingle:1">'
+                    + `<content name="video" senders="both">`
+                    + `<source-frame-height maxHeight="180" sourceName="8d519815-v0" xmlns="http://jitsi.org/jitmeet/video"/>`
+                    + `<source-frame-height maxHeight="2160" sourceName="8d519815-v1" xmlns="http://jitsi.org/jitmeet/video"/>`
+                    + '</content>'
+                    + '</jingle>'
+                    + '</iq>');
+            });
+        });
+        it('fires an event when remote peer sends content-modify', () => {
+            let remoteSourcesRecvMaxFrameHeight;
+            const remoteVideoConstraintsListener = () => {
+                remoteSourcesRecvMaxFrameHeight = jingleSession.getRemoteSourcesRecvMaxFrameHeight();
+            };
+
+            jingleSession.addListener(
+                MediaSessionEvents.REMOTE_SOURCE_CONSTRAINTS_CHANGED,
+                remoteVideoConstraintsListener);
+
+            return new Promise((resolve, reject) => {
+                jingleSession.acceptOffer(
+                    offerIQ,
+                    resolve,
+                    reject,
+                    /* local tracks */ []);
+            }).then(() => {
+                jingleSession.modifyContents(createContentModifyForSourceNames());
+                const v0Height = remoteSourcesRecvMaxFrameHeight[0].maxHeight;
+                const v1Height = remoteSourcesRecvMaxFrameHeight[1].maxHeight;
+
+                expect(v0Height).toBe('180');
+                expect(v1Height).toBe('2160');
             });
         });
     });

--- a/modules/xmpp/JingleSessionPC.spec.js
+++ b/modules/xmpp/JingleSessionPC.spec.js
@@ -26,16 +26,14 @@ function createContentModify(senders = 'both', maxFrameHeight) {
 
 /**
  * Creates 'content-modify' Jingle IQ.
- * @param {string} senders - 'both' or 'none'.
- * @param {number|undefined} maxFrameHeight - the source constraints.
  * @returns {jQuery}
  */
 function createContentModifyForSourceNames() {
     const modifyContentsIq = jQuery.parseXML(
         '<jingle action="content-modify" initiator="peer2" sid="sid12345" xmlns="urn:xmpp:jingle:1">'
-        + `<content name="video" senders="both">`
-        + `<source-frame-height maxHeight="180" sourceName="8d519815-v0" xmlns="http://jitsi.org/jitmeet/video"/>`
-        + `<source-frame-height maxHeight="2160" sourceName="8d519815-v1" xmlns="http://jitsi.org/jitmeet/video"/>`
+        + '<content name="video" senders="both">'
+        + '<source-frame-height maxHeight="180" sourceName="8d519815-v0" xmlns="http://jitsi.org/jitmeet/video"/>'
+        + '<source-frame-height maxHeight="2160" sourceName="8d519815-v1" xmlns="http://jitsi.org/jitmeet/video"/>'
         + '</content>'
         + '</jingle>');
 
@@ -175,9 +173,11 @@ describe('JingleSessionPC w/o source-name signaling', () => {
                 expect(sendIQSpy.calls.first().args[0].toString()).toBe(
                     '<iq to="peer2" type="set" xmlns="jabber:client">'
                     + '<jingle action="content-modify" initiator="peer2" sid="sid12345" xmlns="urn:xmpp:jingle:1">'
-                    + `<content name="video" senders="both">`
-                    + `<source-frame-height maxHeight="180" sourceName="8d519815-v0" xmlns="http://jitsi.org/jitmeet/video"/>`
-                    + `<source-frame-height maxHeight="2160" sourceName="8d519815-v1" xmlns="http://jitsi.org/jitmeet/video"/>`
+                    + '<content name="video" senders="both">'
+                    + '<source-frame-height maxHeight="180" sourceName="8d519815-v0"'
+                    + ' xmlns="http://jitsi.org/jitmeet/video"/>'
+                    + '<source-frame-height maxHeight="2160" sourceName="8d519815-v1"'
+                    + ' xmlns="http://jitsi.org/jitmeet/video"/>'
                     + '</content>'
                     + '</jingle>'
                     + '</iq>');

--- a/modules/xmpp/MediaSessionEvents.spec.ts
+++ b/modules/xmpp/MediaSessionEvents.spec.ts
@@ -4,11 +4,13 @@ import { default as exported } from "./MediaSessionEvents";
 
 describe( "/modules/xmpp/MediaSessionEvents members", () => {
     const {
+        REMOTE_SOURCE_CONSTRAINTS_CHANGED,
         REMOTE_VIDEO_CONSTRAINTS_CHANGED,
         ...others
     } = exported;
 
     it( "known members", () => {
+        expect( REMOTE_SOURCE_CONSTRAINTS_CHANGED ).toBe( 'media_session.REMOTE_SOURCE_CONSTRAINTS_CHANGED' );
         expect( REMOTE_VIDEO_CONSTRAINTS_CHANGED ).toBe( 'media_session.REMOTE_VIDEO_CONSTRAINTS_CHANGED' );
     } );
 

--- a/modules/xmpp/MediaSessionEvents.ts
+++ b/modules/xmpp/MediaSessionEvents.ts
@@ -1,5 +1,10 @@
 enum MediaSessionEvents {
     /**
+     * Event triggered when the remote party signals video max frame heights for its local sources.
+     */
+    REMOTE_SOURCE_CONSTRAINTS_CHANGED = 'media_session.REMOTE_SOURCE_CONSTRAINTS_CHANGED',
+
+    /**
      * Event triggered when the remote party signals it's receive video max frame height.
      */
     REMOTE_VIDEO_CONSTRAINTS_CHANGED = 'media_session.REMOTE_VIDEO_CONSTRAINTS_CHANGED'

--- a/types/auto/modules/qualitycontrol/ReceiveVideoController.d.ts
+++ b/types/auto/modules/qualitycontrol/ReceiveVideoController.d.ts
@@ -16,8 +16,22 @@ export default class ReceiveVideoController {
     _rtc: any;
     _lastN: any;
     _maxFrameHeight: number;
+    /**
+     * The map that holds the max frame height requested for each remote source when source-name signaling is
+     * enabled.
+     *
+     * @type Map<string, number>
+     */
+    _sourceReceiverConstraints: Map<string, number>;
     _receiverVideoConstraints: ReceiverVideoConstraints;
     _selectedEndpoints: any[];
+    /**
+     * Returns a map of all the remote source names and the corresponding max frame heights.
+     *
+     * @param {number} maxFrameHeight
+     * @returns
+     */
+    _getDefaultSourceReceiverConstraints(mediaSession: any, maxFrameHeight: number): Map<any, any>;
     /**
      * Handles the {@link JitsiConferenceEvents.MEDIA_SESSION_STARTED}, that is when the conference creates new media
      * session. The preferred receive frameHeight is applied on the media session.

--- a/types/auto/modules/qualitycontrol/SendVideoController.d.ts
+++ b/types/auto/modules/qualitycontrol/SendVideoController.d.ts
@@ -31,8 +31,7 @@ export default class SendVideoController {
     private _configureConstraintsForLocalSources;
     /**
      * Handles the {@link JitsiConferenceEvents.MEDIA_SESSION_STARTED}, that is when the conference creates new media
-     * session. It doesn't mean it's already active though. For example the JVB connection may be created after
-     * the conference has entered the p2p mode already.
+     * session.
      *
      * @param {JingleSessionPC} mediaSession - the started media session.
      * @private

--- a/types/auto/modules/qualitycontrol/SendVideoController.d.ts
+++ b/types/auto/modules/qualitycontrol/SendVideoController.d.ts
@@ -31,7 +31,8 @@ export default class SendVideoController {
     private _configureConstraintsForLocalSources;
     /**
      * Handles the {@link JitsiConferenceEvents.MEDIA_SESSION_STARTED}, that is when the conference creates new media
-     * session.
+     * session. It doesn't mean it's already active though. For example the JVB connection may be created after
+-    * the conference has entered the p2p mode already.
      *
      * @param {JingleSessionPC} mediaSession - the started media session.
      * @private

--- a/types/auto/modules/xmpp/JingleSessionPC.d.ts
+++ b/types/auto/modules/xmpp/JingleSessionPC.d.ts
@@ -42,6 +42,14 @@ export default class JingleSessionPC extends JingleSession {
      */
     static parseMaxFrameHeight(jingleContents: any): number | null;
     /**
+     * Parses the source-name and max frame height value of the 'content-modify' IQ when source-name signaling
+     * is enabled.
+     *
+     * @param {jQuery} jingleContents - A jQuery selector pointing to the '>jingle' element.
+     * @returns {Object|null}
+     */
+    static parseSourceMaxFrameHeight(jingleContents: any): any | null;
+    /**
      * Creates new <tt>JingleSessionPC</tt>
      * @param {string} sid the Jingle Session ID - random string which identifies the session
      * @param {string} localJid our JID
@@ -107,6 +115,13 @@ export default class JingleSessionPC extends JingleSession {
      */
     localRecvMaxFrameHeight: number | undefined;
     /**
+     * Receiver constraints (max height) set by the application per remote source. Will be used for p2p connection
+     * in lieu of localRecvMaxFrameHeight when source-name signaling is enabled.
+     *
+     * @type {Map<string, number>}
+     */
+    _sourceReceiverConstraints: Map<string, number>;
+    /**
      * Indicates whether or not this session is willing to send/receive
      * video media. When set to <tt>false</tt> the underlying peer
      * connection will disable local video transfer and the remote peer will
@@ -156,6 +171,12 @@ export default class JingleSessionPC extends JingleSession {
      */
     remoteRecvMaxFrameHeight: number | undefined;
     /**
+     * Remote preference for the receive video max frame heights when source-name signaling is enabled.
+     *
+     * @type {Map<string, number>|undefined}
+     */
+    remoteSourceMaxFrameHeights: Map<string, number> | undefined;
+    /**
      * The queue used to serialize operations done on the peerconnection.
      *
      * @type {AsyncQueue}
@@ -204,6 +225,12 @@ export default class JingleSessionPC extends JingleSession {
      * @returns {Number|undefined}
      */
     getRemoteRecvMaxFrameHeight(): number | undefined;
+    /**
+     * Remote preference for receive video max frame heights when source-name signaling is enabled.
+     *
+     * @returns {Map<string, number>|undefined}
+     */
+    getRemoteSourcesRecvMaxFrameHeight(): Map<string, number> | undefined;
     /**
      * Sends given candidate in Jingle 'transport-info' message.
      * @param {RTCIceCandidate} candidate the WebRTC ICE candidate instance
@@ -327,8 +354,9 @@ export default class JingleSessionPC extends JingleSession {
      * the remote party.
      *
      * @param {Number} maxFrameHeight - the new value to set.
+     * @param {Map<string, number>} sourceReceiverConstraints - The receiver constraints per source.
      */
-    setReceiverVideoConstraint(maxFrameHeight: number): void;
+    setReceiverVideoConstraint(maxFrameHeight: number, sourceReceiverConstraints: Map<string, number>): void;
     /**
      * Sends Jingle 'transport-accept' message which is a response to
      * 'transport-replace'.

--- a/types/auto/modules/xmpp/MediaSessionEvents.d.ts
+++ b/types/auto/modules/xmpp/MediaSessionEvents.d.ts
@@ -1,5 +1,9 @@
 declare enum MediaSessionEvents {
     /**
+     * Event triggered when the remote party signals video max frame heights for its local sources.
+     */
+    REMOTE_SOURCE_CONSTRAINTS_CHANGED = "media_session.REMOTE_SOURCE_CONSTRAINTS_CHANGED",
+    /**
      * Event triggered when the remote party signals it's receive video max frame height.
      */
     REMOTE_VIDEO_CONSTRAINTS_CHANGED = "media_session.REMOTE_VIDEO_CONSTRAINTS_CHANGED"


### PR DESCRIPTION
When the user changes the preferred video quality settings from the UI, update the frame height values in content-modify for p2p connection when source-name signaling is enabled.