### PR TITLE
fix(BridgeChannel): close before opening a new one

### DIFF
--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -160,6 +160,9 @@ export default class BridgeChannel {
             try {
                 this._channel.close();
             } catch (error) {} // eslint-disable-line no-empty
+            if (this._wsUrl) {
+                logger.debug(`close() with wsUrl:"${this._wsUrl}"`);
+            }
 
             this._channel = null;
         }

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -233,6 +233,7 @@ export default class RTC extends Listenable {
      * @param {string} [wsUrl] WebSocket URL.
      */
     initializeBridgeChannel(peerconnection, wsUrl) {
+        this._closeBridgeChannel();
         this._channel = new BridgeChannel(peerconnection, wsUrl, this.eventEmitter);
 
         this._channelOpenListener = () => {
@@ -356,6 +357,14 @@ export default class RTC extends Listenable {
      * PeerConnection has been closed using PeerConnection.close() method.
      */
     onCallEnded() {
+        this._closeBridgeChannel();
+    }
+
+    /**
+     * Close the current Bridge Channel.
+     * @private
+     */
+    _closeBridgeChannel() {
         if (this._channel) {
             // The BridgeChannel is not explicitly closed as the PeerConnection
             // is closed on call ended which triggers datachannel onclose

--- a/types/auto/modules/RTC/RTC.d.ts
+++ b/types/auto/modules/RTC/RTC.d.ts
@@ -269,6 +269,11 @@ export default class RTC extends Listenable {
      */
     onCallEnded(): void;
     /**
+     * Close the current Bridge Channel.
+     * @private
+     */
+    private _closeBridgeChannel;
+    /**
      * Sets the capture frame rate to be used for desktop tracks.
      *
      * @param {number} maxFps framerate to be used for desktop track capture.


### PR DESCRIPTION
This happens in the ICE restart scenario when new JingleSession is created.