### PR TITLE
fix(kicked): leave the conference immediately

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1950,10 +1950,9 @@ JitsiConference.prototype.onMemberKicked = function(
     const actorParticipant = this.participants.get(actorId);
 
     if (isSelfPresence) {
+        this.leave().finally(() => this.xmpp.disconnect());
         this.eventEmitter.emit(
             JitsiConferenceEvents.KICKED, actorParticipant, reason, isReplaceParticipant);
-
-        this.leave().finally(() => this.xmpp.disconnect());
 
         return;
     }


### PR DESCRIPTION
There is no reason to wait for for the event to be emitted.

Also fixes uncaught promise error when jitsi-meet leaves the conference when the kicked event is received and then with the old code we will do a second leave which results in the uncaught promise error.

Related to https://github.com/jitsi/jitsi-meet/pull/14022 since the leave would happen in parallel with the feedback dialog and will be executed earlier.