### PR TITLE
feat(RTCStats) Suppress unnecessary error message when rtcstatsEnabled === false

### DIFF
--- a/modules/RTCStats/RTCStats.ts
+++ b/modules/RTCStats/RTCStats.ts
@@ -34,8 +34,8 @@ function connectionFilter(config) {
  * Config and conference changes are handled by the start method.
  */
 class RTCStats {
-    #initialized = false;
-    #trace: any = null;
+    _initialized = false;
+    _trace: any = null;
     public events: EventEmitter = new EventEmitter();
 
     /**
@@ -59,7 +59,7 @@ class RTCStats {
         // If rtcstats is not enabled or already initialized, do nothing.
         // Calling rtcsatsInit multiple times will cause the global objects to be rewritten multiple times,
         // with unforeseen consequences.
-        if (!rtcstatsEnabled || this.#initialized) return;
+        if (!rtcstatsEnabled || this._initialized) return;
 
         rtcstatsInit(
             { statsEntry: this.sendStatsEntry.bind(this) },
@@ -70,7 +70,7 @@ class RTCStats {
               eventCallback: (event) => this.events.emit(RTC_STATS_PC_EVENT, event)}
         );
 
-        this.#initialized = true;
+        this._initialized = true;
     }
 
     /**
@@ -107,7 +107,7 @@ class RTCStats {
         if (!rtcstatsEnabled) return;
 
         // If rtcstats proxy module is not initialized, do nothing.
-        if (!this.#initialized) {
+        if (!this._initialized) {
             logger.error('Calling start before RTCStats proxy module is initialized.');
 
             return;
@@ -127,12 +127,12 @@ class RTCStats {
             const endpointId = conference.myUserId();
             const meetingUniqueId = conference.getMeetingUniqueId();
 
-            this.#trace = traceInit(traceOptions);
+            this._trace = traceInit(traceOptions);
 
             // Connect to the rtcstats server instance. Stats (data obtained from getstats) won't be send until the
             // connect successfully initializes, however calls to GUM are recorded in an internal buffer even if not
             // connected and sent once it is established.
-            this.#trace.connect(isBreakoutRoom);
+            this._trace.connect(isBreakoutRoom);
 
             const identityData = {
                 ...confConfig,
@@ -163,7 +163,7 @@ class RTCStats {
      * @returns {void}
      */
     sendIdentity(identityData) {
-        this.#trace?.identity('identity', null, identityData);
+        this._trace?.identity('identity', null, identityData);
     }
 
     /**
@@ -175,8 +175,8 @@ class RTCStats {
      * @returns {void}
      */
     reset() {
-        this.#trace?.close();
-        this.#trace = null;
+        this._trace?.close();
+        this._trace = null;
     }
 
     /**
@@ -187,7 +187,7 @@ class RTCStats {
      * @returns {void}
      */
     sendStatsEntry(statsType, pcId, data) {
-        this.#trace?.statsEntry(statsType, pcId, data);
+        this._trace?.statsEntry(statsType, pcId, data);
     }
 }
 

--- a/modules/RTCStats/RTCStats.ts
+++ b/modules/RTCStats/RTCStats.ts
@@ -34,8 +34,8 @@ function connectionFilter(config) {
  * Config and conference changes are handled by the start method.
  */
 class RTCStats {
-    _initialized = false;
-    _trace: any = null;
+    private _initialized: boolean = false;
+    private _trace: any = null;
     public events: EventEmitter = new EventEmitter();
 
     /**
@@ -64,9 +64,9 @@ class RTCStats {
         rtcstatsInit(
             { statsEntry: this.sendStatsEntry.bind(this) },
             { connectionFilter,
-                pollInterval,
-                useLegacy,
-                sendSdp,
+              pollInterval,
+              useLegacy,
+              sendSdp,
               eventCallback: (event) => this.events.emit(RTC_STATS_PC_EVENT, event)}
         );
 

--- a/modules/RTCStats/interfaces.ts
+++ b/modules/RTCStats/interfaces.ts
@@ -9,3 +9,10 @@ export interface IRTCStatsConfiguration {
         rtcstatsUseLegacy?: boolean;
     };
 }
+
+export interface RTCStatsState {
+    /** Initialized - doesn't necessarily mean that rtcstats are enabled */
+    initialized: boolean;
+    /** Is true if initialized with `rtcstatsEnabled` being true */
+    enabled: boolean;
+}

--- a/modules/RTCStats/interfaces.ts
+++ b/modules/RTCStats/interfaces.ts
@@ -9,10 +9,3 @@ export interface IRTCStatsConfiguration {
         rtcstatsUseLegacy?: boolean;
     };
 }
-
-export interface RTCStatsState {
-    /** Initialized - doesn't necessarily mean that rtcstats are enabled */
-    initialized: boolean;
-    /** Is true if initialized with `rtcstatsEnabled` being true */
-    enabled: boolean;
-}


### PR DESCRIPTION
There are use cases where `RTCStats.init` is called without the argument property `initConfig.analytics.rtcstatsEnabled` being `true` - it is because by default it is false.

In those cases, calling `connection.initJitsiConference("conference", confOptions);` result in this error below:

![Screenshot_235](https://github.com/jitsi/lib-jitsi-meet/assets/77301332/04e94117-d22e-4f95-bd7b-d5eb54b47c24)

RTCStats is sending a somewhat misleading console error message (as if the user deliberately called `RTCStats.start` without initializing `RTCStats.init`), whereas the browser technically did call `RTCStats.init` before `RTCStats.start` - only `initConfig.analytics.rtcstatsEnabled` was `false` by default.

This pull request handles cases where RTCStats is initialized without being enabled.

Thank you for reviewing my pull request.