### PR TITLE
fix(build) add missed jquery slim imports

### DIFF
--- a/modules/proxyconnection/ProxyConnectionService.js
+++ b/modules/proxyconnection/ProxyConnectionService.js
@@ -1,6 +1,5 @@
-/* globals $ */
-
 import { getLogger } from '@jitsi/logger';
+import $ from 'jquery';
 import { $iq } from 'strophe.js';
 
 import { MediaType } from '../../service/RTC/MediaType';

--- a/modules/sdp/SDP.spec.js
+++ b/modules/sdp/SDP.spec.js
@@ -1,4 +1,4 @@
-/* globals $ */
+import $ from 'jquery';
 import { $iq } from 'strophe.js';
 
 import FeatureFlags from '../flags/FeatureFlags';


### PR DESCRIPTION
Looks like these have slipped away. Most likely due to the header being slightly different `/* global $ */` vs `/* globals $ */`