### PR TITLE
fix(JitsiConference) Check if participants exist before adding the tr…

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3102,7 +3102,10 @@ JitsiConference.prototype._addRemoteP2PTracks = function() {
  * @private
  */
 JitsiConference.prototype._addRemoteTracks = function(logName, remoteTracks) {
-    for (const track of remoteTracks) {
+    // Add tracks for the participants that are still in the call.
+    const existingTracks = remoteTracks.filter(t => this.participants.has(t.ownerEndpointId));
+
+    for (const track of existingTracks) {
         logger.info(`Adding remote ${logName} track: ${track}`);
         this.onRemoteTrackAdded(track);
     }


### PR DESCRIPTION
…acks back.

When the call switches over to JVB after a remote p2p peer leaves, the remote tracks (of the peer that just left) are removed from the conference after the SSRCs are removed from SDP and since it necessitates a renegotiation, the task is pushed to the modification queue. Since the switch to jvb connection happens immediately, the remote jvb remote tracks are present after the switch and they get added to the conference again. Add the check for the remote participant before adding the tracks. This fixes an issue where the remote tracks are present in redux even after the participant leaves.