### PR TITLE
fix(multi-stream): Fix local SSRC cache to include multiple video streams.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1103,6 +1103,12 @@ JitsiConference.prototype.addTrack = function(track) {
         }
 
         if (FeatureFlags.isMultiStreamSupportEnabled() && mediaType === MediaType.VIDEO) {
+            const sourceName = getSourceNameForJitsiTrack(
+                this.myUserId(),
+                mediaType,
+                this.getLocalTracks(mediaType)?.length);
+
+            track.setSourceName(sourceName);
             const addTrackPromises = [];
 
             this.p2pJingleSession && addTrackPromises.push(this.p2pJingleSession.addTracks([ track ]));
@@ -1263,11 +1269,21 @@ JitsiConference.prototype.removeTrack = function(track) {
  */
 JitsiConference.prototype.replaceTrack = function(oldTrack, newTrack) {
     const oldVideoType = oldTrack?.getVideoType();
+    const mediaType = oldTrack?.getType() || newTrack?.getType();
     const newVideoType = newTrack?.getVideoType();
 
     if (FeatureFlags.isMultiStreamSupportEnabled() && oldTrack && newTrack && oldVideoType !== newVideoType) {
         throw new Error(`Replacing a track of videoType=${oldVideoType} with a track of videoType=${newVideoType} is`
             + ' not supported in this mode.');
+    }
+
+    if (FeatureFlags.isSourceNameSignalingEnabled() && newTrack) {
+        const sourceName = getSourceNameForJitsiTrack(
+            this.myUserId(),
+            mediaType,
+            this.getLocalTracks(mediaType)?.length);
+
+        newTrack.setSourceName(sourceName);
     }
     const oldTrackBelongsToConference = this === oldTrack?.conference;
 

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -653,7 +653,7 @@ StatsCollector.prototype.processStatsReport = function() {
                 return;
             }
 
-            const ssrc = this.peerconnection.getLocalSSRC(localVideoTracks[0]);
+            const ssrc = this.peerconnection.getSsrcByTrackId(now.trackIdentifier);
 
             if (!ssrc) {
                 return;


### PR DESCRIPTION
If multiple local video streams are found in the SDP, cache all of them instead of the first video SSRC. This fixes an issue where the resolution/fps stats for the local screenshare track are not available.