### PR TITLE
fix(multi-stream) Send the initial session-accept and then add the secondary video tracks when a session is re-created

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -354,12 +354,13 @@ export class TPCUtils {
      */
     replaceTrack(oldTrack, newTrack) {
         const mediaType = newTrack?.getType() ?? oldTrack?.getType();
+        const localTracks = this.pc.getLocalTracks(mediaType);
         const track = newTrack?.getTrack() ?? null;
         const isNewLocalSource = FeatureFlags.isMultiStreamSupportEnabled()
-            && this.pc.getLocalTracks(mediaType)?.length
+            && localTracks?.length
             && !oldTrack
             && newTrack
-            && !newTrack.conference;
+            && !localTracks.find(t => t === newTrack);
         let transceiver;
 
         // If old track exists, replace the track on the corresponding sender.

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1007,12 +1007,27 @@ export default class JingleSessionPC extends JingleSession {
                 // modify sendSessionAccept method to do that
                 this.sendSessionAccept(() => {
                     success();
-
                     this.room.eventEmitter.emit(XMPPEvents.SESSION_ACCEPT, this);
+
+                    // The first video track is added to the peerconnection and signaled as part of the session-accept.
+                    // Add secondary video tracks (that were already added to conference) to the peerconnection here.
+                    // This will happen when someone shares a secondary source to a two people call, the other user
+                    // leaves and joins the call again, a new peerconnection is created for p2p connection. At this
+                    // point, there are 2 video tracks which need to be signaled to the remote peer.
+                    const videoTracks = localTracks.filter(track => track.getType() === MediaType.VIDEO);
+
+                    videoTracks.length && videoTracks.splice(0, 1);
+                    if (FeatureFlags.isMultiStreamSupportEnabled() && videoTracks.length) {
+                        // Clear the conference field on the secondary local tracks if it was set previously, this is
+                        // needed for correctly identifying the RTCRtpSender for track replacement.
+                        videoTracks.forEach(track => {
+                            track.setConference(null);
+                        });
+                        this.addTracks(videoTracks);
+                    }
                 },
                 error => {
                     failure(error);
-
                     this.room.eventEmitter.emit(XMPPEvents.SESSION_ACCEPT_ERROR, this, error);
                 });
             },
@@ -1034,20 +1049,10 @@ export default class JingleSessionPC extends JingleSession {
         }
         const workFunction = finishedCallback => {
             const addTracks = [];
-            const audioTracks = localTracks.filter(track => track.getType() === MediaType.AUDIO);
-            const videoTracks = localTracks.filter(track => track.getType() === MediaType.VIDEO);
-            let tracks = localTracks;
 
-            // Add only 1 video track at a time. Adding 2 or more video tracks to the peerconnection at the same time
-            // makes the browser go into a renegotiation loop by firing 'negotiationneeded' event after every
-            // renegotiation.
-            if (FeatureFlags.isMultiStreamSupportEnabled() && videoTracks.length > 1) {
-                tracks = [ ...audioTracks, videoTracks[0] ];
-            }
-            for (const track of tracks) {
+            for (const track of localTracks) {
                 addTracks.push(this.peerconnection.addTrack(track, this.isInitiator));
             }
-            videoTracks.length && videoTracks.splice(0, 1);
 
             Promise.all(addTracks)
                 .then(() => this.peerconnection.createOffer(this.mediaConstraints))
@@ -1056,13 +1061,6 @@ export default class JingleSessionPC extends JingleSession {
                     // NOTE that the offer is obtained from the localDescription getter as it needs to go though
                     // the transformation chain.
                     this.sendSessionInitiate(this.peerconnection.localDescription.sdp);
-                })
-                .then(() => {
-                    if (videoTracks.length) {
-                        return this.addTracks(videoTracks);
-                    }
-
-                    return Promise.resolve();
                 })
                 .then(() => finishedCallback(), error => finishedCallback(error));
         };
@@ -1189,7 +1187,6 @@ export default class JingleSessionPC extends JingleSession {
             for (const track of tracks) {
                 addTracks.push(this.peerconnection.addTrack(track, this.isInitiator));
             }
-            videoTracks.length && videoTracks.splice(0, 1);
             const newRemoteSdp = this._processNewJingleOfferIq(jingleOfferAnswerIq);
             const oldLocalSdp = this.peerconnection.localDescription.sdp;
 
@@ -1205,13 +1202,6 @@ export default class JingleSessionPC extends JingleSession {
 
             Promise.all(addTracks)
                 .then(() => this._renegotiate(newRemoteSdp.raw))
-                .then(() => {
-                    if (videoTracks.length) {
-                        return this.addTracks(videoTracks);
-                    }
-
-                    return Promise.resolve();
-                })
                 .then(() => {
                     if (this.state === JingleSessionState.PENDING) {
                         this.state = JingleSessionState.ACTIVE;

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1012,17 +1012,12 @@ export default class JingleSessionPC extends JingleSession {
                     // The first video track is added to the peerconnection and signaled as part of the session-accept.
                     // Add secondary video tracks (that were already added to conference) to the peerconnection here.
                     // This will happen when someone shares a secondary source to a two people call, the other user
-                    // leaves and joins the call again, a new peerconnection is created for p2p connection. At this
+                    // leaves and joins the call again, a new peerconnection is created for p2p/jvb connection. At this
                     // point, there are 2 video tracks which need to be signaled to the remote peer.
                     const videoTracks = localTracks.filter(track => track.getType() === MediaType.VIDEO);
 
                     videoTracks.length && videoTracks.splice(0, 1);
                     if (FeatureFlags.isMultiStreamSupportEnabled() && videoTracks.length) {
-                        // Clear the conference field on the secondary local tracks if it was set previously, this is
-                        // needed for correctly identifying the RTCRtpSender for track replacement.
-                        videoTracks.forEach(track => {
-                            track.setConference(null);
-                        });
                         this.addTracks(videoTracks);
                     }
                 },

--- a/modules/xmpp/JingleSessionPC.spec.js
+++ b/modules/xmpp/JingleSessionPC.spec.js
@@ -40,7 +40,7 @@ function createContentModifyForSourceNames() {
     return $(modifyContentsIq).find('>jingle');
 }
 
-describe('JingleSessionPC w/o source-name signaling', () => {
+describe('JingleSessionPC', () => {
     let jingleSession;
     let connection;
     let rtc;


### PR DESCRIPTION
When a media session is re-created with multiple video sources in the conference as result of peer leaving and joining the call, send out the session-accept with first video source and then add the secondary source and signal it. Otherwise, ice candidates can reach the peer before the seesion-accept because of timing and not be processed (since a remote sdp won't be set) and result in a broken connection. This is needed only for the responder case. In the initiator case, all the tracks are added to the pc and then a session-initiate is sent to the peer. This doesn't seem to trigger the renegotiate loop.