### PR TITLE
Screensharing fixes.

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -222,7 +222,10 @@ const ScreenObtainer = {
         if (typeof desktopSharingFrameRate === 'object') {
             video.frameRate = desktopSharingFrameRate;
         }
-        if (setScreenSharingResolutionConstraints) {
+
+        // Capturing the screenshare at very high resolutions restricts the framerate. Therefore, skip this hack when
+        // the capture framerate is > 5 fps.
+        if (setScreenSharingResolutionConstraints && desktopSharingFrameRate <= SS_DEFAULT_FRAME_RATE) {
             // Set bogus resolution constraints to work around
             // https://bugs.chromium.org/p/chromium/issues/detail?id=1056311
             video.height = 99999;

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -297,8 +297,8 @@ export class TPCUtils {
             // b/w and cpu cases, especially on the low end machines. Suspending the low resolution streams ensures
             // that the highest resolution stream is available always. Safari is an exception here since it does not
             // send the desktop stream at all if only the high resolution stream is enabled.
-            if (this.pc.isSharingLowFpsScreen()
-                && localVideoTrack.getVideoType() === VideoType.DESKTOP
+            if (localVideoTrack.getVideoType() === VideoType.DESKTOP
+                && this.pc._capScreenshareBitrate
                 && this.pc.usesUnifiedPlan()
                 && !browser.isWebKitBased()
                 && this.localStreamEncodingsConfig[idx].scaleResolutionDownBy !== HD_SCALE_FACTOR) {
@@ -323,10 +323,12 @@ export class TPCUtils {
         const desktopShareBitrate = this.pc.options?.videoQuality?.desktopBitrate || DESKTOP_SHARE_RATE;
         const presenterEnabled = localVideoTrack._originalStream
             && localVideoTrack._originalStream.id !== localVideoTrack.getStreamId();
-
+        const lowFpsScreenshare = localVideoTrack.getVideoType() === VideoType.DESKTOP
+            && this.pc._capScreenshareBitrate
+            && !browser.isWebKitBased();
         const encodingsBitrates = this.localStreamEncodingsConfig
         .map(encoding => {
-            const bitrate = this.pc.isSharingLowFpsScreen() && !browser.isWebKitBased()
+            const bitrate = lowFpsScreenshare
 
                 // For low fps screensharing, set a max bitrate of 500 Kbps when presenter is not turned on, 2500 Kbps
                 // otherwise.

--- a/types/auto/modules/RTC/TraceablePeerConnection.d.ts
+++ b/types/auto/modules/RTC/TraceablePeerConnection.d.ts
@@ -647,6 +647,13 @@ export default class TraceablePeerConnection {
      */
     _initializeDtlsTransport(): void;
     /**
+     * Sets the max bitrates on the video m-lines when VP9 is the selected codec.
+     *
+     * @param {RTCSessionDescription} description - The local description that needs to be munged.
+     * @returns RTCSessionDescription
+     */
+    _setVp9MaxBitrates(description: RTCSessionDescription): RTCSessionDescription;
+    /**
      * Configures the stream encodings depending on the video type and the bitrates configured.
      *
      * @param {JitsiLocalTrack} - The local track for which the sender encodings have to configured.


### PR DESCRIPTION
fix(ScreenObtainer) Apply resolution constraints only for low fps SS.
The hack for making Chrome capture the highest resolution possible for desktop track breaks high fps screen capture.

fix(multi-stream) Fix VP9 bitrates in the multi-stream mode.
Set the bitrates on the video m-lines based on the associated track type. In multi-stream mode, there will be two separate m-lines for camera and desktop tracks. Also fallback to SDP munging for setting codec preferences on Chromium.