### PR TITLE
feat(RTC): add support for creating non-standard tracks

### DIFF
--- a/JitsiMeetJS.spec.ts
+++ b/JitsiMeetJS.spec.ts
@@ -13,7 +13,6 @@ describe('JitsiMeetJS', () => {
                 stream: canvasStream,
                 sourceType: 'canvas',
                 mediaType: MediaType.VIDEO,
-                track: canvasStream.getVideoTracks()[0],
                 videoType: VideoType.DESKTOP
             };
             const newTracks = JitsiMeetJS.createLocalTracksFromMediaStreams([ trackInfo ]);
@@ -22,22 +21,19 @@ describe('JitsiMeetJS', () => {
             expect(newTracks.length).toBe(1);
         });
 
-        it('throws an error if track is not from the same stream', () => {
+        it('throws an error if track is not the correct media type', () => {
             const canvas = document.createElement('canvas');
-            const otherCanvas = document.createElement('canvas');
 
             const canvasStream = canvas.captureStream(5);
-            const otherCanvasStream = otherCanvas.captureStream(5);
             const trackInfo = {
                 stream: canvasStream,
                 sourceType: 'canvas',
-                mediaType: MediaType.VIDEO,
-                track: otherCanvasStream.getVideoTracks()[0],
+                mediaType: MediaType.AUDIO,
                 videoType: VideoType.DESKTOP
             };
 
             expect(() => JitsiMeetJS.createLocalTracksFromMediaStreams([ trackInfo ]))
-                .toThrowError(JitsiTrackErrors.TRACK_MISMATCHED_STREAM);
+                .toThrowError(JitsiTrackErrors.TRACK_NO_STREAM_TRACKS_FOUND);
         });
     });
 });

--- a/JitsiMeetJS.spec.ts
+++ b/JitsiMeetJS.spec.ts
@@ -1,0 +1,43 @@
+import JitsiMeetJS from './JitsiMeetJS';
+import { VideoType } from './service/RTC/VideoType';
+import { MediaType } from './service/RTC/MediaType';
+import { JitsiTrackErrors } from './JitsiTrackErrors';
+
+describe('JitsiMeetJS', () => {
+    describe('createLocalTracksFromMediaStreams', () => {
+        it('creates a local track from a media stream', () => {
+            const canvas = document.createElement('canvas');
+
+            const canvasStream = canvas.captureStream(5);
+            const trackInfo = {
+                stream: canvasStream,
+                sourceType: 'canvas',
+                mediaType: MediaType.VIDEO,
+                track: canvasStream.getVideoTracks()[0],
+                videoType: VideoType.DESKTOP
+            };
+            const newTracks = JitsiMeetJS.createLocalTracksFromMediaStreams([ trackInfo ]);
+
+            expect(newTracks).toBeDefined();
+            expect(newTracks.length).toBe(1);
+        });
+
+        it('throws an error if track is not from the same stream', () => {
+            const canvas = document.createElement('canvas');
+            const otherCanvas = document.createElement('canvas');
+
+            const canvasStream = canvas.captureStream(5);
+            const otherCanvasStream = otherCanvas.captureStream(5);
+            const trackInfo = {
+                stream: canvasStream,
+                sourceType: 'canvas',
+                mediaType: MediaType.VIDEO,
+                track: otherCanvasStream.getVideoTracks()[0],
+                videoType: VideoType.DESKTOP
+            };
+
+            expect(() => JitsiMeetJS.createLocalTracksFromMediaStreams([ trackInfo ]))
+                .toThrowError(JitsiTrackErrors.TRACK_MISMATCHED_STREAM);
+        });
+    });
+});

--- a/JitsiMeetJS.ts
+++ b/JitsiMeetJS.ts
@@ -95,7 +95,6 @@ interface ICreateLocalTrackFromMediaStreamOptions {
     stream: MediaStream,
     sourceType: string,
     mediaType: MediaType,
-    track: MediaStreamTrack,
     videoType?: VideoType
 }
 
