### PR TITLE
fix(SignalingLayer) Update SSRC owners on leave.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1933,6 +1933,9 @@ JitsiConference.prototype.onMemberLeft = function(jid, reason) {
 
             remoteTracks && (tracksToBeRemoved = [ ...tracksToBeRemoved, ...remoteTracks ]);
 
+            // Update the SSRC owners list.
+            session._signalingLayer.updateSsrcOwnersOnLeave(id);
+
             // Remove the ssrcs from the remote description and renegotiate.
             session.removeRemoteStreamsOnLeave(id);
         }

--- a/modules/proxyconnection/CustomSignalingLayer.js
+++ b/modules/proxyconnection/CustomSignalingLayer.js
@@ -61,6 +61,19 @@ export default class CustomSignalingLayer extends SignalingLayer {
     /**
      * @inheritDoc
      */
+    removeSSRCOwners(ssrcList) {
+        if (!ssrcList?.length) {
+            return;
+        }
+
+        for (const ssrc of ssrcList) {
+            this.ssrcOwners.delete(ssrc);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
     setSSRCOwner(ssrc, endpointId) {
         if (typeof ssrc !== 'number') {
             throw new TypeError(`SSRC(${ssrc}) must be a number`);
@@ -101,5 +114,20 @@ export default class CustomSignalingLayer extends SignalingLayer {
      * @inheritDoc
      */
     setTrackSourceName(ssrc, sourceName) { // eslint-disable-line no-unused-vars
+    }
+
+    /**
+     * @inheritDoc
+     */
+    updateSsrcOwnersOnLeave(id) {
+        const ssrcs = Array.from(this.ssrcOwners)
+            .filter(entry => entry[1] === id)
+            .map(entry => entry[0]);
+
+        if (!ssrcs?.length) {
+            return;
+        }
+
+        this.removeSSRCOwners(ssrcs);
     }
 }

--- a/modules/proxyconnection/CustomSignalingLayer.js
+++ b/modules/proxyconnection/CustomSignalingLayer.js
@@ -2,9 +2,7 @@ import { getLogger } from '@jitsi/logger';
 
 import SignalingLayer from '../../service/RTC/SignalingLayer';
 
-
 const logger = getLogger(__filename);
-
 
 /**
  * Custom semi-mock implementation for the Proxy connection service.
@@ -27,14 +25,6 @@ export default class CustomSignalingLayer extends SignalingLayer {
          * @type {ChatRoom|null}
          */
         this.chatRoom = null;
-    }
-
-    /**
-     * Sets the <tt>ChatRoom</tt> instance used.
-     * @param {ChatRoom} room
-     */
-    setChatRoom(room) {
-        this.chatRoom = room;
     }
 
     /**
@@ -61,6 +51,13 @@ export default class CustomSignalingLayer extends SignalingLayer {
     /**
      * @inheritDoc
      */
+    getTrackSourceName(ssrc) { // eslint-disable-line no-unused-vars
+        return undefined;
+    }
+
+    /**
+     * @inheritDoc
+     */
     removeSSRCOwners(ssrcList) {
         if (!ssrcList?.length) {
             return;
@@ -69,6 +66,14 @@ export default class CustomSignalingLayer extends SignalingLayer {
         for (const ssrc of ssrcList) {
             this.ssrcOwners.delete(ssrc);
         }
+    }
+
+    /**
+     * Sets the <tt>ChatRoom</tt> instance used.
+     * @param {ChatRoom} room
+     */
+    setChatRoom(room) {
+        this.chatRoom = room;
     }
 
     /**
@@ -101,13 +106,6 @@ export default class CustomSignalingLayer extends SignalingLayer {
      */
     setTrackVideoType(sourceName, videoType) { // eslint-disable-line no-unused-vars
         return false;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    getTrackSourceName(ssrc) { // eslint-disable-line no-unused-vars
-        return undefined;
     }
 
     /**

--- a/modules/xmpp/SignalingLayerImpl.js
+++ b/modules/xmpp/SignalingLayerImpl.js
@@ -210,6 +210,21 @@ export default class SignalingLayerImpl extends SignalingLayer {
     }
 
     /**
+     * Logs a debug or error message to console depending on whether SSRC rewriting is enabled or not.
+     * Owner changes are permitted only when SSRC rewriting is enabled.
+     *
+     * @param {string} message - The message to be logged.
+     * @returns {void}
+     */
+    _logOwnerChangedMessage(message) {
+        if (FeatureFlags.isSsrcRewritingSupported()) {
+            logger.debug(message);
+        } else {
+            logger.error(message);
+        }
+    }
+
+    /**
      * @inheritDoc
      */
     getPeerMediaInfo(owner, mediaType, sourceName) {
@@ -331,8 +346,7 @@ export default class SignalingLayerImpl extends SignalingLayer {
         const existingOwner = this.ssrcOwners.get(ssrc);
 
         if (existingOwner && existingOwner !== endpointId) {
-            !FeatureFlags.isSsrcRewritingSupported()
-                && logger.error(`SSRC owner re-assigned from ${existingOwner} to ${endpointId}`);
+            this._logOwnerChangedMessage(`SSRC owner re-assigned from ${existingOwner} to ${endpointId}`);
         }
         this.ssrcOwners.set(ssrc, endpointId);
     }
@@ -367,7 +381,7 @@ export default class SignalingLayerImpl extends SignalingLayer {
         const existingName = this._sourceNames.get(ssrc);
 
         if (existingName && existingName !== sourceName) {
-            logger.error(`SSRC(${ssrc}) sourceName re-assigned from ${existingName} to ${sourceName}`);
+            this._logOwnerChangedMessage(`SSRC(${ssrc}) sourceName re-assigned from ${existingName} to ${sourceName}`);
         }
 
         this._sourceNames.set(ssrc, sourceName);

--- a/service/RTC/SignalingLayer.js
+++ b/service/RTC/SignalingLayer.js
@@ -136,6 +136,14 @@ export default class SignalingLayer extends Listenable {
     }
 
     /**
+     * Removes the association between a given SSRC and its current owner so that it can re-used when the SSRC gets
+     * remapped to another source from a different endpoint.
+     * @param {number} ssrc a list of SSRCs.
+     */
+    removeSSRCOwners(ssrcList) { // eslint-disable-line no-unused-vars
+    }
+
+    /**
      * Set an SSRC owner.
      * @param {number} ssrc an SSRC to be owned
      * @param {string} endpointId owner's ID (MUC nickname)
@@ -171,5 +179,14 @@ export default class SignalingLayer extends Listenable {
      * @returns {boolean}
      */
     setTrackVideoType(sourceName, videoType) { // eslint-disable-line no-unused-vars
+    }
+
+    /**
+     * Removes the SSRCs associated with a given endpoint from the SSRC owners.
+     *
+     * @param {string} id endpoint id of the participant leaving the call.
+     * @returns {void}
+     */
+    updateSsrcOwnersOnLeave(id) { // eslint-disable-line no-unused-vars
     }
 }

--- a/service/RTC/SignalingLayer.js
+++ b/service/RTC/SignalingLayer.js
@@ -88,16 +88,6 @@ export function getSourceIndexFromSourceName(sourceName) {
  * @interface SignalingLayer
  */
 export default class SignalingLayer extends Listenable {
-
-    /**
-     * Obtains the endpoint ID for given SSRC.
-     * @param {number} ssrc the SSRC number.
-     * @return {string|null} the endpoint ID for given media SSRC.
-     */
-    getSSRCOwner(ssrc) { // eslint-disable-line no-unused-vars
-        throw new Error('not implemented');
-    }
-
     /**
      * Obtains the info about given media advertised in the MUC presence of
      * the participant identified by the given MUC JID.
@@ -127,6 +117,15 @@ export default class SignalingLayer extends Listenable {
     }
 
     /**
+     * Obtains the endpoint ID for given SSRC.
+     * @param {number} ssrc the SSRC number.
+     * @return {string|null} the endpoint ID for given media SSRC.
+     */
+    getSSRCOwner(ssrc) { // eslint-disable-line no-unused-vars
+        throw new Error('not implemented');
+    }
+
+    /**
      * Obtains the source name for given SSRC.
      * @param {number} ssrc the track's SSRC identifier.
      * @returns {SourceName | undefined} the track's source name.
@@ -151,7 +150,6 @@ export default class SignalingLayer extends Listenable {
      */
     setSSRCOwner(ssrc, endpointId) { // eslint-disable-line no-unused-vars
     }
-
 
     /**
      * Adjusts muted status of given track.

--- a/types/hand-crafted/modules/xmpp/SignalingLayerImpl.d.ts
+++ b/types/hand-crafted/modules/xmpp/SignalingLayerImpl.d.ts
@@ -7,5 +7,7 @@ declare class SignalingLayerImpl extends SignalingLayer {
   setChatRoom: ( room: ChatRoom ) => void;
   getPeerMediaInfo: ( owner: string, mediaType: MediaType ) => PeerMediaInfo | null;
   getSSRCOwner: ( ssrc: number ) => string | null;
+  removeSSRCOwners: (ssrcList: Array<number> ) => void;
   setSSRCOwner: ( ssrc: number, endpointId: string ) => void;
+  updateSsrcOwnersOnLeave: ( id: string ) => void;
 }


### PR DESCRIPTION
Update the SSRC owners in the following cases:
1. When a remote endpoint leaves the call.
2. When a source-remove is received.
3. When a source is remapped (with ssrc-rewriting enabled). 

Create the remote track even if presence is not yet received. The ssrc owner check prevents the client from creating a dummy track when the call switches over from p2p to jvb after the last remote endpoint leaves the call.