### PR TITLE
Fallback to plan-b on Electron clients that have chromium ver < 96

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -332,7 +332,9 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     supportsUnifiedPlan() {
-        return !this.isReactNative();
+        // We do not want to enable unified plan on Electron clients that have Chromium version < 96 because of
+        // performance and screensharing issues.
+        return !(this.isReactNative() || (this.isElectron() && (this._getChromiumBasedVersion() < 96)));
     }
 
     /**

--- a/service/RTC/CodecMimeType.spec.ts
+++ b/service/RTC/CodecMimeType.spec.ts
@@ -1,9 +1,11 @@
+import exp from "constants";
 import * as exported from "./CodecMimeType";
 
 // this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
 
 describe( "/service/RTC/CodecMimeType members", () => {
     const {
+        AV1,
         H264,
         OPUS,
         ULPFEC,
@@ -14,12 +16,14 @@ describe( "/service/RTC/CodecMimeType members", () => {
     } = exported as any; // TODO: remove cast after typescript conversion
 
     it( "known members", () => {
+        expect( AV1 ).toBe( 'av1' );
         expect( H264 ).toBe( 'h264' );
         expect( OPUS ).toBe( 'opus' );
         expect( ULPFEC ).toBe( 'ulpfec' );
         expect( VP8 ).toBe( 'vp8' );
         expect( VP9 ).toBe( 'vp9' );
         if ( CodecMimeType ) {
+            expect( CodecMimeType.AV1 ).toBe( 'av1' );
             expect( CodecMimeType.H264 ).toBe( 'h264' );
             expect( CodecMimeType.OPUS ).toBe( 'opus' );
             expect( CodecMimeType.ULPFEC ).toBe( 'ulpfec' );


### PR DESCRIPTION
fix(RTC) Add AV1 to CodecMimeType unit test