### PR TITLE
fix(signaling): Merge ssrcOwners and _sourceName.

### DIFF
--- a/modules/proxyconnection/CustomSignalingLayer.js
+++ b/modules/proxyconnection/CustomSignalingLayer.js
@@ -111,12 +111,6 @@ export default class CustomSignalingLayer extends SignalingLayer {
     /**
      * @inheritDoc
      */
-    setTrackSourceName(ssrc, sourceName) { // eslint-disable-line no-unused-vars
-    }
-
-    /**
-     * @inheritDoc
-     */
     updateSsrcOwnersOnLeave(id) {
         const ssrcs = Array.from(this.ssrcOwners)
             .filter(entry => entry[1] === id)

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -926,16 +926,15 @@ export default class JingleSessionPC extends JingleSession {
 
         ssrcs.each((i, ssrcElement) => {
             const ssrc = Number(ssrcElement.getAttribute('ssrc'));
+            let sourceName;
 
             if (ssrcElement.hasAttribute('name')) {
-                const sourceName = ssrcElement.getAttribute('name');
-
-                this._signalingLayer.setTrackSourceName(ssrc, sourceName);
+                sourceName = ssrcElement.getAttribute('name');
             }
 
             if (this.isP2P) {
                 // In P2P all SSRCs are owner by the remote peer
-                this._signalingLayer.setSSRCOwner(ssrc, Strophe.getResourceFromJid(this.remoteJid));
+                this._signalingLayer.setSSRCOwner(ssrc, Strophe.getResourceFromJid(this.remoteJid), sourceName);
             } else {
                 $(ssrcElement)
                     .find('>ssrc-info[xmlns="http://jitsi.org/jitmeet"]')
@@ -946,7 +945,7 @@ export default class JingleSessionPC extends JingleSession {
                             if (isNaN(ssrc) || ssrc < 0) {
                                 logger.warn(`${this} Invalid SSRC ${ssrc} value received for ${owner}`);
                             } else {
-                                this._signalingLayer.setSSRCOwner(ssrc, getEndpointId(owner));
+                                this._signalingLayer.setSSRCOwner(ssrc, getEndpointId(owner), sourceName);
                             }
                         }
                     });
@@ -1804,7 +1803,7 @@ export default class JingleSessionPC extends JingleSession {
                 logger.debug(`Existing SSRC ${ssrc}: new owner=${owner}, source-name=${source}`);
 
                 // Update the SSRC owner.
-                this._signalingLayer.setSSRCOwner(ssrc, owner);
+                this._signalingLayer.setSSRCOwner(ssrc, owner, source);
 
                 // Update the track with all the relevant info.
                 track.setSourceName(source);

--- a/service/RTC/SignalingLayer.js
+++ b/service/RTC/SignalingLayer.js
@@ -144,11 +144,13 @@ export default class SignalingLayer extends Listenable {
 
     /**
      * Set an SSRC owner.
-     * @param {number} ssrc an SSRC to be owned
-     * @param {string} endpointId owner's ID (MUC nickname)
-     * @throws TypeError if <tt>ssrc</tt> is not a number
+     *
+     * @param {number} ssrc - An SSRC to be owned.
+     * @param {string} endpointId - Owner's ID (MUC nickname).
+     * @param {string} sourceName - The related source name.
+     * @throws TypeError if <tt>ssrc</tt> is not a number.
      */
-    setSSRCOwner(ssrc, endpointId) { // eslint-disable-line no-unused-vars
+    setSSRCOwner(ssrc, endpointId, sourceName) { // eslint-disable-line no-unused-vars
     }
 
     /**
@@ -159,15 +161,6 @@ export default class SignalingLayer extends Listenable {
      * @returns {boolean}
      */
     setTrackMuteStatus(sourceName, muted) { // eslint-disable-line no-unused-vars
-    }
-
-    /**
-     * Saves the source name for a track identified by it's ssrc.
-     * @param {number} ssrc the ssrc of the target track.
-     * @param {SourceName} sourceName the track's source name to save.
-     * @throws TypeError if <tt>ssrc</tt> is not a number
-     */
-    setTrackSourceName(ssrc, sourceName) { // eslint-disable-line no-unused-vars
     }
 
     /**


### PR DESCRIPTION
Additional benefits are:
 - ssrc -> source name will be updated on ssrc remap message from
 the bridge.
 - the map will be correctly cleaned when member leave (this logic was
 not working well for _sourceName map)
 - Looks cleaner and simpler.