### PR TITLE
fix(ts) don't declare types support yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   },
   "browser": "dist/umd/lib-jitsi-meet.min.js",
   "module": "dist/esm/JitsiMeetJS.js",
-  "types": "types/index.d.ts",
   "files": [
     "dist",
     "types",


### PR DESCRIPTION
The generated dts file is slightly broken, and breaks upstream projects:

```
> jitsi-meet@0.0.0 tsc:native
> tsc --noEmit --project tsconfig.native.json

node_modules/lib-jitsi-meet/types/index.d.ts:3120:20 - error TS1005: '(' expected.

3120         constructor: typeof JitsiTrackError;
                        ~

node_modules/lib-jitsi-meet/types/index.d.ts:13832:20 - error TS1005: '(' expected.

13832         constructor: typeof JitsiConference;
                         ~
```