### PR TITLE
fix(moderation): media not working

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -692,6 +692,14 @@ JitsiConferenceEventManager.prototype.setupXMPPListeners = function() {
             conference.startAudioMuted = audioMuted;
             conference.startVideoMuted = videoMuted;
 
+            if (audioMuted) {
+                conference.isMutedByFocus = true;
+            }
+
+            if (videoMuted) {
+                conference.isVideoMutedByFocus = true;
+            }
+
             // mute existing local tracks because this is initial mute from
             // Jicofo
             conference.getLocalTracks().forEach(track => {


### PR DESCRIPTION
When the participant has joined after A/V moderation has been enabled
they are auto muted with the startmuted node in the session-initiate
packet. We were not marking those as muted by the focus and therefore on
unmute we were not sending the <muted>false</muted> IQ to jicofo.
The result was that the bridge wasn't forwarding the media to the
remote participants.