### PR TITLE
fix(JitsiConference) send mute sourceInfo before removing an unmuted track

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1303,6 +1303,9 @@ JitsiConference.prototype.replaceTrack = function(oldTrack, newTrack) {
     // Now replace the stream at the lower levels
     return this._doReplaceTrack(oldTrackBelongsToConference ? oldTrack : null, newTrack)
         .then(() => {
+            if (oldTrackBelongsToConference && !oldTrack.isMuted() && !newTrack) {
+                oldTrack._sendMuteStatus(true);
+            }
             oldTrackBelongsToConference && this.onLocalTrackRemoved(oldTrack);
             newTrack && this._setupNewTrack(newTrack);
 


### PR DESCRIPTION
Workarounds around issue #2037 to have other participants receive the mute event and therefore avoid frozen camera bug.

There may be a better way to fix this, so I leave to the experts to review and figure out what is causing the `sourceInfo` to not be sent on track removal without this trick (or workaround at application level).

The good news is this is far less invasive then my previous workaround in the original issue. My two cents.

Kind regards and thanks in advance.