### PR TITLE
Conference request over HTTP

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2532,11 +2532,7 @@ JitsiConference.prototype.stopRecording = function(sessionID) {
  * Returns true if the SIP calls are supported and false otherwise
  */
 JitsiConference.prototype.isSIPCallingSupported = function() {
-    if (this.room) {
-        return this.room.isSIPCallingSupported();
-    }
-
-    return false;
+    return this.room?.moderator?.isSipGatewayEnabled();
 };
 
 /**

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2532,7 +2532,7 @@ JitsiConference.prototype.stopRecording = function(sessionID) {
  * Returns true if the SIP calls are supported and false otherwise
  */
 JitsiConference.prototype.isSIPCallingSupported = function() {
-    return this.room?.moderator?.isSipGatewayEnabled();
+    return this.room?.moderator?.isSipGatewayEnabled() ?? false;
 };
 
 /**

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -186,13 +186,9 @@ export default class ChatRoom extends Listenable {
 
             // there is no point of sending conference iq when in visitor mode
             const preJoin
-                = this.options.disableFocus || this.options.hosts?.visitorFocus
+                = this.options.disableFocus
                     ? Promise.resolve()
                     : this.moderator.allocateConferenceFocus();
-
-            if (this.options.hosts?.visitorFocus) {
-                this.moderator.setFocusUserJid(this.options.hosts.visitorFocus);
-            }
 
             preJoin.then(() => {
                 this.sendPresence(true);
@@ -478,8 +474,7 @@ export default class ChatRoom extends Listenable {
         const jid = mucUserItem && mucUserItem.getAttribute('jid');
 
         member.jid = jid;
-        member.isFocus
-            = jid && jid.indexOf(`${this.moderator.getFocusUserJid()}/`) === 0;
+        member.isFocus = this.moderator.isFocusJid(jid);
         member.isHiddenDomain
             = jid && jid.indexOf('@') > 0
                 && this.options.hiddenDomain

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1650,17 +1650,6 @@ export default class ChatRoom extends Listenable {
     }
 
     /**
-     * Returns true if the SIP calls are supported and false otherwise
-     */
-    isSIPCallingSupported() {
-        if (this.moderator) {
-            return this.moderator.isSipGatewayEnabled();
-        }
-
-        return false;
-    }
-
-    /**
      * Dials a number.
      * @param number the number
      */

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -132,11 +132,7 @@ export default class ChatRoom extends Listenable {
         this.focusMucJid = null;
         this.noBridgeAvailable = false;
         this.options = options || {};
-        this.moderator
-            = new Moderator(this.roomjid, this.xmpp, this.eventEmitter, {
-                connection: this.xmpp.options,
-                conference: this.options
-            });
+        this.moderator = new Moderator(this.roomjid, this.xmpp, this.eventEmitter, options);
         if (typeof this.options.enableLobby === 'undefined' || this.options.enableLobby) {
             this.lobby = new Lobby(this);
         }

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -962,7 +962,7 @@ export default class ChatRoom extends Listenable {
      * whether this is the focus that left
      * @param reason the reason for leaving (optional).
      */
-    onParticipantLeft(jid, skipEvents, reason) {
+    onParticipantLeft(jid, skipEvents, reason, isFocus) {
         delete this.lastPresences[jid];
 
         if (skipEvents) {
@@ -971,9 +971,7 @@ export default class ChatRoom extends Listenable {
 
         this.eventEmitter.emit(XMPPEvents.MUC_MEMBER_LEFT, jid, reason);
 
-        const resource = Strophe.getResourceFromJid(jid);
-
-        if (resource === 'focus') {
+        if (isFocus) {
             logger.info('Focus has left the room - leaving conference');
             this.eventEmitter.emit(XMPPEvents.FOCUS_LEFT);
         }
@@ -1066,7 +1064,7 @@ export default class ChatRoom extends Listenable {
                 const member = this.members[jid];
 
                 delete this.members[jid];
-                this.onParticipantLeft(jid, member.isFocus);
+                this.onParticipantLeft(jid, member.isFocus, null, member.isFocus);
             });
             this.connection.emuc.doLeave(this.roomjid);
 
@@ -1084,7 +1082,7 @@ export default class ChatRoom extends Listenable {
             }
 
             delete this.members[from];
-            this.onParticipantLeft(from, false, reason);
+            this.onParticipantLeft(from, false, reason, member.isFocus);
         }
     }
 

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -971,7 +971,12 @@ export default class ChatRoom extends Listenable {
 
         this.eventEmitter.emit(XMPPEvents.MUC_MEMBER_LEFT, jid, reason);
 
-        this.moderator.onMucMemberLeft(jid);
+        const resource = Strophe.getResourceFromJid(jid);
+
+        if (resource === 'focus') {
+            logger.info('Focus has left the room - leaving conference');
+            this.eventEmitter.emit(XMPPEvents.FOCUS_LEFT);
+        }
     }
 
     /**

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1059,7 +1059,7 @@ export default class ChatRoom extends Listenable {
 
             // In this case we *do* fire MUC_MEMBER_LEFT for the focus?
             this.eventEmitter.emit(XMPPEvents.MUC_MEMBER_LEFT, from, reason);
-            if (member.isFocus) {
+            if (member?.isFocus) {
                 logger.info('Focus has left the room - leaving conference');
                 this.eventEmitter.emit(XMPPEvents.FOCUS_LEFT);
             }

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1033,9 +1033,9 @@ export default class ChatRoom extends Listenable {
                 const member = this.members[jid];
 
                 delete this.members[jid];
-                delete this.lastPresences[member.jid];
+                delete this.lastPresences[jid];
                 if (!member.isFocus) {
-                    this.eventEmitter.emit(XMPPEvents.MUC_MEMBER_LEFT, member.jid);
+                    this.eventEmitter.emit(XMPPEvents.MUC_MEMBER_LEFT, jid);
                 }
             });
             this.connection.emuc.doLeave(this.roomjid);
@@ -1058,7 +1058,7 @@ export default class ChatRoom extends Listenable {
             delete this.lastPresences[from];
 
             // In this case we *do* fire MUC_MEMBER_LEFT for the focus?
-            this.eventEmitter.emit(XMPPEvents.MUC_MEMBER_LEFT, member.jid, reason);
+            this.eventEmitter.emit(XMPPEvents.MUC_MEMBER_LEFT, from, reason);
             if (member.isFocus) {
                 logger.info('Focus has left the room - leaving conference');
                 this.eventEmitter.emit(XMPPEvents.FOCUS_LEFT);

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -188,7 +188,7 @@ export default class ChatRoom extends Listenable {
             const preJoin
                 = this.options.disableFocus
                     ? Promise.resolve()
-                    : this.moderator.allocateConferenceFocus();
+                    : this.moderator.sendConferenceRequest();
 
             preJoin.then(() => {
                 this.sendPresence(true);

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -323,11 +323,6 @@ Moderator.prototype._allocateConferenceFocusError = function(error, callback) {
         logger.info('Session expired! - removing');
         Settings.sessionId = undefined;
     }
-    if ($(error).find('>error>graceful-shutdown').length) {
-        this.eventEmitter.emit(XMPPEvents.GRACEFUL_SHUTDOWN);
-
-        return;
-    }
 
     // Check for error returned by the reservation system
     const reservationErr = $(error).find('>error>reservation-error');

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -18,6 +18,7 @@ const logger = getLogger(__filename);
  */
 function createExpBackoffTimer(step) {
     let count = 1;
+    const maxTimeout = 120000;
 
     return function(reset) {
         // Reset call
@@ -32,7 +33,7 @@ function createExpBackoffTimer(step) {
 
         count += 1;
 
-        return timeout * step;
+        return Math.min(timeout * step, maxTimeout);
     };
 }
 

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -1,3 +1,4 @@
+/* eslint-disable newline-per-chained-call */
 import { getLogger } from '@jitsi/logger';
 import $ from 'jquery';
 import { $iq } from 'strophe.js';
@@ -34,8 +35,6 @@ function createExpBackoffTimer(step) {
         return timeout * step;
     };
 }
-
-/* eslint-disable max-params */
 
 /**
  *
@@ -230,16 +229,11 @@ Moderator.prototype._createConferenceIq = function() {
 Moderator.prototype._parseConferenceIq = function(resultIq) {
     const conferenceRequest = { properties: {} };
 
-    conferenceRequest.focusJid = $(resultIq).find('conference')
-        .attr('focusjid');
-    conferenceRequest.sessionId = $(resultIq).find('conference')
-        .attr('session-id');
-    conferenceRequest.identity = $(resultIq).find('>conference')
-        .attr('identity');
-    conferenceRequest.ready = $(resultIq).find('conference')
-        .attr('ready');
-    conferenceRequest.vnode = $(resultIq).find('conference')
-        .attr('vnode');
+    conferenceRequest.focusJid = $(resultIq).find('conference').attr('focusjid');
+    conferenceRequest.sessionId = $(resultIq).find('conference').attr('session-id');
+    conferenceRequest.identity = $(resultIq).find('>conference').attr('identity');
+    conferenceRequest.ready = $(resultIq).find('conference').attr('ready');
+    conferenceRequest.vnode = $(resultIq).find('conference').attr('vnode');
 
     if ($(resultIq).find('>conference>property[name=\'authentication\'][value=\'true\']').length > 0) {
         conferenceRequest.properties.authentication = 'true';
@@ -345,7 +339,6 @@ Moderator.prototype._handleSuccess = function(conferenceRequest, callback) {
     this.sipGatewayEnabled = conferenceRequest.properties.sipGatewayEnabled;
     logger.info(`Sip gateway enabled:  ${this.sipGatewayEnabled}`);
 
-    // eslint-disable-next-line newline-per-chained-call
     if (conferenceRequest.ready) {
         // Reset the non-error timeout (because we've succeeded here).
         this.getNextTimeout(true);
@@ -395,14 +388,14 @@ Moderator.prototype._handleError = function(sessionError, notAuthorized, callbac
         this.getNextTimeout(true);
         window.setTimeout(() => this.sendConferenceRequest().then(callback), waitMs);
     } else {
-        const errmsg = `Focus error, retry after ${waitMs}`;
+        const errmsg = 'Failed to get a successful response, giving up.';
         const error = new Error(errmsg);
 
         logger.error(errmsg, error);
         GlobalOnErrorHandler.callErrorHandler(error);
+        // This is a "fatal" error and the user of the lib should handle it accordingly.
+        // TODO: change the event name to something accurate.
         this.eventEmitter.emit(XMPPEvents.FOCUS_DISCONNECTED);
-
-        // Do we need to resolve()? Or throw an error?
     }
 };
 
@@ -469,8 +462,7 @@ Moderator.prototype.authenticate = function() {
         this.connection.sendIQ(
             this._createConferenceIq(),
             result => {
-                const sessionId = $(result).find('conference')
-                    .attr('session-id');
+                const sessionId = $(result).find('conference').attr('session-id');
 
                 if (sessionId) {
                     logger.info(`Received sessionId:  ${sessionId}`);
@@ -482,10 +474,8 @@ Moderator.prototype.authenticate = function() {
                 resolve();
             },
             errorIq => reject({
-                error: $(errorIq).find('iq>error :first')
-                    .prop('tagName'),
-                message: $(errorIq).find('iq>error>text')
-                    .text()
+                error: $(errorIq).find('iq>error :first').prop('tagName'),
+                message: $(errorIq).find('iq>error>text').text()
             })
         );
     });
@@ -533,7 +523,6 @@ Moderator.prototype._getLoginUrl = function(popup, urlCb, failureCb) {
     this.connection.sendIQ(
         iq,
         result => {
-            // eslint-disable-next-line newline-per-chained-call
             let url = $(result).find('login-url').attr('url');
 
             url = decodeURIComponent(url);
@@ -569,7 +558,6 @@ Moderator.prototype.logout = function(callback) {
     this.connection.sendIQ(
         iq,
         result => {
-            // eslint-disable-next-line newline-per-chained-call
             let logoutUrl = $(result).find('logout').attr('logout-url');
 
             if (logoutUrl) {

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -61,11 +61,11 @@ export default function Moderator(roomName, xmpp, emitter, options) {
 
     this.connection = xmpp.connection;
 
-    this.focusComponent = this.options.connection?.hosts?.focus;
+    this.focusComponent = this.options.hosts?.focus;
 
     // If not specified default to 'focus.domain'
     if (!this.focusComponent) {
-        this.focusComponent = `focus.${this.options.connection?.hosts?.domain}`;
+        this.focusComponent = `focus.${this.options.hosts?.domain}`;
     }
 
     // FIXME: Message listener that talks to POPUP window
@@ -135,7 +135,7 @@ Moderator.prototype._createConferenceRequest = function() {
 
     // Session Id used for authentication
     const { sessionId, machineUID } = Settings;
-    const config = this.options.conference;
+    const config = this.options;
     const properties = {};
 
     if (config.startBitrate) {
@@ -145,11 +145,11 @@ Moderator.prototype._createConferenceRequest = function() {
         properties.minBitrate = config.minBitrate;
     }
 
-    if (this.options.conference.startAudioMuted !== undefined) {
-        properties.startAudioMuted = this.options.conference.startAudioMuted;
+    if (config.startAudioMuted !== undefined) {
+        properties.startAudioMuted = config.startAudioMuted;
     }
-    if (this.options.conference.startVideoMuted !== undefined) {
-        properties.startVideoMuted = this.options.conference.startVideoMuted;
+    if (config.startVideoMuted !== undefined) {
+        properties.startVideoMuted = config.startVideoMuted;
     }
 
     // this flag determines whether the bridge will include this call in its
@@ -158,7 +158,7 @@ Moderator.prototype._createConferenceRequest = function() {
     // react/features/rtcstats/functions.js in jitsi-meet). The server-side
     // components default to true to match the pre-existing behavior so we only
     // signal if false.
-    const rtcstatsEnabled = this.options.conference?.analytics?.rtcstatsEnabled ?? false;
+    const rtcstatsEnabled = config?.analytics?.rtcstatsEnabled ?? false;
 
     if (!rtcstatsEnabled) {
         properties.rtcstatsEnabled = false;
@@ -272,8 +272,8 @@ Moderator.prototype._parseConfigOptions = function(resultIq) {
  */
 Moderator.prototype.allocateConferenceFocus = function() {
     return new Promise(resolve => {
-        // Try to use focus user JID from the config
-        this.setFocusUserJid(this.options.connection.focusUserJid);
+        // Try to use focus user JID from the config. TODO why do we override this just prior to sending a request?
+        this.setFocusUserJid(this.options.focusUserJid);
 
         // Send create conference IQ
         this.connection.sendIQ(
@@ -340,7 +340,7 @@ Moderator.prototype._allocateConferenceFocusError = function(error, callback) {
         logger.warn('Unauthorized to start the conference', error);
         const toDomain = Strophe.getDomainFromJid(error.getAttribute('to'));
 
-        if (toDomain !== this.options.connection.hosts.anonymousdomain) {
+        if (toDomain !== this.options.hosts.anonymousdomain) {
             // FIXME "is external" should come either from the focus or
             // config.js
             this.externalAuthEnabled = true;

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -77,11 +77,6 @@ export default function Moderator(roomName, xmpp, emitter, options) {
         this.focusUserJids.add(options.focusUserJid);
     }
 
-    // TODO: this one is redundant, we can use the one above instead.
-    if (options.hosts?.visitorFocus) {
-        this.focusUserJids.add(options.hosts?.visitorFocus);
-    }
-
     // FIXME: Message listener that talks to POPUP window
     /**
      *
@@ -122,8 +117,6 @@ Moderator.prototype.isFocusJid = function(jid) {
 
     return false;
 };
-
-/* eslint-enable max-params */
 
 Moderator.prototype.isExternalAuthEnabled = function() {
     return this.externalAuthEnabled;

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -100,16 +100,6 @@ Moderator.prototype.isSipGatewayEnabled = function() {
     return this.sipGatewayEnabled;
 };
 
-Moderator.prototype.onMucMemberLeft = function(jid) {
-    const resource = Strophe.getResourceFromJid(jid);
-
-    if (resource === 'focus') {
-        logger.info(
-            'Focus has left the room - leaving conference');
-        this.eventEmitter.emit(XMPPEvents.FOCUS_LEFT);
-    }
-};
-
 Moderator.prototype.setFocusUserJid = function(focusJid) {
     if (!this.focusUserJid) {
         this.focusUserJid = focusJid;


### PR DESCRIPTION
- ref: Inline onMucMemberLeft (has nothing to do with "moderator" and is broken).
- fix: Use isFocus instead of just reading the resource.
- ref: Inline onParticipantLeft.
- ref: Add _ to private function names.
- ref: Remove redundant function.
- ref: Initialize focusComponent once.
- ref: Remove two copies of "options".
- ref: Simplify the focusJid flow.
- ref: Rename focusCompoonent to targetJid.
- fix: Only retry on "invalid sessin" errors
- ref: Remove use of visitorFocus.
- ref: Remove graceful shutdown handling (never used in backend).
- feat: Support conference request over HTTP.
- ref: eslint cleanup.
- fix: Add max timeout 2 minutes.
- squash: Fixes conference request handling.
