### PR TITLE
Use conventional syntax for depending on git repos as deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",
-        "@jitsi/sdp-interop": "https://git@github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
+        "@jitsi/sdp-interop": "git+https://github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
         "@jitsi/sdp-simulcast": "0.4.0",
         "async": "3.2.3",
         "base64-js": "1.3.1",
@@ -24,7 +24,7 @@
         "sdp-transform": "2.3.0",
         "strophe.js": "1.3.4",
         "strophejs-plugin-disco": "0.0.2",
-        "strophejs-plugin-stream-management": "https://git@github.com/jitsi/strophejs-plugin-stream-management#001cf02bef2357234e1ac5d163611b4d60bf2b6a",
+        "strophejs-plugin-stream-management": "git+https://github.com/jitsi/strophejs-plugin-stream-management#001cf02bef2357234e1ac5d163611b4d60bf2b6a",
         "uuid": "8.1.0",
         "webrtc-adapter": "8.1.1"
       },
@@ -8300,7 +8300,7 @@
     "@jitsi/sdp-interop": {
       "version": "git+https://git@github.com/jitsi/sdp-interop.git#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
       "integrity": "sha512-80u69QNTBArnCd1CGbTTrl/8AsZOOMF82dQhrgXBQAnrimdpomX1fMZ82ZkxyWyYvRMPG167u43Tp8y1g2DLNA==",
-      "from": "@jitsi/sdp-interop@https://git@github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
+      "from": "@jitsi/sdp-interop@git+https://github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
       "requires": {
         "lodash.clonedeep": "4.5.0",
         "sdp-transform": "2.14.1"
@@ -11394,7 +11394,7 @@
     "strophejs-plugin-stream-management": {
       "version": "git+https://git@github.com/jitsi/strophejs-plugin-stream-management.git#001cf02bef2357234e1ac5d163611b4d60bf2b6a",
       "integrity": "sha512-ijQSXeEEmGl4dfLx8RcQDCvzg1UPtEArowaCHZr8ITdBOH/X6JxxGzy/DVeMLVSvSy73tH7pGK6iPjBqQajwdQ==",
-      "from": "strophejs-plugin-stream-management@https://git@github.com/jitsi/strophejs-plugin-stream-management#001cf02bef2357234e1ac5d163611b4d60bf2b6a",
+      "from": "strophejs-plugin-stream-management@git+https://github.com/jitsi/strophejs-plugin-stream-management#001cf02bef2357234e1ac5d163611b4d60bf2b6a",
       "requires": {}
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@jitsi/js-utils": "2.0.0",
     "@jitsi/logger": "2.0.0",
-    "@jitsi/sdp-interop": "https://git@github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
+    "@jitsi/sdp-interop": "git+https://github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
     "@jitsi/sdp-simulcast": "0.4.0",
     "async": "3.2.3",
     "base64-js": "1.3.1",
@@ -31,7 +31,7 @@
     "sdp-transform": "2.3.0",
     "strophe.js": "1.3.4",
     "strophejs-plugin-disco": "0.0.2",
-    "strophejs-plugin-stream-management": "https://git@github.com/jitsi/strophejs-plugin-stream-management#001cf02bef2357234e1ac5d163611b4d60bf2b6a",
+    "strophejs-plugin-stream-management": "git+https://github.com/jitsi/strophejs-plugin-stream-management#001cf02bef2357234e1ac5d163611b4d60bf2b6a",
     "uuid": "8.1.0",
     "webrtc-adapter": "8.1.1"
   },


### PR DESCRIPTION
I am adding this as a dependency to a project managed by Yarn v2, which is a bit more persnickety regarding dependency syntax. It can't infer how to resolve the package.

```diff
-https://git@github.com
+git+https://github.com
```

This change should be functionally identical to the current behavior, but now it plays nicely with Yarn v1, v2, and npm.