### PR TITLE
fix(conference): Remove the tracks that were filtered out.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1216,6 +1216,9 @@ JitsiConference.prototype._getInitialLocalTracks = function() {
                 return true;
             }
 
+            // Remove the track from the conference.
+            this.onLocalTrackRemoved(track);
+
             return false;
         });
 };
@@ -3247,7 +3250,7 @@ JitsiConference.prototype._startP2PSession = function(remoteJid) {
             enableInsertableStreams: this.isE2EEEnabled() || FeatureFlags.isRunInLiteModeEnabled()
         });
 
-    const localTracks = this.getLocalTracks();
+    const localTracks = this._getInitialLocalTracks();
 
     this.p2pJingleSession.invite(localTracks);
 };


### PR DESCRIPTION
When tracks are not included in the initial offer/answer, remove them from the conference. Otherwise, the tracks in conference will be out of sync with those in the media sessions.