### PR TITLE
feat: Adds debug log around connected.

### DIFF
--- a/modules/xmpp/XmppConnection.js
+++ b/modules/xmpp/XmppConnection.js
@@ -495,6 +495,9 @@ export default class XmppConnection extends Listenable {
      */
     send(stanza) {
         if (!this.connected) {
+            logger.error(`Trying to send stanza while not connected. Status:${this._status} Proto:${
+                this.isUsingWebSocket ? this._stropheConn?._proto?.socket?.readyState : 'bosh'
+            }`);
             throw new Error('Not connected');
         }
         this._stropheConn.send(stanza);

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -795,8 +795,8 @@ export default class XMPP extends Listenable {
         this.disconnectInProgress = new Promise(resolve => {
             const disconnectListener = (credentials, status) => {
                 if (status === Strophe.Status.DISCONNECTED) {
-                    resolve();
                     this.eventEmitter.removeListener(XMPPEvents.CONNECTION_STATUS_CHANGED, disconnectListener);
+                    resolve();
                 }
             };
 


### PR DESCRIPTION
With visitors we rarely see not able to send messages or presence because not connected error. Seems the status of the connection is wrong when quickly disconnecting and connecting again.