### PR TITLE
Fix ProxyConnectionPC, use a custom signaling layer

### DIFF
--- a/modules/proxyconnection/CustomSignalingLayer.js
+++ b/modules/proxyconnection/CustomSignalingLayer.js
@@ -1,0 +1,105 @@
+import { getLogger } from '@jitsi/logger';
+
+import SignalingLayer from '../../service/RTC/SignalingLayer';
+
+
+const logger = getLogger(__filename);
+
+
+/**
+ * Custom semi-mock implementation for the Proxy connection service.
+ */
+export default class CustomSignalingLayer extends SignalingLayer {
+    /**
+     * Creates new instance.
+     */
+    constructor() {
+        super();
+
+        /**
+         * A map that stores SSRCs of remote streams.
+         * @type {Map<number, string>} maps SSRC number to jid
+         */
+        this.ssrcOwners = new Map();
+
+        /**
+         *
+         * @type {ChatRoom|null}
+         */
+        this.chatRoom = null;
+    }
+
+    /**
+     * Sets the <tt>ChatRoom</tt> instance used.
+     * @param {ChatRoom} room
+     */
+    setChatRoom(room) {
+        this.chatRoom = room;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    getPeerMediaInfo(owner, mediaType, sourceName) { // eslint-disable-line no-unused-vars
+        return {};
+    }
+
+    /**
+     * @inheritDoc
+     */
+    getPeerSourceInfo(owner, sourceName) { // eslint-disable-line no-unused-vars
+        return undefined;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    getSSRCOwner(ssrc) {
+        return this.ssrcOwners.get(ssrc);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    setSSRCOwner(ssrc, endpointId) {
+        if (typeof ssrc !== 'number') {
+            throw new TypeError(`SSRC(${ssrc}) must be a number`);
+        }
+
+        // Now signaling layer instance is shared between different JingleSessionPC instances, so although very unlikely
+        // an SSRC conflict could potentially occur. Log a message to make debugging easier.
+        const existingOwner = this.ssrcOwners.get(ssrc);
+
+        if (existingOwner && existingOwner !== endpointId) {
+            logger.error(`SSRC owner re-assigned from ${existingOwner} to ${endpointId}`);
+        }
+        this.ssrcOwners.set(ssrc, endpointId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    setTrackMuteStatus(sourceName, muted) { // eslint-disable-line no-unused-vars
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    setTrackVideoType(sourceName, videoType) { // eslint-disable-line no-unused-vars
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    getTrackSourceName(ssrc) { // eslint-disable-line no-unused-vars
+        return undefined;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    setTrackSourceName(ssrc, sourceName) { // eslint-disable-line no-unused-vars
+    }
+}

--- a/modules/proxyconnection/ProxyConnectionPC.js
+++ b/modules/proxyconnection/ProxyConnectionPC.js
@@ -4,9 +4,9 @@ import RTCEvents from '../../service/RTC/RTCEvents';
 import { XMPPEvents } from '../../service/xmpp/XMPPEvents';
 import RTC from '../RTC/RTC';
 import JingleSessionPC from '../xmpp/JingleSessionPC';
-import SignalingLayerImpl from '../xmpp/SignalingLayerImpl';
 import { DEFAULT_STUN_SERVERS } from '../xmpp/xmpp';
 
+import CustomSignalingLayer from './CustomSignalingLayer';
 import { ACTIONS } from './constants';
 
 const logger = getLogger(__filename);
@@ -271,7 +271,7 @@ export default class ProxyConnectionPC {
             this._options.isInitiator // isInitiator
         );
 
-        const signalingLayer = new SignalingLayerImpl();
+        const signalingLayer = new CustomSignalingLayer();
 
         signalingLayer.setChatRoom(roomStub);
 

--- a/modules/xmpp/SignalingLayerImpl.js
+++ b/modules/xmpp/SignalingLayerImpl.js
@@ -372,10 +372,7 @@ export default class SignalingLayerImpl extends SignalingLayer {
     }
 
     /**
-     * Set an SSRC owner.
-     * @param {number} ssrc an SSRC to be owned
-     * @param {string} endpointId owner's ID (MUC nickname)
-     * @throws TypeError if <tt>ssrc</tt> is not a number
+     * @inheritDoc
      */
     setSSRCOwner(ssrc, endpointId) {
         if (typeof ssrc !== 'number') {
@@ -393,11 +390,7 @@ export default class SignalingLayerImpl extends SignalingLayer {
     }
 
     /**
-     * Adjusts muted status of given track.
-     *
-     * @param {SourceName} sourceName - the name of the track's source.
-     * @param {boolean} muted - the new muted status.
-     * @returns {boolean}
+     * @inheritDoc
      */
     setTrackMuteStatus(sourceName, muted) {
         if (!this._localSourceState[sourceName]) {
@@ -417,10 +410,7 @@ export default class SignalingLayerImpl extends SignalingLayer {
     }
 
     /**
-     * Sets track's video type.
-     * @param {SourceName} sourceName - the track's source name.
-     * @param {VideoType} videoType - the new video type.
-     * @returns {boolean}
+     * @inheritDoc
      */
     setTrackVideoType(sourceName, videoType) {
         if (!this._localSourceState[sourceName]) {
@@ -448,10 +438,7 @@ export default class SignalingLayerImpl extends SignalingLayer {
     }
 
     /**
-     * Saves the source name for a track identified by it's ssrc.
-     * @param {number} ssrc the ssrc of the target track.
-     * @param {SourceName} sourceName the track's source name to save.
-     * @throws TypeError if <tt>ssrc</tt> is not a number
+     * @inheritDoc
      */
     setTrackSourceName(ssrc, sourceName) {
         if (typeof ssrc !== 'number') {

--- a/service/RTC/SignalingLayer.js
+++ b/service/RTC/SignalingLayer.js
@@ -116,4 +116,42 @@ export default class SignalingLayer extends Listenable {
     getTrackSourceName(ssrc) { // eslint-disable-line no-unused-vars
         throw new Error('not implemented');
     }
+
+    /**
+     * Set an SSRC owner.
+     * @param {number} ssrc an SSRC to be owned
+     * @param {string} endpointId owner's ID (MUC nickname)
+     * @throws TypeError if <tt>ssrc</tt> is not a number
+     */
+    setSSRCOwner(ssrc, endpointId) { // eslint-disable-line no-unused-vars
+    }
+
+
+    /**
+     * Adjusts muted status of given track.
+     *
+     * @param {SourceName} sourceName - the name of the track's source.
+     * @param {boolean} muted - the new muted status.
+     * @returns {boolean}
+     */
+    setTrackMuteStatus(sourceName, muted) { // eslint-disable-line no-unused-vars
+    }
+
+    /**
+     * Saves the source name for a track identified by it's ssrc.
+     * @param {number} ssrc the ssrc of the target track.
+     * @param {SourceName} sourceName the track's source name to save.
+     * @throws TypeError if <tt>ssrc</tt> is not a number
+     */
+    setTrackSourceName(ssrc, sourceName) { // eslint-disable-line no-unused-vars
+    }
+
+    /**
+     * Sets track's video type.
+     * @param {SourceName} sourceName - the track's source name.
+     * @param {VideoType} videoType - the new video type.
+     * @returns {boolean}
+     */
+    setTrackVideoType(sourceName, videoType) { // eslint-disable-line no-unused-vars
+    }
 }

--- a/types/auto/modules/proxyconnection/CustomSignalingLayer.d.ts
+++ b/types/auto/modules/proxyconnection/CustomSignalingLayer.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Custom semi-mock implementation for the Proxy connection service.
+ */
+export default class CustomSignalingLayer extends SignalingLayer {
+    /**
+     * Creates new instance.
+     */
+    constructor();
+    /**
+     * A map that stores SSRCs of remote streams.
+     * @type {Map<number, string>} maps SSRC number to jid
+     */
+    ssrcOwners: Map<number, string>;
+    /**
+     *
+     * @type {ChatRoom|null}
+     */
+    chatRoom: any | null;
+    /**
+     * Sets the <tt>ChatRoom</tt> instance used.
+     * @param {ChatRoom} room
+     */
+    setChatRoom(room: any): void;
+}
+import SignalingLayer from "../../service/RTC/SignalingLayer";

--- a/types/auto/modules/xmpp/SignalingLayerImpl.d.ts
+++ b/types/auto/modules/xmpp/SignalingLayerImpl.d.ts
@@ -81,35 +81,5 @@ export default class SignalingLayerImpl extends SignalingLayer {
      * @private
      */
     private _findEndpointSourceInfoForMediaType;
-    /**
-     * Set an SSRC owner.
-     * @param {number} ssrc an SSRC to be owned
-     * @param {string} endpointId owner's ID (MUC nickname)
-     * @throws TypeError if <tt>ssrc</tt> is not a number
-     */
-    setSSRCOwner(ssrc: number, endpointId: string): void;
-    /**
-     * Adjusts muted status of given track.
-     *
-     * @param {SourceName} sourceName - the name of the track's source.
-     * @param {boolean} muted - the new muted status.
-     * @returns {boolean}
-     */
-    setTrackMuteStatus(sourceName: any, muted: boolean): boolean;
-    /**
-     * Sets track's video type.
-     * @param {SourceName} sourceName - the track's source name.
-     * @param {VideoType} videoType - the new video type.
-     * @returns {boolean}
-     */
-    setTrackVideoType(sourceName: any, videoType: VideoType): boolean;
-    /**
-     * Saves the source name for a track identified by it's ssrc.
-     * @param {number} ssrc the ssrc of the target track.
-     * @param {SourceName} sourceName the track's source name to save.
-     * @throws TypeError if <tt>ssrc</tt> is not a number
-     */
-    setTrackSourceName(ssrc: number, sourceName: any): void;
 }
 import SignalingLayer from "../../service/RTC/SignalingLayer";
-import { VideoType } from "../../service/RTC/VideoType";

--- a/types/auto/service/RTC/SignalingLayer.d.ts
+++ b/types/auto/service/RTC/SignalingLayer.d.ts
@@ -76,6 +76,35 @@ export default class SignalingLayer extends Listenable {
      * @returns {SourceName | undefined} the track's source name.
      */
     getTrackSourceName(ssrc: number): SourceName | undefined;
+    /**
+     * Set an SSRC owner.
+     * @param {number} ssrc an SSRC to be owned
+     * @param {string} endpointId owner's ID (MUC nickname)
+     * @throws TypeError if <tt>ssrc</tt> is not a number
+     */
+    setSSRCOwner(ssrc: number, endpointId: string): void;
+    /**
+     * Adjusts muted status of given track.
+     *
+     * @param {SourceName} sourceName - the name of the track's source.
+     * @param {boolean} muted - the new muted status.
+     * @returns {boolean}
+     */
+    setTrackMuteStatus(sourceName: SourceName, muted: boolean): boolean;
+    /**
+     * Saves the source name for a track identified by it's ssrc.
+     * @param {number} ssrc the ssrc of the target track.
+     * @param {SourceName} sourceName the track's source name to save.
+     * @throws TypeError if <tt>ssrc</tt> is not a number
+     */
+    setTrackSourceName(ssrc: number, sourceName: SourceName): void;
+    /**
+     * Sets track's video type.
+     * @param {SourceName} sourceName - the track's source name.
+     * @param {VideoType} videoType - the new video type.
+     * @returns {boolean}
+     */
+    setTrackVideoType(sourceName: SourceName, videoType: any): boolean;
 }
 export type EndpointId = string;
 export type SourceName = string;


### PR DESCRIPTION
The existing SignalingLayerImpl is too intertwined with ChatRoom, and it has become too hard to use for ProxyConnectionPC.

Thus I ventured into creating a custom implementation that has the absolute bare minimum for that connection to work. WDYT @jallamsetty1 ?

While I was there I noticed the interface was outdated since the new functionality for multi-stream requires some implementation of certain methods, so I added them there.

Generally speaking, I'm not happy at all with this, and if we get to work on Spot I'd love to try and replace this with something that doesn't need to involve LJM internals so much. Oh well.