### PR TITLE
feat(ScreenObtainer): add more control over screen obtainer

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -189,7 +189,9 @@ const ScreenObtainer = {
 
         const audio = this._getAudioConstraints();
         let video = {};
+        const constraintOpts = {};
         const {
+            desktopDisplaySurface,
             desktopSharingFrameRate,
             desktopSurfaceSwitching,
             desktopSelfBrowserSurface,
@@ -208,19 +210,23 @@ const ScreenObtainer = {
         if (browser.isChromiumBased()) {
             // Show users the current tab is the preferred capture source, default: false.
             browser.isEngineVersionGreaterThan(93)
-                && (video.preferCurrentTab = desktopPreferCurrentTab || false);
+                && (constraintOpts.preferCurrentTab = desktopPreferCurrentTab || false);
 
             // Allow users to select system audio, default: include.
             browser.isEngineVersionGreaterThan(104)
-                && (video.systemAudio = desktopSystemAudio || 'include');
+                && (constraintOpts.systemAudio = desktopSystemAudio || 'include');
 
             // Allow users to seamlessly switch which tab they are sharing without having to select the tab again.
             browser.isEngineVersionGreaterThan(106)
-                && (video.surfaceSwitching = desktopSurfaceSwitching || 'include');
+                && (constraintOpts.surfaceSwitching = desktopSurfaceSwitching || 'include');
+
+            // Allow a user to be shown a preference for what screen is to be captured, default: unset.
+            browser.isEngineVersionGreaterThan(106) && desktopDisplaySurface
+                && (video.displaySurface = desktopDisplaySurface);
 
             // Allow users to select the current tab as a capture source, default: exclude.
             browser.isEngineVersionGreaterThan(111)
-                && (video.selfBrowserSurface = desktopSelfBrowserSurface || 'exclude');
+                && (constraintOpts.selfBrowserSurface = desktopSelfBrowserSurface || 'exclude');
 
             // Set bogus resolution constraints to work around
             // https://bugs.chromium.org/p/chromium/issues/detail?id=1056311 for low fps screenshare. Capturing SS at
@@ -231,6 +237,11 @@ const ScreenObtainer = {
             }
         }
 
+        // Allow a user to be shown a preference for what screen is to be captured.
+        if (browser.isSafari() && browser.isEngineVersionGreaterThan(11) && desktopDisplaySurface) {
+            video.displaySurface = desktopDisplaySurface;
+        }
+
         if (Object.keys(video).length === 0) {
             video = true;
         }
@@ -238,6 +249,7 @@ const ScreenObtainer = {
         const constraints = {
             video,
             audio,
+            ...constraintOpts,
             cursor: 'always'
         };
 

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -189,7 +189,13 @@ const ScreenObtainer = {
 
         const audio = this._getAudioConstraints();
         let video = {};
-        const { desktopSharingFrameRate } = this.options;
+        const {
+            desktopSharingFrameRate,
+            desktopSurfaceSwitching,
+            desktopSelfBrowserSurface,
+            desktopPreferCurrentTab,
+            desktopSystemAudio
+        } = this.options;
 
         if (typeof desktopSharingFrameRate === 'object') {
             video.frameRate = desktopSharingFrameRate;
@@ -200,8 +206,21 @@ const ScreenObtainer = {
         video.frameRate && delete video.frameRate.min;
 
         if (browser.isChromiumBased()) {
+            // Show users the current tab is the preferred capture source, default: false.
+            browser.isEngineVersionGreaterThan(93)
+                && (video.preferCurrentTab = desktopPreferCurrentTab || false);
+
+            // Allow users to select system audio, default: include.
+            browser.isEngineVersionGreaterThan(104)
+                && (video.systemAudio = desktopSystemAudio || 'include');
+
             // Allow users to seamlessly switch which tab they are sharing without having to select the tab again.
-            browser.isEngineVersionGreaterThan(106) && (video.surfaceSwitching = 'include');
+            browser.isEngineVersionGreaterThan(106)
+                && (video.surfaceSwitching = desktopSurfaceSwitching || 'include');
+
+            // Allow users to select the current tab as a capture source, default: exclude.
+            browser.isEngineVersionGreaterThan(111)
+                && (video.selfBrowserSurface = desktopSelfBrowserSurface || 'exclude');
 
             // Set bogus resolution constraints to work around
             // https://bugs.chromium.org/p/chromium/issues/detail?id=1056311 for low fps screenshare. Capturing SS at

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -191,12 +191,8 @@ const ScreenObtainer = {
         let video = {};
         const constraintOpts = {};
         const {
-            desktopDisplaySurface,
             desktopSharingFrameRate,
-            desktopSurfaceSwitching,
-            desktopSelfBrowserSurface,
-            desktopPreferCurrentTab,
-            desktopSystemAudio
+            screenShareSettings
         } = this.options;
 
         if (typeof desktopSharingFrameRate === 'object') {
@@ -210,23 +206,23 @@ const ScreenObtainer = {
         if (browser.isChromiumBased()) {
             // Show users the current tab is the preferred capture source, default: false.
             browser.isEngineVersionGreaterThan(93)
-                && (constraintOpts.preferCurrentTab = desktopPreferCurrentTab || false);
+                && (constraintOpts.preferCurrentTab = screenShareSettings?.desktopPreferCurrentTab || false);
 
             // Allow users to select system audio, default: include.
             browser.isEngineVersionGreaterThan(104)
-                && (constraintOpts.systemAudio = desktopSystemAudio || 'include');
+                && (constraintOpts.systemAudio = screenShareSettings?.desktopSystemAudio || 'include');
 
             // Allow users to seamlessly switch which tab they are sharing without having to select the tab again.
             browser.isEngineVersionGreaterThan(106)
-                && (constraintOpts.surfaceSwitching = desktopSurfaceSwitching || 'include');
+                && (constraintOpts.surfaceSwitching = screenShareSettings?.desktopSurfaceSwitching || 'include');
 
             // Allow a user to be shown a preference for what screen is to be captured, default: unset.
-            browser.isEngineVersionGreaterThan(106) && desktopDisplaySurface
-                && (video.displaySurface = desktopDisplaySurface);
+            browser.isEngineVersionGreaterThan(106) && screenShareSettings?.desktopDisplaySurface
+                && (video.displaySurface = screenShareSettings?.desktopDisplaySurface);
 
             // Allow users to select the current tab as a capture source, default: exclude.
             browser.isEngineVersionGreaterThan(111)
-                && (constraintOpts.selfBrowserSurface = desktopSelfBrowserSurface || 'exclude');
+                && (constraintOpts.selfBrowserSurface = screenShareSettings?.desktopSelfBrowserSurface || 'exclude');
 
             // Set bogus resolution constraints to work around
             // https://bugs.chromium.org/p/chromium/issues/detail?id=1056311 for low fps screenshare. Capturing SS at
@@ -238,8 +234,8 @@ const ScreenObtainer = {
         }
 
         // Allow a user to be shown a preference for what screen is to be captured.
-        if (browser.isSafari() && desktopDisplaySurface) {
-            video.displaySurface = desktopDisplaySurface;
+        if (browser.isSafari() && screenShareSettings?.desktopDisplaySurface) {
+            video.displaySurface = screenShareSettings?.desktopDisplaySurface;
         }
 
         if (Object.keys(video).length === 0) {

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -238,7 +238,7 @@ const ScreenObtainer = {
         }
 
         // Allow a user to be shown a preference for what screen is to be captured.
-        if (browser.isSafari() && browser.isEngineVersionGreaterThan(11) && desktopDisplaySurface) {
+        if (browser.isSafari() && desktopDisplaySurface) {
             video.displaySurface = desktopDisplaySurface;
         }
 


### PR DESCRIPTION
We have implemented these changes on our application, to allow for additional control of the screen obtainer on the browser.

It may not apply to Jitsi, however I thought I would propose these changes for more control over the library.