### PR TITLE
fix(JitsiConference) Do not apply the startMutedPolicy locally on the moderator.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2675,7 +2675,10 @@ JitsiConference.prototype.setStartMutedPolicy = function(policy) {
 
         return;
     }
-    this.startMutedPolicy = policy;
+
+    // Do not apply the startMutedPolicy locally on the moderator, the moderator should join with available local
+    // sources and the policy needs to be applied only on users that join the call after.
+    // this.startMutedPolicy = policy;
     this.room.addOrReplaceInPresence('startmuted', {
         attributes: {
             audio: policy.audio,

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -446,22 +446,16 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
         });
 
     chatRoom.addPresenceListener('startmuted', (data, from) => {
-        let isModerator = false;
-
-        if (conference.myUserId() === from && conference.isModerator()) {
-            isModerator = true;
-        } else {
-            const participant = conference.getParticipantById(from);
-
-            if (participant && participant.isModerator()) {
-                isModerator = true;
-            }
-        }
-
-        if (!isModerator) {
+        // Ignore the strartmuted policy if the presence is received from self. The moderator should join with
+        // available local sources and the policy needs to be applied only on users that join the call after.
+        if (conference.myUserId() === from) {
             return;
         }
+        const participant = conference.getParticipantById(from);
 
+        if (!participant || !participant.isModerator()) {
+            return;
+        }
         const startAudioMuted = data.attributes.audio === 'true';
         const startVideoMuted = data.attributes.video === 'true';
 


### PR DESCRIPTION
Fixes a corner case where the local tracks are not added to the jvb pc if the session-initiate from Jicofo is received after the policy is set. This doesn't reproduce manually and happens only in torture on certain deployments because its timing specific.