### PR TITLE
Use insertable streams to drop all media when in lite mode.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -28,6 +28,7 @@ import { E2EEncryption } from './modules/e2ee/E2EEncryption';
 import E2ePing from './modules/e2eping/e2eping';
 import Jvb121EventGenerator from './modules/event/Jvb121EventGenerator';
 import FeatureFlags from './modules/flags/FeatureFlags';
+import { LiteModeContext } from './modules/litemode/LiteModeContext';
 import ReceiveVideoController from './modules/qualitycontrol/ReceiveVideoController';
 import SendVideoController from './modules/qualitycontrol/SendVideoController';
 import RecordingManager from './modules/recording/RecordingManager';
@@ -280,6 +281,12 @@ export default function JitsiConference(options) {
         logger.info('End-to-End Encryption is supported');
 
         this._e2eEncryption = new E2EEncryption(this);
+    }
+
+    if (FeatureFlags.isRunInLiteModeEnabled()) {
+        logger.info('Lite mode enabled');
+
+        this._liteModeContext = new LiteModeContext(this);
     }
 
     /**
@@ -2246,7 +2253,7 @@ JitsiConference.prototype._acceptJvbIncomingCall = function(jingleSession, jingl
             this._signalingLayer,
             {
                 ...this.options.config,
-                enableInsertableStreams: this.isE2EEEnabled()
+                enableInsertableStreams: this.isE2EEEnabled() || FeatureFlags.isRunInLiteModeEnabled()
             });
     } catch (error) {
         GlobalOnErrorHandler.callErrorHandler(error);
@@ -3005,7 +3012,7 @@ JitsiConference.prototype._acceptP2PIncomingCall = function(jingleSession, jingl
         this._signalingLayer,
         {
             ...this.options.config,
-            enableInsertableStreams: this.isE2EEEnabled()
+            enableInsertableStreams: this.isE2EEEnabled() || FeatureFlags.isRunInLiteModeEnabled()
         });
 
     logger.info('Starting CallStats for P2P connection...');
@@ -3373,7 +3380,7 @@ JitsiConference.prototype._startP2PSession = function(remoteJid) {
         this._signalingLayer,
         {
             ...this.options.config,
-            enableInsertableStreams: this.isE2EEEnabled()
+            enableInsertableStreams: this.isE2EEEnabled() || FeatureFlags.isRunInLiteModeEnabled()
         });
 
     logger.info('Starting CallStats for P2P connection...');

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2525,10 +2525,6 @@ TraceablePeerConnection.prototype.setRemoteDescription = function(description) {
 
             remoteDescription = this.interop.toUnifiedPlan(remoteDescription, currentDescription);
             this.trace('setRemoteDescription::postTransform (Unified)', dumpSDP(remoteDescription));
-
-            if (FeatureFlags.isRunInLiteModeEnabled()) {
-                remoteDescription = this._mungeInactive(remoteDescription);
-            }
         }
         if (this.isSimulcastOn()) {
             remoteDescription = this.tpcUtils.insertUnifiedPlanSimulcastReceive(remoteDescription);

--- a/modules/flags/FeatureFlags.js
+++ b/modules/flags/FeatureFlags.js
@@ -28,13 +28,13 @@ class FeatureFlags {
 
     /**
      * Checks if the run in lite mode is enabled.
-     * This will cause any media to be received and not decoded. (Directions are inactive and no ssrc and ssrc-groups
-     * are added to the remote description). This can be used for various test scenarios.
+     * This will cause any media to be received and not decoded. (Insertable streams are used to discard
+     * all media before it is decoded). This can be used for various test scenarios.
      *
      * @returns {boolean}
      */
     isRunInLiteModeEnabled() {
-        return this._runInLiteMode;
+        return this._runInLiteMode && browser.supportsInsertableStreams();
     }
 
     /**

--- a/modules/litemode/LiteModeContext.js
+++ b/modules/litemode/LiteModeContext.js
@@ -42,7 +42,7 @@ export class LiteModeContext {
         const receiver = tpc.findReceiverForTrack(track.track);
 
         if (!receiver) {
-            logger.warn(`Could set up lite mode for ${track}: receiver not found in: ${tpc}`);
+            logger.warn(`Could not set up lite mode for ${track}: receiver not found in: ${tpc}`);
 
             return;
         }
@@ -54,25 +54,12 @@ export class LiteModeContext {
 
         const receiverStreams = receiver.createEncodedStreams();
 
-        this._setupLiteMode(receiverStreams.readable, receiverStreams.writable);
-    }
-
-    /**
-     * Setup lite mode for receiver streams
-     */
-    _setupLiteMode(readableStream, writableStream) {
         const transformStream = new TransformStream({
-            transform: this.dropAll
+            transform: () => {
+                // Don't call controller.enqueue(encodedFrame), and so drop everything
+            }
         });
 
-        readableStream.pipeThrough(transformStream).pipeTo(writableStream);
-    }
-
-    /**
-     * Drop all encoded media received
-     * Function that will be injected in a stream and will encrypt the given encoded frames.
-     */
-    dropAll() {
-        // Don't call controller.enqueue(encodedFrame), and so drop everything
+        receiverStreams.readable.pipeThrough(transformStream).pipeTo(receiverStreams.writable);
     }
 }

