### PR TITLE
fix(codec-selection) Calc preferred codec after media session is established

### DIFF
--- a/modules/RTC/CodecSelection.js
+++ b/modules/RTC/CodecSelection.js
@@ -57,6 +57,9 @@ export class CodecSelection {
             + `disabled=${this.p2pDisabledCodec}`);
 
         this.conference.on(
+            JitsiConferenceEvents._MEDIA_SESSION_STARTED,
+            session => this._selectPreferredCodec(session));
+        this.conference.on(
             JitsiConferenceEvents.USER_JOINED,
             () => this._selectPreferredCodec());
         this.conference.on(


### PR DESCRIPTION
Fixes an issue on mobile where the videos of users joining after the mobile endpoint are not being rendered.