### PR TITLE
fix(receiver-constraints) Update maxHeight if only default constraint…

### DIFF
--- a/modules/qualitycontrol/ReceiveVideoController.js
+++ b/modules/qualitycontrol/ReceiveVideoController.js
@@ -124,6 +124,10 @@ class ReceiverVideoConstraints {
 
         if (changed) {
             this._receiverVideoConstraints = videoConstraints;
+
+            if (videoConstraints.defaultConstraints?.maxHeight) {
+                this.updateReceiveResolution(videoConstraints.defaultConstraints.maxHeight);
+            }
             logger.debug(`Updating ReceiverVideoConstraints ${JSON.stringify(videoConstraints)}`);
         }
 


### PR DESCRIPTION
…s are used.

Fixes an issue in the load-test client where correct constraints are not send when the media session is established.