### PR TITLE
watchRTC as a feature for Jitsi meet

### DIFF
--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -201,7 +201,7 @@ export default function Statistics(xmpp, options) {
 
     // WatchRTC is not required to work for react native
     if (!browser.isReactNative()) {
-        WatchRTC.start(options.roomName, options.userName);
+        WatchRTC.start(this.options.roomName, this.options.userName);
     }
 }
 Statistics.audioLevelsEnabled = false;

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -7,6 +7,7 @@ import { FEEDBACK } from '../../service/statistics/AnalyticsEvents';
 import * as StatisticsEvents from '../../service/statistics/Events';
 import browser from '../browser';
 import ScriptUtil from '../util/ScriptUtil';
+import WatchRTC from '../watchRTC/WatchRTC';
 
 import analytics from './AnalyticsAdapter';
 import CallStats from './CallStats';
@@ -127,6 +128,11 @@ Statistics.init = function(options) {
     }
 
     Statistics.disableThirdPartyRequests = options.disableThirdPartyRequests;
+
+    // WatchRTC is not required to work for react native
+    if (!browser.isReactNative()) {
+        WatchRTC.init(options);
+    }
 };
 
 /**
@@ -192,6 +198,11 @@ export default function Statistics(xmpp, options) {
     this.callsStatsInstances = new Map();
 
     Statistics.instances.add(this);
+
+    // WatchRTC is not required to work for react native
+    if (!browser.isReactNative()) {
+        WatchRTC.start(options.roomName, options.userName);
+    }
 }
 Statistics.audioLevelsEnabled = false;
 Statistics.audioLevelsInterval = 200;

--- a/modules/watchRTC/WatchRTC.ts
+++ b/modules/watchRTC/WatchRTC.ts
@@ -34,10 +34,6 @@ class WatchRTCHandler {
                 return;
             }
 
-            // watchRTC "proxies" WebRTC functions such as GUM and RTCPeerConnection by rewriting the global
-            // window functions. Because lib-jitsi-meet uses references to those functions that are taken on
-            // init, we need to add these proxies before it initializes, otherwise lib-jitsi-meet will use the
-            // original non proxy versions of these functions.
             try {
                 if (options?.watchRTCConfigParams?.rtcApiKey) {
                     watchRTC.init({

--- a/modules/watchRTC/functions.ts
+++ b/modules/watchRTC/functions.ts
@@ -1,0 +1,32 @@
+/**
+ * Checks whether analytics is enabled or not.
+ *
+ * @param {Object} options - Init options.
+ * @returns {boolean}
+ */
+export function isAnalyticsEnabled(options): boolean {
+    const { analytics, disableThirdPartyRequests } = options;
+    return !(analytics?.disabled || disableThirdPartyRequests);
+}
+
+/**
+ * Checks whether rtcstats is enabled or not.
+ *
+ * @param {Object} options - Init options.
+ * @returns {boolean}
+ */
+export function isRtcstatsEnabled(options): boolean {
+    const { analytics } = options;
+    return analytics?.rtcstatsEnabled ?? false;
+}
+
+/**
+ * Checks whether watchrtc is enabled or not.
+ *
+ * @param {Object} options - Init options.
+ * @returns {boolean}
+ */
+export function isWatchRTCEnabled(options): boolean {
+    const { analytics } = options;
+    return analytics?.watchRTCEnabled ?? false;
+}

