### PR TITLE
fix(browser-support) Enable device selection in mobile Safari.

### DIFF
--- a/JitsiMediaDevices.js
+++ b/JitsiMediaDevices.js
@@ -262,7 +262,7 @@ class JitsiMediaDevices {
      * @returns {boolean}
      */
     isMultipleAudioInputSupported() {
-        return !(browser.isFirefox() || browser.isIosBrowser());
+        return !(browser.isFirefox() || (browser.isIosBrowser() && browser.isVersionLessThan('15.4')));
     }
 
     /**

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -762,8 +762,10 @@ class RTCUtils extends Listenable {
 
         // Calling getUserMedia again (for preview) kills the track returned by the first getUserMedia call because of
         // https://bugs.webkit.org/show_bug.cgi?id=179363. Therefore, do not show microphone/camera options on mobile
-        // Safari.
-        if ((deviceType === 'audioinput' || deviceType === 'input') && browser.isIosBrowser()) {
+        // Safari. Bug fixed in Safari 15.4.
+        if ((deviceType === 'audioinput' || deviceType === 'input')
+            && browser.isIosBrowser()
+            && browser.isVersionLessThan('15.4')) {
             return false;
         }
 


### PR DESCRIPTION
With https://bugs.webkit.org/show_bug.cgi?id=179363 being fixed, we should now be able to switch between devices in call.