### PR TITLE
fix(codec-selection): put Av1 support behind a flag.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -381,7 +381,8 @@ JitsiConference.prototype._init = function(options = {}) {
                 ? config.videoQuality.mobileCodecPreferenceOrder
                 : config.videoQuality?.codecPreferenceOrder,
             disabledCodec: _getCodecMimeType(config.videoQuality?.disabledCodec),
-            preferredCodec: _getCodecMimeType(config.videoQuality?.preferredCodec)
+            preferredCodec: _getCodecMimeType(config.videoQuality?.preferredCodec),
+            supportsAv1: config.testing?.enableAv1Support
         },
         p2p: {
             preferenceOrder: browser.isMobileDevice() && config.p2p?.mobileCodecPreferenceOrder

--- a/modules/RTC/CodecSelection.js
+++ b/modules/RTC/CodecSelection.js
@@ -9,7 +9,7 @@ import browser from '../browser';
 const logger = getLogger(__filename);
 
 // Default video codec preferences on mobile and desktop endpoints.
-const DESKTOP_VIDEO_CODEC_ORDER = [ CodecMimeType.VP9, CodecMimeType.VP8, CodecMimeType.H264, CodecMimeType.AV1 ];
+const DESKTOP_VIDEO_CODEC_ORDER = [ CodecMimeType.VP9, CodecMimeType.VP8, CodecMimeType.H264 ];
 const MOBILE_P2P_VIDEO_CODEC_ORDER = [ CodecMimeType.H264, CodecMimeType.VP8, CodecMimeType.VP9 ];
 const MOBILE_VIDEO_CODEC_ORDER = [ CodecMimeType.VP8, CodecMimeType.VP9, CodecMimeType.H264 ];
 
@@ -111,6 +111,10 @@ export class CodecSelection {
         const videoCodecMimeTypes = browser.isMobileDevice() && connectionType === 'p2p'
             ? MOBILE_P2P_VIDEO_CODEC_ORDER
             : browser.isMobileDevice() ? MOBILE_VIDEO_CODEC_ORDER : DESKTOP_VIDEO_CODEC_ORDER;
+
+        if (connectionType === 'p2p' || this.options.jvb.supportsAv1) {
+            videoCodecMimeTypes.push(CodecMimeType.AV1);
+        }
 
         const supportedCodecs = videoCodecMimeTypes.filter(codec =>
             (window.RTCRtpReceiver?.getCapabilities?.(MediaType.VIDEO)?.codecs ?? [])


### PR DESCRIPTION
Fixes an issue with audio after p2p->jvb switch when the media active state is set to false because of a setVideoCodecs call after a remote user joins the call.