### PR TITLE
fix(TPC): make screen share bitrate configurable

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -50,47 +50,6 @@ export class TPCUtils {
     }
 
     /**
-     * The startup configuration for the stream encodings that are applicable to
-     * the video stream when a new sender is created on the peerconnection. The initial
-     * config takes into account the differences in browser's simulcast implementation.
-     *
-     * Encoding parameters:
-     * active - determine the on/off state of a particular encoding.
-     * maxBitrate - max. bitrate value to be applied to that particular encoding
-     *  based on the encoding's resolution and config.js videoQuality settings if applicable.
-     * rid - Rtp Stream ID that is configured for a particular simulcast stream.
-     * scaleResolutionDownBy - the factor by which the encoding is scaled down from the
-     *  original resolution of the captured video.
-     *
-     *  @param {VideoType} videoType
-     */
-    _getVideoStreamEncodings(videoType) {
-        const maxVideoRate = videoType === VideoType.DESKTOP
-            ? this.encodingBitrates.ssHigh : this.encodingBitrates.high;
-
-        return [
-            {
-                active: true,
-                maxBitrate: browser.isFirefox() ? maxVideoRate : this.encodingBitrates.low,
-                rid: SIM_LAYER_1_RID,
-                scaleResolutionDownBy: browser.isFirefox() ? HD_SCALE_FACTOR : LD_SCALE_FACTOR
-            },
-            {
-                active: true,
-                maxBitrate: this.encodingBitrates.standard,
-                rid: SIM_LAYER_2_RID,
-                scaleResolutionDownBy: SD_SCALE_FACTOR
-            },
-            {
-                active: true,
-                maxBitrate: browser.isFirefox() ? this.encodingBitrates.low : maxVideoRate,
-                rid: SIM_LAYER_3_RID,
-                scaleResolutionDownBy: browser.isFirefox() ? LD_SCALE_FACTOR : HD_SCALE_FACTOR
-            }
-        ];
-    }
-
-    /**
      * Obtains stream encodings that need to be configured on the given track based
      * on the track media type and the simulcast setting.
      * @param {JitsiLocalTrack} localTrack
@@ -106,6 +65,47 @@ export class TPCUtils {
                 maxBitrate: this.videoBitrates.high
             } ]
             : [ { active: true } ];
+    }
+
+    /**
+     * The startup configuration for the stream encodings that are applicable to
+     * the video stream when a new sender is created on the peerconnection. The initial
+     * config takes into account the differences in browser's simulcast implementation.
+     *
+     * Encoding parameters:
+     * active - determine the on/off state of a particular encoding.
+     * maxBitrate - max. bitrate value to be applied to that particular encoding
+     *  based on the encoding's resolution and config.js videoQuality settings if applicable.
+     * rid - Rtp Stream ID that is configured for a particular simulcast stream.
+     * scaleResolutionDownBy - the factor by which the encoding is scaled down from the
+     *  original resolution of the captured video.
+     *
+     *  @param {VideoType} videoType
+     */
+    _getVideoStreamEncodings(videoType) {
+        const maxVideoBitrate = videoType === VideoType.DESKTOP && this.encodingBitrates.ssHigh
+            ? this.encodingBitrates.ssHigh : this.encodingBitrates.high;
+
+        return [
+            {
+                active: true,
+                maxBitrate: browser.isFirefox() ? maxVideoBitrate : this.encodingBitrates.low,
+                rid: SIM_LAYER_1_RID,
+                scaleResolutionDownBy: browser.isFirefox() ? HD_SCALE_FACTOR : LD_SCALE_FACTOR
+            },
+            {
+                active: true,
+                maxBitrate: this.encodingBitrates.standard,
+                rid: SIM_LAYER_2_RID,
+                scaleResolutionDownBy: SD_SCALE_FACTOR
+            },
+            {
+                active: true,
+                maxBitrate: browser.isFirefox() ? this.encodingBitrates.low : maxVideoBitrate,
+                rid: SIM_LAYER_3_RID,
+                scaleResolutionDownBy: browser.isFirefox() ? LD_SCALE_FACTOR : HD_SCALE_FACTOR
+            }
+        ];
     }
 
     /**

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -38,7 +38,8 @@ export class TPCUtils {
         const standardBitrates = {
             low: LD_BITRATE,
             standard: SD_BITRATE,
-            high: HD_BITRATE
+            high: HD_BITRATE,
+            ssHigh: HD_BITRATE
         };
 
         // Check if the max. bitrates for video are specified through config.js videoQuality settings.

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -47,28 +47,6 @@ export class TPCUtils {
         // configured on the SDP using b:AS line.
         this.videoBitrates = bitrateSettings ?? standardBitrates;
         this.encodingBitrates = this.videoBitrates.VP8 ?? this.videoBitrates;
-
-
-        this.localStreamEncodingsConfig = [
-            {
-                active: true,
-                maxBitrate: browser.isFirefox() ? encodingBitrates.high : encodingBitrates.low,
-                rid: SIM_LAYER_1_RID,
-                scaleResolutionDownBy: browser.isFirefox() ? HD_SCALE_FACTOR : LD_SCALE_FACTOR
-            },
-            {
-                active: true,
-                maxBitrate: encodingBitrates.standard,
-                rid: SIM_LAYER_2_RID,
-                scaleResolutionDownBy: SD_SCALE_FACTOR
-            },
-            {
-                active: true,
-                maxBitrate: browser.isFirefox() ? encodingBitrates.low : encodingBitrates.high,
-                rid: SIM_LAYER_3_RID,
-                scaleResolutionDownBy: browser.isFirefox() ? LD_SCALE_FACTOR : HD_SCALE_FACTOR
-            }
-        ];
     }
 
     /**

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -46,21 +46,9 @@ export class TPCUtils {
         // Right now only VP8 bitrates are configured on the simulcast encodings, VP9 bitrates have to be
         // configured on the SDP using b:AS line.
         this.videoBitrates = bitrateSettings ?? standardBitrates;
-        const encodingBitrates = this.videoBitrates.VP8 ?? this.videoBitrates;
+        this.encodingBitrates = this.videoBitrates.VP8 ?? this.videoBitrates;
 
-        /**
-         * The startup configuration for the stream encodings that are applicable to
-         * the video stream when a new sender is created on the peerconnection. The initial
-         * config takes into account the differences in browser's simulcast implementation.
-         *
-         * Encoding parameters:
-         * active - determine the on/off state of a particular encoding.
-         * maxBitrate - max. bitrate value to be applied to that particular encoding
-         *  based on the encoding's resolution and config.js videoQuality settings if applicable.
-         * rid - Rtp Stream ID that is configured for a particular simulcast stream.
-         * scaleResolutionDownBy - the factor by which the encoding is scaled down from the
-         *  original resolution of the captured video.
-         */
+
         this.localStreamEncodingsConfig = [
             {
                 active: true,
@@ -84,13 +72,54 @@ export class TPCUtils {
     }
 
     /**
+     * The startup configuration for the stream encodings that are applicable to
+     * the video stream when a new sender is created on the peerconnection. The initial
+     * config takes into account the differences in browser's simulcast implementation.
+     *
+     * Encoding parameters:
+     * active - determine the on/off state of a particular encoding.
+     * maxBitrate - max. bitrate value to be applied to that particular encoding
+     *  based on the encoding's resolution and config.js videoQuality settings if applicable.
+     * rid - Rtp Stream ID that is configured for a particular simulcast stream.
+     * scaleResolutionDownBy - the factor by which the encoding is scaled down from the
+     *  original resolution of the captured video.
+     *
+     *  @param {VideoType} videoType
+     */
+    _getVideoStreamEncodings(videoType) {
+        const maxVideoRate = videoType === VideoType.DESKTOP
+            ? this.encodingBitrates.ssHigh : this.encodingBitrates.high;
+
+        return [
+            {
+                active: true,
+                maxBitrate: browser.isFirefox() ? maxVideoRate : this.encodingBitrates.low,
+                rid: SIM_LAYER_1_RID,
+                scaleResolutionDownBy: browser.isFirefox() ? HD_SCALE_FACTOR : LD_SCALE_FACTOR
+            },
+            {
+                active: true,
+                maxBitrate: this.encodingBitrates.standard,
+                rid: SIM_LAYER_2_RID,
+                scaleResolutionDownBy: SD_SCALE_FACTOR
+            },
+            {
+                active: true,
+                maxBitrate: browser.isFirefox() ? this.encodingBitrates.low : maxVideoRate,
+                rid: SIM_LAYER_3_RID,
+                scaleResolutionDownBy: browser.isFirefox() ? LD_SCALE_FACTOR : HD_SCALE_FACTOR
+            }
+        ];
+    }
+
+    /**
      * Obtains stream encodings that need to be configured on the given track based
      * on the track media type and the simulcast setting.
      * @param {JitsiLocalTrack} localTrack
      */
     _getStreamEncodings(localTrack) {
         if (this.pc.isSimulcastOn() && localTrack.isVideoTrack()) {
-            return this.localStreamEncodingsConfig;
+            return this._getVideoStreamEncodings(localTrack.getVideoType());
         }
 
         return localTrack.isVideoTrack()
@@ -278,7 +307,8 @@ export class TPCUtils {
     calculateEncodingsActiveState(localVideoTrack, newHeight) {
         const localTrack = localVideoTrack.getTrack();
         const { height } = localTrack.getSettings();
-        const encodingsState = this.localStreamEncodingsConfig
+        const videoStreamEncodings = this._getVideoStreamEncodings(localVideoTrack.getVideoType());
+        const encodingsState = videoStreamEncodings
         .map(encoding => height / encoding.scaleResolutionDownBy)
         .map((frameHeight, idx) => {
             let active = localVideoTrack.getVideoType() === VideoType.CAMERA
@@ -287,7 +317,7 @@ export class TPCUtils {
                 // resolution. This can happen when camera is captured at resolutions higher than 720p but the
                 // requested resolution is 180. Since getParameters doesn't give us information about the resolutions
                 // of the simulcast encodings, we have to rely on our initial config for the simulcast streams.
-                ? newHeight > 0 && this.localStreamEncodingsConfig[idx]?.scaleResolutionDownBy === LD_SCALE_FACTOR
+                ? newHeight > 0 && videoStreamEncodings[idx]?.scaleResolutionDownBy === LD_SCALE_FACTOR
                     ? true
                     : frameHeight <= newHeight
 
@@ -303,7 +333,7 @@ export class TPCUtils {
                 && this.pc._capScreenshareBitrate
                 && this.pc.usesUnifiedPlan()
                 && !browser.isWebKitBased()
-                && this.localStreamEncodingsConfig[idx].scaleResolutionDownBy !== HD_SCALE_FACTOR) {
+                && videoStreamEncodings[idx].scaleResolutionDownBy !== HD_SCALE_FACTOR) {
                 active = false;
             }
 
@@ -326,7 +356,7 @@ export class TPCUtils {
         const lowFpsScreenshare = localVideoTrack.getVideoType() === VideoType.DESKTOP
             && this.pc._capScreenshareBitrate
             && !browser.isWebKitBased();
-        const encodingsBitrates = this.localStreamEncodingsConfig
+        const encodingsBitrates = this._getVideoStreamEncodings(localVideoTrack.getVideoType())
         .map(encoding => {
             const bitrate = lowFpsScreenshare
                 ? desktopShareBitrate
@@ -492,10 +522,11 @@ export class TPCUtils {
      * that were configured on the RTCRtpSender when the source was added to the peerconnection.
      * This should prevent us from overriding the default values if the browser returns
      * erroneous values when RTCRtpSender.getParameters is used for getting the encodings info.
+     * @param {JitsiLocalTrack} localVideoTrack The local video track.
      * @param {Object} parameters - the RTCRtpEncodingParameters obtained from the browser.
      * @returns {void}
      */
-    updateEncodingsResolution(parameters) {
+    updateEncodingsResolution(localVideoTrack, parameters) {
         if (!(browser.isWebKitBased() && parameters.encodings && Array.isArray(parameters.encodings))) {
             return;
         }
@@ -505,8 +536,10 @@ export class TPCUtils {
 
         // Implement the workaround only when all the encodings report the same resolution.
         if (allEqualEncodings(parameters.encodings)) {
+            const videoStreamEncodings = this._getVideoStreamEncodings(localVideoTrack.getVideoType());
+
             parameters.encodings.forEach((encoding, idx) => {
-                encoding.scaleResolutionDownBy = this.localStreamEncodingsConfig[idx].scaleResolutionDownBy;
+                encoding.scaleResolutionDownBy = videoStreamEncodings[idx].scaleResolutionDownBy;
             });
         }
     }

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2396,11 +2396,12 @@ TraceablePeerConnection.prototype._setVp9MaxBitrates = function(description, isL
         if (this.codecPreference.mimeType === CodecMimeType.VP9) {
             const bitrates = this.tpcUtils.videoBitrates.VP9 || this.tpcUtils.videoBitrates;
             const hdBitrate = bitrates.high ? bitrates.high : HD_BITRATE;
+            const ssHdBitrate = bitrates.ssHigh ? bitrates.ssHigh : HD_BITRATE;
             const mid = mLine.mid;
             const isSharingScreen = FeatureFlags.isMultiStreamSendSupportEnabled()
                 ? mid === this._getDesktopTrackMid()
                 : this._isSharingScreen();
-            const limit = Math.floor((isSharingScreen ? HD_BITRATE : hdBitrate) / 1000);
+            const limit = Math.floor((isSharingScreen ? ssHdBitrate : hdBitrate) / 1000);
 
             // Use only the HD bitrate for now as there is no API available yet for configuring
             // the bitrates on the individual SVC layers.

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2642,7 +2642,7 @@ TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeig
                 }
             }
         }
-        this.tpcUtils.updateEncodingsResolution(parameters);
+        this.tpcUtils.updateEncodingsResolution(localVideoTrack, parameters);
 
     // For p2p and cases and where simulcast is explicitly disabled.
     } else if (frameHeight > 0) {


### PR DESCRIPTION
This makes the screenshare bitrate configurable if using VP9. Happy to make changes.

Not sure if `localStreamEncodingsConfig` needs to change as well