### PR TITLE
chore(enableLayerSuspension) remove all enableLayerSuspension references

### DIFF
--- a/modules/qualitycontrol/SendVideoController.spec.js
+++ b/modules/qualitycontrol/SendVideoController.spec.js
@@ -52,9 +52,7 @@ class MockConference extends Listenable {
      */
     constructor() {
         super();
-        this.options = {
-            config: { enableLayerSuspension: true }
-        };
+        this.options = {};
         this.activeMediaSession = undefined;
         this.mediaSessions = [];
     }

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -68,7 +68,6 @@ function getEndpointId(jidOrEndpointId) {
  * @property {boolean} disableSimulcast - Described in the config.js[1].
  * @property {boolean} enableInsertableStreams - Set to true when the insertable streams constraints is to be enabled
  * on the PeerConnection.
- * @property {boolean} enableLayerSuspension - Described in the config.js[1].
  * @property {boolean} failICE - it's an option used in the tests. Set to
  * <tt>true</tt> to block any real candidates and make the ICE fail.
  * @property {boolean} gatherStats - Described in the config.js[1].

--- a/types/auto/modules/xmpp/JingleSessionPC.d.ts
+++ b/types/auto/modules/xmpp/JingleSessionPC.d.ts
@@ -8,7 +8,6 @@
  * @property {boolean} disableSimulcast - Described in the config.js[1].
  * @property {boolean} enableInsertableStreams - Set to true when the insertable streams constraints is to be enabled
  * on the PeerConnection.
- * @property {boolean} enableLayerSuspension - Described in the config.js[1].
  * @property {boolean} failICE - it's an option used in the tests. Set to
  * <tt>true</tt> to block any real candidates and make the ICE fail.
  * @property {boolean} gatherStats - Described in the config.js[1].
@@ -654,10 +653,6 @@ export type JingleSessionPCOptions = {
      * on the PeerConnection.
      */
     enableInsertableStreams: boolean;
-    /**
-     * - Described in the config.js[1].
-     */
-    enableLayerSuspension: boolean;
     /**
      * - it's an option used in the tests. Set to
      * <tt>true</tt> to block any real candidates and make the ICE fail.


### PR DESCRIPTION
Hi,

this PR removes all references to `enableLayerSuspension`.
The use of this flag was removed in https://github.com/jitsi/lib-jitsi-meet/commit/b749b0e4e7ea1a826066768f9d5a367f8c8fdb21