### PR TITLE
feat: add AV1 mime type

### DIFF
--- a/service/RTC/CodecMimeType.js
+++ b/service/RTC/CodecMimeType.js
@@ -4,6 +4,11 @@
  */
 const CodecMimeType = {
     /**
+     * AV1 codec mime type.
+     */
+    AV1: 'av1',
+
+    /**
      * The h264 codec mime type.
      */
     H264: 'h264',


### PR DESCRIPTION
With that, it's possible to set AV1 as preferred codec for p2p and try it on Chrome.