### PR TITLE
fix(RTCRtpSender) Race condition on resetting transaction id.

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -472,13 +472,12 @@ export class TPCUtils {
             return Promise.resolve();
         }
         parameters.encodings = this._getStreamEncodings(track);
-        const promise = transceiver.sender.setParameters(parameters);
 
         if (mediaType === MediaType.VIDEO) {
-            return this.pc._updateVideoSenderParameters(promise);
+            return this.pc._updateVideoSenderParameters(() => transceiver.sender.setParameters(parameters));
         }
 
-        return promise;
+        return transceiver.sender.setParameters(parameters);
     }
 
     /**
@@ -503,12 +502,11 @@ export class TPCUtils {
                     encoding.active = enable;
                 }
             }
-            const setActivePromise = sender.setParameters(parameters);
 
             if (sender.track.kind === MediaType.VIDEO) {
-                promises.push(this.pc._updateVideoSenderParameters(setActivePromise));
+                promises.push(this.pc._updateVideoSenderParameters(() => sender.setParameters(parameters)));
             } else {
-                promises.push(setActivePromise);
+                promises.push(sender.setParameters(parameters));
             }
         }
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2651,7 +2651,9 @@ TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeig
 
     this._senderMaxHeights.set(sourceName, frameHeight);
 
-    return this._updateVideoSenderParameters(this._updateVideoSenderEncodings(frameHeight, localVideoTrack));
+    return this._updateVideoSenderParameters(
+        () => this._updateVideoSenderEncodings(frameHeight, localVideoTrack)
+    );
 };
 
 /**
@@ -2659,12 +2661,12 @@ TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeig
  * This is needed on Chrome as it resets the transaction id after executing setParameters() and can affect the next on
  * the fly updates if they are not chained.
  * https://chromium.googlesource.com/external/webrtc/+/master/pc/rtp_sender.cc#340
- * @param {Promise} promise - The promise that needs to be chained.
+ * @param {Function} nextFunction - The function to be called when the last video sender update promise is settled.
  * @returns {Promise}
  */
-TraceablePeerConnection.prototype._updateVideoSenderParameters = function(promise) {
+TraceablePeerConnection.prototype._updateVideoSenderParameters = function(nextFunction) {
     const nextPromise = this._lastVideoSenderUpdatePromise
-        .finally(() => promise);
+        .finally(nextFunction);
 
     this._lastVideoSenderUpdatePromise = nextPromise;
 


### PR DESCRIPTION
Adjusted wrapping method to have RTCRtpSender setting parameters in sequential manner in order to solve race condition when transaction id can be reset at the end of videoSender setParameters and cause exception if another update was already in fly and before its check for transaction id presence.

The issue "Failed to execute 'setParameters' on 'RTCRtpSender': Failed to set parameters since getParameters() has never been called" happened because the actual setting params were not called sequentially, the function was executed and promise was chained what broke the logic - [code_link](https://github.com/jitsi/lib-jitsi-meet/blob/master/modules/RTC/TraceablePeerConnection.js#L2654)

Similar change was made in past - [github_link](https://github.com/jitsi/lib-jitsi-meet/pull/2228)

Also after the change I run npm run test/lint
![Screenshot 2023-06-27 at 10 18 11](https://github.com/jitsi/lib-jitsi-meet/assets/104766779/aff98dd7-6bc1-493f-9711-44eb980fc92b)