@@ -439,16 +438,25 @@ export default {
     createLocalTracksFromMediaStreams(tracksInfo) {
         return RTC.createLocalTracks(tracksInfo.map((trackInfo) => {
             const tracks = trackInfo.stream.getTracks();
+
             if (!tracks || tracks.length === 0) {
-                throw new JitsiTrackError(JitsiTrackErrors.TRACK_NO_STREAM_TRACKS_FOUND);
+                throw new JitsiTrackError(JitsiTrackErrors.TRACK_NO_STREAM_TRACKS_FOUND, null, null);
             }
 
             if (tracks.length > 1) {
-                throw new JitsiTrackError(JitsiTrackErrors.TRACK_TOO_MANY_TRACKS_IN_STREAM);
+                throw new JitsiTrackError(JitsiTrackErrors.TRACK_TOO_MANY_TRACKS_IN_STREAM, null, null);
             }
 
-            if (tracks.indexOf(trackInfo.track) === -1) {
-                throw new JitsiTrackError(JitsiTrackErrors.TRACK_MISMATCHED_STREAM);
+            if (trackInfo.mediaType === MediaType.AUDIO) {
+                trackInfo.track = tracks.find(track => track.kind === 'audio');
+            } else if (trackInfo.mediaType === MediaType.VIDEO) {
+                trackInfo.track = tracks.find(track => track.kind === 'video');
+            } else {
+                throw new JitsiTrackError(JitsiTrackErrors.NOT_FOUND, null, null);
+            }
+
+            if (!trackInfo.track) {
+                throw new JitsiTrackError(JitsiTrackErrors.TRACK_NO_STREAM_TRACKS_FOUND, null, null);
             }
 
             if (!trackInfo.sourceId) {

--- a/JitsiMeetJS.ts
+++ b/JitsiMeetJS.ts
@@ -450,10 +450,6 @@ export default {
 
             trackInfo.track = tracks[0];
 
-            if (!trackInfo.sourceId) {
-                trackInfo.sourceId = 'GENERATEDVALUEHERE';
-            }
-
             return trackInfo;
         }));
     },

--- a/JitsiMeetJS.ts
+++ b/JitsiMeetJS.ts
@@ -437,7 +437,8 @@ export default {
      */
     createLocalTracksFromMediaStreams(tracksInfo) {
         return RTC.createLocalTracks(tracksInfo.map((trackInfo) => {
-            const tracks = trackInfo.stream.getTracks();
+            const tracks = trackInfo.stream.getTracks()
+                .filter(track => track.kind === trackInfo.mediaType);
 
             if (!tracks || tracks.length === 0) {
                 throw new JitsiTrackError(JitsiTrackErrors.TRACK_NO_STREAM_TRACKS_FOUND, null, null);
@@ -447,17 +448,7 @@ export default {
                 throw new JitsiTrackError(JitsiTrackErrors.TRACK_TOO_MANY_TRACKS_IN_STREAM, null, null);
             }
 
-            if (trackInfo.mediaType === MediaType.AUDIO) {
-                trackInfo.track = tracks.find(track => track.kind === 'audio');
-            } else if (trackInfo.mediaType === MediaType.VIDEO) {
-                trackInfo.track = tracks.find(track => track.kind === 'video');
-            } else {
-                throw new JitsiTrackError(JitsiTrackErrors.NOT_FOUND, null, null);
-            }
-
-            if (!trackInfo.track) {
-                throw new JitsiTrackError(JitsiTrackErrors.TRACK_NO_STREAM_TRACKS_FOUND, null, null);
-            }
+            trackInfo.track = tracks[0];
 
             if (!trackInfo.sourceId) {
                 trackInfo.sourceId = 'GENERATEDVALUEHERE';

--- a/JitsiMeetJS.ts
+++ b/JitsiMeetJS.ts
@@ -422,6 +422,16 @@ export default {
     },
 
     /**
+     * Manually create JitsiLocalTrack's from the provided track info, by exposing the RTC method
+     *
+     * @param {Array<Object>} tracksInfo - array of track information
+     * @returns {Array<JitsiLocalTrack>} - created local tracks
+     */
+    createLocalTracksFromMediaStreams(tracksInfo) {
+        return RTC.createLocalTracks(tracksInfo);
+    },
+
+    /**
      * Create a TrackVADEmitter service that connects an audio track to an VAD (voice activity detection) processor in
      * order to obtain VAD scores for individual PCM audio samples.
      * @param {string} localAudioDeviceId - The target local audio device.

--- a/JitsiTrackErrors.spec.ts
+++ b/JitsiTrackErrors.spec.ts
@@ -16,6 +16,8 @@ describe( "/JitsiTrackErrors members", () => {
         TRACK_IS_DISPOSED,
         TRACK_NO_STREAM_FOUND,
         UNSUPPORTED_RESOLUTION,
+        TRACK_TOO_MANY_TRACKS_IN_STREAM,
+        TRACK_NO_STREAM_TRACKS_FOUND,
         JitsiTrackErrors,
         ...others
     } = exported;
@@ -33,6 +35,8 @@ describe( "/JitsiTrackErrors members", () => {
         expect( TRACK_IS_DISPOSED ).toBe( 'track.track_is_disposed' );
         expect( TRACK_NO_STREAM_FOUND ).toBe( 'track.no_stream_found' );
         expect( UNSUPPORTED_RESOLUTION ).toBe( 'gum.unsupported_resolution' );
+        expect( TRACK_TOO_MANY_TRACKS_IN_STREAM ).toBe( 'track.too_many_tracks_in_stream' );
+        expect( TRACK_NO_STREAM_TRACKS_FOUND ).toBe( 'track.no_stream_tracks_found' );
 
         expect( JitsiTrackErrors ).toBeDefined();
 
@@ -48,6 +52,8 @@ describe( "/JitsiTrackErrors members", () => {
         expect( JitsiTrackErrors.TRACK_IS_DISPOSED ).toBe( 'track.track_is_disposed' );
         expect( JitsiTrackErrors.TRACK_NO_STREAM_FOUND ).toBe( 'track.no_stream_found' );
         expect( JitsiTrackErrors.UNSUPPORTED_RESOLUTION ).toBe( 'gum.unsupported_resolution' );
+        expect( JitsiTrackErrors.TRACK_TOO_MANY_TRACKS_IN_STREAM ).toBe( 'track.too_many_tracks_in_stream' );
+        expect( JitsiTrackErrors.TRACK_NO_STREAM_TRACKS_FOUND ).toBe( 'track.no_stream_tracks_found' );
     } );
 
     it( "unknown members", () => {

--- a/JitsiTrackErrors.ts
+++ b/JitsiTrackErrors.ts
@@ -79,11 +79,6 @@ export enum JitsiTrackErrors {
      * An error which indicates that no tracks were found in the media stream
      */
     TRACK_NO_STREAM_TRACKS_FOUND = 'track.no_stream_tracks_found',
-
-    /**
-     * An error which indicates that the track does not belong to the provided media stream
-     */
-    TRACK_MISMATCHED_STREAM = 'track.mismatched_stream'
 }
 
 // exported for backward compatibility
@@ -101,4 +96,3 @@ export const TRACK_NO_STREAM_FOUND = JitsiTrackErrors.TRACK_NO_STREAM_FOUND;
 export const UNSUPPORTED_RESOLUTION = JitsiTrackErrors.UNSUPPORTED_RESOLUTION;
 export const TRACK_TOO_MANY_TRACKS_IN_STREAM = JitsiTrackErrors.TRACK_TOO_MANY_TRACKS_IN_STREAM;
 export const TRACK_NO_STREAM_TRACKS_FOUND = JitsiTrackErrors.TRACK_NO_STREAM_TRACKS_FOUND;
-export const TRACK_MISMATCHED_STREAM = JitsiTrackErrors.TRACK_MISMATCHED_STREAM;

--- a/JitsiTrackErrors.ts
+++ b/JitsiTrackErrors.ts
@@ -68,7 +68,22 @@ export enum JitsiTrackErrors {
      * An error which indicates that requested video resolution is not supported
      * by a webcam.
      */
-    UNSUPPORTED_RESOLUTION = 'gum.unsupported_resolution'
+    UNSUPPORTED_RESOLUTION = 'gum.unsupported_resolution',
+
+    /**
+     * An error which indicates that there are too many tracks in the provided media stream
+     */
+    TRACK_TOO_MANY_TRACKS_IN_STREAM = 'track.too_many_tracks_in_stream',
+
+    /**
+     * An error which indicates that no tracks were found in the media stream
+     */
+    TRACK_NO_STREAM_TRACKS_FOUND = 'track.no_stream_tracks_found',
+
+    /**
+     * An error which indicates that the track does not belong to the provided media stream
+     */
+    TRACK_MISMATCHED_STREAM = 'track.mismatched_stream'
 }
 
 // exported for backward compatibility
@@ -84,3 +99,6 @@ export const TIMEOUT = JitsiTrackErrors.TIMEOUT;
 export const TRACK_IS_DISPOSED = JitsiTrackErrors.TRACK_IS_DISPOSED;
 export const TRACK_NO_STREAM_FOUND = JitsiTrackErrors.TRACK_NO_STREAM_FOUND;
 export const UNSUPPORTED_RESOLUTION = JitsiTrackErrors.UNSUPPORTED_RESOLUTION;
+export const TRACK_TOO_MANY_TRACKS_IN_STREAM = JitsiTrackErrors.TRACK_TOO_MANY_TRACKS_IN_STREAM;
+export const TRACK_NO_STREAM_TRACKS_FOUND = JitsiTrackErrors.TRACK_NO_STREAM_TRACKS_FOUND;
+export const TRACK_MISMATCHED_STREAM = JitsiTrackErrors.TRACK_MISMATCHED_STREAM;

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -47,8 +47,8 @@ export default class JitsiLocalTrack extends JitsiTrack {
      * @param {number} trackInfo.resolution - The the video resolution if it's a video track
      * @param {string} trackInfo.deviceId - The ID of the local device for this track.
      * @param {string} trackInfo.facingMode - Thehe camera facing mode used in getUserMedia call (for mobile only).
-     * @param {sourceId} trackInfo.sourceId - The id of the desktop sharing source. NOTE: defined for desktop sharing
-     * tracks only.
+     * @param {sourceId} trackInfo.sourceId - The id of the desktop sharing source, which is the Chrome media source ID,
+     * returned by Desktop Picker on Electron. NOTE: defined for desktop sharing tracks only.
      */
     constructor({
         deviceId,

--- a/types/hand-crafted/JitsiMeetJS.d.ts
+++ b/types/hand-crafted/JitsiMeetJS.d.ts
@@ -122,6 +122,8 @@ export type JitsiMeetJSType = {
 
   getActiveAudioDevice: () => Promise<Object>; // TODO: can we improve on object?
 
+  createLocalTracksFromMediaStreams: ( tracksInfo: unknown[] ) => JitsiLocalTrack[]; // TODO:
+
   // isDeviceListAvailable: () => boolean; // obsosete
 
   // isDeviceChangeAvailable: ( deviceType: string ) => boolean; // obsosete


### PR DESCRIPTION
We have this manually patched into our copy of lib-jitsi-meet, but thought it might be worth sharing.

This change allows applications that use lib-jitsi-meet to manually create JitiLocalTracks from some track metadata and mediastream, similar to what the library does internally, but exposing it.

We use it to create a track for our Canvas, that we then add to the conference, similar to below:

```
    const canvasStream = myCanvas.captureStream(desktopShareFPS);
    const newTracks = JitsiMeetJS.createLocalTracksFromMediaStreams([
      {
        stream: canvasStream,
        sourceId: 'my:canvas',
        sourceType: 'canvas',
        track: canvasStream.getVideoTracks()[0],
        videoType: 'desktop'
      }
    ]);
```

This would possibly fix https://github.com/jitsi/lib-jitsi-meet/pull/1593