### PR TITLE
Revert "Adjusted wrapping method to have RTCRtpSender setting paramet…

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -485,12 +485,13 @@ export class TPCUtils {
             return Promise.resolve();
         }
         parameters.encodings = this._getStreamEncodings(track);
+        const promise = transceiver.sender.setParameters(parameters);
 
         if (mediaType === MediaType.VIDEO) {
-            return this.pc._updateVideoSenderParameters(() => transceiver.sender.setParameters(parameters));
+            return this.pc._updateVideoSenderParameters(promise);
         }
 
-        return transceiver.sender.setParameters(parameters);
+        return promise;
     }
 
     /**
@@ -515,11 +516,12 @@ export class TPCUtils {
                     encoding.active = enable;
                 }
             }
+            const setActivePromise = sender.setParameters(parameters);
 
             if (sender.track.kind === MediaType.VIDEO) {
-                promises.push(this.pc._updateVideoSenderParameters(() => sender.setParameters(parameters)));
+                promises.push(this.pc._updateVideoSenderParameters(setActivePromise));
             } else {
-                promises.push(sender.setParameters(parameters));
+                promises.push(setActivePromise);
             }
         }
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2676,9 +2676,7 @@ TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeig
 
     this._senderMaxHeights.set(sourceName, frameHeight);
 
-    return this._updateVideoSenderParameters(
-        () => this._updateVideoSenderEncodings(frameHeight, localVideoTrack)
-    );
+    return this._updateVideoSenderParameters(this._updateVideoSenderEncodings(frameHeight, localVideoTrack));
 };
 
 /**
@@ -2686,12 +2684,12 @@ TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeig
  * This is needed on Chrome as it resets the transaction id after executing setParameters() and can affect the next on
  * the fly updates if they are not chained.
  * https://chromium.googlesource.com/external/webrtc/+/master/pc/rtp_sender.cc#340
- * @param {Function} nextFunction - The function to be called when the last video sender update promise is settled.
+ * @param {Promise} promise - The promise that needs to be chained.
  * @returns {Promise}
  */
-TraceablePeerConnection.prototype._updateVideoSenderParameters = function(nextFunction) {
+TraceablePeerConnection.prototype._updateVideoSenderParameters = function(promise) {
     const nextPromise = this._lastVideoSenderUpdatePromise
-        .finally(nextFunction);
+        .finally(() => promise);
 
     this._lastVideoSenderUpdatePromise = nextPromise;
 


### PR DESCRIPTION
…ers in sequential manner in order to solve race condition when transaction id can be reset at the end of videoSender setParameters and cause exception if another update was already in fly and before its check for transaction id presence."

This reverts commit 17ade96a70971b7429b6beac73b919885e665f16.

It causes setParameters failures which can cause media being leaved to JVB when in a P2P connection.