### PR TITLE
Remove deprecated conference properties

### DIFF
--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -211,27 +211,9 @@ Moderator.prototype.createConferenceIq = function() {
         elem.c(
             'property', {
                 name: 'rtcstatsEnabled',
-                value: rtcstatsEnabled
+                value: false
             }).up();
     }
-
-    const { callStatsID, callStatsSecret, disableThirdPartyRequests, enableCallStats } = this.options.conference;
-    const callstatsDisabled = !callStatsID || !callStatsSecret || !enableCallStats
-
-        // Even though AppID and AppSecret may be specified, the integration
-        // of callstats.io may be disabled because of globally-disallowed
-        // requests to any third parties.
-        || disableThirdPartyRequests === true;
-
-    // since the default is true across all the server-side components, only signal if false.
-    if (callstatsDisabled) {
-        elem.c(
-            'property', {
-                name: 'callstatsEnabled',
-                value: !callstatsDisabled
-            }).up();
-    }
-    elem.up();
 
     return elem;
 };

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -156,13 +156,6 @@ Moderator.prototype.createConferenceIq = function() {
         elem.attrs({ 'session-id': sessionId });
     }
 
-    if (config.audioPacketDelay !== undefined) {
-        elem.c(
-            'property', {
-                name: 'audioPacketDelay',
-                value: config.audioPacketDelay
-            }).up();
-    }
     if (config.startBitrate) {
         elem.c(
             'property', {

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -156,12 +156,6 @@ Moderator.prototype.createConferenceIq = function() {
         elem.attrs({ 'session-id': sessionId });
     }
 
-    elem.c(
-        'property', {
-            name: 'disableRtx',
-            value: Boolean(config.disableRtx)
-        }).up();
-
     if (config.audioPacketDelay !== undefined) {
         elem.c(
             'property', {


### PR DESCRIPTION
- Remove callstats conference property.
- Remove RTX conference property (removed from backend).
- Remove audioPacketDelay conference property (removed from backend).
