### PR TITLE
fix(TPC) Disable media instead of changing dir for p2p->jvb switch.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1637,7 +1637,7 @@ JitsiConference.prototype.setLastN = function(lastN) {
         const isVideoActive = n !== 0;
 
         this.p2pJingleSession
-            .setMediaTransferActive(isVideoActive)
+            .setP2pVideoTransferActive(isVideoActive)
             .catch(error => {
                 logger.error(`Failed to adjust video transfer status (${isVideoActive})`, error);
             });
@@ -3288,7 +3288,7 @@ JitsiConference.prototype._removeRemoteTracks = function(sessionNickname, remote
  */
 JitsiConference.prototype._resumeMediaTransferForJvbConnection = function() {
     logger.info('Resuming media transfer over the JVB connection...');
-    this.jvbJingleSession.resumeOrSuspendMedia(true)
+    this.jvbJingleSession.setMediaTransferActive(true)
         .then(() => {
             logger.info('Resumed media transfer over the JVB connection!');
         })
@@ -3325,7 +3325,7 @@ JitsiConference.prototype._setP2PStatus = function(newStatus) {
         // when the lastN value was being adjusted.
         const isVideoActive = this.getLastN() !== 0;
 
-        this.p2pJingleSession.setMediaTransferActive(isVideoActive)
+        this.p2pJingleSession.setP2pVideoTransferActive(isVideoActive)
             .catch(error => {
                 logger.error(`Failed to sync up P2P video transfer status (${isVideoActive}), ${error}`);
             });
@@ -3412,7 +3412,7 @@ JitsiConference.prototype._startP2PSession = function(remoteJid) {
  */
 JitsiConference.prototype._suspendMediaTransferForJvbConnection = function() {
     logger.info('Suspending media transfer over the JVB connection...');
-    this.jvbJingleSession.resumeOrSuspendMedia(false)
+    this.jvbJingleSession.setMediaTransferActive(false)
         .then(() => {
             logger.info('Suspended media transfer over the JVB connection !');
         })

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1632,17 +1632,14 @@ JitsiConference.prototype.setLastN = function(lastN) {
     }
     this.receiveVideoController.setLastN(n);
 
-    // If the P2P session is not fully established yet, we wait until it gets
-    // established.
+    // If the P2P session is not fully established yet, we wait until it gets established.
     if (this.p2pJingleSession) {
         const isVideoActive = n !== 0;
 
         this.p2pJingleSession
-            .setMediaTransferActive(true, isVideoActive)
+            .setMediaTransferActive(isVideoActive)
             .catch(error => {
-                logger.error(
-                    `Failed to adjust video transfer status (${isVideoActive})`,
-                    error);
+                logger.error(`Failed to adjust video transfer status (${isVideoActive})`, error);
             });
     }
 };
@@ -3291,14 +3288,12 @@ JitsiConference.prototype._removeRemoteTracks = function(sessionNickname, remote
  */
 JitsiConference.prototype._resumeMediaTransferForJvbConnection = function() {
     logger.info('Resuming media transfer over the JVB connection...');
-    this.jvbJingleSession.setMediaTransferActive(true, true).then(
-        () => {
+    this.jvbJingleSession.resumeOrSuspendMedia(true)
+        .then(() => {
             logger.info('Resumed media transfer over the JVB connection!');
-        },
-        error => {
-            logger.error(
-                'Failed to resume media transfer over the JVB connection:',
-                error);
+        })
+        .catch(error => {
+            logger.error('Failed to resume media transfer over the JVB connection:', error);
         });
 };
 
@@ -3330,12 +3325,9 @@ JitsiConference.prototype._setP2PStatus = function(newStatus) {
         // when the lastN value was being adjusted.
         const isVideoActive = this.getLastN() !== 0;
 
-        this.p2pJingleSession
-            .setMediaTransferActive(true, isVideoActive)
+        this.p2pJingleSession.setMediaTransferActive(isVideoActive)
             .catch(error => {
-                logger.error(
-                    'Failed to sync up P2P video transfer status'
-                        + `(${isVideoActive})`, error);
+                logger.error(`Failed to sync up P2P video transfer status (${isVideoActive}), ${error}`);
             });
     } else {
         logger.info('Peer to peer connection closed!');
@@ -3420,14 +3412,12 @@ JitsiConference.prototype._startP2PSession = function(remoteJid) {
  */
 JitsiConference.prototype._suspendMediaTransferForJvbConnection = function() {
     logger.info('Suspending media transfer over the JVB connection...');
-    this.jvbJingleSession.setMediaTransferActive(false, false).then(
-        () => {
+    this.jvbJingleSession.resumeOrSuspendMedia(false)
+        .then(() => {
             logger.info('Suspended media transfer over the JVB connection !');
-        },
-        error => {
-            logger.error(
-                'Failed to suspend media transfer over the JVB connection:',
-                error);
+        })
+        .catch(error => {
+            logger.error('Failed to suspend media transfer over the JVB connection:', error);
         });
 };
 

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -61,10 +61,10 @@ export class TPCUtils {
 
         return localTrack.isVideoTrack()
             ? [ {
-                active: true,
+                active: this.pc.videoTransferActive,
                 maxBitrate: this.videoBitrates.high
             } ]
-            : [ { active: true } ];
+            : [ { active: this.pc.audioTransferActive } ];
     }
 
     /**
@@ -88,19 +88,19 @@ export class TPCUtils {
 
         return [
             {
-                active: true,
+                active: this.pc.videoTransferActive,
                 maxBitrate: browser.isFirefox() ? maxVideoBitrate : this.encodingBitrates.low,
                 rid: SIM_LAYER_1_RID,
                 scaleResolutionDownBy: browser.isFirefox() ? HD_SCALE_FACTOR : LD_SCALE_FACTOR
             },
             {
-                active: true,
+                active: this.pc.videoTransferActive,
                 maxBitrate: this.encodingBitrates.standard,
                 rid: SIM_LAYER_2_RID,
                 scaleResolutionDownBy: SD_SCALE_FACTOR
             },
             {
-                active: true,
+                active: this.pc.videoTransferActive,
                 maxBitrate: browser.isFirefox() ? this.encodingBitrates.low : maxVideoBitrate,
                 rid: SIM_LAYER_3_RID,
                 scaleResolutionDownBy: browser.isFirefox() ? LD_SCALE_FACTOR : HD_SCALE_FACTOR
@@ -353,12 +353,13 @@ export class TPCUtils {
     }
 
     /**
-     * Returns the max resolution encoded by the client for a given local video track.
+     * Returns the max resolution that the client is configured to encode for a given local video track. The actual
+     * send resolution might be downscaled based on cpu and bandwidth constraints.
      *
      * @param {JitsiLocalTrack} localVideoTrack - The local video track.
      * @returns {number} The max encoded resolution for the given video track.
      */
-    getEncodedResolution(localVideoTrack) {
+    getConfiguredEncodeResolution(localVideoTrack) {
         const localTrack = localVideoTrack.getTrack();
         const { height } = localTrack.getSettings();
         const videoSender = this.pc.findSenderForTrack(localVideoTrack.getTrack());
@@ -449,34 +450,6 @@ export class TPCUtils {
     }
 
     /**
-     * Resumes or suspends media on the peerconnection by setting the active state on RTCRtpEncodingParameters
-     * associates with all the senders that have a track attached to it.
-     *
-     * @param {boolean} enable - whether media needs to be enabled or suspended.
-     * @returns {Promise} - A promise that is resolved with an array of results when the change is succesful on all the
-     * senders, rejected otherwise.
-     */
-    resumeOrSuspendMedia(enable) {
-        logger.info(`${this.pc} ${enable ? 'Resuming' : 'Suspending'} media transfer.`);
-
-        const senders = this.pc.peerconnection.getSenders().filter(s => Boolean(s.track));
-        const promises = [];
-
-        for (const sender of senders) {
-            const parameters = sender.getParameters();
-
-            if (parameters?.encodings?.length) {
-                for (const encoding of parameters.encodings) {
-                    encoding.active = enable;
-                }
-            }
-            promises.push(sender.setParameters(parameters));
-        }
-
-        return Promise.all(promises);
-    }
-
-    /**
      * Set the simulcast stream encoding properties on the RTCRtpSender.
      * @param {JitsiLocalTrack} track - the current track in use for which
      * the encodings are to be set.
@@ -499,9 +472,38 @@ export class TPCUtils {
     }
 
     /**
+     * Resumes or suspends media on the peerconnection by setting the active state on RTCRtpEncodingParameters
+     * associated with all the senders that have a track attached to it.
+     *
+     * @param {boolean} enable - whether media needs to be enabled or suspended.
+     * @returns {Promise} - A promise that is resolved with an array of results when the change is succesful on all the
+     * senders, rejected otherwise.
+     */
+    setMediaTransferActive(enable) {
+        logger.info(`${this.pc} ${enable ? 'Resuming' : 'Suspending'} media transfer.`);
+
+        const senders = this.pc.peerconnection.getSenders().filter(s => Boolean(s.track));
+        const promises = [];
+
+        for (const sender of senders) {
+            const parameters = sender.getParameters();
+
+            if (parameters?.encodings?.length) {
+                for (const encoding of parameters.encodings) {
+                    encoding.active = enable;
+                }
+            }
+            promises.push(sender.setParameters(parameters));
+        }
+
+        return Promise.all(promises);
+    }
+
+    /**
      * Enables/disables video media transmission on the peer connection. When disabled the SDP video media direction in
      * the local SDP will be adjusted to 'inactive' which means that no data will be sent nor accepted, but the
-     * connection should be kept alive.
+     * connection should be kept alive. This is used for setting lastn=0 on p2p connection.
+     *
      * @param {boolean} active - true to enable media transmission or false to disable.
      * @returns {void}
      */

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2557,7 +2557,7 @@ TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeig
     // Ignore sender constraints for the following cases -
     // 1. If the media on the peerconnection is suspended (jvb conn when p2p is currently active).
     // 2. If the client is already sending video of the requested resolution.
-    if (!this.videoTransferActive || this.tpcUtils.getEncodedResolution(localVideoTrack) === frameHeight) {
+    if (!this.videoTransferActive || this.tpcUtils.getConfiguredEncodeResolution(localVideoTrack) === frameHeight) {
         return Promise.resolve();
     }
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2422,6 +2422,13 @@ TraceablePeerConnection.prototype._setVp9MaxBitrates = function(description, isL
  * @returns {Promise} promise that will be resolved when the operation is successful and rejected otherwise.
  */
 TraceablePeerConnection.prototype.configureSenderVideoEncodings = function(localVideoTrack = null) {
+    // If media is suspended on the peerconnection, make sure that media stays disabled. The default 'active' state for
+    // the encodings after the source is added to the peerconnection is 'true', so it needs to be explicitly disabled
+    // after the source is added.
+    if (!(this.videoTransferActive && this.audioTransferActive)) {
+        return this.tpcUtils.setMediaTransferActive(false);
+    }
+
     if (localVideoTrack) {
         return this.setSenderVideoConstraints(
             this._senderMaxHeights.get(localVideoTrack.getSourceName()),

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -2278,6 +2278,20 @@ export default class JingleSessionPC extends JingleSession {
     }
 
     /**
+     * Resumes or suspends media transfer over the underlying peer connection.
+     *
+     * @param {boolean} enable
+     * @returns {Promise}
+     */
+    resumeOrSuspendMedia(enable) {
+        return this.peerconnection.tpcUtils.resumeOrSuspendMedia(enable)
+            .then(() => {
+                this.peerconnection.audioTransferActive = enable;
+                this.peerconnection.videoTransferActive = enable;
+            });
+    }
+
+    /**
      * Replaces <tt>oldTrack</tt> with <tt>newTrack</tt> and performs a single
      * offer/answer cycle after both operations are done. Either
      * <tt>oldTrack</tt> or <tt>newTrack</tt> can be null; replacing a valid
@@ -2598,68 +2612,34 @@ export default class JingleSessionPC extends JingleSession {
     }
 
     /**
-     * Resumes or suspends media transfer over the underlying peer connection.
-     * @param {boolean} audioActive <tt>true</tt> to enable audio media
-     * transfer or <tt>false</tt> to suspend audio media transmission.
-     * @param {boolean} videoActive <tt>true</tt> to enable video media
-     * transfer or <tt>false</tt> to suspend video media transmission.
-     * @return {Promise} a <tt>Promise</tt> which will resolve once
-     * the operation is done. It will be rejected with an error description as
-     * a string in case anything goes wrong.
+     * Resumes or suspends video media transfer over the underlying peer connection.
+     * @param {boolean} videoActive <tt>true</tt> to enable video media transfer or <tt>false</tt> to suspend video
+     * media transmission.
+     * @return {Promise} a <tt>Promise</tt> which will resolve once the operation is done. It will be rejected with
+     * an error description as a string in case anything goes wrong.
      */
-    setMediaTransferActive(audioActive, videoActive) {
+    setMediaTransferActive(videoActive) {
         if (!this.peerconnection) {
-            return Promise.reject(
-                'Can not modify transfer active state,'
+            return Promise.reject('Can not modify video transfer active state,'
                     + ' before "initialize" is called');
         }
 
-        const logAudioStr = audioActive ? 'audio active' : 'audio inactive';
         const logVideoStr = videoActive ? 'video active' : 'video inactive';
 
-        logger.info(`${this} Queued make ${logVideoStr}, ${logAudioStr} task`);
+        logger.info(`${this} Queued make ${logVideoStr} task`);
 
         const workFunction = finishedCallback => {
             const isSessionActive = this.state === JingleSessionState.ACTIVE;
 
-            // Because the value is modified on the queue it's impossible to
-            // check it's final value reliably prior to submitting the task.
-            // The rule here is that the last submitted state counts.
-            // Check the values here to avoid unnecessary renegotiation cycle.
-            const audioActiveChanged
-                = this.peerconnection.setAudioTransferActive(audioActive);
-
             if (this._localVideoActive !== videoActive) {
                 this._localVideoActive = videoActive;
-
-                // Do only for P2P - Jicofo will reply with 'bad-request'
-                // We don't want to send 'content-modify', before the initial
-                // O/A (state === JingleSessionState.ACTIVE), because that will
-                // mess up video media direction in the remote SDP.
-                // 'content-modify' when processed only affects the media
-                // direction in the local SDP. We're doing that, because setting
-                // 'inactive' on video media in remote SDP will mess up our SDP
-                // translation chain (simulcast, RTX, video mute etc.).
                 if (this.isP2P && isSessionActive) {
                     this.sendContentModify();
                 }
             }
 
-            const pcVideoActiveChanged
-                = this.peerconnection.setVideoTransferActive(
-                    this._localVideoActive && this._remoteVideoActive);
-
-            // Will do the sRD/sLD cycle to update SDPs and adjust the media
-            // direction
-            if (isSessionActive
-                    && (audioActiveChanged || pcVideoActiveChanged)) {
-                this._renegotiate()
-                    .then(
-                        finishedCallback,
-                        finishedCallback /* will be called with an error */);
-            } else {
-                finishedCallback();
-            }
+            this.peerconnection.setVideoTransferActive(this._localVideoActive && this._remoteVideoActive);
+            finishedCallback();
         };
 
         return new Promise((resolve, reject) => {
@@ -2667,10 +2647,10 @@ export default class JingleSessionPC extends JingleSession {
                 workFunction,
                 error => {
                     if (error) {
-                        logger.error(`${this} Make ${logVideoStr}, ${logAudioStr} task failed!`);
+                        logger.error(`${this} Make ${logVideoStr} task failed!`);
                         reject(error);
                     } else {
-                        logger.debug(`${this} Make ${logVideoStr}, ${logAudioStr} task done!`);
+                        logger.debug(`${this} Make ${logVideoStr} task done!`);
                         resolve();
                     }
                 });
@@ -2721,13 +2701,12 @@ export default class JingleSessionPC extends JingleSession {
     }
 
     /**
-     * Processes new value of remote video "senders" Jingle attribute and tries
-     * to apply it for {@link _remoteVideoActive}.
-     * @param {string} remoteVideoSenders the value of "senders" attribute of
-     * Jingle video content element advertised by remote peer.
-     * @return {boolean} <tt>true</tt> if the change affected state of
-     * the underlying peerconnection and renegotiation is required for
-     * the changes to take effect.
+     * Processes new value of remote video "senders" Jingle attribute and tries to apply it for
+     * {@link _remoteVideoActive}.
+     * @param {string} remoteVideoSenders the value of "senders" attribute of Jingle video content element advertised
+     * by remote peer.
+     * @return {boolean} <tt>true</tt> if the change affected state of the underlying peerconnection and renegotiation
+     * is required for the changes to take effect.
      * @private
      */
     _modifyRemoteVideoActive(remoteVideoSenders) {
@@ -2739,9 +2718,11 @@ export default class JingleSessionPC extends JingleSession {
         if (isRemoteVideoActive !== this._remoteVideoActive) {
             logger.debug(`${this} new remote video active: ${isRemoteVideoActive}`);
             this._remoteVideoActive = isRemoteVideoActive;
+
+            return this.peerconnection.setVideoTransferActive(this._localVideoActive && this._remoteVideoActive);
         }
 
-        return this.peerconnection.setVideoTransferActive(this._localVideoActive && this._remoteVideoActive);
+        return false;
     }
 
     /**

--- a/types/hand-crafted/modules/RTC/TPCUtils.d.ts
+++ b/types/hand-crafted/modules/RTC/TPCUtils.d.ts
@@ -12,9 +12,8 @@ export default class TPCUtils {
   getLocalStreamHeightConstraints: ( localTrack: JitsiLocalTrack ) => number[];
   removeTrackMute: ( localTrack: JitsiLocalTrack ) => Promise<void>;
   replaceTrack: ( oldTrack: JitsiLocalTrack, newTrack: JitsiLocalTrack ) => Promise<void>;
-  setAudioTransferActive: ( active: boolean ) => void;
   setEncodings: ( track: JitsiLocalTrack ) => Promise<void>;
-  setMediaTransferActive: ( mediaType: MediaType, active: boolean ) => void;
+  setMediaTransferActive: ( active: boolean ) => void;
   setVideoTransferActive: ( active: boolean ) => void;
   updateEncodingsResolution: ( parameters: RTCRtpEncodingParameters ) => void;
 }

--- a/types/hand-crafted/modules/RTC/TraceablePeerConnection.d.ts
+++ b/types/hand-crafted/modules/RTC/TraceablePeerConnection.d.ts
@@ -103,7 +103,6 @@ export default class TraceablePeerConnection {
   removeTrackMute: ( localTrack: JitsiLocalTrack ) => Promise<boolean>;
   createDataChannel: ( label: unknown, opts: unknown ) => unknown; // TODO:
   setLocalDescription: ( description: unknown ) => Promise<unknown>;
-  setAudioTransferActive: ( active: boolean ) => boolean;
   setSenderVideoDegradationPreference: () => Promise<void>;
   setMaxBitRate: () => Promise<void>; // TODO: definite bug in the JSDocs
   setRemoteDescription: ( description: unknown ) => unknown; // TODO:

--- a/types/hand-crafted/modules/xmpp/JingleSessionPC.d.ts
+++ b/types/hand-crafted/modules/xmpp/JingleSessionPC.d.ts
@@ -40,7 +40,7 @@ export default class JingleSessionPC extends JingleSession {
   replaceTrack: ( oldTrack: JitsiLocalTrack | null, newTrack: JitsiLocalTrack | null ) => Promise<unknown>; // TODO:
   addTrackAsUnmute: ( track: JitsiLocalTrack ) => Promise<unknown>; // TODO:
   removeTrackAsMute: ( track: JitsiLocalTrack ) => Promise<unknown>; // TODO:
-  setMediaTransferActive: ( audioActive: boolean, videoActive: boolean ) => Promise<unknown>; // TODO:
+  setMediaTransferActive: ( videoActive: boolean ) => Promise<unknown>; // TODO:
   modifyContents: ( jingleContents: JQuery ) => void;
   notifyMySSRCUpdate: ( oldSDP: unknown, newSDP: unknown ) => void; // TODO:
   newJingleErrorHandler: ( request: unknown, failureCb: ( error: Error ) => void ) => ( this: JingleSessionPC ) => unknown; // TODO:


### PR DESCRIPTION
Resume or suspend the media on the jvb peerconnection by changing the RTCRtpEncodingParamters.active state instead of changing the direction on the transceiver. This avoids the needs to start a O/A renegotiation cycle for these operations. The media direction will be changed only for p2p lastn=0 case since video needs to be disabled on both the sender and the peer for p2p lastn=0 case.