### PR TITLE
fix(JingleSessionPC,ProxyConnectionPC) handle empty local tracks

### DIFF
--- a/modules/proxyconnection/ProxyConnectionPC.js
+++ b/modules/proxyconnection/ProxyConnectionPC.js
@@ -368,7 +368,8 @@ export default class ProxyConnectionPC {
                 this._options.peerJid,
                 ACTIONS.CONNECTION_ERROR,
                 'session initiate error'
-            )
+            ),
+            []
         );
     }
 

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -988,7 +988,7 @@ export default class JingleSessionPC extends JingleSession {
      * other operations which originate in the XMPP Jingle messages related with this session to be executed with an
      * assumption that the initial offer/answer cycle has been executed already.
      */
-    acceptOffer(jingleOffer, success, failure, localTracks) {
+    acceptOffer(jingleOffer, success, failure, localTracks = []) {
         this.setOfferAnswerCycle(
             jingleOffer,
             () => {


### PR DESCRIPTION
When accepting a new offer.