### PR TITLE
fix(RTC) fix stop track with effect (#2127)

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -592,19 +592,16 @@ export default class JitsiLocalTrack extends JitsiTrack {
      * @extends JitsiTrack#dispose
      * @returns {Promise}
      */
-    dispose() {
-        let promise = Promise.resolve();
+    async dispose() {
 
         // Remove the effect instead of stopping it so that the original stream is restored
         // on both the local track and on the peerconnection.
         if (this._streamEffect) {
-            promise = this.setEffect();
+            await this.setEffect();
         }
 
-        let removeTrackPromise = Promise.resolve();
-
         if (this.conference) {
-            removeTrackPromise = this.conference.removeTrack(this);
+            await this.conference.removeTrack(this);
         }
 
         if (this.stream) {
@@ -619,7 +616,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
                 this._onAudioOutputDeviceChanged);
         }
 
-        return Promise.allSettled([ promise, removeTrackPromise ]).then(() => super.dispose());
+        return super.dispose();
     }
 
     /**


### PR DESCRIPTION
When a track has an effect, `setEffect` is finished after `stopStream` which leave the original track not stopped.