### PR TITLE
ref(FeatureFlags) fix JSDoc

### DIFF
--- a/modules/flags/FeatureFlags.js
+++ b/modules/flags/FeatureFlags.js
@@ -11,12 +11,13 @@ class FeatureFlags {
     /**
      * Configures the module.
      *
-     * @param {boolean} flags.runInLiteMode - Enables lite mode for testing to disable media decoding.
-     * @param {boolean} flags.receiveMultipleVideoStreams - Signal support for receiving multiple video streams.
-     * @param {boolean} flags.sendMultipleVideoStreams - Signal support for sending multiple video streams.
-     * @param {boolean} flags.sourceNameSignaling - Enables source names in the signaling.
-     * @param {boolean} flags.ssrcRewritingEnabled - Use SSRC rewriting. Requires sourceNameSignaling to be enabled.
-     * @param {boolean} flags.enableUnifiedOnChrome - Use unified plan signaling on chrome browsers.
+     * @param {object} flags - The feature flags.
+     * @param {boolean=} flags.runInLiteMode - Enables lite mode for testing to disable media decoding.
+     * @param {boolean=} flags.receiveMultipleVideoStreams - Signal support for receiving multiple video streams.
+     * @param {boolean=} flags.sendMultipleVideoStreams - Signal support for sending multiple video streams.
+     * @param {boolean=} flags.sourceNameSignaling - Enables source names in the signaling.
+     * @param {boolean=} flags.ssrcRewritingEnabled - Use SSRC rewriting. Requires sourceNameSignaling to be enabled.
+     * @param {boolean=} flags.enableUnifiedOnChrome - Use unified plan signaling on chrome browsers.
      */
     init(flags) {
         this._runInLiteMode = Boolean(flags.runInLiteMode);


### PR DESCRIPTION
This brings back a change from a previous pull I've submitted:
https://github.com/jitsi/lib-jitsi-meet/pull/2126/files#diff-e7edcd8944deb07d06306a33c3e6b0c56b24b84c777fb98cb44ad5348117e4a4R14

So JSDoc can be more complete and actually mark all options as optional.