### PR TITLE
fix(JingleSession) actually call browser.supportsCodecPreferences

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1051,7 +1051,7 @@ export default class JingleSessionPC extends JingleSession {
 
                 // Munge the codec order on the outgoing offer for clients that don't support
                 // RTCRtpTransceiver#setCodecPreferences.
-                if (!browser.supportsCodecPreferences) {
+                if (!browser.supportsCodecPreferences()) {
                     localDescription = this.peerconnection._mungeCodecOrder(localDescription);
                 }
                 this.sendSessionInitiate(localDescription.sdp);


### PR DESCRIPTION
supportsCodecPreferences is a function, and must be called. Am I right?

Thanks.

PS: needs testing as AFAIK _mungeCodecOrder was never getting called.