### PR TITLE
fix(SignalingLayer) prevent Jicofo «Source does not exist» error

### DIFF
--- a/service/RTC/SignalingLayer.js
+++ b/service/RTC/SignalingLayer.js
@@ -27,7 +27,7 @@ import { MediaType } from '../../service/RTC/MediaType';
 export function getSourceNameForJitsiTrack(endpointId, mediaType, trackIdx) {
     const firstLetterOfMediaType = mediaType.substring(0, 1);
 
-    return `${endpointId}-${firstLetterOfMediaType}${trackIdx}`;
+    return `${endpointId}-${firstLetterOfMediaType}${trackIdx || 0}`;
 }
 
 /**


### PR DESCRIPTION
Use `0` as track index if `undefined`, otherwise there will be `aundefined`, `vundefined` tracks in corner cases.

We've been getting this error lately on some percentage of the clients !? (I've snipped all identifiable information away for privacy):
```
Jicofo 2023-05-08 15:08:39.148 INFO: [1308] [remoteJid=*SNIP*@conference.*SNIP*/*SNIP* sid=*SNIP*] JingleSession.doProcessIq#145: Returning error: request=<iq xmlns='jabber:client' to='focus@auth.*SNIP*/focus' from='*SNIP*@conference.*SNIP*/*SNIP*' id='*SNIP*' type='set'><jingle xmlns='urn:xmpp:jingle:1' action='source-remove' initiator='*SNIP*@conference.*SNIP*/focus' sid='*SNIP*'><content name='audio'><description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'><source xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' name='*SNIP*-aundefined' ssrc='*SNIP*'/></description></content></jingle></iq>, error=<error xmlns='jabber:client' type='modify'><bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/><text xmlns='urn:ietf:params:xml:ns:xmpp-stanzas' xml:lang='en'>Source does not exist or is not owned by endpoint null.</text></error>
```