### PR TITLE
Feat ssrc rewriting

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -574,15 +574,15 @@ JitsiConferenceEventManager.prototype.setupRTCListeners = function() {
     });
 
     rtc.addListener(RTCEvents.VIDEO_SSRCS_REMAPPED, msg => {
-        const sess = this.conference.getActiveMediaSession();
-
-        sess.videoSsrcsRemapped(msg);
+        for (const session of this.conference.getMediaSessions()) {
+            session.processSourceMap(msg, MediaType.VIDEO);
+        }
     });
 
     rtc.addListener(RTCEvents.AUDIO_SSRCS_REMAPPED, msg => {
-        const sess = this.conference.getActiveMediaSession();
-
-        sess.audioSsrcsRemapped(msg);
+        for (const session of this.conference.getMediaSessions()) {
+            session.processSourceMap(msg, MediaType.AUDIO);
+        }
     });
 
     rtc.addListener(RTCEvents.ENDPOINT_MESSAGE_RECEIVED,

--- a/JitsiConferenceEvents.spec.ts
+++ b/JitsiConferenceEvents.spec.ts
@@ -31,6 +31,7 @@ describe( "/JitsiConferenceEvents members", () => {
         JVB121_STATUS,
         KICKED,
         PARTICIPANT_KICKED,
+        PARTICIPANT_SOURCE_UPDATED,
         LAST_N_ENDPOINTS_CHANGED,
         FORWARDED_SOURCES_CHANGED,
         LOCK_STATE_CHANGED,
@@ -108,6 +109,7 @@ describe( "/JitsiConferenceEvents members", () => {
         expect( JVB121_STATUS ).toBe( 'conference.jvb121Status' );
         expect( KICKED ).toBe( 'conference.kicked' );
         expect( PARTICIPANT_KICKED ).toBe( 'conference.participant_kicked' );
+        expect( PARTICIPANT_SOURCE_UPDATED ).toBe( 'conference.participant_source_updated' );
         expect( LAST_N_ENDPOINTS_CHANGED ).toBe( 'conference.lastNEndpointsChanged' );
         expect( FORWARDED_SOURCES_CHANGED ).toBe( 'conference.forwardedSourcesChanged' );
         expect( LOCK_STATE_CHANGED ).toBe( 'conference.lock_state_changed' );

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -242,6 +242,11 @@ export enum JitsiConferenceEvents {
     PARTICIPANT_PROPERTY_CHANGED = 'conference.participant_property_changed',
 
     /**
+     * Indicates the state of sources attached to a given remote participant has changed.
+     */
+    PARTICIPANT_SOURCE_UPDATED = 'conference.participant_source_updated',
+
+    /**
      * Indicates that the conference has switched between JVB and P2P connections.
      * The first argument of this event is a <tt>boolean</tt> which when set to
      * <tt>true</tt> means that the conference is running on the P2P connection.
@@ -490,6 +495,7 @@ export const E2EE_VERIFICATION_COMPLETED = JitsiConferenceEvents.E2EE_VERIFICATI
 export const JVB121_STATUS = JitsiConferenceEvents.JVB121_STATUS;
 export const KICKED = JitsiConferenceEvents.KICKED;
 export const PARTICIPANT_KICKED = JitsiConferenceEvents.PARTICIPANT_KICKED;
+export const PARTICIPANT_SOURCE_UPDATED = JitsiConferenceEvents.PARTICIPANT_SOURCE_UPDATED;
 export const LAST_N_ENDPOINTS_CHANGED = JitsiConferenceEvents.LAST_N_ENDPOINTS_CHANGED;
 export const FORWARDED_SOURCES_CHANGED = JitsiConferenceEvents.FORWARDED_SOURCES_CHANGED;
 export const LOCK_STATE_CHANGED = JitsiConferenceEvents.LOCK_STATE_CHANGED;

--- a/JitsiParticipant.js
+++ b/JitsiParticipant.js
@@ -43,6 +43,7 @@ export default class JitsiParticipant {
         this._isReplacing = isReplacing;
         this._isReplaced = isReplaced;
         this._features = new Set();
+        this._sources = new Map();
     }
 
     /**
@@ -59,6 +60,32 @@ export default class JitsiParticipant {
             (muted, track) =>
                 muted && (track.getType() !== mediaType || track.isMuted()),
             true);
+    }
+
+    /**
+     * Sets source info.
+     * @param {MediaType} mediaType The media type, 'audio' or 'video'.
+     * @param {boolean} muted The new muted state.
+     * @param {string} sourceName The name of the source.
+     * @param {string} videoType The video type of the source.
+     * @returns {void}
+     */
+    _setSources(mediaType, muted, sourceName, videoType) {
+        let sourceByMediaType = this._sources.get(mediaType);
+        const sourceInfo = {
+            muted,
+            videoType
+        };
+
+        if (sourceByMediaType?.size) {
+            sourceByMediaType.set(sourceName, sourceInfo);
+
+            return;
+        }
+
+        sourceByMediaType = new Map();
+        sourceByMediaType.set(sourceName, sourceInfo);
+        this._sources.set(mediaType, sourceByMediaType);
     }
 
     /**
@@ -128,6 +155,19 @@ export default class JitsiParticipant {
      */
     getRole() {
         return this._role;
+    }
+
+    /**
+     * Returns the sources for a given media type.
+     * @param {string} mediaType The type of media, 'audio' or 'video'.
+     * @returns {Map<string, Object>}
+     */
+    getSources(mediaType) {
+        if (!mediaType) {
+            return this._sources;
+        }
+
+        return this._sources.get(mediaType);
     }
 
     /**

--- a/JitsiParticipant.js
+++ b/JitsiParticipant.js
@@ -43,6 +43,18 @@ export default class JitsiParticipant {
         this._isReplacing = isReplacing;
         this._isReplaced = isReplaced;
         this._features = new Set();
+
+        /**
+         * Remote sources associated with the participant in the following format.
+         * Map<mediaType, Map<sourceName, sourceInfo>>
+         *
+         * mediaType - 'audio' or 'video'.
+         * sourceName - name of the remote source.
+         * sourceInfo: {
+         *   muted: boolean;
+         *   videoType: string;
+         * }
+         */
         this._sources = new Map();
     }
 
@@ -158,16 +170,11 @@ export default class JitsiParticipant {
     }
 
     /**
-     * Returns the sources for a given media type.
-     * @param {string} mediaType The type of media, 'audio' or 'video'.
-     * @returns {Map<string, Object>}
+     * Returns the sources associated with this participant.
+     * @returns Map<string, Map<string, Object>>
      */
-    getSources(mediaType) {
-        if (!mediaType) {
-            return this._sources;
-        }
-
-        return this._sources.get(mediaType);
+    getSources() {
+        return this._sources;
     }
 
     /**

--- a/modules/xmpp/SignalingLayerImpl.js
+++ b/modules/xmpp/SignalingLayerImpl.js
@@ -172,7 +172,7 @@ export default class SignalingLayerImpl extends SignalingLayer {
                     }
                 }
 
-                if (sourceChanged) {
+                if (sourceChanged && FeatureFlags.isSsrcRewritingSupported()) {
                     this.eventEmitter.emit(
                         SignalingEvents.SOURCE_UPDATED,
                         sourceName,

--- a/modules/xmpp/SignalingLayerImpl.spec.js
+++ b/modules/xmpp/SignalingLayerImpl.spec.js
@@ -196,12 +196,19 @@ describe('SignalingLayerImpl', () => {
                 }, 'endpoint1');
 
                 // Just once event though the legacy presence is there as well
-                expect(emitterSpy).toHaveBeenCalledTimes(1);
-                expect(emitterSpy).toHaveBeenCalledWith(
+                expect(emitterSpy).toHaveBeenCalledTimes(2);
+                expect(emitterSpy.calls.argsFor(0)).toEqual([
                     SignalingEvents.SOURCE_MUTED_CHANGED,
                     '12345678-a0',
                     true
-                );
+                ]);
+                expect(emitterSpy.calls.argsFor(1)).toEqual([
+                    SignalingEvents.SOURCE_UPDATED,
+                    '12345678-a0',
+                    'endpoint1',
+                    true,
+                    undefined
+                ]);
             });
         });
     });

--- a/modules/xmpp/SignalingLayerImpl.spec.js
+++ b/modules/xmpp/SignalingLayerImpl.spec.js
@@ -179,7 +179,7 @@ describe('SignalingLayerImpl', () => {
                     true
                 );
             });
-            it('from a user with SourceInfo', () => {
+            it('from a user with SourceInfo and ssrc-rewriting disabled', () => {
                 const emitterSpy = spyOn(signalingLayer.eventEmitter, 'emit');
                 const sourceInfo = {
                     '12345678-a0': {
@@ -196,12 +196,32 @@ describe('SignalingLayerImpl', () => {
                 }, 'endpoint1');
 
                 // Just once event though the legacy presence is there as well
-                expect(emitterSpy).toHaveBeenCalledTimes(2);
-                expect(emitterSpy.calls.argsFor(0)).toEqual([
+                expect(emitterSpy).toHaveBeenCalledTimes(1);
+                expect(emitterSpy).toHaveBeenCalledWith(
                     SignalingEvents.SOURCE_MUTED_CHANGED,
                     '12345678-a0',
                     true
-                ]);
+                );
+            });
+
+            it('from a user with sourceInfo and ssrc-rewriting enabled', () => {
+                FeatureFlags.init({ ssrcRewritingEnabled: true });
+                const emitterSpy = spyOn(signalingLayer.eventEmitter, 'emit');
+                const sourceInfo = {
+                    '12345678-a0': {
+                        muted: true
+                    }
+                };
+
+                chatRoom.mockSourceInfoPresence('endpoint1', sourceInfo);
+
+                // <audiomuted/> still included for backwards compat and ChatRoom will emit the presence event
+                chatRoom.emitPresenceListener({
+                    tagName: 'audiomuted',
+                    value: 'true'
+                }, 'endpoint1');
+
+                expect(emitterSpy).toHaveBeenCalledTimes(2);
                 expect(emitterSpy.calls.argsFor(1)).toEqual([
                     SignalingEvents.SOURCE_UPDATED,
                     '12345678-a0',

--- a/service/RTC/SignalingEvents.spec.ts
+++ b/service/RTC/SignalingEvents.spec.ts
@@ -7,6 +7,7 @@ describe( "/service/RTC/SignalingEvents members", () => {
         PEER_MUTED_CHANGED,
         PEER_VIDEO_TYPE_CHANGED,
         SOURCE_MUTED_CHANGED,
+        SOURCE_UPDATED,
         SOURCE_VIDEO_TYPE_CHANGED,
         SignalingEvents,
         ...others
@@ -16,6 +17,7 @@ describe( "/service/RTC/SignalingEvents members", () => {
         expect( PEER_MUTED_CHANGED ).toBe( 'signaling.peerMuted' );
         expect( PEER_VIDEO_TYPE_CHANGED ).toBe( 'signaling.peerVideoType' );
         expect( SOURCE_MUTED_CHANGED ).toBe( 'signaling.sourceMuted');
+        expect( SOURCE_UPDATED ).toBe( 'signaling.sourceUpdated' );
         expect( SOURCE_VIDEO_TYPE_CHANGED ).toBe( 'signaling.sourceVideoType');
 
         expect( SignalingEvents ).toBeDefined();

--- a/service/RTC/SignalingEvents.ts
+++ b/service/RTC/SignalingEvents.ts
@@ -25,6 +25,16 @@ export enum SignalingEvents {
     SOURCE_MUTED_CHANGED = 'signaling.sourceMuted',
 
     /**
+     * Event triggered when presence for a source is received.
+     *
+     * @param {string} sourceName - The name of the source.
+     * @param {string} endpointId - The endpoint id.
+     * @param {boolean} muted - The new muted state.
+     * @param {string} videoType - The video type of the source.
+     */
+    SOURCE_UPDATED = 'signaling.sourceUpdated',
+
+    /**
      * Event triggered when source's video type changes.
      *
      * @param {string} source - The name of the source.
@@ -37,4 +47,5 @@ export enum SignalingEvents {
 export const PEER_MUTED_CHANGED = SignalingEvents.PEER_MUTED_CHANGED;
 export const PEER_VIDEO_TYPE_CHANGED = SignalingEvents.PEER_VIDEO_TYPE_CHANGED;
 export const SOURCE_MUTED_CHANGED = SignalingEvents.SOURCE_MUTED_CHANGED;
+export const SOURCE_UPDATED = SignalingEvents.SOURCE_UPDATED;
 export const SOURCE_VIDEO_TYPE_CHANGED = SignalingEvents.SOURCE_VIDEO_TYPE_CHANGED;


### PR DESCRIPTION
In this feature:

- There will be a fixed set of remote tracks and therefore a fixed set of SSRCs.

- The bridge will re-map those SSRCs to a remote sender based on what is being requested and then the owner (source) of a remote track will change.

- The bridge does the remapping based on the receiver constraints received from the client.

- However, the receiver constraints currently are derived from the tracks in redux but with ssrc-rewriting, the tracks won't be created unless it is signaled. So it is a chicken and egg problem. Therefore, we will be constructing the receiver constraints based on the remote presence since all the source information is already signaled in presence.

There is jitsi-meet PR which does the receiver constraints part - https://github.com/jitsi/jitsi-meet/pull/12408/files#diff-ce724de6e7f229a65b2483d045183950192efdb68e35f9c5587a139609a49de6L371