### PR TITLE
ref: remove references to legacy endpoint based signaling switch

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -609,10 +609,6 @@ JitsiConference.prototype.isP2PTestModeEnabled = function() {
  * @returns {Promise}
  */
 JitsiConference.prototype.leave = async function(reason) {
-    if (this.participantConnectionStatus) {
-        this.participantConnectionStatus.dispose();
-        this.participantConnectionStatus = null;
-    }
     if (this.avgRtpStatsReporter) {
         this.avgRtpStatsReporter.dispose();
         this.avgRtpStatsReporter = null;

--- a/modules/qualitycontrol/ReceiveVideoController.spec.js
+++ b/modules/qualitycontrol/ReceiveVideoController.spec.js
@@ -59,7 +59,7 @@ describe('ReceiveVideoController', () => {
 
     describe('when sourceNameSignaling is enabled', () => {
         beforeEach(() => {
-            FeatureFlags.init({ sourceNameSignaling: true });
+            FeatureFlags.init({ });
         });
 
         it('should call setNewReceiverVideoConstraints with the source names format.', () => {

--- a/modules/sdp/SDP.spec.js
+++ b/modules/sdp/SDP.spec.js
@@ -101,7 +101,7 @@ describe('SDP', () => {
             expect(videoSources.length).toBe(2);
         });
         it('put source names as source element attributes', () => {
-            FeatureFlags.init({ sourceNameSignaling: true });
+            FeatureFlags.init({ });
 
             const sdp = new SDP(testSdp);
             const accept = $iq({

--- a/modules/sdp/SDPDiffer.spec.js
+++ b/modules/sdp/SDPDiffer.spec.js
@@ -41,7 +41,7 @@ describe('SDPDiffer', () => {
         /* eslint-enable max-len*/
 
         it('should include source names in added/removed sources', () => {
-            FeatureFlags.init({ sourceNameSignaling: true });
+            FeatureFlags.init({ });
 
             const newToOldDiff = new SDPDiffer(new SDP(testSdpNew), new SDP(testSdpOld));
             const sourceRemoveIq = $iq({})

--- a/modules/xmpp/JingleSessionPC.spec.js
+++ b/modules/xmpp/JingleSessionPC.spec.js
@@ -65,7 +65,7 @@ describe('JingleSessionPC', () => {
 
     describe('send/receive video constraints w/ source-name', () => {
         beforeEach(() => {
-            FeatureFlags.init({ sourceNameSignaling: true });
+            FeatureFlags.init({ });
         });
 
         it('sends content-modify with recv frame size', () => {

--- a/modules/xmpp/SignalingLayerImpl.spec.js
+++ b/modules/xmpp/SignalingLayerImpl.spec.js
@@ -68,7 +68,7 @@ describe('SignalingLayerImpl', () => {
             let chatRoom;
 
             beforeEach(() => {
-                FeatureFlags.init({ sourceNameSignaling: true });
+                FeatureFlags.init({ });
                 signalingLayer = new SignalingLayerImpl();
                 chatRoom = createMockChatRoom();
                 signalingLayer.setChatRoom(chatRoom);


### PR DESCRIPTION
Cleans up otherwise unused participantConnectionStatus and sourceNameSignaling things.