### PR TITLE
fix(statistics) Use RTCRtpReceiver:getSynchronizationSources for audioLevels always

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -531,7 +531,7 @@ JitsiConference.prototype._init = function(options = {}) {
     }
 
     // Generates events based on no audio input detector.
-    if (config.enableNoAudioDetection) {
+    if (config.enableNoAudioDetection && !config.disableAudioLevels) {
         this._noAudioSignalDetection = new NoAudioSignalDetection(this);
         this._noAudioSignalDetection.on(DetectionEvents.NO_AUDIO_INPUT, () => {
             this.eventEmitter.emit(JitsiConferenceEvents.NO_AUDIO_INPUT);
@@ -540,7 +540,6 @@ JitsiConference.prototype._init = function(options = {}) {
             this.eventEmitter.emit(JitsiConferenceEvents.AUDIO_INPUT_STATE_CHANGE, hasAudioSignal);
         });
     }
-
 
     if ('channelLastN' in config) {
         this.setLastN(config.channelLastN);

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -200,11 +200,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      */
     supportsReceiverStats() {
         return typeof window.RTCRtpReceiver !== 'undefined'
-            && Object.keys(RTCRtpReceiver.prototype).indexOf('getSynchronizationSources') > -1
-
-            // Disable this on Safari because it is reporting 0.000001 as the audio levels for all
-            // remote audio tracks.
-            && !this.isWebKitBased();
+            && Object.keys(RTCRtpReceiver.prototype).indexOf('getSynchronizationSources') > -1;
     }
 
     /**

--- a/modules/detection/NoAudioSignalDetection.js
+++ b/modules/detection/NoAudioSignalDetection.js
@@ -2,7 +2,6 @@ import EventEmitter from 'events';
 
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 import * as JitsiTrackEvents from '../../JitsiTrackEvents';
-import browser from '../browser';
 
 import * as DetectionEvents from './DetectionEvents';
 
@@ -32,9 +31,6 @@ export default class NoAudioSignalDetection extends EventEmitter {
         this._timeoutTrigger = null;
         this._hasAudioInput = null;
 
-        if (!browser.supportsReceiverStats()) {
-            conference.statistics.addAudioLevelListener(this._audioLevel.bind(this));
-        }
         conference.on(JitsiConferenceEvents.TRACK_ADDED, this._trackAdded.bind(this));
     }
 
@@ -132,21 +128,19 @@ export default class NoAudioSignalDetection extends EventEmitter {
             this._clearTriggerTimeout();
 
             // Listen for the audio levels on the newly added audio track
-            if (browser.supportsReceiverStats()) {
-                track.on(
-                    JitsiTrackEvents.NO_AUDIO_INPUT,
-                    audioLevel => {
-                        this._handleNoAudioInputDetection(audioLevel);
-                    }
-                );
-                track.on(
-                    JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED,
-                    audioLevel => {
-                        this._handleNoAudioInputDetection(audioLevel);
-                        this._handleAudioInputStateChange(audioLevel);
-                    }
-                );
-            }
+            track.on(
+                JitsiTrackEvents.NO_AUDIO_INPUT,
+                audioLevel => {
+                    this._handleNoAudioInputDetection(audioLevel);
+                }
+            );
+            track.on(
+                JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED,
+                audioLevel => {
+                    this._handleNoAudioInputDetection(audioLevel);
+                    this._handleAudioInputStateChange(audioLevel);
+                }
+            );
         }
     }
 }

--- a/types/hand-crafted/modules/statistics/RTPStatsCollector.d.ts
+++ b/types/hand-crafted/modules/statistics/RTPStatsCollector.d.ts
@@ -7,7 +7,6 @@ export default class StatsCollector {
   start: ( startAudioLevelStats: unknown ) => void;
   getNonNegativeStat: ( report: unknown, name: string ) => number;
   processStatsReport: () => void;
-  processAudioLevelReport: () => void;
   getNonNegativeValue: ( v: unknown ) => number; // TODO:
   setSpeakerList: ( speakerList: Array<string> ) => void;
 }


### PR DESCRIPTION
Track based stats have been removed recently and RTCRtpReceiver:getSynchronizationSources has been available in the browsers for a while now.