### PR TITLE
feat(ScreenObtainer) Allow seamless switching of tab capture.

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -221,6 +221,11 @@ const ScreenObtainer = {
             && this.options?.testing?.setScreenSharingResolutionConstraints;
         let video = {};
 
+        // Allow users to seamlessly switch which tab they are sharing without having to select the tab again.
+        if (browser.isChromiumBased() && browser.isVersionGreaterThan(106)) {
+            video.surfaceSwitching = 'include';
+        }
+
         if (typeof desktopSharingFrameRate === 'object') {
             video.frameRate = desktopSharingFrameRate;
         }


### PR DESCRIPTION
Allow users to seamlessly switch which tab they are sharing without having to stop the current share and select a new tab again. This is supported on Chrome 107 onwards.
A new button "Share this tab instead" will be shown when the user switches to a tab that is not being shared.

![Screen Shot 2022-10-20 at 2 42 27 PM](https://user-images.githubusercontent.com/54324652/197032691-6acf69fc-09f2-4de4-8995-21bfea96d4b4.png)

