### PR TITLE
fix(qualitycontrol): Cleanup old receiver constraints.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1582,38 +1582,6 @@ JitsiConference.prototype.unlock = function() {
 };
 
 /**
- * Elects the participant with the given id to be the selected participant in
- * order to receive higher video quality (if simulcast is enabled).
- * Or cache it if channel is not created and send it once channel is available.
- * @param participantId the identifier of the participant
- * @throws NetworkError or InvalidStateError or Error if the operation fails.
- * @returns {void}
- */
-JitsiConference.prototype.selectParticipant = function(participantId) {
-    this.selectParticipants([ participantId ]);
-};
-
-/*
- * Elects participants with given ids to be the selected participants in order
- * to receive higher video quality (if simulcast is enabled). The argument
- * should be an array of participant id strings or an empty array; an error will
- * be thrown if a non-array is passed in. The error is thrown as a layer of
- * protection against passing an invalid argument, as the error will happen in
- * the bridge and may not be visible in the client.
- *
- * @param {Array<strings>} participantIds - An array of identifiers for
- * participants.
- * @returns {void}
- */
-JitsiConference.prototype.selectParticipants = function(participantIds) {
-    if (!Array.isArray(participantIds)) {
-        throw new Error('Invalid argument; participantIds must be an array.');
-    }
-
-    this.receiveVideoController.selectEndpoints(participantIds);
-};
-
-/**
  * Obtains the current value for "lastN". See {@link setLastN} for more info.
  * @returns {number}
  */

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -233,41 +233,11 @@ export default class BridgeChannel {
     }
 
     /**
-     * Sends a "selected endpoints changed" message via the channel.
-     *
-     * @param {Array<string>} endpointIds - The ids of the selected endpoints.
-     * @throws NetworkError or InvalidStateError from RTCDataChannel#send (@see
-     * {@link https://developer.mozilla.org/docs/Web/API/RTCDataChannel/send})
-     * or from WebSocket#send or Error with "No opened channel" message.
-     */
-    sendSelectedEndpointsMessage(endpointIds) {
-        logger.log(`Sending selected endpoints: ${endpointIds}.`);
-
-        this._send({
-            colibriClass: 'SelectedEndpointsChangedEvent',
-            selectedEndpoints: endpointIds
-        });
-    }
-
-    /**
-     * Sends a "receiver video constraint" message via the channel.
-     * @param {Number} maxFrameHeightPixels the maximum frame height,
-     * in pixels, this receiver is willing to receive
-     */
-    sendReceiverVideoConstraintMessage(maxFrameHeightPixels) {
-        logger.log(`Sending ReceiverVideoConstraint with maxFrameHeight=${maxFrameHeightPixels}px`);
-        this._send({
-            colibriClass: 'ReceiverVideoConstraint',
-            maxFrameHeight: maxFrameHeightPixels
-        });
-    }
-
-    /**
      * Sends a 'ReceiverVideoConstraints' message via the bridge channel.
      *
      * @param {ReceiverVideoConstraints} constraints video constraints.
      */
