### PR TITLE
Support multiple audio inputs in Firefox 101

### DIFF
--- a/JitsiMediaDevices.js
+++ b/JitsiMediaDevices.js
@@ -262,7 +262,10 @@ class JitsiMediaDevices {
      * @returns {boolean}
      */
     isMultipleAudioInputSupported() {
-        return !(browser.isFirefox() || (browser.isIosBrowser() && browser.isVersionLessThan('15.4')));
+        return !(
+            (browser.isFirefox() && browser.isVersionLessThan('101'))
+            || (browser.isIosBrowser() && browser.isVersionLessThan('15.4'))
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/jitsi/jitsi-meet/issues/2835.

Since https://bugzilla.mozilla.org/show_bug.cgi?id=1238038 has been merged and the latest Firefox Nightly has been build (see https://hg.mozilla.org/mozilla-central/rev/61d8c578d367ea82c64fa5f55c8a4af54fe84c21, build ID `20220419093010`), Firefox now supports the selection of multiple audio inputs.
Therefore, `isMultipleAudioInputSupported` should return true for Firefox versions 101 and later.

I tested this in Firefox Nightly 101.0a1 (2022-04-19) on macOS 12.3.1 and confirmed that the microphone selection (as described in the linked issue) is working properly.