### PR TITLE
Fix ssrc rewriting

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3091,18 +3091,18 @@ JitsiConference.prototype._addRemoteP2PTracks = function() {
 
 /**
  * Generates fake "remote track added" events for given Jingle session.
- * @param {string} logName the session's nickname which will appear in log
- * messages.
+ * @param {string} logName the session's nickname which will appear in log messages.
  * @param {Array<JitsiRemoteTrack>} remoteTracks the tracks that will be added
  * @private
  */
 JitsiConference.prototype._addRemoteTracks = function(logName, remoteTracks) {
-    // Add tracks for the participants that are still in the call.
-    const existingTracks = remoteTracks.filter(t => this.participants.has(t.ownerEndpointId));
-
-    for (const track of existingTracks) {
-        logger.info(`Adding remote ${logName} track: ${track}`);
-        this.onRemoteTrackAdded(track);
+    for (const track of remoteTracks) {
+        // There will be orphan (with no owner) tracks when ssrc-rewriting is enabled and all of them need to be addded
+        // back to the conference.
+        if (FeatureFlags.isSsrcRewritingSupported() || this.participants.has(track.ownerEndpointId)) {
+            logger.info(`Adding remote ${logName} track: ${track}`);
+            this.onRemoteTrackAdded(track);
+        }
     }
 };
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -626,6 +626,10 @@ TraceablePeerConnection.prototype._sourceMutedChanged = function(sourceName, isM
     const track = this.getRemoteTracks().find(t => t.getSourceName() === sourceName);
 
     if (!track) {
+        if (FeatureFlags.isSsrcRewritingSupported()) {
+            logger.debug(`Remote track not found for source=${sourceName}, mute update failed!`);
+        }
+
         return;
     }
 

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -3,6 +3,7 @@ import { getLogger } from '@jitsi/logger';
 import { MediaType } from '../../service/RTC/MediaType';
 import * as StatisticsEvents from '../../service/statistics/Events';
 import browser from '../browser';
+import FeatureFlags from '../flags/FeatureFlags';
 
 const GlobalOnErrorHandler = require('../util/GlobalOnErrorHandler');
 
@@ -340,7 +341,9 @@ StatsCollector.prototype._processAndEmitReport = function() {
                 };
 
                 codecs[participantId] = userCodecs;
-            } else {
+
+            // All tracks in ssrc-rewriting mode need not have a participant associated with it.
+            } else if (!FeatureFlags.isSsrcRewritingSupported()) {
                 logger.error(`No participant ID returned by ${track}`);
             }
         }

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1815,6 +1815,12 @@ export default class JingleSessionPC extends JingleSession {
 
                         track._setVideoType(type);
                     }
+
+                    // Update the muted state on the track since the presence for this track could have been received
+                    // before the updated source map is received on the bridge channel.
+                    const peerMediaInfo = this._signalingLayer.getPeerMediaInfo(owner, mediaType, source);
+
+                    peerMediaInfo && this.peerconnection._sourceMutedChanged(source, peerMediaInfo.muted);
                 } else {
                     logger.error(`Remote track attached to a remote SSRC=${ssrc} not found`);
                 }


### PR DESCRIPTION
Set track owners to null when remote participant leaves.
Update mute state after source is re-mapped.
Also add all the orphan jvb tracks to the conference when the call switches over from p2p to jvb.