### PR TITLE
fix(JitsiConference) log a warning instead of an error is p2p fails

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2393,8 +2393,8 @@ JitsiConference.prototype._setBridgeChannel = function(offerIq, pc) {
  * @private
  */
 JitsiConference.prototype._rejectIncomingCall = function(jingleSession, options) {
-    if (options && options.errorMsg) {
-        GlobalOnErrorHandler.callErrorHandler(new Error(options.errorMsg));
+    if (options?.errorMsg) {
+        logger.warn(options.errorMsg);
     }
 
     // Terminate the jingle session with a reason


### PR DESCRIPTION
In most cases it's not a real issue and it's still part of the logs,
throwing an unhandled exception at the global handler just prints an
ugly trackeback in the JS console which looks much worse than it really
is.