--- a/modules/litemode/LiteModeContext.js
+++ b/modules/litemode/LiteModeContext.js
@@ -1,0 +1,78 @@
+/* global TransformStream */
+import { getLogger } from '@jitsi/logger';
+
+import RTCEvents from '../../service/RTC/RTCEvents';
+import FeatureFlags from '../flags/FeatureFlags';
+
+// Flag to set on receivers to avoid setting up the lite mode
+// more than once.
+const kJitsiLiteMode = Symbol('kJitsiLiteMode');
+
+const logger = getLogger(__filename);
+
+/**
+ * This module implements a discard-all insertable stream.  Use to reduce decoder CPU load for testing.
+ */
+export class LiteModeContext {
+    /**
+     * A constructor.
+     * @param {JitsiConference} conference - The conference instance for which lite mode is to be enabled.
+     */
+    constructor(conference) {
+        this.enabled = FeatureFlags.isRunInLiteModeEnabled();
+        if (!this.enabled) {
+            return;
+        }
+
+        conference.rtc.on(
+            RTCEvents.REMOTE_TRACK_ADDED,
+            (track, tpc) => this._setupLiteModeForTrack(tpc, track));
+    }
+
+    /**
+     * Setup Lite Mode for a track.
+     *
+     * @private
+     */
+    _setupLiteModeForTrack(tpc, track) {
+        if (!this.enabled) {
+            return;
+        }
+
+        const receiver = tpc.findReceiverForTrack(track.track);
+
+        if (!receiver) {
+            logger.warn(`Could set up lite mode for ${track}: receiver not found in: ${tpc}`);
+
+            return;
+        }
+
+        if (receiver[kJitsiLiteMode]) {
+            return;
+        }
+        receiver[kJitsiLiteMode] = true;
+
+        const receiverStreams = receiver.createEncodedStreams();
+
+        this._setupLiteMode(receiverStreams.readable, receiverStreams.writable);
+    }
+
+    /**
+     * Setup lite mode for receiver streams
+     */
+    _setupLiteMode(readableStream, writableStream) {
+        const transformStream = new TransformStream({
+            transform: this.dropAll
+        });
+
+        readableStream.pipeThrough(transformStream).pipeTo(writableStream);
+    }
+
+    /**
+     * Drop all encoded media received
+     * Function that will be injected in a stream and will encrypt the given encoded frames.
+     */
+    dropAll() {
+        // Don't call controller.enqueue(encodedFrame), and so drop everything
+    }
+}


### PR DESCRIPTION
(Rather than moving streams to inactive in SDP.)