### PR TITLE
fix(JingleSession) start modification queue after session is established

### DIFF
--- a/modules/util/AsyncQueue.js
+++ b/modules/util/AsyncQueue.js
@@ -35,6 +35,13 @@ export default class AsyncQueue {
     }
 
     /**
+     * Pauses the execution of the tasks on the queue.
+     */
+    pause() {
+        this._queue.pause();
+    }
+
+    /**
      * The 'task' function will be given a callback it MUST call with either:
      *  1) No arguments if it was successful or
      *  2) An error argument if there was an error
@@ -58,6 +65,13 @@ export default class AsyncQueue {
             return;
         }
         this._queue.push(task, callback);
+    }
+
+    /**
+     * Resumes the execution of the tasks on the queue.
+     */
+    resume() {
+        this._queue.resume();
     }
 
     /**


### PR DESCRIPTION
Pull initial offer/answer tasks out of the modification queue and execute them right away. Only track and codec related operations that necessitate a renegotiation cycle need to be pushed to the modification queue. The queue execution is paused until the session is established. This avoids track operations being executed before the session is established. This fixes an issue seen in p2p connections where sources of the initiator are not signaled to the remote since the tracks are added while the initiator is waiting for a session-accept from the peer.