### PR TITLE
Fix screenshare issues

### DIFF
--- a/JitsiMeetJS.ts
+++ b/JitsiMeetJS.ts
@@ -334,15 +334,6 @@ export default {
                     }
                 }
 
-                // set the contentHint to "detail" for desktop tracks
-                // eslint-disable-next-line prefer-const
-                for (const track of tracks) {
-                    if (track.type === MediaType.VIDEO
-                        && track.videoType === 'desktop') {
-                        this.setVideoTrackContentHints(track.track, 'detail');
-                    }
-                }
-
                 return tracks;
             })
             .catch(error => {
@@ -529,24 +520,6 @@ export default {
      */
     setNetworkInfo({ isOnline }) {
         NetworkInfo.updateNetworkInfo({ isOnline });
-    },
-
-    /**
-     * Set the contentHint on the transmitted stream track to indicate
-     * charaterstics in the video stream, which informs PeerConnection
-     * on how to encode the track (to prefer motion or individual frame detail)
-     * @param {MediaStreamTrack} track - the track that is transmitted
-     * @param {String} hint - contentHint value that needs to be set on the track
-     */
-    setVideoTrackContentHints(track, hint) {
-        if ('contentHint' in track) {
-            track.contentHint = hint;
-            if (track.contentHint !== hint) {
-                logger.debug('Invalid video track contentHint');
-            }
-        } else {
-            logger.debug('MediaStreamTrack contentHint attribute not supported');
-        }
     },
 
     precallTest,

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -180,11 +180,15 @@ const ScreenObtainer = {
 
                         // We have to use the old API on Electron to get a desktop stream.
                         navigator.mediaDevices.getUserMedia(constraints)
-                            .then(stream => onSuccess({
-                                stream,
-                                sourceId: streamId,
-                                sourceType: streamType
-                            }), onFailure);
+                            .then(stream => {
+                                this.setContentHint(stream);
+                                onSuccess({
+                                    stream,
+                                    sourceId: streamId,
+                                    sourceType: streamType
+                                });
+                            })
+                            .catch(err => onFailure(err));
                     } else {
                         // As noted in Chrome Desktop Capture API:
                         // If user didn't select any source (i.e. canceled the prompt)
@@ -257,6 +261,7 @@ const ScreenObtainer = {
 
         getDisplayMedia(constraints)
             .then(stream => {
+                this.setContentHint(stream);
                 callback({
                     stream,
                     sourceId: stream.id
@@ -294,6 +299,7 @@ const ScreenObtainer = {
 
         navigator.mediaDevices.getDisplayMedia({ video: true })
             .then(stream => {
+                this.setContentHint(stream);
                 callback({
                     stream,
                     sourceId: stream.id });
@@ -302,6 +308,24 @@ const ScreenObtainer = {
                 errorCallback(new JitsiTrackError(JitsiTrackErrors
                     .SCREENSHARING_USER_CANCELED));
             });
+    },
+
+    /** Sets the contentHint on the transmitted MediaStreamTrack to indicate charaterstics in the video stream, which
+     * informs RTCPeerConnection on how to encode the track (to prefer motion or individual frame detail).
+     *
+     * @param {MediaStream} stream - The captured desktop stream.
+     * @returns {void}
+     */
+    setContentHint(stream) {
+        const { desktopSharingFrameRate } = this.options;
+        const desktopTrack = stream.getVideoTracks()[0];
+
+        // Set contentHint on the desktop track based on the fps requested.
+        if ('contentHint' in desktopTrack) {
+            desktopTrack.contentHint = desktopSharingFrameRate?.max > SS_DEFAULT_FRAME_RATE ? 'motion' : 'detail';
+        } else {
+            logger.warn('MediaStreamTrack contentHint attribute not supported');
+        }
     },
 
     /**

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -2289,6 +2289,15 @@ export default class JingleSessionPC extends JingleSession {
             .then(() => {
                 this.peerconnection.audioTransferActive = active;
                 this.peerconnection.videoTransferActive = active;
+
+                // Reconfigure the video tracks so that only the correct encodings are active.
+                const promises = [];
+
+                for (const track of this.rtc.getLocalVideoTracks()) {
+                    promises.push(this.peerconnection.configureSenderVideoEncodings(track));
+                }
+
+                return Promise.allSettled(promises);
             });
     }
 

--- a/types/hand-crafted/JitsiMeetJS.d.ts
+++ b/types/hand-crafted/JitsiMeetJS.d.ts
@@ -137,8 +137,6 @@ export type JitsiMeetJSType = {
 
   setNetworkInfo: ( { isOnline: boolean } ) => void;
 
-  setVideoTrackContentHints: ( track: MediaStreamTrack, hint: string ) => void;
-
   precallTest: PrecallTest;
 
   util: {


### PR DESCRIPTION
- fix(JingleSession) Reconfigure the stream encodings after p2p->jvb switch.

Fixes blurry screenshare in some cases. There is a higher probability of the higher layers getting suspended when all the stream encodings are enabled for low fps SS. Make sure only the highest spatial layer is sent for low fps SS after p2p->jvb switch. Make sure all the stream encodings are enabled for high fps SS after p2p->jvb switch.

- fix(ScreenObtainer): Apply contentHint on captured desktop track correctly.

contentHint needs to be set to 'motion' for high fps SS and 'detail' otherwise. Fixes https://github.com/jitsi/lib-jitsi-meet/issues/2298.