### PR TITLE
fix(SDP): don't separate fmtp parameter with spaces

### DIFF
--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -707,7 +707,7 @@ SDP.prototype.jingle2media = function(content) {
                                 + parameter.getAttribute('value'));
                     })
                     .get()
-                    .join('; ');
+                    .join(';');
             sdp += '\r\n';
         }
 


### PR DESCRIPTION
Fmtp parameters in SDP are only separated by semicolons, not by spaces. This PR omits the space when generating the SDP.