### PR TITLE
fix(multi-stream) Block addition of multiple video streams of the same videoType

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1127,7 +1127,11 @@ JitsiConference.prototype.addTrack = function(track) {
             return Promise.resolve(track);
         }
 
-        if (FeatureFlags.isMultiStreamSupportEnabled() && mediaType === MediaType.VIDEO) {
+        // Currently, only adding multiple video streams of different video types is supported.
+        // TODO - remove this limitation once issues with jitsi-meet trying to add multiple camera streams is fixed.
+        if (FeatureFlags.isMultiStreamSupportEnabled()
+            && mediaType === MediaType.VIDEO
+            && !localTracks.find(t => t.getVideoType() === track.getVideoType())) {
             const sourceName = getSourceNameForJitsiTrack(
                 this.myUserId(),
                 mediaType,


### PR DESCRIPTION
This fixes an issue where mute camera operation doesn't stop sending camera stream even though locally it appears to the user that they are muted. This happens when multiple camera streams are added to peerconnection because of how toggle of the video button is implemented. This limitation will be removed when the application is fixed.