### PR TITLE
fix(video-quality): Adjust encodings bitrates/scalefactor for high capture resolutions

### DIFF
--- a/modules/RTC/TPCUtils.spec.js
+++ b/modules/RTC/TPCUtils.spec.js
@@ -863,6 +863,222 @@ describe('TPCUtils', () => {
             });
         });
 
+        describe('VP9 camera tracks with 1080p resolutions ', () => {
+            const codec = CodecMimeType.VP9;
+            const track = new MockJitsiLocalTrack(1080, 'video', 'camera');
+
+            beforeEach(() => {
+                pc = new MockPeerConnection('1', true, true /* simulcast */);
+                pc.options = { videoQuality };
+                tpcUtils = new TPCUtils(pc);
+            });
+
+            afterEach(() => {
+                pc = null;
+                tpcUtils = null;
+            });
+
+            it('and requested resolution is 2160', () => {
+                height = 2160;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(1500000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+            });
+
+            it('and requested resolution is 720', () => {
+                height = 720;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(1200000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(1.5);
+            });
+
+            it('and requested resolution is 360', () => {
+                height = 360;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(300000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(3);
+            });
+
+            it('and requested resolution is 180', () => {
+                height = 180;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(100000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(6);
+            });
+
+            it('and requested resolution is 0', () => {
+                height = 0;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(false);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+            });
+        });
+
+        describe('VP9 camera tracks with odd resolutions ', () => {
+            const codec = CodecMimeType.VP9;
+            const track = new MockJitsiLocalTrack(550, 'video', 'camera');
+
+            beforeEach(() => {
+                pc = new MockPeerConnection('1', true, true /* simulcast */);
+                pc.options = { videoQuality };
+                tpcUtils = new TPCUtils(pc);
+            });
+
+            afterEach(() => {
+                pc = null;
+                tpcUtils = null;
+            });
+
+            it('and requested resolution is 2160', () => {
+                height = 2160;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(300000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+            });
+
+            it('and requested resolution is 720', () => {
+                height = 720;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(300000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+            });
+
+            it('and requested resolution is 360', () => {
+                height = 360;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(300000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(550 / 360);
+            });
+
+            it('and requested resolution is 180', () => {
+                height = 180;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(100000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(550 / 180);
+            });
+
+            it('and requested resolution is 0', () => {
+                height = 0;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(false);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+            });
+        });
+
         describe('VP9 camera tracks for p2p', () => {
             const track = new MockJitsiLocalTrack(720, 'video', 'camera');
             const codec = CodecMimeType.VP9;

--- a/modules/RTC/TPCUtils.spec.js
+++ b/modules/RTC/TPCUtils.spec.js
@@ -326,7 +326,7 @@ describe('TPCUtils', () => {
                 expect(activeState[2]).toBe(false);
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
-                expect(maxBitrates[0]).toBe(1500000);
+                expect(maxBitrates[0]).toBe(2500000);
                 expect(maxBitrates[1]).toBe(0);
                 expect(maxBitrates[2]).toBe(0);
 
@@ -456,7 +456,7 @@ describe('TPCUtils', () => {
                 expect(activeState[2]).toBe(false);
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
-                expect(maxBitrates[0]).toBe(500000);
+                expect(maxBitrates[0]).toBe(2500000);
                 expect(maxBitrates[1]).toBe(0);
                 expect(maxBitrates[2]).toBe(0);
 
@@ -500,13 +500,13 @@ describe('TPCUtils', () => {
                 expect(activeState[0]).toBe(true);
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
-                expect(maxBitrates[0]).toBe(500000);
+                expect(maxBitrates[0]).toBe(2500000);
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -622,7 +622,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -795,7 +795,7 @@ describe('TPCUtils', () => {
                 expect(activeState[2]).toBe(false);
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
-                expect(maxBitrates[0]).toBe(500000);
+                expect(maxBitrates[0]).toBe(2500000);
                 expect(maxBitrates[1]).toBe(0);
                 expect(maxBitrates[2]).toBe(0);
 
@@ -1084,9 +1084,9 @@ describe('TPCUtils', () => {
                 expect(activeState[2]).toBe(true);
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
-                expect(maxBitrates[0]).toBe(500000);
-                expect(maxBitrates[1]).toBe(500000);
-                expect(maxBitrates[2]).toBe(500000);
+                expect(maxBitrates[0]).toBe(2500000);
+                expect(maxBitrates[1]).toBe(2500000);
+                expect(maxBitrates[2]).toBe(2500000);
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
@@ -1358,7 +1358,7 @@ describe('TPCUtils', () => {
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(highResolutiontrack, codec, height);
                 expect(maxBitrates[0]).toBe(200000);
                 expect(maxBitrates[1]).toBe(500000);
-                expect(maxBitrates[2]).toBe(2000000);
+                expect(maxBitrates[2]).toBe(4000000);
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(highResolutiontrack, codec, height);
                 expect(scalabilityModes).toBe(undefined);
@@ -1394,9 +1394,9 @@ describe('TPCUtils', () => {
                 expect(activeState[2]).toBe(true);
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
-                expect(maxBitrates[0]).toBe(500000);
-                expect(maxBitrates[1]).toBe(500000);
-                expect(maxBitrates[2]).toBe(500000);
+                expect(maxBitrates[0]).toBe(2500000);
+                expect(maxBitrates[1]).toBe(2500000);
+                expect(maxBitrates[2]).toBe(2500000);
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes).toBe(undefined);
@@ -1556,7 +1556,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1571,7 +1571,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 2160 again', () => {
@@ -1586,7 +1586,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -2151,9 +2151,9 @@ describe('TPCUtils', () => {
                 expect(activeState[2]).toBe(true);
 
                 bitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
-                expect(bitrates[0]).toBe(500000);
-                expect(bitrates[1]).toBe(500000);
-                expect(bitrates[2]).toBe(500000);
+                expect(bitrates[0]).toBe(2500000);
+                expect(bitrates[1]).toBe(2500000);
+                expect(bitrates[2]).toBe(2500000);
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes).toBe(undefined);
@@ -2173,9 +2173,9 @@ describe('TPCUtils', () => {
                 expect(activeState[2]).toBe(false);
 
                 bitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
-                expect(bitrates[0]).toBe(500000);
-                expect(bitrates[1]).toBe(500000);
-                expect(bitrates[2]).toBe(500000);
+                expect(bitrates[0]).toBe(2500000);
+                expect(bitrates[1]).toBe(2500000);
+                expect(bitrates[2]).toBe(2500000);
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes).toBe(undefined);

--- a/modules/RTC/TPCUtils.spec.js
+++ b/modules/RTC/TPCUtils.spec.js
@@ -3,7 +3,7 @@ import CodecMimeType from '../../service/RTC/CodecMimeType';
 import VideoEncoderScalabilityMode from '../../service/RTC/VideoEncoderScalabilityMode';
 
 import { MockJitsiLocalTrack, MockPeerConnection } from './MockClasses';
-import { HD_SCALE_FACTOR, LD_SCALE_FACTOR, SD_SCALE_FACTOR, TPCUtils } from './TPCUtils';
+import { TPCUtils } from './TPCUtils';
 
 describe('TPCUtils', () => {
     describe('ensureCorrectOrderOfSsrcs()', () => {
@@ -249,7 +249,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -270,7 +270,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(SD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -291,7 +291,136 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+            });
+
+            it('and requested resolution is 0', () => {
+                height = 0;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(false);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+            });
+        });
+
+        describe('AV1 high resolution camera tracks', () => {
+            const track = new MockJitsiLocalTrack(2160, 'video', 'camera');
+            const codec = CodecMimeType.AV1;
+
+            beforeEach(() => {
+                pc = new MockPeerConnection('1', true, true /* simulcast */);
+                pc.options = { videoQuality };
+                tpcUtils = new TPCUtils(pc);
+            });
+
+            afterEach(() => {
+                pc = null;
+                tpcUtils = null;
+            });
+
+            it('and requested resolution is 2160', () => {
+                height = 2160;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(1500000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+            });
+
+            it('and requested resolution is 1080', () => {
+                height = 1080;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(1200000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(2);
+            });
+
+            it('and requested resolution is 720', () => {
+                height = 720;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(1000000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(3);
+            });
+
+            it('and requested resolution is 360', () => {
+                height = 360;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(300000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(6);
+            });
+
+            it('and requested resolution is 180', () => {
+                height = 180;
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(maxBitrates[0]).toBe(100000);
+                expect(maxBitrates[1]).toBe(0);
+                expect(maxBitrates[2]).toBe(0);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
+                expect(scalabilityModes[1]).toBe(undefined);
+                expect(scalabilityModes[2]).toBe(undefined);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(12);
             });
 
             it('and requested resolution is 0', () => {
@@ -337,7 +466,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -424,7 +553,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -463,7 +592,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -478,7 +607,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(SD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
             });
 
             it('and requested resolution is 720 again', () => {
@@ -508,7 +637,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -545,7 +674,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -588,7 +717,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -609,7 +738,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(SD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -630,7 +759,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -676,7 +805,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -722,7 +851,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -761,7 +890,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -776,7 +905,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(SD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -791,7 +920,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -828,7 +957,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -871,9 +1000,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -894,9 +1023,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -917,9 +1046,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -965,9 +1094,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1013,9 +1142,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1054,7 +1183,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1069,7 +1198,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(SD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1084,7 +1213,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1121,7 +1250,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1162,9 +1291,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1183,9 +1312,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1204,9 +1333,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1229,15 +1358,15 @@ describe('TPCUtils', () => {
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(highResolutiontrack, codec, height);
                 expect(maxBitrates[0]).toBe(200000);
                 expect(maxBitrates[1]).toBe(500000);
-                expect(maxBitrates[2]).toBe(1500000);
+                expect(maxBitrates[2]).toBe(2000000);
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(highResolutiontrack, codec, height);
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(highResolutiontrack, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
         });
 
@@ -1273,9 +1402,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1319,9 +1448,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1360,7 +1489,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1375,7 +1504,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(SD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1390,7 +1519,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1495,7 +1624,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1565,9 +1694,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1589,9 +1718,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1613,9 +1742,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1637,9 +1766,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
         });
 
@@ -1690,9 +1819,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1714,9 +1843,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1738,9 +1867,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1762,9 +1891,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
         });
 
@@ -1807,9 +1936,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1829,9 +1958,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1851,9 +1980,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1873,9 +2002,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
         });
 
@@ -1918,9 +2047,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1940,9 +2069,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1962,9 +2091,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1984,9 +2113,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
         });
 
@@ -2030,9 +2159,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -2052,9 +2181,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
         });
 
@@ -2098,9 +2227,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -2120,9 +2249,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
-                expect(scaleFactor[1]).toBe(SD_SCALE_FACTOR);
-                expect(scaleFactor[2]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
             });
         });
 
@@ -2161,7 +2290,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -2177,7 +2306,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(SD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -2193,7 +2322,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -2248,7 +2377,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -2266,7 +2395,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(SD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -2284,7 +2413,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -2334,7 +2463,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(HD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -2352,7 +2481,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(SD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -2370,7 +2499,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(LD_SCALE_FACTOR);
+                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
             });
 
             it('and requested resolution is 0', () => {

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -8,6 +8,7 @@ import { MediaType } from '../../service/RTC/MediaType';
 import RTCEvents from '../../service/RTC/RTCEvents';
 import * as SignalingEvents from '../../service/RTC/SignalingEvents';
 import { getSourceIndexFromSourceName } from '../../service/RTC/SignalingLayer';
+import { SIM_LAYERS } from '../../service/RTC/StandardVideoSettings';
 import { VideoType } from '../../service/RTC/VideoType';
 import { SS_DEFAULT_FRAME_RATE } from '../RTC/ScreenObtainer';
 import browser from '../browser';
@@ -21,7 +22,7 @@ import { SdpTransformWrap } from '../sdp/SdpTransformUtil';
 
 import JitsiRemoteTrack from './JitsiRemoteTrack';
 import RTC from './RTC';
-import { SIM_LAYER_RIDS, TPCUtils } from './TPCUtils';
+import { TPCUtils } from './TPCUtils';
 
 // FIXME SDP tools should end up in some kind of util module
 
@@ -284,7 +285,7 @@ export default function TraceablePeerConnection(
 
     this.interop = new Interop();
 
-    this.simulcast = new SdpSimulcast({ numOfLayers: SIM_LAYER_RIDS.length });
+    this.simulcast = new SdpSimulcast({ numOfLayers: SIM_LAYERS.length });
 
     /**
      * Munges local SDP provided to the Jingle Session in order to prevent from

--- a/modules/sdp/SdpSimulcast.ts
+++ b/modules/sdp/SdpSimulcast.ts
@@ -1,17 +1,12 @@
 import { MediaDirection } from '../../service/RTC/MediaDirection';
 import { MediaType } from '../../service/RTC/MediaType';
+import { SIM_LAYERS } from '../../service/RTC/StandardVideoSettings';
 
 import * as transform from 'sdp-transform';
-
-const DEFAULT_NUM_OF_LAYERS = 3;
 
 interface Description {
     type: RTCSdpType;
     sdp: string;
-}
-
-interface Options {
-    numOfLayers?: number
 }
 
 /**
@@ -22,7 +17,7 @@ interface Options {
  * to a given endpoint.
  */
 export default class SdpSimulcast {
-    private _options: Options;
+    private _numOfLayers: number;
     private _ssrcCache: Map<string, Array<number>>;
 
     /**
@@ -30,13 +25,9 @@ export default class SdpSimulcast {
      *
      * @param options
      */
-    constructor(options: Options) {
-        this._options = options;
+    constructor() {
         this._ssrcCache = new Map();
-
-        if (!this._options.numOfLayers) {
-            this._options.numOfLayers = DEFAULT_NUM_OF_LAYERS;
-        }
+        this._numOfLayers = SIM_LAYERS.length;
     }
 
     /**
@@ -120,7 +111,7 @@ export default class SdpSimulcast {
         // Generate SIM layers.
         const simSsrcs = [];
 
-        for (let i = 0; i < this._options.numOfLayers - 1; ++i) {
+        for (let i = 0; i < this._numOfLayers - 1; ++i) {
             const simSsrc = this._generateSsrc();
 
             addAssociatedAttributes(mLine, simSsrc);

--- a/service/RTC/StandardVideoSettings.ts
+++ b/service/RTC/StandardVideoSettings.ts
@@ -27,7 +27,8 @@ export const STANDARD_CODEC_SETTINGS = {
             high: 1000000,
             fullHd: 1200000,
             ultraHd: 2500000,
-            ssHigh: 2500000
+            ssHigh: 2500000,
+            none: 0
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI(),
         useSimulcast: false, // defaults to SVC.
@@ -40,7 +41,8 @@ export const STANDARD_CODEC_SETTINGS = {
             high: 1500000,
             fullHd: 2000000,
             ultraHd: 4000000,
-            ssHigh: 2500000
+            ssHigh: 2500000,
+            none: 0
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI()
     },
@@ -51,7 +53,8 @@ export const STANDARD_CODEC_SETTINGS = {
             high: 1500000,
             fullHd: 2000000,
             ultraHd: 4000000,
-            ssHigh: 2500000
+            ssHigh: 2500000,
+            none: 0
         },
         scalabilityModeEnabled: false
     },
@@ -62,7 +65,8 @@ export const STANDARD_CODEC_SETTINGS = {
             high: 1200000,
             fullHd: 1500000,
             ultraHd: 3000000,
-            ssHigh: 2500000
+            ssHigh: 2500000,
+            none: 0
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI(),
         useSimulcast: false, // defaults to SVC.
@@ -97,6 +101,10 @@ export const VIDEO_QUALITY_LEVELS = [
         level: 'standard'
     },
     {
+        height: 480,
+        level: 'standard'
+    },
+    {
         height: 360,
         level: 'standard'
     },
@@ -107,6 +115,14 @@ export const VIDEO_QUALITY_LEVELS = [
     {
         height: 180,
         level: 'low'
+    },
+    {
+        height: 90,
+        level: 'low'
+    },
+    {
+        height: 0,
+        level: 'none'
     }
 ];
 
@@ -127,5 +143,8 @@ export enum VIDEO_QUALITY_SETTINGS {
     STANDARD = 'standard',
 
     // 320x180 or Low Definition.
-    LOW = 'low'
+    LOW = 'low',
+
+    // When the camera is turned off.
+    NONE = 'none'
 };

--- a/service/RTC/StandardVideoSettings.ts
+++ b/service/RTC/StandardVideoSettings.ts
@@ -1,5 +1,21 @@
 import browser from '../../modules/browser';
 
+// Default simulcast encodings config.
+export const SIM_LAYERS = [
+    {
+        rid: '1',
+        scaleFactor: 4.0
+    },
+    {
+        rid: '2',
+        scaleFactor: 2.0
+    },
+    {
+        rid: '3',
+        scaleFactor: 1.0
+    }
+];
+
 /**
  * Standard scalability mode settings for different video codecs and the default bitrates.
  */
@@ -9,6 +25,8 @@ export const STANDARD_CODEC_SETTINGS = {
             low: 100000,
             standard: 300000,
             high: 1000000,
+            fullHd: 1200000,
+            ultraHd: 1500000,
             ssHigh: 2500000
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI(),
@@ -20,6 +38,8 @@ export const STANDARD_CODEC_SETTINGS = {
             low: 200000,
             standard: 500000,
             high: 1500000,
+            fullHd: 1800000,
+            ultraHd: 2000000,
             ssHigh: 2500000
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI()
@@ -29,6 +49,8 @@ export const STANDARD_CODEC_SETTINGS = {
             low: 200000,
             standard: 500000,
             high: 1500000,
+            fullHd: 1800000,
+            ultraHd: 2000000,
             ssHigh: 2500000
         },
         scalabilityModeEnabled: false
@@ -38,6 +60,8 @@ export const STANDARD_CODEC_SETTINGS = {
             low: 100000,
             standard: 300000,
             high: 1200000,
+            fullHd: 1500000,
+            ultraHd: 1800000,
             ssHigh: 2500000
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI(),
@@ -45,3 +69,42 @@ export const STANDARD_CODEC_SETTINGS = {
         useKSVC: true // defaults to L3T3_KEY for SVC mode.
     }
 };
+
+/**
+ * Standard video resolutions and the corresponding quality level that will be picked for the given resolution.
+ * For quality levels:
+ * 'high' and above - the encoder will be configured to encode 3 spatial layers.
+ * 'standard' - the encoder will be configured to encode 2 spatial laters.
+ * 'low' - the encoder will be configured to encode only 1 spatial layer.
+ * In all the above cases, each of the layers will again have 3 temporal layers.
+ */
+export const VIDEO_QUALITY_LEVELS = [
+    {
+        height: 2160,
+        level: 'ultraHd'
+    },
+    {
+        height: 1080,
+        level: 'fullHd'
+    },
+    {
+        height: 720,
+        level: 'high'
+    },
+    {
+        height: 540,
+        level: 'standard'
+    },
+    {
+        height: 360,
+        level: 'standard'
+    },
+    {
+        height: 270,
+        level: 'low'
+    },
+    {
+        height: 180,
+        level: 'low'
+    }
+];

--- a/service/RTC/StandardVideoSettings.ts
+++ b/service/RTC/StandardVideoSettings.ts
@@ -26,7 +26,7 @@ export const STANDARD_CODEC_SETTINGS = {
             standard: 300000,
             high: 1000000,
             fullHd: 1200000,
-            ultraHd: 1500000,
+            ultraHd: 2500000,
             ssHigh: 2500000
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI(),
@@ -38,8 +38,8 @@ export const STANDARD_CODEC_SETTINGS = {
             low: 200000,
             standard: 500000,
             high: 1500000,
-            fullHd: 1800000,
-            ultraHd: 2000000,
+            fullHd: 2000000,
+            ultraHd: 4000000,
             ssHigh: 2500000
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI()
@@ -49,8 +49,8 @@ export const STANDARD_CODEC_SETTINGS = {
             low: 200000,
             standard: 500000,
             high: 1500000,
-            fullHd: 1800000,
-            ultraHd: 2000000,
+            fullHd: 2000000,
+            ultraHd: 4000000,
             ssHigh: 2500000
         },
         scalabilityModeEnabled: false
@@ -61,7 +61,7 @@ export const STANDARD_CODEC_SETTINGS = {
             standard: 300000,
             high: 1200000,
             fullHd: 1500000,
-            ultraHd: 1800000,
+            ultraHd: 3000000,
             ssHigh: 2500000
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI(),
@@ -76,7 +76,8 @@ export const STANDARD_CODEC_SETTINGS = {
  * 'high' and above - the encoder will be configured to encode 3 spatial layers.
  * 'standard' - the encoder will be configured to encode 2 spatial laters.
  * 'low' - the encoder will be configured to encode only 1 spatial layer.
- * In all the above cases, each of the layers will again have 3 temporal layers.
+ * In all the above cases, each of the layers will again have 3 temporal layers, except for VP8 codec for which only
+ * 2 temporal layers are configured by default.
  */
 export const VIDEO_QUALITY_LEVELS = [
     {
@@ -108,3 +109,23 @@ export const VIDEO_QUALITY_LEVELS = [
         level: 'low'
     }
 ];
+
+/**
+ * Enumerate the supported video resolutions.
+ */
+export enum VIDEO_QUALITY_SETTINGS {
+    // 3840x2160 or 4k.
+    ULTRA = 'ultraHd',
+
+    // 1920x1080 or full High Definition.
+    FULL = 'fullHd',
+
+    // 1280x720 or High Definition.
+    HIGH = 'high',
+
+    // 640x360 or Standard Definition.
+    STANDARD = 'standard',
+
+    // 320x180 or Low Definition.
+    LOW = 'low'
+};

--- a/types/hand-crafted/modules/RTC/TPCUtils.d.ts
+++ b/types/hand-crafted/modules/RTC/TPCUtils.d.ts
@@ -1,7 +1,4 @@
 import JitsiLocalTrack from './JitsiLocalTrack';
-import { MediaType } from '../../service/RTC/MediaType';
-
-export const SIM_LAYER_RIDS: string[];
 
 export default class TPCUtils {
   constructor(peerconnection: unknown, videoBitrates: unknown); // TODO:


### PR DESCRIPTION
When the client is configured to capture camera sources at 1080p or higher, adjust the bitrates and the encodings scale factor accordingly.