### PR TITLE
feat: Listens for visitor IQs.

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1572,6 +1572,23 @@ export default class ChatRoom extends Listenable {
     }
 
     /**
+     * Redirected back.
+     * @param iq The received iq.
+     */
+    onVisitorIQ(iq) {
+        const visitors = $(iq).find('>visitors[xmlns="jitsi:visitors"]');
+        const response = $(iq).find('response-promotion');
+
+        if (visitors.length && response.length
+            && String(response.attr('allow')).toLowerCase() === 'true') {
+            logger.warn('Redirected back to main room.');
+
+            this.eventEmitter.emit(
+                XMPPEvents.REDIRECTED, undefined, visitors.attr('focusjid'), response.attr('username'));
+        }
+    }
+
+    /**
      * Obtains the info about given media advertised (in legacy format) in the MUC presence of the participant
      * identified by the given endpoint JID. This is for mantining interop with endpoints that do not support
      * source-name signaling (Jigasi and very old mobile clients).

--- a/modules/xmpp/strophe.emuc.js
+++ b/modules/xmpp/strophe.emuc.js
@@ -216,12 +216,7 @@ export default class MucConnectionPlugin extends ConnectionPluginListenable {
         const from = iq.getAttribute('from');
         const room = this.rooms[Strophe.getBareJidFromJid(from)];
 
-        // Returning false would result in the listener being deregistered by Strophe
-        if (!room) {
-            return true;
-        }
-
-        room.onVisitorIQ(iq);
+        room?.onVisitorIQ(iq);
 
         return true;
     }

--- a/modules/xmpp/strophe.emuc.js
+++ b/modules/xmpp/strophe.emuc.js
@@ -43,6 +43,8 @@ export default class MucConnectionPlugin extends ConnectionPluginListenable {
             'http://jitsi.org/jitmeet/audio', 'iq', 'set', null, null);
         this.connection.addHandler(this.onMuteVideo.bind(this),
             'http://jitsi.org/jitmeet/video', 'iq', 'set', null, null);
+        this.connection.addHandler(this.onVisitors.bind(this),
+            'jitsi:visitors', 'iq', 'set', null, null);
     }
 
     /**
@@ -201,6 +203,25 @@ export default class MucConnectionPlugin extends ConnectionPluginListenable {
         }
 
         room.onMuteVideo(iq);
+
+        return true;
+    }
+
+    /**
+     * A visitor IQ is received, pass it to the room.
+     * @param iq The received iq.
+     * @returns {boolean}
+     */
+    onVisitors(iq) {
+        const from = iq.getAttribute('from');
+        const room = this.rooms[Strophe.getBareJidFromJid(from)];
+
+        // Returning false would result in the listener being deregistered by Strophe
+        if (!room) {
+            return true;
+        }
+
+        room.onVisitorIQ(iq);
 
         return true;
     }


### PR DESCRIPTION
Moderator now merges conference config over connection config. We need it in case we want to keep the connection but use other settings for the conference (visitors mode).