### PR TITLE
fix(SDP): Add msid to generated RTX SSRC only when present on primary SSRC.

### DIFF
--- a/modules/sdp/RtxModifier.js
+++ b/modules/sdp/RtxModifier.js
@@ -42,7 +42,7 @@ function updateAssociatedRtxStream(mLine, primarySsrcInfo, rtxSsrc) {
         attribute: 'cname',
         value: primarySsrcCname
     });
-    mLine.addSSRCAttribute({
+    primarySsrcMsid && mLine.addSSRCAttribute({
         id: rtxSsrc,
         attribute: 'msid',
         value: primarySsrcMsid


### PR DESCRIPTION
Fixes setLocalDescription failing in the case where simulcast is disabled since the answer produced by the browser (after a local source is added) does not have the msid line.