### PR TITLE
fix(ts) skip generating type definitions for index.js

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,13 +17,14 @@
     "outDir": "dist/esm/",
   },
   "exclude": [
-    "doc",
     "dist",
+    "doc",
+    "types",
     "**/*.spec.js",
     "**/*.spec.ts",
     "*.conf*.js",
-    "webpack*.js",
+    "index.js",
     "lib-jitsi-meet.*.js",
-    "types"
+    "webpack*.js",
   ]
 }

--- a/types/auto/index.d.ts
+++ b/types/auto/index.d.ts
@@ -1,2 +1,0 @@
-declare const _exports: any;
-export = _exports;


### PR DESCRIPTION
It's only used for the UMD bundle.