--- a/modules/watchRTC/interfaces.ts
+++ b/modules/watchRTC/interfaces.ts
@@ -1,0 +1,18 @@
+export interface IWatchRTCConfiguration {
+    allowBrowserLogCollection?: boolean;
+    collectionInterval?: number;
+    console?: {
+        level: string;
+        override: boolean;
+    };
+    debug?: boolean;
+    keys?: any;
+    logGetStats?: boolean;
+    proxyUrl?: string;
+    rtcApiKey: string;
+    rtcPeerId?: string;
+    rtcRoomId?: string;
+    rtcTags?: string[];
+    rtcToken?: string;
+    wsUrl?: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@jitsi/logger": "2.0.0",
         "@jitsi/sdp-interop": "git+https://github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
         "@jitsi/sdp-simulcast": "0.4.0",
+        "@testrtc/watchrtc-sdk": "^1.36.3",
         "async": "3.2.3",
         "base64-js": "1.3.1",
         "current-executing-script": "0.1.3",
@@ -2099,6 +2100,11 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
+    },
+    "node_modules/@testrtc/watchrtc-sdk": {
+      "version": "1.36.3",
+      "resolved": "https://registry.npmjs.org/@testrtc/watchrtc-sdk/-/watchrtc-sdk-1.36.3.tgz",
+      "integrity": "sha512-JtcTvvh20t553n8q5ZHpWQeSUTENkQrZbGNvQ05jD8SA2V5PHBok/7my1ZDuA44sgT0y1OfUA8VT7dhcs0VxWg=="
     },
     "node_modules/@types/async": {
       "version": "3.2.12",
@@ -8779,6 +8785,11 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
+    },
+    "@testrtc/watchrtc-sdk": {
+      "version": "1.36.3",
+      "resolved": "https://registry.npmjs.org/@testrtc/watchrtc-sdk/-/watchrtc-sdk-1.36.3.tgz",
+      "integrity": "sha512-JtcTvvh20t553n8q5ZHpWQeSUTENkQrZbGNvQ05jD8SA2V5PHBok/7my1ZDuA44sgT0y1OfUA8VT7dhcs0VxWg=="
     },
     "@types/async": {
       "version": "3.2.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@jitsi/logger": "2.0.0",
         "@jitsi/sdp-interop": "git+https://github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
         "@jitsi/sdp-simulcast": "0.4.0",
-        "@testrtc/watchrtc-sdk": "^1.36.3",
+        "@testrtc/watchrtc-sdk": "1.36.3",
         "async": "3.2.3",
         "base64-js": "1.3.1",
         "current-executing-script": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@jitsi/logger": "2.0.0",
     "@jitsi/sdp-interop": "git+https://github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
     "@jitsi/sdp-simulcast": "0.4.0",
+    "@testrtc/watchrtc-sdk": "^1.36.3",
     "async": "3.2.3",
     "base64-js": "1.3.1",
     "current-executing-script": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@jitsi/logger": "2.0.0",
     "@jitsi/sdp-interop": "git+https://github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
     "@jitsi/sdp-simulcast": "0.4.0",
-    "@testrtc/watchrtc-sdk": "^1.36.3",
+    "@testrtc/watchrtc-sdk": "1.36.3",
     "async": "3.2.3",
     "base64-js": "1.3.1",
     "current-executing-script": "0.1.3",

--- a/webpack-shared-config.js
+++ b/webpack-shared-config.js
@@ -75,8 +75,8 @@ module.exports = (minimize, analyzeBundle) => {
         },
         performance: {
             hints: minimize ? 'error' : false,
-            maxAssetSize: 825 * 1024,
-            maxEntrypointSize: 825 * 1024
+            maxAssetSize: 1.08 * 1024 * 1024,
+            maxEntrypointSize: 1.08 * 1024 * 1024
         },
         plugins: [
             new IgnorePlugin({ resourceRegExp: /^(@xmldom\/xmldom|ws)$/ }),


### PR DESCRIPTION
Following PR contains changes required to add watchRTC as a module within lib jitsi meet

This involves adding

- watchRTC SDK package (npm i @testrtc/watchrtc-sdk).
- watchRTC SDK is initialized within Statistics.init to proxy WebRTC functions such as GUM and RTCPeerConnection.
- watchRTC SDK then starts collecting required stats when the conference begins. Here we check if the user has not configured room name or user/peer name, if not, then use relevant data available from Jitsi.
- watchRTC SDK does not require to function for react native. 
- checks implemented to run watchRTC SDK when
-- watchRTC is enabled
-- rtcstats must be disabled
-- analytics should be enabled
-- third party requests are not disabled