### PR TITLE
fix(startMutedFocus):remove tracks not added to PC

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -745,6 +745,10 @@ JitsiConferenceEventManager.prototype.setupXMPPListeners = function() {
                 }
             });
 
+            // Remove the tracks that won't be added to the peerconnection because otherwise they won't be able to be
+            // removed ever beacase fail replaceTrack calls when there is no transciever for the old track.
+            conference._removeUnusedTracksOnInit();
+
             conference.eventEmitter.emit(JitsiConferenceEvents.STARTED_MUTED);
         });
 


### PR DESCRIPTION
Currenly those tracks are stuck in the conference and can't be removed
because of the check on replaceTrack for transciever of the old track.