### PR TITLE
fix(stats): Skip bandwidth calc if there is no uplink/downlink bitrate.

### DIFF
--- a/modules/statistics/AvgRTPStatsReporter.js
+++ b/modules/statistics/AvgRTPStatsReporter.js
@@ -40,10 +40,12 @@ class AverageStatReport {
      * @param {number} nextValue
      */
     addNext(nextValue) {
+        if (typeof nextValue === 'undefined') {
+            return;
+        }
+
         if (typeof nextValue !== 'number') {
-            logger.error(
-                `${this.name} - invalid value for idx: ${this.count}`,
-                nextValue);
+            logger.error(`${this.name} - invalid value for idx: ${this.count}`, nextValue);
         } else if (!isNaN(nextValue)) {
             this.sum += nextValue;
             this.samples.push(nextValue);


### PR DESCRIPTION
This fixes an error that gets logged when no media is being sent/received by the endpoint.
Logger.js:154 2022-09-12T14:40:53.476Z [modules/statistics/AvgRTPStatsReporter.js] <xl.addNext>:  bandwidth_upload - invalid value for idx: 0