### PR TITLE
fix(package.json) Replace 'module' field with 'export' in package.json

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -826,8 +826,7 @@ export default class RTC extends Listenable {
      * @returns {boolean}
      */
     static isUserStreamById(streamId) {
-        return streamId && streamId !== 'mixedmslabel'
-            && streamId !== 'default';
+        return RTCUtils.isUserStreamById(streamId);
     }
 
     /**

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -718,7 +718,7 @@ class RTCUtils extends Listenable {
     /**
      * Returns true if changing the input (camera / microphone) or output
      * (audio) device is supported and false if not.
-     * @params {string} [deviceType] - type of device to change. Default is
+     * @param {string} [deviceType] - type of device to change. Default is
      *      undefined or 'input', 'output' - for audio output device change.
      * @returns {boolean} true if available, false otherwise.
      */
@@ -845,6 +845,17 @@ class RTCUtils extends Listenable {
         deviceList.push(deviceData);
 
         return { deviceList };
+    }
+
+
+    /**
+     * Returns boolean value indicating whether given stream ID
+     * indicates user stream or not
+     * @param {string} [streamId] - ID of a stream
+     * @returns {boolean}
+     */
+    isUserStreamById(streamId) {
+        return streamId && streamId !== 'mixedmslabel' && streamId !== 'default';
     }
 }
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -22,7 +22,7 @@ import { SdpTransformWrap } from '../sdp/SdpTransformUtil';
 import * as GlobalOnErrorHandler from '../util/GlobalOnErrorHandler';
 
 import JitsiRemoteTrack from './JitsiRemoteTrack';
