### PR TITLE
ref(stereo-flags-munging): add enableOpusDtx to mungedConfig

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2264,7 +2264,7 @@ TraceablePeerConnection.prototype._adjustRemoteMediaDirection = function(remoteD
 TraceablePeerConnection.prototype._mungeOpus = function(description) {
     const { audioQuality } = this.options;
 
-    if (!audioQuality?.stereo && !audioQuality?.opusMaxAverageBitrate) {
+    if (!audioQuality?.enableOpusDtx && !audioQuality?.stereo && !audioQuality?.opusMaxAverageBitrate) {
         return description;
     }
 
@@ -2299,6 +2299,12 @@ TraceablePeerConnection.prototype._mungeOpus = function(description) {
 
             if (audioQuality?.opusMaxAverageBitrate) {
                 fmtpConfig.maxaveragebitrate = audioQuality.opusMaxAverageBitrate;
+                sdpChanged = true;
+            }
+
+            // On Firefox, the OpusDtx enablement has no effect
+            if (!browser.isFirefox() && audioQuality?.enableOpusDtx) {
+                fmtpConfig.usedtx = 1;
                 sdpChanged = true;
             }
 


### PR DESCRIPTION
Added setting Opus DTX in munged config for reduction in the audio traffic, when a participant is silent then the audio packet won’t be transmitted.