### PR TITLE
fix(SignalingLayer,TPC) do not set videoType for audio sources

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1012,7 +1012,7 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track, tr
     // Assume default presence state for remote source. Presence can be received after source signaling. This shouldn't
     // prevent the endpoint from creating a remote track for the source.
     let muted = true;
-    let videoType = mediaType === MediaType.VIDEO ? VideoType.CAMERA : undefined // 'camera' by default
+    let videoType = mediaType === MediaType.VIDEO ? VideoType.CAMERA : undefined; // 'camera' by default
 
     if (peerMediaInfo) {
         muted = peerMediaInfo.muted;

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1012,7 +1012,7 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track, tr
     // Assume default presence state for remote source. Presence can be received after source signaling. This shouldn't
     // prevent the endpoint from creating a remote track for the source.
     let muted = true;
-    let videoType = VideoType.CAMERA;
+    let videoType = mediaType === MediaType.VIDEO ? VideoType.CAMERA : undefined // 'camera' by default
 
     if (peerMediaInfo) {
         muted = peerMediaInfo.muted;

--- a/modules/xmpp/SignalingLayerImpl.js
+++ b/modules/xmpp/SignalingLayerImpl.js
@@ -282,9 +282,10 @@ export default class SignalingLayerImpl extends SignalingLayer {
      * @inheritDoc
      */
     getPeerSourceInfo(owner, sourceName) {
+        const mediaType = getMediaTypeFromSourceName(sourceName);
         const mediaInfo = {
             muted: true, // muted by default
-            videoType: VideoType.CAMERA // 'camera' by default
+            videoType: mediaType === MediaType.VIDEO ? VideoType.CAMERA : undefined // 'camera' by default
         };
 
         return this._remoteSourceState[owner]


### PR DESCRIPTION
As implemented in other parts of the code, do not set videoType for audio sources.

Related to #1979