### PR TITLE
fix(RTC) Use mute/unmute track operation for effects.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1487,54 +1487,51 @@ JitsiConference.prototype._setTrackMuteStatus = function(mediaType, localTrack, 
 };
 
 /**
- * Method called by the {@link JitsiLocalTrack} (a video one) in order to add
- * back the underlying WebRTC MediaStream to the PeerConnection (which has
- * removed on video mute).
- * @param {JitsiLocalTrack} track the local track that will be added as part of
- * the unmute operation.
- * @return {Promise} resolved when the process is done or rejected with a string
- * which describes the error.
+ * Method called by the {@link JitsiLocalTrack} in order to add the underlying MediaStream to the RTCPeerConnection.
+ *
+ * @param {JitsiLocalTrack} track the local track that will be added to the pc.
+ * @return {Promise} resolved when the process is done or rejected with a string which describes the error.
  */
-JitsiConference.prototype._addLocalTrackAsUnmute = function(track) {
-    const addAsUnmutePromises = [];
+JitsiConference.prototype._addLocalTrackToPc = function(track) {
+    const addPromises = [];
 
     if (this.jvbJingleSession) {
-        addAsUnmutePromises.push(this.jvbJingleSession.addTrackAsUnmute(track));
+        addPromises.push(this.jvbJingleSession.addTrackToPc(track));
     } else {
-        logger.debug('Add local MediaStream as unmute - no JVB Jingle session started yet');
+        logger.debug('Add local MediaStream - no JVB Jingle session started yet');
     }
 
     if (this.p2pJingleSession) {
-        addAsUnmutePromises.push(this.p2pJingleSession.addTrackAsUnmute(track));
+        addPromises.push(this.p2pJingleSession.addTrackToPc(track));
     } else {
-        logger.debug('Add local MediaStream as unmute - no P2P Jingle session started yet');
+        logger.debug('Add local MediaStream - no P2P Jingle session started yet');
     }
 
-    return Promise.allSettled(addAsUnmutePromises);
+    return Promise.allSettled(addPromises);
 };
 
 /**
- * Method called by the {@link JitsiLocalTrack} (a video one) in order to remove
- * the underlying WebRTC MediaStream from the PeerConnection. The purpose of
- * that is to stop sending any data and turn off the HW camera device.
+ * Method called by the {@link JitsiLocalTrack} in order to remove the underlying MediaStream from the
+ * RTCPeerConnection.
+ *
  * @param {JitsiLocalTrack} track the local track that will be removed.
- * @return {Promise}
+ * @return {Promise} resolved when the process is done or rejected with a string which describes the error.
  */
-JitsiConference.prototype._removeLocalTrackAsMute = function(track) {
-    const removeAsMutePromises = [];
+JitsiConference.prototype._removeLocalTrackFromPc = function(track) {
+    const removePromises = [];
 
     if (this.jvbJingleSession) {
-        removeAsMutePromises.push(this.jvbJingleSession.removeTrackAsMute(track));
+        removePromises.push(this.jvbJingleSession.removeTrackFromPc(track));
     } else {
         logger.debug('Remove local MediaStream - no JVB JingleSession started yet');
     }
     if (this.p2pJingleSession) {
-        removeAsMutePromises.push(this.p2pJingleSession.removeTrackAsMute(track));
+        removePromises.push(this.p2pJingleSession.removeTrackFromPc(track));
     } else {
         logger.debug('Remove local MediaStream - no P2P JingleSession started yet');
     }
 
-    return Promise.allSettled(removeAsMutePromises);
+    return Promise.allSettled(removePromises);
 };
 
 /**

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1312,13 +1312,7 @@ JitsiConference.prototype.replaceTrack = function(oldTrack, newTrack) {
             if ((oldTrackBelongsToConference && oldTrack?.isVideoTrack()) || newTrack?.isVideoTrack()) {
                 this._sendBridgeVideoTypeMessage(newTrack);
             }
-
-            // We do not want to send presence update during setEffect switching, which removes and then adds the same
-            // track back to the conference.
-            if (!(oldTrack?._setEffectInProgress || newTrack?._setEffectInProgress)) {
-                this._updateRoomPresence(this.getActiveMediaSession());
-            }
-
+            this._updateRoomPresence(this.getActiveMediaSession());
             if (newTrack !== null && (this.isMutedByFocus || this.isVideoMutedByFocus)) {
                 this._fireMuteChangeEvent(newTrack);
             }

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -227,7 +227,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
         // TPC and JingleSessionPC which would contain the queue and would notify the signaling layer when local SSRCs
         // are changed. This would help to separate XMPP from the RTC module.
         return new Promise((resolve, reject) => {
-            this.conference._addLocalTrackAsUnmute(this)
+            this.conference._addLocalTrackToPc(this)
                 .then(resolve, error => reject(new Error(error)));
         });
     }
@@ -329,7 +329,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
 
             return;
         }
-        this.conference._removeLocalTrackAsMute(this).then(
+        this.conference._removeLocalTrackFromPc(this).then(
             successCallback,
             error => errorCallback(new Error(error)));
     }
@@ -863,14 +863,14 @@ export default class JitsiLocalTrack extends JitsiTrack {
 
         this._setEffectInProgress = true;
 
-        return conference._removeLocalTrackAsMute(this)
+        return conference._removeLocalTrackFromPc(this)
             .then(() => {
                 this._switchStreamEffect(effect);
                 if (this.isVideoTrack()) {
                     this.containers.forEach(cont => RTCUtils.attachMediaStream(cont, this.stream));
                 }
 
-                return conference._addLocalTrackAsUnmute(this);
+                return conference._addLocalTrackToPc(this);
             })
             .then(() => {
                 this._setEffectInProgress = false;

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -863,15 +863,14 @@ export default class JitsiLocalTrack extends JitsiTrack {
 
         this._setEffectInProgress = true;
 
-        // TODO: Create new JingleSessionPC method for replacing a stream in JitsiLocalTrack without offer answer.
-        return conference.removeTrack(this)
+        return conference._removeLocalTrackAsMute(this)
             .then(() => {
                 this._switchStreamEffect(effect);
                 if (this.isVideoTrack()) {
                     this.containers.forEach(cont => RTCUtils.attachMediaStream(cont, this.stream));
                 }
 
-                return conference.addTrack(this);
+                return conference._addLocalTrackAsUnmute(this);
             })
             .then(() => {
                 this._setEffectInProgress = false;

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1748,17 +1748,16 @@ TraceablePeerConnection.prototype.addTrack = function(track, isInitiator = false
 };
 
 /**
- * Adds local track as part of the unmute operation.
- * @param {JitsiLocalTrack} track the track to be added as part of the unmute operation.
+ * Adds local track to the RTCPeerConnection.
  *
- * @return {Promise<boolean>} Promise that resolves to true if the underlying PeerConnection's
- * state has changed and renegotiation is required, false if no renegotiation is needed or
- * Promise is rejected when something goes wrong.
+ * @param {JitsiLocalTrack} track the track to be added to the pc.
+ * @return {Promise<boolean>} Promise that resolves to true if the underlying PeerConnection's state has changed and
+ * renegotiation is required, false if no renegotiation is needed or Promise is rejected when something goes wrong.
  */
-TraceablePeerConnection.prototype.addTrackUnmute = function(track) {
-    logger.info(`${this} Adding track=${track} as unmute`);
+TraceablePeerConnection.prototype.addTrackToPc = function(track) {
+    logger.info(`${this} Adding track=${track} to PC`);
 
-    if (!this._assertTrackBelongs('addTrackUnmute', track)) {
+    if (!this._assertTrackBelongs('addTrackToPc', track)) {
         // Abort
 
         return Promise.reject('Track not found on the peerconnection');
@@ -1767,7 +1766,7 @@ TraceablePeerConnection.prototype.addTrackUnmute = function(track) {
     const webRtcStream = track.getOriginalStream();
 
     if (!webRtcStream) {
-        logger.error(`${this} Unable to add track=${track} as unmute - no WebRTC stream`);
+        logger.error(`${this} Unable to add track=${track} to PC - no WebRTC stream`);
 
         return Promise.reject('Stream not found');
     }
@@ -1912,7 +1911,7 @@ TraceablePeerConnection.prototype.isMediaStreamInPc = function(mediaStream) {
  * Remove local track from this TPC.
  * @param {JitsiLocalTrack} localTrack the track to be removed from this TPC.
  *
- * FIXME It should probably remove a boolean just like {@link removeTrackMute}
+ * FIXME It should probably remove a boolean just like {@link removeTrackFromPc}
  *       The same applies to addTrack.
  */
 TraceablePeerConnection.prototype.removeTrack = function(localTrack) {
@@ -2089,19 +2088,18 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
 };
 
 /**
- * Removes local track as part of the mute operation.
- * @param {JitsiLocalTrack} localTrack the local track to be remove as part of
- * the mute operation.
- * @return {Promise<boolean>} Promise that resolves to true if the underlying PeerConnection's
- * state has changed and renegotiation is required, false if no renegotiation is needed or
- * Promise is rejected when something goes wrong.
+ * Removes local track from the RTCPeerConnection.
+ *
+ * @param {JitsiLocalTrack} localTrack the local track to be removed.
+ * @return {Promise<boolean>} Promise that resolves to true if the underlying PeerConnection's state has changed and
+ * renegotiation is required, false if no renegotiation is needed or Promise is rejected when something goes wrong.
  */
-TraceablePeerConnection.prototype.removeTrackMute = function(localTrack) {
+TraceablePeerConnection.prototype.removeTrackFromPc = function(localTrack) {
     const webRtcStream = localTrack.getOriginalStream();
 
-    this.trace('removeTrackMute', localTrack.rtcId, webRtcStream ? webRtcStream.id : null);
+    this.trace('removeTrack', localTrack.rtcId, webRtcStream ? webRtcStream.id : null);
 
-    if (!this._assertTrackBelongs('removeTrackMute', localTrack)) {
+    if (!this._assertTrackBelongs('removeTrack', localTrack)) {
         // Abort - nothing to be done here
         return Promise.reject('Track not found in the peerconnection');
     }
@@ -2111,13 +2109,13 @@ TraceablePeerConnection.prototype.removeTrackMute = function(localTrack) {
     }
 
     if (webRtcStream) {
-        logger.info(`${this} Removing track=${localTrack} as mute`);
+        logger.info(`${this} Removing track=${localTrack} from PC`);
         this._removeStream(webRtcStream);
 
         return Promise.resolve(true);
     }
 
-    logger.error(`${this} removeTrackMute - no WebRTC stream for track=${localTrack}`);
+    logger.error(`${this} removeTrack - no WebRTC stream for track=${localTrack}`);
 
     return Promise.reject('Stream not found');
 };

--- a/types/auto/JitsiConference.d.ts
+++ b/types/auto/JitsiConference.d.ts
@@ -472,23 +472,20 @@ declare class JitsiConference {
     private _setNewVideoType;
     private _setTrackMuteStatus;
     /**
-     * Method called by the {@link JitsiLocalTrack} (a video one) in order to add
-     * back the underlying WebRTC MediaStream to the PeerConnection (which has
-     * removed on video mute).
-     * @param {JitsiLocalTrack} track the local track that will be added as part of
-     * the unmute operation.
-     * @return {Promise} resolved when the process is done or rejected with a string
-     * which describes the error.
+     * Method called by the {@link JitsiLocalTrack} in order to add the underlying MediaStream to the RTCPeerConnection.
+     *
+     * @param {JitsiLocalTrack} track the local track that will be added to the pc.
+     * @return {Promise} resolved when the process is done or rejected with a string which describes the error.
      */
-    _addLocalTrackAsUnmute(track: any): Promise<any>;
+    _addLocalTrackToPc(track: any): Promise<any>;
     /**
-     * Method called by the {@link JitsiLocalTrack} (a video one) in order to remove
-     * the underlying WebRTC MediaStream from the PeerConnection. The purpose of
-     * that is to stop sending any data and turn off the HW camera device.
+     * Method called by the {@link JitsiLocalTrack} in order to remove the underlying MediaStream from the
+     * RTCPeerConnection.
+     *
      * @param {JitsiLocalTrack} track the local track that will be removed.
-     * @return {Promise}
+     * @return {Promise} resolved when the process is done or rejected with a string which describes the error.
      */
-    _removeLocalTrackAsMute(track: any): Promise<any>;
+    _removeLocalTrackFromPc(track: any): Promise<any>;
     /**
      * Get role of the local user.
      * @returns {string} user role: 'moderator' or 'none'

--- a/types/auto/modules/RTC/TraceablePeerConnection.d.ts
+++ b/types/auto/modules/RTC/TraceablePeerConnection.d.ts
@@ -504,14 +504,13 @@ export default class TraceablePeerConnection {
      */
     addTrack(track: any, isInitiator?: boolean): Promise<void>;
     /**
-     * Adds local track as part of the unmute operation.
-     * @param {JitsiLocalTrack} track the track to be added as part of the unmute operation.
+     * Adds local track to the RTCPeerConnection.
      *
-     * @return {Promise<boolean>} Promise that resolves to true if the underlying PeerConnection's
-     * state has changed and renegotiation is required, false if no renegotiation is needed or
-     * Promise is rejected when something goes wrong.
+     * @param {JitsiLocalTrack} track the track to be added to the pc.
+     * @return {Promise<boolean>} Promise that resolves to true if the underlying PeerConnection's state has changed and
+     * renegotiation is required, false if no renegotiation is needed or Promise is rejected when something goes wrong.
      */
-    addTrackUnmute(track: any): Promise<boolean>;
+    addTrackToPc(track: any): Promise<boolean>;
     private _addStream;
     /**
      * Removes WebRTC media stream from the underlying PeerConection
@@ -582,7 +581,7 @@ export default class TraceablePeerConnection {
      * Remove local track from this TPC.
      * @param {JitsiLocalTrack} localTrack the track to be removed from this TPC.
      *
-     * FIXME It should probably remove a boolean just like {@link removeTrackMute}
+     * FIXME It should probably remove a boolean just like {@link removeTrackFromPc}
      *       The same applies to addTrack.
      */
     removeTrack(localTrack: any): void;
@@ -623,14 +622,13 @@ export default class TraceablePeerConnection {
      */
     replaceTrack(oldTrack: any | null, newTrack: any | null): Promise<boolean>;
     /**
-     * Removes local track as part of the mute operation.
-     * @param {JitsiLocalTrack} localTrack the local track to be remove as part of
-     * the mute operation.
-     * @return {Promise<boolean>} Promise that resolves to true if the underlying PeerConnection's
-     * state has changed and renegotiation is required, false if no renegotiation is needed or
-     * Promise is rejected when something goes wrong.
+     * Removes local track from the RTCPeerConnection.
+     *
+     * @param {JitsiLocalTrack} localTrack the local track to be removed.
+     * @return {Promise<boolean>} Promise that resolves to true if the underlying PeerConnection's state has changed and
+     * renegotiation is required, false if no renegotiation is needed or Promise is rejected when something goes wrong.
      */
-    removeTrackMute(localTrack: any): Promise<boolean>;
+    removeTrackFromPc(localTrack: any): Promise<boolean>;
     createDataChannel(label: any, opts: any): RTCDataChannel;
     private _ensureSimulcastGroupIsLast;
     private _adjustLocalMediaDirection;

--- a/types/auto/modules/xmpp/JingleSessionPC.d.ts
+++ b/types/auto/modules/xmpp/JingleSessionPC.d.ts
@@ -530,14 +530,13 @@ export default class JingleSessionPC extends JingleSession {
      */
     private _verifyNoSSRCChanged;
     /**
-     * Adds local track back to this session, as part of the unmute operation.
+     * Adds local track back to the peerconnection associated with this session.
      * @param {JitsiLocalTrack} track
-     * @return {Promise} a promise that will resolve once the local track is
-     * added back to this session and renegotiation succeeds. Will be rejected
-     * with a <tt>string</tt> that provides some error details in case something
-     * goes wrong.
+     * @return {Promise} a promise that will resolve once the local track is added back to this session and
+     * renegotiation succeeds (if its warranted). Will be rejected with a <tt>string</tt> that provides some error
+     * details in case something goes wrong.
      */
-    addTrackAsUnmute(track: any): Promise<any>;
+    addTrackToPc(track: any): Promise<any>;
     /**
      * Remove local track as part of the mute operation.
      * @param {JitsiLocalTrack} track the local track to be removed
@@ -546,15 +545,14 @@ export default class JingleSessionPC extends JingleSession {
      * The promise will be rejected with a <tt>string</tt> that the describes
      * the error if anything goes wrong.
      */
-    removeTrackAsMute(track: any): Promise<any>;
+    removeTrackFromPc(track: any): Promise<any>;
     /**
-     * See {@link addTrackAsUnmute} and {@link removeTrackAsMute}.
-     * @param {boolean} isMute <tt>true</tt> for "remove as mute" or
-     * <tt>false</tt> for "add as unmute".
+     * See {@link addTrackToPc} and {@link removeTrackFromPc}.
+     * @param {boolean} isRemove <tt>true</tt> for "remove" operation or <tt>false</tt> for "add" operation.
      * @param {JitsiLocalTrack} track the track that will be added/removed
      * @private
      */
-    private _addRemoveTrackAsMuteUnmute;
+    private _addRemoveTrack;
     /**
      * Resumes or suspends media transfer over the underlying peer connection.
      * @param {boolean} audioActive <tt>true</tt> to enable audio media


### PR DESCRIPTION
Since the track is only temporarily removed and added back, it can be treated like mute & unmute operation. Fixes https://github.com/jitsi/lib-jitsi-meet/issues/2048. Remove a TODO thats no longer needed, track replace operation don't force renegotiations anymore.