### PR TITLE
Output single TypeScript declaration file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ indent_style = space
 max_line_length = 80
 trim_trailing_whitespace = true
 
+[*.json]
+indent_size = 2
+
 [*.md]
 max_line_length = 120
 trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ npm-*.log
 stats.json
 .vscode
 dist
+index.d.ts
 types/auto
 types/types-comparer/auto.json
 types/types-comparer/hand-crafted.json

--- a/modules/util/Listenable.js
+++ b/modules/util/Listenable.js
@@ -1,43 +1,20 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 /**
  * The class implements basic event operations - add/remove listener.
  * NOTE: The purpose of the class is to be extended in order to add
  * this functionality to other classes.
  */
-export default class Listenable {
+export default class Listenable extends EventEmitter {
     /**
      * Creates new instance.
-     * @param {EventEmitter} eventEmitter
      * @constructor
      */
-    constructor(eventEmitter = new EventEmitter()) {
-        this.eventEmitter = eventEmitter;
+    constructor() {
+        super();
 
         // aliases for addListener/removeListener
         this.addEventListener = this.on = this.addListener;
         this.removeEventListener = this.off = this.removeListener;
-    }
-
-    /**
-     * Adds new listener.
-     * @param {String} eventName the name of the event
-     * @param {Function} listener the listener.
-     * @returns {Function} - The unsubscribe function.
-     */
-    addListener(eventName, listener) {
-        this.eventEmitter.addListener(eventName, listener);
-
-        return () => this.removeEventListener(eventName, listener);
-    }
-
-    /**
-     * Removes listener.
-     * @param {String} eventName the name of the event that triggers the
-     * listener
-     * @param {Function} listener the listener.
-     */
-    removeListener(eventName, listener) {
-        this.eventEmitter.removeListener(eventName, listener);
     }
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "build:webpack": "LIB_JITSI_MEET_COMMIT_HASH=$(git rev-parse --short HEAD 2>/dev/null) webpack",
     "build:webpack-dev": "webpack --mode development",
     "build:tsc": "tsc --build --clean && tsc",
-    "gen-types": "tsc --declaration --declarationDir types/auto --emitDeclarationOnly",
+    "gen-types": "tsc --declaration --emitDeclarationOnly --out index.js",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
     "postinstall": "patch-package",
@@ -81,9 +81,11 @@
   },
   "browser": "dist/umd/lib-jitsi-meet.min.js",
   "module": "dist/esm/JitsiMeetJS.js",
+  "types": "index.d.ts",
   "files": [
     "dist",
-    "types"
+    "types",
+    "index.d.ts"
   ],
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
Hey!
Opening this as a draft, but its essentially finished. Wanted to get thoughts on this,

1. Last step from generating a single declaration file was fixing the Listenable, to correctly implement EventEmitter instead of instantiating it. (As recommended by NodeJS) https://nodejs.org/api/events.html#events_events
2. Updated the gen-types command to output a single declaration file, which is now referenced in package.json
3. Updated editorconfig to match the 2 spaces in the json files

Now the main potentially breaking change is:

1. Listenable addEventListener does not return an unsubscribe function anymore, however I could not find a use of it in the code.
2. The types/auto directory is no longer generated, we could get around this by creating a new command, but I thought it was redundant.

What do you think @saghul ?