### PR TITLE
fix(BridgeChannel): prevent multiple websockets on retries

### DIFF
--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -100,6 +100,16 @@ export default class BridgeChannel {
         let timeoutS = 1;
 
         const reload = () => {
+            const isConnecting = this._channel && (this._channel.readyState === 'connecting'
+                    || this._channel.readyState === WebSocket.CONNECTING);
+
+            // Should not spawn new websockets while one is already trying to connect.
+            if (isConnecting) {
+                this._retryTimeout = setTimeout(reload, timeoutS * 1000);
+
+                return;
+            }
+
             if (this.isOpen()) {
                 return;
             }

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -422,10 +422,10 @@ export default class BridgeChannel {
         };
 
         channel.onclose = event => {
-            logger.info(`Channel closed by ${this._closedFromClient ? 'client' : 'server'}`);
+            logger.debug(`Channel closed by ${this._closedFromClient ? 'client' : 'server'}`);
 
             if (channel !== this._channel) {
-                logger.info('Skip close handler, channel instance is not equal to stored one');
+                logger.debug('Skip close handler, channel instance is not equal to stored one');
 
                 return;
             }

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -420,11 +420,13 @@ export default class BridgeChannel {
         };
 
         channel.onclose = event => {
+            logger.info(`Channel closed by ${this._closedFromClient ? 'client' : 'server'}`);
+
             if (channel !== this._channel) {
+                logger.info('Skip close handler, channel instance is not equal to stored one');
+
                 return;
             }
-
-            logger.info(`Channel closed by ${this._closedFromClient ? 'client' : 'server'}`);
 
             if (this._mode === 'websocket') {
                 if (!this._closedFromClient) {

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -420,6 +420,10 @@ export default class BridgeChannel {
         };
 
         channel.onclose = event => {
+            if (channel !== this._channel) {
+                return;
+            }
+
             logger.info(`Channel closed by ${this._closedFromClient ? 'client' : 'server'}`);
 
             if (this._mode === 'websocket') {

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -105,6 +105,8 @@ export default class BridgeChannel {
 
             // Should not spawn new websockets while one is already trying to connect.
             if (isConnecting) {
+                // Timeout is still required as there is flag `_areRetriesEnabled` that
+                // blocks new retrying cycles until any channel opens in current cycle.
                 this._retryTimeout = setTimeout(reload, timeoutS * 1000);
 
                 return;


### PR DESCRIPTION
Multiple WebSockets could lead to client being unable to send any bridge messages due to lost `this._channel` reference.

Scenario:
1. `WebSocket #1` (`WS1`) is closed somehow by server -> start backoff retrying.
3. Spawn `WS2` in 1 sec -> `WS2` connecting -> store `WS2` in `this._channel`.
4. Spawn `WS3` in 2 sec -> `WS3` connecting -> store `WS3` in `this._channel`.
5. `WS2` connects -> stop retrying. But we have `WS3` in `this._channel`.
6. `WS3` connects moments after `WS2` -> at same moment `WS2` is closed by server (same url with `WS3`) -> `WS2` `onclose` handler resets `this._channel` to `null` and should start retries again, but `WS3` `onopen` handler stops them.
7. `WS3` survives and receives messages, but `this._channel` is `null` -> `isOpen` returns `false` -> `_send` throws error 

