### PR TITLE
JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED expose jitsiTrack as listener parameter

### DIFF
--- a/modules/connectivity/TrackStreamingStatus.ts
+++ b/modules/connectivity/TrackStreamingStatus.ts
@@ -337,7 +337,7 @@ export class TrackStreamingStatusImpl {
                 }));
 
             // It's common for the event listeners to access the JitsiRemoteTrack. Thus pass it as a parameter here.
-            this.track.emit(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED, newStatus, this.track);
+            this.track.emit(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED, this.track, newStatus);
         }
     }
 

--- a/modules/connectivity/TrackStreamingStatus.ts
+++ b/modules/connectivity/TrackStreamingStatus.ts
@@ -336,7 +336,8 @@ export class TrackStreamingStatusImpl {
                     status: newStatus
                 }));
 
-            this.track.emit(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED, newStatus);
+            // It's common for the event listeners to access the JitsiRemoteTrack. Thus pass it as a parameter here.
+            this.track.emit(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED, newStatus, this.track);
         }
     }
 


### PR DESCRIPTION
So that we don't have to maintain `jitsiTrack` in the scope where listeners are defined. 

This change is a dependency for https://github.com/jitsi/jitsi-meet/pull/11377