### PR TITLE
fix: add required events dependency for browser environments #1841

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "",
   "readmeFilename": "README.md",
   "dependencies": {
+    "events": "^3.2.0",
     "@jitsi/js-utils": "2.0.0",
     "@jitsi/logger": "2.0.0",
     "@jitsi/sdp-interop": "git+https://github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",


### PR DESCRIPTION
We added "events": "^3.2.0" to the package.json file to specify the version of the events module that we want to use. The ^ symbol means that we are willing to accept any version of the module that is greater than or equal to 3.2.0. This allows us to ensure that we are using a compatible version of the module, while also allowing us to take advantage of any bug fixes or new features that have been added to the module in later versions.

The events module is a core module in Node.js that provides a way for objects to emit events and for other objects to listen for those events. This allows objects to communicate with each other without having to know about each other's implementation details. The events module is used by many other modules in Node.js, so it is important to ensure that we are using a compatible version of the module.