### PR TITLE
fix(CodecSelection) Switch codec to VP8 when E2EE is enabled.

### DIFF
--- a/modules/RTC/CodecSelection.spec.js
+++ b/modules/RTC/CodecSelection.spec.js
@@ -69,6 +69,14 @@ class MockConference extends Listenable {
     }
 
     /**
+     * Checks if E2EE is enabled.
+     * @returns {boolean}
+     */
+    isE2EEEnabled() {
+        return false;
+    }
+
+    /**
      * Removes the participant from the conference.
      * @param {MockParticipant} endpoint
      */


### PR DESCRIPTION
E2EE is not supported by the application when VP9 is the selected codec. Therefore, switch to using VP8 for video encode/decode.