### PR TITLE
fix(multi-stream) Set the source name of replaced track before configuring it.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1282,10 +1282,6 @@ JitsiConference.prototype.replaceTrack = function(oldTrack, newTrack) {
         logger.warn(`JitsiConference.replaceTrack oldTrack (${oldTrack} does not belong to this conference`);
     }
 
-    if (FeatureFlags.isMultiStreamSupportEnabled() && oldTrack && newTrack && oldTrack.isVideoTrack()) {
-        newTrack.setSourceName(oldTrack.getSourceName());
-    }
-
     // Now replace the stream at the lower levels
     return this._doReplaceTrack(oldTrackBelongsToConference ? oldTrack : null, newTrack)
         .then(() => {

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -2259,6 +2259,14 @@ export default class JingleSessionPC extends JingleSession {
                     }
 
                     return promise.then(() => {
+                        // Set the source name of the new track.
+                        if (FeatureFlags.isSourceNameSignalingEnabled()
+                            && oldTrack
+                            && newTrack
+                            && oldTrack.isVideoTrack()) {
+                            newTrack.setSourceName(oldTrack.getSourceName());
+                        }
+
                         if (newTrack?.isVideoTrack()) {
                             logger.debug(`${this} replaceTrack worker: configuring video stream`);
 


### PR DESCRIPTION
With just source-name enabled, set the source name of the replaced track before configuring the encodings, this fixes an issues where the sender constraints are not applied on the p2p connection because the source name is undefined.