-import RTC from './RTC';
+import RTCUtils from './RTCUtils';
 import {
     HD_BITRATE,
     HD_SCALE_FACTOR,
@@ -819,7 +819,7 @@ TraceablePeerConnection.prototype.getSsrcByTrackId = function(id) {
 TraceablePeerConnection.prototype._remoteStreamAdded = function(stream) {
     const streamId = stream.id;
 
-    if (!RTC.isUserStreamById(streamId)) {
+    if (!RTCUtils.isUserStreamById(streamId)) {
         logger.info(`${this} ignored remote 'stream added' event for non-user stream[id=${streamId}]`);
 
         return;
@@ -864,7 +864,7 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track, tr
     const streamId = stream.id;
     const mediaType = track.kind;
 
-    if (!this.isP2P && !RTC.isUserStreamById(streamId)) {
+    if (!this.isP2P && !RTCUtils.isUserStreamById(streamId)) {
         logger.info(`${this} ignored remote 'stream added' event for non-user stream[id=${streamId}]`);
 
         return;
@@ -1059,7 +1059,7 @@ TraceablePeerConnection.prototype._createRemoteTrack = function(
  * PeerConnection
  */
 TraceablePeerConnection.prototype._remoteStreamRemoved = function(stream) {
-    if (!RTC.isUserStream(stream)) {
+    if (!RTCUtils.isUserStreamById(stream.id)) {
         logger.info(`Ignored remote 'stream removed' event for stream[id=${stream.id}]`);
 
         return;
@@ -1089,7 +1089,7 @@ TraceablePeerConnection.prototype._remoteTrackRemoved = function(stream, track) 
     const streamId = stream.id;
     const trackId = track?.id;
 
-    if (!RTC.isUserStreamById(streamId)) {
+    if (!RTCUtils.isUserStreamById(streamId)) {
         logger.info(`${this} ignored remote 'stream removed' event for non-user stream[id=${streamId}]`);
 
         return;

--- a/package.json
+++ b/package.json
@@ -71,7 +71,10 @@
     "watch": "webpack --config webpack.config.js --watch --mode development"
   },
   "browser": "dist/umd/lib-jitsi-meet.min.js",
-  "module": "dist/esm/JitsiMeetJS.js",
+  "exports": {
+    "import": "./dist/esm/JitsiMeetJS.js",
+    "default": "./dist/umd/lib-jitsi-meet.min.js"
+  },
   "files": [
     "dist",
     "types",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "validate": "npm ls",
     "watch": "webpack --config webpack.config.js --watch --mode development"
   },
-  "browser": "dist/umd/lib-jitsi-meet.min.js",
+  "react-native": "./dist/esm/JitsiMeetJS.js",
   "exports": {
     "import": "./dist/esm/JitsiMeetJS.js",
     "default": "./dist/umd/lib-jitsi-meet.min.js"

--- a/types/auto/modules/RTC/RTCUtils.d.ts
+++ b/types/auto/modules/RTC/RTCUtils.d.ts
@@ -93,11 +93,11 @@ declare class RTCUtils extends Listenable {
     /**
      * Returns true if changing the input (camera / microphone) or output
      * (audio) device is supported and false if not.
-     * @params {string} [deviceType] - type of device to change. Default is
+     * @param {string} [deviceType] - type of device to change. Default is
      *      undefined or 'input', 'output' - for audio output device change.
      * @returns {boolean} true if available, false otherwise.
      */
-    isDeviceChangeAvailable(deviceType: any): boolean;
+    isDeviceChangeAvailable(deviceType?: string): boolean;
     /**
      * A method to handle stopping of the stream.
      * One point to handle the differences in various implementations.
@@ -147,5 +147,12 @@ declare class RTCUtils extends Listenable {
      * @returns {MediaDeviceInfo} device.
      */
     getEventDataForActiveDevice(device: any): MediaDeviceInfo;
+    /**
+     * Returns boolean value indicating whether given stream ID
+     * indicates user stream or not
+     * @param {string} [streamId] - ID of a stream
+     * @returns {boolean}
+     */
+    isUserStreamById(streamId?: string): boolean;
 }
 import Listenable from "../util/Listenable";

--- a/types/auto/modules/RTC/TraceablePeerConnection.d.ts
+++ b/types/auto/modules/RTC/TraceablePeerConnection.d.ts
@@ -23,7 +23,7 @@
  *
  * @constructor
  */
-export default function TraceablePeerConnection(rtc: RTC, id: number, signalingLayer: any, pcConfig: object, constraints: object, isP2P: boolean, options: {
+export default function TraceablePeerConnection(rtc: any, id: number, signalingLayer: any, pcConfig: object, constraints: object, isP2P: boolean, options: {
     disableSimulcast: boolean;
     disableRtx: boolean;
     disabledCodec: string;
@@ -57,7 +57,7 @@ export default class TraceablePeerConnection {
      *
      * @constructor
      */
-    constructor(rtc: RTC, id: number, signalingLayer: any, pcConfig: object, constraints: object, isP2P: boolean, options: {
+    constructor(rtc: any, id: number, signalingLayer: any, pcConfig: object, constraints: object, isP2P: boolean, options: {
         disableSimulcast: boolean;
         disableRtx: boolean;
         disabledCodec: string;
@@ -112,7 +112,7 @@ export default class TraceablePeerConnection {
      * <tt>TracablePeerConnection</tt>.
      * @type {RTC}
      */
-    rtc: RTC;
+    rtc: any;
     /**
      * The peer connection identifier assigned by the RTC module.
      * @type {number}
@@ -801,7 +801,6 @@ export default class TraceablePeerConnection {
      */
     toString(): string;
 }
-import RTC from "./RTC";
 import { MediaType } from "../../service/RTC/MediaType";
 import JitsiRemoteTrack from "./JitsiRemoteTrack";
 import { TPCUtils } from "./TPCUtils";


### PR DESCRIPTION
This PR updates package.json and replaces currently used 'module' field with a recommended by NodeJS 'export' field. [According to documentation](https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#dual-commonjses-module-packages) the 'module' field is ignored by NodeJS and only used by bundlers. After changing it however everything seems to be building fine.

### The reasoning behind this change:
- Currently when installing the package via npm using a link to a released archive, for example: https://github.com/jitsi/lib-jitsi-meet/releases/download/v1486.0.0+73bc6ba2/lib-jitsi-meet.tgz importing the lib throws a build error as it can't locate the module, given 'module' field being ignored by NodeJS and there is no index.js in the root directory.

With this change it's possible to import the package without any hiccups:
```js
import JitsiMeetJS from 'lib-jitsi-meet';
```

I noticed that in jitsi-meet app you're importing the package like that already, but I'm not entirely sure why it works for you, perhaps you got some extra configuration that resolves modules by looking at that 'module' field 🤔 