### PR TITLE
fix(TPC) Avoid applying constraints on desktop tracks if not needed.

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -373,9 +373,12 @@ export class TPCUtils {
         if (!parameters?.encodings?.length) {
             return maxHeight;
         }
-        for (const encoding of parameters.encodings) {
-            if (encoding.active) {
-                maxHeight = Math.max(maxHeight, height / encoding.scaleResolutionDownBy);
+        for (const encoding in parameters.encodings) {
+            if (parameters.encodings[encoding].active) {
+                const scaleResolutionDownBy
+                    = this._getVideoStreamEncodings(localVideoTrack.getVideoType())[encoding].scaleResolutionDownBy;
+
+                maxHeight = Math.max(maxHeight, height / scaleResolutionDownBy);
             }
         }
 

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -376,7 +376,9 @@ export class TPCUtils {
         for (const encoding in parameters.encodings) {
             if (parameters.encodings[encoding].active) {
                 const scaleResolutionDownBy
-                    = this._getVideoStreamEncodings(localVideoTrack.getVideoType())[encoding].scaleResolutionDownBy;
+                    = this.pc.isSimulcastOn()
+                        ? this._getVideoStreamEncodings(localVideoTrack.getVideoType())[encoding].scaleResolutionDownBy
+                        : parameters.encodings[encoding].scaleResolutionDownBy;
 
                 maxHeight = Math.max(maxHeight, height / scaleResolutionDownBy);
             }

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2585,10 +2585,9 @@ TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeig
         return Promise.resolve();
     }
 
-    return this._updateVideoSenderParameters(this._updateVideoSenderEncodings(frameHeight, localVideoTrack))
-        .then(() => {
-            this._senderMaxHeights.set(sourceName, frameHeight);
-        });
+    this._senderMaxHeights.set(sourceName, frameHeight);
+
+    return this._updateVideoSenderParameters(this._updateVideoSenderEncodings(frameHeight, localVideoTrack));
 };
 
 /**


### PR DESCRIPTION
Ignore sender constraints if the client is already sending video of the requested resolution. For desktop tracks, max resolution will be the height of the window being captured irrespective of the height being requested by the peer. Therfore, check if the configured resolution is equal to the track height for all requested heights > 0. Fixes an issue where the track addition fails because of setParameters failing on the video track. This is only seen the torture tests because this is very timing specific.