### PR TITLE
ref(e2ee) mark _decryptFrame function with correct jsdoc

### DIFF
--- a/modules/e2ee/Context.js
+++ b/modules/e2ee/Context.js
@@ -204,7 +204,7 @@ export class Context {
      * @param {RTCEncodedVideoFrame|RTCEncodedAudioFrame} encodedFrame - Encoded video frame.
      * @param {number} keyIndex - the index of the decryption data in _cryptoKeyRing array.
      * @param {number} ratchetCount - the number of retries after ratcheting the key.
-     * @returns {RTCEncodedVideoFrame|RTCEncodedAudioFrame} - The decrypted frame.
+     * @returns {Promise<RTCEncodedVideoFrame|RTCEncodedAudioFrame>} - The decrypted frame.
      * @private
      */
     async _decryptFrame(

--- a/types/auto/modules/e2ee/Context.d.ts
+++ b/types/auto/modules/e2ee/Context.d.ts
@@ -64,7 +64,7 @@ export class Context {
      * @param {RTCEncodedVideoFrame|RTCEncodedAudioFrame} encodedFrame - Encoded video frame.
      * @param {number} keyIndex - the index of the decryption data in _cryptoKeyRing array.
      * @param {number} ratchetCount - the number of retries after ratcheting the key.
-     * @returns {RTCEncodedVideoFrame|RTCEncodedAudioFrame} - The decrypted frame.
+     * @returns {Promise<RTCEncodedVideoFrame|RTCEncodedAudioFrame>} - The decrypted frame.
      * @private
      */
     private _decryptFrame;


### PR DESCRIPTION
the editor will no longer complain about superfluous await when calling

related to #2026