### PR TITLE
fix: Double MUC_JOINED event.

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1866,6 +1866,12 @@ export default class ChatRoom extends Listenable {
             const onMucLeft = (doReject = false) => {
                 this.eventEmitter.removeListener(XMPPEvents.MUC_LEFT, onMucLeft);
                 clearTimeout(timeout);
+
+                // This will reset the joined flag to false. If we reset it earlier any self presence will be
+                // interpreted as muc join. That's why we reset the flag once we have received presence unavalable
+                // (MUC_LEFT).
+                this.clean();
+
                 if (doReject) {
                     // The timeout expired. Make sure we clean the EMUC state.
                     this.connection.emuc.doLeave(this.roomjid);
@@ -1877,8 +1883,6 @@ export default class ChatRoom extends Listenable {
 
             if (this.joined) {
                 timeout = setTimeout(() => onMucLeft(true), 5000);
-
-                this.clean();
                 this.eventEmitter.on(XMPPEvents.MUC_LEFT, onMucLeft);
                 this.doLeave(reason);
             } else {

--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -309,6 +309,11 @@ export default class Lobby {
             this.lobbyRoom.addEventListener(
                 XMPPEvents.MUC_DESTROYED,
                 (reason, jid) => {
+                    this.lobbyRoom?.clean();
+
+                    this.lobbyRoom = undefined;
+                    logger.info('Lobby room left(destroyed)!');
+
                     // we are receiving the jid of the main room
                     // means we are invited to join, maybe lobby was disabled
                     if (jid) {
@@ -316,8 +321,6 @@ export default class Lobby {
 
                         return;
                     }
-
-                    this.lobbyRoom.clean();
 
                     this.mainRoom.eventEmitter.emit(XMPPEvents.MUC_DESTROYED, reason);
                 });
@@ -327,7 +330,9 @@ export default class Lobby {
             this.mainRoom.addEventListener(
                 XMPPEvents.MUC_JOINED,
                 () => {
-                    this.leave();
+                    this.leave().catch(() => {
+                        // this may happen if the room has been destroyed.
+                    });
                 });
         }
 


### PR DESCRIPTION
When a self presence is received ( from mute or something else) during
leave operation, after presence unavailable is sent and before the final
presence unavaliable is received, we were interpreting it as muc joined
since the joined flag was immediately set to false.