### PR TITLE
Unify events and output single TypeScript declaration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ npm-*.log
 stats.json
 .vscode
 dist
+index.d.ts
 types/auto
 types/types-comparer/auto.json
 types/types-comparer/hand-crafted.json

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1,5 +1,4 @@
 import { getLogger } from '@jitsi/logger';
-import EventEmitter from 'events';
 import $ from 'jquery';
 import isEqual from 'lodash.isequal';
 import { Strophe } from 'strophe.js';
@@ -39,6 +38,7 @@ import LocalStatsCollector from './modules/statistics/LocalStatsCollector';
 import SpeakerStatsCollector from './modules/statistics/SpeakerStatsCollector';
 import Statistics from './modules/statistics/statistics';
 import GlobalOnErrorHandler from './modules/util/GlobalOnErrorHandler';
+import Listenable from './modules/util/Listenable';
 import RandomUtil from './modules/util/RandomUtil';
 import ComponentsVersions from './modules/version/ComponentsVersions';
 import VideoSIPGW from './modules/videosipgw/VideoSIPGW';
@@ -150,7 +150,7 @@ export default function JitsiConference(options) {
         logger.error(errmsg);
         throw new Error(errmsg);
     }
-    this.eventEmitter = new EventEmitter();
+    this.eventEmitter = new Listenable();
     this.options = options;
     this.eventManager = new JitsiConferenceEventManager(this);
 

--- a/JitsiMediaDevices.js
+++ b/JitsiMediaDevices.js
@@ -1,8 +1,7 @@
-import EventEmitter from 'events';
-
 import * as JitsiMediaDevicesEvents from './JitsiMediaDevicesEvents';
 import RTC from './modules/RTC/RTC';
 import browser from './modules/browser';
+import Listenable from './modules/util/Listenable';
 import { MediaType } from './service/RTC/MediaType';
 import RTCEvents from './service/RTC/RTCEvents';
 
@@ -13,13 +12,13 @@ const VIDEO_PERMISSION_NAME = 'camera';
 /**
  * Media devices utilities for Jitsi.
  */
