### PR TITLE
ref(JitsiTrackEvents.LOCAL_TRACK_STOPPED) expose jitsiLocalTrack as listener parameter

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -67,7 +67,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
             /* conference */ null,
             stream,
             track,
-            /* streamInactiveHandler */ () => this.emit(LOCAL_TRACK_STOPPED),
+            /* streamInactiveHandler */ () => this.emit(LOCAL_TRACK_STOPPED, this),
             mediaType,
             videoType);
 


### PR DESCRIPTION
It is useful in our custom application to know the track reference which got stopped at the listener level.

I've seen examples like this in other places of the project such as: 6b629a194a0d8bc357325b599c3ee57166d81d42

Please take a look.