### PR TITLE
fix(SDP): search for extmap at session level

### DIFF
--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -319,7 +319,7 @@ SDP.prototype.toJingle = function(elem, thecreator) {
             this.rtcpFbToJingle(i, elem, '*');
 
             // XEP-0294
-            const extmapLines = SDPUtil.findLines(this.media[i], 'a=extmap:');
+            const extmapLines = SDPUtil.findLines(this.media[i], 'a=extmap:', this.session);
 
             for (let j = 0; j < extmapLines.length; j++) {
                 const extmap = SDPUtil.parseExtmap(extmapLines[j]);


### PR DESCRIPTION
According to the RFC's extmap attributes are allowed at the media and the session level. This makes us look for them at the session level as well in case something starts doing that one day.