### PR TITLE
Expose JWT identity claims through public API

### DIFF
--- a/JitsiParticipant.js
+++ b/JitsiParticipant.js
@@ -149,6 +149,16 @@ export default class JitsiParticipant {
     }
 
     /**
+     * Returns the XMPP identity. This is defined by your application in the
+     * JWT `context` claims section.
+     *
+     * @returns {object|undefined} - XMPP user identity.
+     */
+    getIdentity() {
+        return this._identity;
+    }
+
+    /**
      * @returns {String} The JID of this participant.
      */
     getJid() {

--- a/types/hand-crafted/JitsiParticipant.d.ts
+++ b/types/hand-crafted/JitsiParticipant.d.ts
@@ -10,6 +10,7 @@ export default class JitsiParticipant {
   getDisplayName: () => string;
   getFeatures: () => Promise<Set<string> | Error>;
   getId: () => string;
+  getIdentity: () => undefined | JwtIdentity;
   getJid: () => string;
   getProperty: ( name: string ) => string;
   getRole: () => string;
@@ -31,4 +32,24 @@ export default class JitsiParticipant {
   setProperty: ( name: string, value: string ) => void;
   setRole: ( role: string ) => void;
   supportsDTMF: () => boolean;
+}
+
+/**
+ * Application-defined values carried in the JWT claims section.
+ *
+ * @see https://github.com/jitsi/lib-jitsi-meet/blob/master/doc/tokens.md#token-identifiers-structure-optional
+ */
+interface JwtIdentity {
+  group: string;
+  user: {
+    id: string;
+    email: string;
+    name: string;
+    avatar: string;
+  };
+  callee?: {
+    id: string;
+    name: string;
+    avatar: string;
+  };
 }


### PR DESCRIPTION
Our application needs access to the `_identity` JWT claims for each participant. It's already stored on `participant._identity`, this PR just exposes it with a new getter:

```ts
jitsiParticipant.getIdentity()
// => { user: Object }
```

References:

- [JWT context structure](https://github.com/jitsi/lib-jitsi-meet/blob/master/doc/tokens.md#token-identifiers-structure-optional)
- [Prior art](https://github.com/jitsi/lib-jitsi-meet/pull/1393) (PR appears dead)