### PR TITLE
fix(speaker-stats): set faceLandmarks on update only if it is has data

### DIFF
--- a/modules/statistics/SpeakerStatsCollector.js
+++ b/modules/statistics/SpeakerStatsCollector.js
@@ -190,7 +190,9 @@ export default class SpeakerStatsCollector {
                 speakerStatsToUpdate.totalDominantSpeakerTime
                     = newStats[userId].totalDominantSpeakerTime;
 
-                speakerStatsToUpdate.setFaceLandmarks(newStats[userId].faceLandmarks);
+                if (Array.isArray(newStats[userId].faceLandmarks)) {
+                    speakerStatsToUpdate.setFaceLandmarks(newStats[userId].faceLandmarks);
+                }
             }
         }
     }


### PR DESCRIPTION
Because Lua does not have an array object, {} can be set for faceLandmarks if there the participant has speaker time and no facelandmarks in prodosy. https://github.com/jitsi/jitsi-meet/blob/master/resources/prosody-plugins/mod_speakerstats_component.lua#L254