### PR TITLE
fix(video-quality) Enable TCC support for Firefox 115 and later.

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -233,9 +233,9 @@ export default class XMPP extends Listenable {
             this.caps.addFeature('http://jitsi.org/remb');
         }
 
-        // Disable TCC on Firefox 116 and older versions because of a known issue where BWE is halved on every
+        // Disable TCC on Firefox 114 and older versions because of a known issue where BWE is halved on every
         // renegotiation.
-        if (!(browser.isFirefox() && browser.isVersionLessThan(117))
+        if (!(browser.isFirefox() && browser.isVersionLessThan(115))
             && (typeof this.options.enableTcc === 'undefined' || this.options.enableTcc)) {
             this.caps.addFeature('http://jitsi.org/tcc');
         }


### PR DESCRIPTION
Firefox ESR 115 stops sending REMBs to the bridge under certain network conditions making the bridge suspend all video streams sent to the Firefox eps. It is still unclear why Firefox stops sending REMBs so enabling TCC support as workaround since TCC no longer seems to have issues with uplink BWE (uplink getting halved on every renegotiation) like in the older versions.