### PR TITLE
fix(spot client, screenshare) - fix addHandler/deleteHandler & sharescreen remote - spot

### DIFF
--- a/modules/proxyconnection/ProxyConnectionService.js
+++ b/modules/proxyconnection/ProxyConnectionService.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import { $iq } from 'strophe.js';
 
 import { MediaType } from '../../service/RTC/MediaType';
+import { getSourceNameForJitsiTrack } from '../../service/RTC/SignalingLayer';
 import { VideoType } from '../../service/RTC/VideoType';
 import RTC from '../RTC/RTC';
 
@@ -136,6 +137,12 @@ export default class ProxyConnectionService {
         this._peerConnection = this._createPeerConnection(peerJid, {
             isInitiator: true,
             receiveVideo: false
+        });
+
+        localTracks.forEach((localTrack, localTrackIndex) => {
+            const localSourceNameTrack = getSourceNameForJitsiTrack('peer', localTrack.getType(), localTrackIndex);
+
+            localTrack.setSourceName(localSourceNameTrack);
         });
 
         this._peerConnection.start(localTracks);

--- a/modules/xmpp/XmppConnection.js
+++ b/modules/xmpp/XmppConnection.js
@@ -237,10 +237,19 @@ export default class XmppConnection extends Listenable {
     /**
      * See {@link Strophe.Connection.addHandler}
      *
-     * @returns {void}
+     * @returns {Object} - handler for the connection.
      */
     addHandler(...args) {
-        this._stropheConn.addHandler(...args);
+        return this._stropheConn.addHandler(...args);
+    }
+
+    /**
+     * See {@link Strophe.Connection.deleteHandler}
+     *
+     * @returns {void}
+     */
+    deleteHandler(...args) {
+        this._stropheConn.deleteHandler(...args);
     }
 
     /* eslint-disable max-params */


### PR DESCRIPTION
- fix issue undefined on spot client around `addHandler` and `deleteHandler` as it's using  xmpp connection  (with latest lib-jitsi-meet now we have a wrapper `XmppConnection`)
- fix issue when spot remote starts sharing the screen (error thrown in TraceablePeerConnection -> `_processLocalSSRCsMap` -> `getSourceIndexFromSourceName` because sourceName is null with Spot flow (`setSourceName` is not called)) 