### PR TITLE
fix(TPCUtils) filter stopped transceivers

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -468,6 +468,10 @@ export class TPCUtils {
 
         logger.info(`${this.pc} ${active ? 'Enabling' : 'Suspending'} ${mediaType} media transfer.`);
         transceivers.forEach(transceiver => {
+            if (transceiver.stopped) {
+                return;
+            }
+
             if (active) {
                 const localTrackMids = Array.from(this.pc._localTrackTransceiverMids);
 


### PR DESCRIPTION
When tracks are removed from a PC the transceiver will transition to a stopped state.

In the JVB PC this means we want to filter it out when setting the connection to inactive, since changing the direction of a stopped transceiver throws an exception.