### PR TITLE
fix(TPC): Ignore stopped transceivers on FF during new track addition.

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -379,7 +379,7 @@ export class TPCUtils {
 
                 // Re-use any existing recvonly transceiver (if available) for p2p case.
                 && ((this.pc.isP2P && t.currentDirection === MediaDirection.RECVONLY)
-                    || t.currentDirection === MediaDirection.INACTIVE));
+                    || (t.currentDirection === MediaDirection.INACTIVE && !t.stopped)));
 
         // For mute/unmute operations, find the transceiver based on the track index in the source name if present,
         // otherwise it is assumed to be the first local track that was added to the peerconnection.


### PR DESCRIPTION
Firefox lists stopped transceivers when getTranceivers is called, ignore these when picking a trancceiver for a screenshare track. Fixes an issue when starting screenshare fails if there are stopped tranceivers in the peerconnection (i.e., if some remote users with sources have left the call).