### PR TITLE
fix: parse connectinon failed message error

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -544,6 +544,7 @@ export default class XMPP extends Listenable {
             return null;
         }
 
+        FAILURE_REGEX.lastIndex = 0;
         const matches = FAILURE_REGEX.exec(msg);
 
         return matches ? matches[1] : null;


### PR DESCRIPTION
last Index must be set as 0 for each time because of when _parse ConnectionFailed Message triggered twice message will be undefined.

[For more information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex)

Example:
```js
const regex1 = new RegExp('foo', 'g');
const str1 = 'table football, foosball';

console.log('result 1: ', regex1.test(str1));

console.log('index: ', regex1.lastIndex);

console.log('result 2: ', regex1.test(str1));

console.log('index: ', regex1.lastIndex);

console.log('result 3: ', regex1.test(str1)); 

console.log('index: ', regex1.lastIndex);
```

output:
```
> "result 1: " true
> "index: " 9
> "result 2: " true
> "index: " 19
> "result 3: " false
> "index: " 0
```