-    sendNewReceiverVideoConstraintsMessage(constraints) {
+    sendReceiverVideoConstraintsMessage(constraints) {
         logger.log(`Sending ReceiverVideoConstraints with ${JSON.stringify(constraints)}`);
         this._send({
             colibriClass: 'ReceiverVideoConstraints',
@@ -276,21 +246,7 @@ export default class BridgeChannel {
     }
 
     /**
-     * Sends a 'VideoTypeMessage' message via the bridge channel.
-     *
-     * @param {string} videoType 'camera', 'desktop' or 'none'.
-     * @deprecated to be replaced with sendSourceVideoTypeMessage
-     */
-    sendVideoTypeMessage(videoType) {
-        logger.debug(`Sending VideoTypeMessage with video type as ${videoType}`);
-        this._send({
-            colibriClass: 'VideoTypeMessage',
-            videoType
-        });
-    }
-
-    /**
-     * Sends a 'VideoTypeMessage' message via the bridge channel.
+     * Sends a 'SourceVideoTypeMessage' message via the bridge channel.
      *
      * @param {BridgeVideoType} videoType - the video type.
      * @param {SourceName} sourceName - the source name of the video track.
@@ -375,15 +331,6 @@ export default class BridgeChannel {
                 logger.info(`New forwarded sources: ${forwardedSources}`);
                 emitter.emit(RTCEvents.FORWARDED_SOURCES_CHANGED, forwardedSources);
 
-                break;
-            }
-            case 'SenderVideoConstraints': {
-                const videoConstraints = obj.videoConstraints;
-
-                if (videoConstraints) {
-                    logger.info(`SenderVideoConstraints: ${JSON.stringify(videoConstraints)}`);
-                    emitter.emit(RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED, videoConstraints);
-                }
                 break;
             }
             case 'SenderSourceConstraints': {

--- a/modules/qualitycontrol/ReceiveVideoController.js
+++ b/modules/qualitycontrol/ReceiveVideoController.js
@@ -194,7 +194,7 @@ export default class ReceiveVideoController {
             this._receiverVideoConstraints = new ReceiverVideoConstraints();
             const lastNUpdated = this._receiverVideoConstraints.updateLastN(this._lastN);
 
-            lastNUpdated && this._rtc.setNewReceiverVideoConstraints(this._receiverVideoConstraints.constraints);
+            lastNUpdated && this._rtc.setReceiverVideoConstraints(this._receiverVideoConstraints.constraints);
         } else {
             this._rtc.setLastN(this._lastN);
         }
@@ -237,7 +237,7 @@ export default class ReceiveVideoController {
             mediaSession.setReceiverVideoConstraint(this._maxFrameHeight, this._sourceReceiverConstraints);
         } else {
             this._receiverVideoConstraints.updateReceiveResolution(this._maxFrameHeight);
-            this._rtc.setNewReceiverVideoConstraints(this._receiverVideoConstraints.constraints);
+            this._rtc.setReceiverVideoConstraints(this._receiverVideoConstraints.constraints);
         }
     }
 
@@ -270,7 +270,7 @@ export default class ReceiveVideoController {
 
             // Send bridge message only when the constraints change.
             if (!isEqual(newConstraints, oldConstraints)) {
-                this._rtc.setNewReceiverVideoConstraints(newConstraints);
+                this._rtc.setReceiverVideoConstraints(newConstraints);
             }
 
             return;
@@ -293,7 +293,7 @@ export default class ReceiveVideoController {
                 const lastNUpdated = this._receiverVideoConstraints.updateLastN(value);
 
                 // Send out the message on the bridge channel if lastN was updated.
-                lastNUpdated && this._rtc.setNewReceiverVideoConstraints(this._receiverVideoConstraints.constraints);
+                lastNUpdated && this._rtc.setReceiverVideoConstraints(this._receiverVideoConstraints.constraints);
 
                 return;
             }
@@ -319,7 +319,7 @@ export default class ReceiveVideoController {
                 const resolutionUpdated = this._receiverVideoConstraints.updateReceiveResolution(maxFrameHeight);
 
                 resolutionUpdated
-                    && this._rtc.setNewReceiverVideoConstraints(this._receiverVideoConstraints.constraints);
+                    && this._rtc.setReceiverVideoConstraints(this._receiverVideoConstraints.constraints);
             }
         }
     }
@@ -345,7 +345,7 @@ export default class ReceiveVideoController {
         if (constraintsChanged) {
             this._lastN = constraints.lastN ?? this._lastN;
             this._selectedEndpoints = constraints.selectedEndpoints ?? this._selectedEndpoints;
-            this._rtc.setNewReceiverVideoConstraints(constraints);
+            this._rtc.setReceiverVideoConstraints(constraints);
 
             const p2pSession = this._conference.getMediaSessions().find(session => session.isP2P);
 

--- a/modules/qualitycontrol/ReceiveVideoController.spec.js
+++ b/modules/qualitycontrol/ReceiveVideoController.spec.js
@@ -40,8 +40,7 @@ export class MockRTC extends Listenable {
     }
 
     // eslint-disable-next-line no-empty-function
-    setNewReceiverVideoConstraints() {
-
+    setReceiverVideoConstraints() {
     }
 }
 
@@ -62,8 +61,8 @@ describe('ReceiveVideoController', () => {
             FeatureFlags.init({ });
         });
 
-        it('should call setNewReceiverVideoConstraints with the source names format.', () => {
-            const rtcSpy = spyOn(rtc, 'setNewReceiverVideoConstraints');
+        it('should call setReceiverVideoConstraints with the source names format.', () => {
+            const rtcSpy = spyOn(rtc, 'setReceiverVideoConstraints');
             const constraints = {
                 onStageSources: [ 'A_camera_1', 'B_screen_2', 'C_camera_1' ],
                 selectedSources: [ 'A_camera_1' ]

--- a/types/hand-crafted/JitsiConference.d.ts
+++ b/types/hand-crafted/JitsiConference.d.ts
@@ -70,8 +70,6 @@ export default class JitsiConference {
   isModerator: () => boolean | null;
   lock: ( password: string ) => Promise<unknown | Error>;
   unlock: () => Promise<unknown | Error>;
-  selectParticipant: ( participantId: string ) => void;
-  selectParticipants: ( participantIds: string[] ) => void;
   getLastN: () => number;
   setLastN: ( lastN: number ) => void;
   getParticipants: () => JitsiParticipant[];

--- a/types/hand-crafted/modules/RTC/BridgeChannel.d.ts
+++ b/types/hand-crafted/modules/RTC/BridgeChannel.d.ts
@@ -1,3 +1,5 @@
+import { ReceiverVideoConstraints } from "../qualitycontrol/ReceiveVideoController";
+
 export default class BridgeChannel {
   constructor( peerconnection: unknown, wsUrl: unknown, emitter: unknown ); // TODO:
   mode: () => null | "datachannel" | "websocket";
@@ -5,9 +7,6 @@ export default class BridgeChannel {
   isOpen: () => boolean;
   sendMessage: ( to: string, payload: unknown ) => void; // TODO:
   sendSetLastNMessage: ( value: number ) => void;
-  sendSelectedEndpointsMessage: ( endpointIds: string[] ) => void;
-  sendReceiverVideoConstraintMessage: ( maxFrameHeightPixels: number ) => void;
   sendEndpointStatsMessage: ( payload: unknown ) => void; // TODO:
-  sendNewReceiverVideoConstraintsMessage: ( constraints: ReceiverVideoConstraints ) => void; // TODO:
-  sendVideoTypeMessage: ( videoType: string ) => void;
+  sendReceiverVideoConstraintsMessage: ( constraints: ReceiverVideoConstraints ) => void;
 }

--- a/types/hand-crafted/modules/RTC/RTC.d.ts
+++ b/types/hand-crafted/modules/RTC/RTC.d.ts
@@ -12,8 +12,6 @@ export default class RTC extends Listenable {
   initializeBridgeChannel: ( perrconnection: RTCPeerConnection, wsUrl: string ) => void;
   onCallEnded: () => void;
   setDesktopSharingFrameRate: (maxFps: number) => void;
-  setReceiverVideoConstraint: ( maxFrameHeight: number ) => void;
-  selectEndpoints: ( ids: string[] ) => void;
   static addListener: ( eventType: string, listener: unknown ) => void; // TODO: this should be typed to an enum of eventTypes with appropriate definition for the listeners
   static removeListener: ( eventType: string, listener: unknown ) => void; // TODO: this should be typed to an enum of eventTypes with appropriate definition for the listeners
   static init: ( options: unknown ) => unknown; // TODO:
@@ -44,8 +42,7 @@ export default class RTC extends Listenable {
   sendChannelMessage: ( to: string, payload: unknown ) => void; // TODO:
   setLastN: ( value: number ) => void;
   isInForwardedSources: ( sourceName: string ) => boolean;
-  setNewReceiverVideoConstraints: ( constraints: unknown ) => void; // TODO:
-  setVideoType: ( videoType: string ) => void;
+  setReceiverVideoConstraints: ( constraints: unknown ) => void; // TODO:
   setVideoMute: ( value: unknown ) => Promise<unknown>; // TODO:
   arePermissionsGrantedForAvailableDevices: () => boolean;
   sendEndpointStatsMessage: ( payload: unknown ) => void; // TODO:


### PR DESCRIPTION
Endpoint based receiver constraints and other endpoint based bridge signaling messages are no longer supported by latest JVB after the switch to source-name signaling.

Rename method names 'sendNewReceiverVideoConstraintsMessage'->'sendReceiverVideoConstraintsMessage', 'setNewReceiverVideoConstraints'->'setReceiverVideoConstraints'