### PR TITLE
fix(AsyncQueue): call the callback only if it's a function (#2370)

### DIFF
--- a/modules/util/AsyncQueue.js
+++ b/modules/util/AsyncQueue.js
@@ -35,7 +35,7 @@ export default class AsyncQueue {
     clear() {
         for (const finishedCallback of this._taskCallbacks.values()) {
             try {
-                finishedCallback(new ClearedQueueError('The queue has been cleared'));
+                finishedCallback?.(new ClearedQueueError('The queue has been cleared'));
             } catch (error) {
                 logger.error('Error in callback while clearing the queue:', error);
             }


### PR DESCRIPTION
Following my PR for #2370, I ran into `TypeError`s in my console where the task callback was called without being defined. The error is caught and logged so it's not critical, but it pollutes the console.