-class JitsiMediaDevices {
+class JitsiMediaDevices extends Listenable {
     /**
      * Initializes a {@code JitsiMediaDevices} object. There will be a single
      * instance of this class.
      */
     constructor() {
-        this._eventEmitter = new EventEmitter();
+        super();
         this._permissions = {};
 
         RTC.addListener(

--- a/modules/RTC/BridgeChannel.js
+++ b/modules/RTC/BridgeChannel.js
@@ -21,7 +21,7 @@ export default class BridgeChannel {
      * @param {RTCPeerConnection} [peerconnection] WebRTC peer connection
      * instance.
      * @param {string} [wsUrl] WebSocket URL.
-     * @param {EventEmitter} emitter the EventEmitter instance to use for event emission.
+     * @param {EventManager} emitter the EventEmitter instance to use for event emission.
      * @param {JitsiConference} conference the conference instance.
      */
     constructor(peerconnection, wsUrl, emitter, conference) {
@@ -48,7 +48,7 @@ export default class BridgeChannel {
         // for the first connection attempt. Then transition to either true or false.
         this._connected = undefined;
 
-        // @type {EventEmitter}
+        // @type {EventManager}
         this._eventEmitter = emitter;
 
         // Whether a RTCDataChannel or WebSocket is internally used.

--- a/modules/RTC/CodecSelection.spec.js
+++ b/modules/RTC/CodecSelection.spec.js
@@ -1,5 +1,3 @@
-import EventEmitter from 'events';
-
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents.ts';
 import Listenable from '../util/Listenable.js';
 import JingleSessionPC from '../xmpp/JingleSessionPC.js';
@@ -42,7 +40,6 @@ class MockConference extends Listenable {
         };
 
         this.activeMediaSession = undefined;
-        this.eventEmitter = new EventEmitter();
         this.mediaSessions = [];
         this.participants = [];
         this._signalingLayer = new MockSignalingLayerImpl();

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -1,9 +1,9 @@
 import { getLogger } from '@jitsi/logger';
-import EventEmitter from 'events';
 
 import * as JitsiTrackEvents from '../../JitsiTrackEvents';
 import { MediaType } from '../../service/RTC/MediaType';
 import browser from '../browser';
+import EventManager from '../util/EventManager';
 
 import RTCUtils from './RTCUtils';
 
@@ -21,7 +21,7 @@ const trackHandler2Prop = {
 /**
  * Represents a single media track (either audio or video).
  */
-export default class JitsiTrack extends EventEmitter {
+export default class JitsiTrack extends EventManager {
     /* eslint-disable max-params */
     /**
      * Represents a single media track (either audio or video).
@@ -43,10 +43,6 @@ export default class JitsiTrack extends EventEmitter {
             trackMediaType,
             videoType) {
         super();
-
-        // aliases for addListener/removeListener
-        this.addEventListener = this.addListener;
-        this.removeEventListener = this.off = this.removeListener;
 
         /**
          * Array with the HTML elements that are displaying the streams.

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -1,5 +1,4 @@
 import { getLogger } from '@jitsi/logger';
-import EventEmitter from 'events';
 import clonedeep from 'lodash.clonedeep';
 import 'webrtc-adapter';
 
@@ -12,6 +11,7 @@ import { VideoType } from '../../service/RTC/VideoType';
 import { AVAILABLE_DEVICE } from '../../service/statistics/AnalyticsEvents';
 import browser from '../browser';
 import Statistics from '../statistics/statistics';
+import EventManager from '../util/EventManager';
 import GlobalOnErrorHandler from '../util/GlobalOnErrorHandler';
 import Listenable from '../util/Listenable';
 
@@ -19,7 +19,7 @@ import screenObtainer from './ScreenObtainer';
 
 const logger = getLogger(__filename);
 
-const eventEmitter = new EventEmitter();
+const eventEmitter = new EventManager();
 
 const AVAILABLE_DEVICES_POLL_INTERVAL_TIME = 3000; // ms
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -320,7 +320,7 @@ export default function TraceablePeerConnection(
 
     /**
      * TracablePeerConnection uses RTC's eventEmitter
-     * @type {EventEmitter}
+     * @type {EventManager}
      */
     this.eventEmitter = rtc.eventEmitter;
     this.rtxModifier = new RtxModifier();

--- a/modules/RTCStats/RTCStats.ts
+++ b/modules/RTCStats/RTCStats.ts
@@ -2,7 +2,6 @@ import { getLogger } from '@jitsi/logger';
 
 import rtcstatsInit from '@jitsi/rtcstats/rtcstats';
 import traceInit from '@jitsi/rtcstats/trace-ws';
-import EventEmitter from 'events';
 
 import {
     CONFERENCE_JOINED,
@@ -12,6 +11,7 @@ import {
 import JitsiConference from '../../JitsiConference';
 import { IRTCStatsConfiguration } from './interfaces';
 import { RTC_STATS_PC_EVENT, RTC_STATS_WC_DISCONNECTED } from './RTCStatsEvents';
+import EventManager from '../util/EventManager';
 
 const logger = getLogger(__filename);
 
@@ -22,7 +22,7 @@ const logger = getLogger(__filename);
 class RTCStats {
     private _initialized: boolean = false;
     private _trace: any = null;
-    public events: EventEmitter = new EventEmitter();
+    public events: EventManager = new EventManager();
 
     /**
      * RTCStats "proxies" WebRTC functions such as GUM and RTCPeerConnection by rewriting the global objects.

--- a/modules/detection/NoAudioSignalDetection.js
+++ b/modules/detection/NoAudioSignalDetection.js
@@ -1,7 +1,7 @@
-import EventEmitter from 'events';
-
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 import * as JitsiTrackEvents from '../../JitsiTrackEvents';
+
+import EventManager from '../util/EventManager';
 
 import * as DetectionEvents from './DetectionEvents';
 
@@ -17,7 +17,7 @@ const SILENCE_PERIOD_MS = 4000;
  * @fires DetectionEvents.AUDIO_INPUT_STATE_CHANGE
  * @fires DetectionEvents.NO_AUDIO_INPUT
  */
-export default class NoAudioSignalDetection extends EventEmitter {
+export default class NoAudioSignalDetection extends EventManager {
     /**
      * Creates new NoAudioSignalDetection.
      *

--- a/modules/detection/TrackVADEmitter.js
+++ b/modules/detection/TrackVADEmitter.js
@@ -1,6 +1,5 @@
-import EventEmitter from 'events';
-
 import RTC from '../RTC/RTC';
+import EventManager from '../util/EventManager';
 import { createAudioContext } from '../webaudio/WebAudioUtils';
 
 import { VAD_SCORE_PUBLISHED } from './DetectionEvents';
@@ -14,7 +13,7 @@ import { VAD_SCORE_PUBLISHED } from './DetectionEvents';
  *
  * @fires VAD_SCORE_PUBLISHED
  */
-export default class TrackVADEmitter extends EventEmitter {
+export default class TrackVADEmitter extends EventManager {
     /**
      * Constructor.
      *

--- a/modules/detection/VADAudioAnalyser.js
+++ b/modules/detection/VADAudioAnalyser.js
@@ -1,7 +1,7 @@
 import { getLogger } from '@jitsi/logger';
-import { EventEmitter } from 'events';
 
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
+import EventManager from '../util/EventManager';
 
 import { DETECTOR_STATE_CHANGE, VAD_SCORE_PUBLISHED } from './DetectionEvents';
 import TrackVADEmitter from './TrackVADEmitter';
@@ -18,7 +18,7 @@ const VAD_EMITTER_SAMPLE_RATE = 4096;
  * Connects a TrackVADEmitter to the target conference local audio track and manages various services that use
  * the data to produce audio analytics (VADTalkMutedDetection and VADNoiseDetection).
  */
-export default class VADAudioAnalyser extends EventEmitter {
+export default class VADAudioAnalyser extends EventManager {
     /**
      * Creates <tt>VADAudioAnalyser</tt>
      * @param {JitsiConference} conference - JitsiConference instance that created us.

--- a/modules/detection/VADNoiseDetection.js
+++ b/modules/detection/VADNoiseDetection.js
@@ -1,5 +1,4 @@
-import { EventEmitter } from 'events';
-
+import EventManager from '../util/EventManager';
 import { calculateAverage, filterPositiveValues } from '../util/MathUtil';
 
 import { DETECTOR_STATE_CHANGE, VAD_NOISY_DEVICE } from './DetectionEvents';
@@ -37,7 +36,7 @@ const PROCESS_TIME_FRAME_SPAN_MS = 1500;
 /**
  * Detect if provided VAD score and PCM data is considered noise.
  */
-export default class VADNoiseDetection extends EventEmitter {
+export default class VADNoiseDetection extends EventManager {
     /**
      * Creates <tt>VADNoiseDetection</tt>
      *

--- a/modules/detection/VADReportingService.js
+++ b/modules/detection/VADReportingService.js
@@ -1,5 +1,6 @@
 import { getLogger } from '@jitsi/logger';
-import EventEmitter from 'events';
+
+import EventManager from '../util/EventManager';
 
 import * as DetectionEvents from './DetectionEvents';
 import TrackVADEmitter from './TrackVADEmitter';
@@ -22,7 +23,7 @@ const SCRIPT_NODE_SAMPLE_RATE = 4096;
  * The service is not reusable if destroyed a new one needs to be created, i.e. when a new device is added to the system
  * a new service needs to be created and the old discarded.
  */
-export default class VADReportingService extends EventEmitter {
+export default class VADReportingService extends EventManager {
 
     /**
      *

--- a/modules/detection/VADTalkMutedDetection.js
+++ b/modules/detection/VADTalkMutedDetection.js
@@ -1,5 +1,4 @@
-import { EventEmitter } from 'events';
-
+import EventManager from '../util/EventManager';
 import { calculateAverage } from '../util/MathUtil';
 
 import { DETECTOR_STATE_CHANGE, VAD_TALK_WHILE_MUTED } from './DetectionEvents';
@@ -32,7 +31,7 @@ const PROCESS_TIME_FRAME_SPAN_MS = 700;
 /**
  * Detect if provided VAD score which is generated on a muted device is voice and fires an event.
  */
-export default class VADTalkMutedDetection extends EventEmitter {
+export default class VADTalkMutedDetection extends EventManager {
     /**
      * Creates <tt>VADTalkMutedDetection</tt>
      * @constructor

--- a/modules/statistics/SpeakerStatsCollector.spec.js
+++ b/modules/statistics/SpeakerStatsCollector.spec.js
@@ -1,9 +1,8 @@
-import EventEmitter from 'events';
-
 import JitsiConference from '../../JitsiConference';
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 import JitsiParticipant from '../../JitsiParticipant';
 
+import EventManager from '../util/EventManager';
 import SpeakerStats from './SpeakerStats';
 import SpeakerStatsCollector from './SpeakerStatsCollector';
 
@@ -19,7 +18,7 @@ const mockRemoteUser = {
  * @constructor
  */
 function MockConference() {
-    this.eventEmitter = new EventEmitter();
+    this.eventEmitter = new EventManager();
 }
 MockConference.prototype = Object.create(JitsiConference.prototype);
 MockConference.prototype.constructor = JitsiConference;

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -1,11 +1,10 @@
-import EventEmitter from 'events';
-
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 import { JitsiTrackEvents } from '../../JitsiTrackEvents';
 import { FEEDBACK } from '../../service/statistics/AnalyticsEvents';
 import * as StatisticsEvents from '../../service/statistics/Events';
 import RTCStats from '../RTCStats/RTCStats';
 import browser from '../browser';
+import EventManager from '../util/EventManager';
 import WatchRTC from '../watchRTC/WatchRTC';
 
 import analytics from './AnalyticsAdapter';
@@ -66,7 +65,7 @@ export default function Statistics(conference, options) {
      * @type {Map<string, RTPStats}
      */
     this.rtpStatsMap = new Map();
-    this.eventEmitter = new EventEmitter();
+    this.eventEmitter = new EventManager();
     this.conference = conference;
     this.xmpp = conference?.xmpp;
     this.options = options || {};

--- a/modules/util/EventManager.js
+++ b/modules/util/EventManager.js
@@ -1,0 +1,18 @@
+import EventEmitter from 'events';
+
+/**
+ * The class creates our own EventEmitter instance
+ */
+export default class EventManager extends EventEmitter {
+    /**
+     * Creates new instance.
+     * @constructor
+     */
+    constructor() {
+        super();
+
+        // aliases for addListener/removeListener
+        this.addEventListener = this.on = this.addListener;
+        this.removeEventListener = this.off = this.removeListener;
+    }
+}

--- a/modules/util/Listenable.js
+++ b/modules/util/Listenable.js
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import EventManager from './EventManager';
 
 /**
  * The class implements basic event operations - add/remove listener.
@@ -8,11 +8,10 @@ import EventEmitter from 'events';
 export default class Listenable {
     /**
      * Creates new instance.
-     * @param {EventEmitter} eventEmitter
      * @constructor
      */
-    constructor(eventEmitter = new EventEmitter()) {
-        this.eventEmitter = eventEmitter;
+    constructor() {
+        this.eventEmitter = new EventManager();
 
         // aliases for addListener/removeListener
         this.addEventListener = this.on = this.addListener;
@@ -20,15 +19,25 @@ export default class Listenable {
     }
 
     /**
-     * Adds new listener.
+     * Adds new cancellable listener.
      * @param {String} eventName the name of the event
      * @param {Function} listener the listener.
      * @returns {Function} - The unsubscribe function.
      */
-    addListener(eventName, listener) {
-        this.eventEmitter.addListener(eventName, listener);
+    addCancellableListener(eventName, listener) {
+        this.addListener(eventName, listener);
 
-        return () => this.removeEventListener(eventName, listener);
+        return () => this.removeListener(eventName, listener);
+    }
+
+    /**
+     * Adds new listener.
+     * @param {String} eventName the name of the event
+     * @param {Function} listener the listener.
+     * @returns {EventManager} - The unsubscribe function.
+     */
+    addListener(eventName, listener) {
+        return this.eventEmitter.addListener(eventName, listener);
     }
 
     /**
@@ -36,8 +45,9 @@ export default class Listenable {
      * @param {String} eventName the name of the event that triggers the
      * listener
      * @param {Function} listener the listener.
+     * @returns {EventManager} - The unsubscribe function.
      */
     removeListener(eventName, listener) {
-        this.eventEmitter.removeListener(eventName, listener);
+        return this.eventEmitter.removeListener(eventName, listener);
     }
 }

--- a/modules/xmpp/ResumeTask.js
+++ b/modules/xmpp/ResumeTask.js
@@ -51,7 +51,7 @@ export default class ResumeTask {
         this._resumeRetryN += 1;
 
         this._networkOnlineListener
-            = NetworkInfo.addEventListener(
+            = NetworkInfo.addCancellableListener(
                 NETWORK_INFO_EVENT,
                 ({ isOnline }) => {
                     if (isOnline) {

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -57,7 +57,7 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
     /**
      * Creates new <tt>JingleConnectionPlugin</tt>
      * @param {XMPP} xmpp
-     * @param {EventEmitter} eventEmitter
+     * @param {EventManager} eventEmitter
      * @param {Object} iceConfig an object that holds the iceConfig to be passed
      * to the p2p and the jvb <tt>PeerConnection</tt>.
      */

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "build:webpack": "LIB_JITSI_MEET_COMMIT_HASH=$(git rev-parse --short HEAD 2>/dev/null) webpack",
     "build:webpack-dev": "webpack --mode development",
     "build:tsc": "tsc --build --clean && tsc",
-    "gen-types": "tsc --declaration --declarationDir types/auto --emitDeclarationOnly",
+    "gen-types": "tsc --declaration --emitDeclarationOnly --out index.js",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
     "postinstall": "patch-package",
@@ -83,7 +83,8 @@
   "module": "dist/esm/JitsiMeetJS.js",
   "files": [
     "dist",
-    "types"
+    "types",
+    "index.d.ts"
   ],
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
Found a less destructive way than my previous PR #2406 

Copy from that PR:

1. Last step from generating a single declaration file was fixing the Listenable, to correctly implement and extend EventEmitter instead of instantiating it. (As recommended by NodeJS) https://nodejs.org/api/events.html#events_events
2. Updated the gen-types command to output a single declaration file, which is now referenced in package.json

Now the main potentially breaking change is:

1. Updated to add addCancellableEventListener to return an unsubscribe function, only one instance found where it was being used.
2. The types/auto directory is no longer generated, we could get around this by creating a new command, but I thought it was redundant.

What do you think @saghul ?