### PR TITLE
fix(conference) Make sure media on jvb connection stays suspended.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1439,6 +1439,11 @@ JitsiConference.prototype._setupNewTrack = function(newTrack) {
     this.rtc.addLocalTrack(newTrack);
     newTrack.setConference(this);
 
+    // Suspend media on the inactive media session since it gets automatically enabled for a newly added source.
+    if (this.isP2PActive()) {
+        this._suspendMediaTransferForJvbConnection();
+    }
+
     // Add event handlers.
     newTrack.muteHandler = this._fireMuteChangeEvent.bind(this, newTrack);
     newTrack.addEventListener(JitsiTrackEvents.TRACK_MUTE_CHANGED, newTrack.muteHandler);


### PR DESCRIPTION
Fixes an issue where media gets sent on jvb connection even when the connection is suspended.