### PR TITLE
fix(BridgeChannel): Attempt conn retries when there are remote endpoints.

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -193,7 +193,7 @@ export default class RTC extends Listenable {
      * @param {string} [wsUrl] WebSocket URL.
      */
     initializeBridgeChannel(peerconnection, wsUrl) {
-        this._channel = new BridgeChannel(peerconnection, wsUrl, this.eventEmitter);
+        this._channel = new BridgeChannel(peerconnection, wsUrl, this.eventEmitter, this.conference);
 
         this._channelOpenListener = () => {
             const logError = (error, msgType, value) => {


### PR DESCRIPTION
Currently, the client doesn't attempt to re-establish bridge WS when the connection is closed by the remote end with a code 1001. We have noticed that Cloudflare terminates the WS with the same error code when it recycles its proxies. When that happens, client ends up not having a bridge channel which can result quality issues. Client now tries to re-establish connection when there are remote endpoints in the call.