### PR TITLE
fix(TPC) Set maxbitrates via b=AS line on the remote SDP as well.

### DIFF
--- a/types/auto/modules/RTC/TraceablePeerConnection.d.ts
+++ b/types/auto/modules/RTC/TraceablePeerConnection.d.ts
@@ -656,9 +656,10 @@ export default class TraceablePeerConnection {
      * Sets the max bitrates on the video m-lines when VP9 is the selected codec.
      *
      * @param {RTCSessionDescription} description - The local description that needs to be munged.
+     * @param {boolean} isLocalSdp - Whether the max bitrate (via b=AS line in SDP) is set on local SDP.
      * @returns RTCSessionDescription
      */
-    _setVp9MaxBitrates(description: RTCSessionDescription): RTCSessionDescription;
+    _setVp9MaxBitrates(description: RTCSessionDescription, isLocalSdp?: boolean): RTCSessionDescription;
     /**
      * Configures the stream encodings depending on the video type and the bitrates configured.
      *


### PR DESCRIPTION
This fixes an issue where the bitrates for screenshare were much higher than before for VP9 causing the JVB to suspend SS streams more often.