### PR TITLE
fix(codec-selection): Codec selection fixes.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -81,6 +81,21 @@ const logger = getLogger(__filename);
 const JINGLE_SI_TIMEOUT = 5000;
 
 /**
+ * Checks if a given string is a valid video codec mime type.
+ *
+ * @param {string} codec the codec string that needs to be validated.
+ * @returns {CodecMimeType|null} mime type if valid, null otherwise.
+ * @private
+ */
+function _getCodecMimeType(codec) {
+    if (typeof codec === 'string') {
+        return Object.values(CodecMimeType).find(value => value === codec.toLowerCase());
+    }
+
+    return null;
+}
+
+/**
  * Creates a JitsiConference object with the given name and properties.
  * Note: this constructor is not a part of the public API (objects should be
  * created using JitsiConnection.createConference).
@@ -355,18 +370,12 @@ JitsiConference.prototype._init = function(options = {}) {
     const { config } = this.options;
 
     // Get the codec preference settings from config.js.
-    // 'preferH264' and 'disableH264' settings have been deprecated for a while,
-    // 'preferredCodec' and 'disabledCodec' will have precedence over them.
     const codecSettings = {
-        disabledCodec: config.videoQuality
-            ? config.videoQuality.disabledCodec
-            : config.p2p && config.p2p.disableH264 && CodecMimeType.H264,
-        enforcePreferredCodec: config.videoQuality && config.videoQuality.enforcePreferredCodec,
-        jvbCodec: (config.videoQuality && config.videoQuality.preferredCodec)
-            || (config.preferH264 && CodecMimeType.H264),
-        p2pCodec: config.p2p
-            ? config.p2p.preferredCodec || (config.p2p.preferH264 && CodecMimeType.H264)
-            : CodecMimeType.VP8
+        jvbDisabledCodec: _getCodecMimeType(config.videoQuality?.disabledCodec),
+        p2pDisabledCodec: _getCodecMimeType(config.p2p?.disabledCodec),
+        enforcePreferredCodec: config.videoQuality?.enforcePreferredCodec,
+        jvbPreferredCodec: _getCodecMimeType(config.videoQuality?.preferredCodec),
+        p2pPreferredCodec: _getCodecMimeType(config.p2p?.preferredCodec)
     };
 
     this.codecSelection = new CodecSelection(this, codecSettings);

--- a/modules/RTC/CodecSelection.js
+++ b/modules/RTC/CodecSelection.js
@@ -32,24 +32,29 @@ export class CodecSelection {
     constructor(conference, options) {
         this.conference = conference;
         this.options = options;
+        this.enforcePreferredCodec = options.enforcePreferredCodec;
 
-        // VP8 cannot be disabled and it will be the default codec when no preference is set.
-        this.disabledCodec = options.disabledCodec === CodecMimeType.VP8
-            ? undefined
-            : this._getCodecMimeType(options.disabledCodec);
+        // VP8 cannot be disabled since it the default codec.
+        this.p2pDisabledCodec = options.p2pDisabledCodec !== CodecMimeType.VP8
+            && this._isCodecSupported(options.p2pDisabledCodec)
+            && options.p2pDisabledCodec;
+        this.jvbDisabledCodec = options.jvbDisabledCodec !== CodecMimeType.VP8
+            && this._isCodecSupported(options.jvbDisabledCodec)
+            && options.jvbDisabledCodec;
 
-        // Check if the codec values passed are valid.
-        const jvbCodec = this._getCodecMimeType(options.jvbCodec);
-        const p2pCodec = this._getCodecMimeType(options.p2pCodec);
+        // Determine the preferred codecs.
+        this.p2pPreferredCodec = this._isCodecSupported(options.p2pPreferredCodec)
+            && options.p2pPreferredCodec !== options.p2pDisabledCodec
+            ? options.p2pPreferredCodec
+            : CodecMimeType.VP8;
+        this.jvbPreferredCodec = this._isCodecSupported(options.jvbPreferredCodec)
+            && options.jvbPreferredCodec !== options.jvbDisabledCodec
+            ? options.jvbPreferredCodec
+            : CodecMimeType.VP8;
 
-        this.jvbPreferredCodec = jvbCodec && this._isCodecSupported(jvbCodec) ? jvbCodec : CodecMimeType.VP8;
-        this.p2pPreferredCodec = p2pCodec && this._isCodecSupported(p2pCodec) ? p2pCodec : CodecMimeType.VP8;
-        logger.debug(`Codec preferences for the conference are JVB: ${this.jvbPreferredCodec},
-            P2P: ${this.p2pPreferredCodec}`);
-
-        if (this.jvbPreferredCodec === CodecMimeType.VP9 && !browser.supportsVP9()) {
-            this.jvbPreferredCodec = CodecMimeType.VP8;
-        }
+        logger.debug(`Codec preferences for the conference are JVB: preferred=${this.jvbPreferredCodec},`
+            + `disabled=${this.jvbDisabledCodec} P2P: preferred=${this.p2pPreferredCodec},`
+            + `disabled=${this.p2pDisabledCodec}`);
 
         this.conference.on(
             JitsiConferenceEvents.USER_JOINED,
@@ -59,22 +64,7 @@ export class CodecSelection {
             () => this._selectPreferredCodec());
         this.conference.on(
             JitsiConferenceEvents._MEDIA_SESSION_STARTED,
-            session => this._onMediaSessionStarted(session));
-    }
-
-    /**
-     * Checks if a given string is a valid video codec mime type.
-     *
-     * @param {string} codec the codec string that needs to be validated.
-     * @returns {CodecMimeType|null} mime type if valid, null otherwise.
-     * @private
-     */
-    _getCodecMimeType(codec) {
-        if (typeof codec === 'string') {
-            return Object.values(CodecMimeType).find(value => value === codec.toLowerCase());
-        }
-
-        return null;
+            session => this._selectPreferredCodec(session));
     }
 
     /**
@@ -85,8 +75,16 @@ export class CodecSelection {
      * @private
      */
     _isCodecSupported(preferredCodec) {
+        if (!preferredCodec) {
+            return false;
+        }
+
+        if (preferredCodec === CodecMimeType.VP9 && !this.enforcePreferredCodec && !browser.supportsVP9()) {
+            return false;
+        }
+
         // Skip the check on FF because it does not support the getCapabilities API.
-        // It is safe to assume both of them support all the codecs supported by Chrome.
+        // It is safe to assume that Firefox supports all the codecs supported by Chrome.
         if (browser.isFirefox()) {
             return true;
         }
@@ -98,50 +96,43 @@ export class CodecSelection {
     }
 
     /**
-     * Handles the {@link JitsiConferenceEvents._MEDIA_SESSION_STARTED} event. Codecs need to be
-     * configured on the media session that is newly created.
-     *
-     * @param {JingleSessionPC} mediaSession media session that started.
-     * @returns {void}
-     * @private
-     */
-    _onMediaSessionStarted(mediaSession) {
-        const preferredCodec = mediaSession.isP2P ? this.p2pPreferredCodec : this.jvbPreferredCodec;
-        const disabledCodec = this.disabledCodec && this._isCodecSupported(this.disabledCodec)
-            ? this.disabledCodec
-            : null;
-
-        this._selectPreferredCodec(mediaSession, preferredCodec, disabledCodec);
-    }
-
-    /**
-     * Sets the codec on the media session based on the preferred codec setting and the supported codecs
+     * Sets the codec on the media session based on the preferred/disabled codec setting and the supported codecs
      * published by the remote participants in their presence.
      *
      * @param {JingleSessionPC} mediaSession session for which the codec selection has to be made.
-     * @param {CodecMimeType} preferredCodec preferred codec.
-     * @param {CodecMimeType} disabledCodec codec that needs to be disabled.
      */
-    _selectPreferredCodec(mediaSession = null, preferredCodec = null, disabledCodec = null) {
+    _selectPreferredCodec(mediaSession) {
         const session = mediaSession ? mediaSession : this.conference.jvbJingleSession;
-        const currentCodec = preferredCodec ? preferredCodec : this.jvbPreferredCodec;
-        let selectedCodec = currentCodec;
 
-        if (session && !session.isP2P && !this.options.enforcePreferredCodec) {
+        if (!session) {
+            return;
+        }
+        const preferredCodec = session.isP2P ? this.p2pPreferredCodec : this.jvbPreferredCodec;
+        const disabledCodec = session.isP2P ? this.p2pDisabledCodec : this.jvbDisabledCodec;
+        const currentCodec = session?.peerconnection.getConfiguredVideoCodec();
+        let selectedCodec = preferredCodec ?? currentCodec;
+
+        if (!this.enforcePreferredCodec) {
             const remoteParticipants = this.conference.getParticipants().map(participant => participant.getId());
-
-            for (const remote of remoteParticipants) {
+            const remoteCodecs = remoteParticipants?.map(remote => {
                 const peerMediaInfo = session._signalingLayer.getPeerMediaInfo(remote, MediaType.VIDEO);
-                const peerCodec = peerMediaInfo?.codecType;
 
-                if (peerCodec
-                    && peerCodec !== currentCodec
-                    && (peerCodec !== CodecMimeType.VP9 || browser.supportsVP9())) {
-                    selectedCodec = peerCodec;
-                }
+                return peerMediaInfo?.codecType;
+            });
+
+            const nonPreferredCodecs = remoteCodecs.filter(codec => codec !== selectedCodec && codec !== disabledCodec);
+
+            // Find the fallback codec when there are endpoints in the call that don't have the same preferred codec
+            // set.
+            if (nonPreferredCodecs.length) {
+                // Always prefer VP8 as that is the default codec supported on all client types.
+                selectedCodec = nonPreferredCodecs.find(codec => codec === CodecMimeType.VP8)
+                    ?? nonPreferredCodecs.find(codec => this._isCodecSupported(codec));
             }
         }
-        session && session.setVideoCodecs(selectedCodec, disabledCodec);
+        if (selectedCodec !== currentCodec || disabledCodec) {
+            session.setVideoCodecs(selectedCodec, disabledCodec);
+        }
     }
 
     /**

--- a/modules/sdp/SDPUtil.js
+++ b/modules/sdp/SDPUtil.js
@@ -645,6 +645,8 @@ const SDPUtil = {
                 payloadTypes.unshift(pt);
             }
             mline.payloads = payloadTypes.join(' ');
+        } else {
+            logger.error(`No matching RTP payload type found for ${codecName}, failed to set preferred codecs`);
         }
     },
 


### PR DESCRIPTION
1. Checks peer's preferred codec in p2p case. Mobile and web have different preferred codecs.
2. Log an error message when the preferred codec is not offered by JVB.
3. Clean up code related to deprecated config.js settings 'preferH264' and 'disableH264'.
4. Refactor the codec selection logic so that correct codec is picked.