### PR TITLE
fix(JingleSessionPC): call task callbacks upon clearing (#2370)

### DIFF
--- a/modules/util/AsyncQueue.js
+++ b/modules/util/AsyncQueue.js
@@ -35,7 +35,7 @@ export default class AsyncQueue {
     clear() {
         for (const finishedCallback of this._taskCallbacks.values()) {
             try {
-            finishedCallback(new ClearedQueueError('The queue has been cleared'));
+                finishedCallback(new ClearedQueueError('The queue has been cleared'));
             } catch (error) {
                 logger.error('Error in callback while clearing the queue:', error);
             }

--- a/modules/util/AsyncQueue.js
+++ b/modules/util/AsyncQueue.js
@@ -34,7 +34,11 @@ export default class AsyncQueue {
      */
     clear() {
         for (const finishedCallback of this._taskCallbacks.values()) {
+            try {
             finishedCallback(new ClearedQueueError('The queue has been cleared'));
+            } catch (error) {
+                logger.error('Error in callback while clearing the queue:', error);
+            }
         }
         this._queue.kill();
     }

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -18,7 +18,7 @@ import SDP from '../sdp/SDP';
 import SDPDiffer from '../sdp/SDPDiffer';
 import SDPUtil from '../sdp/SDPUtil';
 import Statistics from '../statistics/statistics';
-import AsyncQueue from '../util/AsyncQueue';
+import AsyncQueue, { ClearedQueueError } from '../util/AsyncQueue';
 import GlobalOnErrorHandler from '../util/GlobalOnErrorHandler';
 
 import browser from './../browser';
@@ -1321,6 +1321,11 @@ export default class JingleSessionPC extends JingleSession {
             workFunction,
             error => {
                 if (error) {
+                    if (error instanceof ClearedQueueError) {
+                        // The session might have been terminated before the task was executed, making it obsolete.
+                        logger.debug(`${this} ICE restart task aborted: session terminated`);
+                        success();
+                    }
                     logger.error(`${this} ICE restart task failed: ${error}`);
                     failure(error);
                 } else {
@@ -2194,6 +2199,11 @@ export default class JingleSessionPC extends JingleSession {
                 workFunction,
                 error => {
                     if (error) {
+                        if (error instanceof ClearedQueueError) {
+                            // The session might have been terminated before the task was executed, making it obsolete.
+                            logger.debug(`${this} renegotiation after addTrack aborted: session terminated`);
+                            resolve();
+                        }
                         logger.error(`${this} renegotiation after addTrack error`, error);
                         reject(error);
                     } else {
@@ -2306,6 +2316,11 @@ export default class JingleSessionPC extends JingleSession {
                 workFunction,
                 error => {
                     if (error) {
+                        if (error instanceof ClearedQueueError) {
+                            // The session might have been terminated before the task was executed, making it obsolete.
+                            logger.debug('Replace track aborted: session terminated');
+                            resolve();
+                        }
                         logger.error(`${this} Replace track error:`, error);
                         reject(error);
                     } else {
@@ -2504,6 +2519,11 @@ export default class JingleSessionPC extends JingleSession {
                 workFunction,
                 error => {
                     if (error) {
+                        if (error instanceof ClearedQueueError) {
+                            // The session might have been terminated before the task was executed, making it obsolete.
+                            logger.debug(`${this} ${operationName} aborted: session terminated`);
+                            resolve();
+                        }
                         logger.error(`${this} ${operationName} failed`);
                         reject(error);
                     } else {

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1325,6 +1325,8 @@ export default class JingleSessionPC extends JingleSession {
                         // The session might have been terminated before the task was executed, making it obsolete.
                         logger.debug(`${this} ICE restart task aborted: session terminated`);
                         success();
+
+                        return;
                     }
                     logger.error(`${this} ICE restart task failed: ${error}`);
                     failure(error);
@@ -2203,6 +2205,8 @@ export default class JingleSessionPC extends JingleSession {
                             // The session might have been terminated before the task was executed, making it obsolete.
                             logger.debug(`${this} renegotiation after addTrack aborted: session terminated`);
                             resolve();
+
+                            return;
                         }
                         logger.error(`${this} renegotiation after addTrack error`, error);
                         reject(error);
@@ -2320,6 +2324,8 @@ export default class JingleSessionPC extends JingleSession {
                             // The session might have been terminated before the task was executed, making it obsolete.
                             logger.debug('Replace track aborted: session terminated');
                             resolve();
+
+                            return;
                         }
                         logger.error(`${this} Replace track error:`, error);
                         reject(error);
@@ -2523,6 +2529,8 @@ export default class JingleSessionPC extends JingleSession {
                             // The session might have been terminated before the task was executed, making it obsolete.
                             logger.debug(`${this} ${operationName} aborted: session terminated`);
                             resolve();
+
+                            return;
                         }
                         logger.error(`${this} ${operationName} failed`);
                         reject(error);

--- a/types/hand-crafted/modules/util/AsyncQueue.d.ts
+++ b/types/hand-crafted/modules/util/AsyncQueue.d.ts
@@ -1,3 +1,7 @@
+export class ClearedQueueError extends Error {
+  constructor();
+}
+
 export default class AsyncQueue {
   constructor();
   push: ( task: ( callback: ( err?: Error ) => void ) => void, callback?: ( err: Error ) => void ) => void; // TODO: check this


### PR DESCRIPTION
This ensures that promises relying on the task callback will settle.