### PR TITLE
fix(TPCUtils): Use track resolution instead of height.

### DIFF
--- a/modules/RTC/MockClasses.js
+++ b/modules/RTC/MockClasses.js
@@ -315,6 +315,7 @@ export class MockJitsiLocalTrack {
      * A constructor
      */
     constructor(height, mediaType, videoType) {
+        this.resolution = height;
         this.track = new MockTrack(height);
         this.type = mediaType;
         this.videoType = videoType;

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -87,7 +87,7 @@ export class TPCUtils {
      */
     _calculateActiveEncodingParams(localVideoTrack, codec, newHeight) {
         const codecBitrates = this.codecSettings[codec].maxBitratesVideo;
-        const trackCaptureHeight = localVideoTrack.getHeight();
+        const trackCaptureHeight = localVideoTrack.resolution;
         const effectiveNewHeight = newHeight > trackCaptureHeight ? trackCaptureHeight : newHeight;
         const desktopShareBitrate = this.pc.options?.videoQuality?.desktopbitrate || codecBitrates.ssHigh;
         const isScreenshare = localVideoTrack.getVideoType() === VideoType.DESKTOP;
@@ -182,7 +182,7 @@ export class TPCUtils {
      * @param {String} codec
      */
     _getVideoStreamEncodings(localTrack, codec) {
-        const captureResolution = localTrack.getHeight();
+        const captureResolution = localTrack.resolution;
         const codecBitrates = this.codecSettings[codec].maxBitratesVideo;
         const videoType = localTrack.getVideoType();
         const { level } = VIDEO_QUALITY_LEVELS.find(lvl => lvl.height <= captureResolution);
@@ -358,7 +358,7 @@ export class TPCUtils {
      * @returns {Array<boolean>}
      */
     calculateEncodingsActiveState(localVideoTrack, codec, newHeight) {
-        const height = localVideoTrack.getHeight();
+        const height = localVideoTrack.resolution;
         const videoStreamEncodings = this._getVideoStreamEncodings(localVideoTrack, codec);
         const encodingsState = videoStreamEncodings
         .map(encoding => height / encoding.scaleResolutionDownBy)
@@ -541,7 +541,7 @@ export class TPCUtils {
      * @returns {number|null} The max encoded resolution for the given video track.
      */
     getConfiguredEncodeResolution(localVideoTrack, codec) {
-        const height = localVideoTrack.getHeight();
+        const height = localVideoTrack.resolution;
         const videoSender = this.pc.findSenderForTrack(localVideoTrack.getTrack());
         let maxHeight = 0;
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2056,7 +2056,7 @@ TraceablePeerConnection.prototype._setMaxBitrates = function(description, isLoca
             if (localTrack.getVideoType() === VideoType.DESKTOP) {
                 maxBitrate = codecScalabilityModeSettings.maxBitratesVideo.ssHigh;
             } else {
-                const { level } = VIDEO_QUALITY_LEVELS.find(lvl => lvl.height <= localTrack.getHeight());
+                const { level } = VIDEO_QUALITY_LEVELS.find(lvl => lvl.height <= localTrack.resolution);
 
                 maxBitrate = codecScalabilityModeSettings.maxBitratesVideo[level];
             }
@@ -2234,7 +2234,7 @@ TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeig
     if ((localVideoTrack.getVideoType() === VideoType.CAMERA && configuredResolution === frameHeight)
         || (localVideoTrack.getVideoType() === VideoType.DESKTOP
             && frameHeight > 0
-            && configuredResolution === localVideoTrack.getHeight())) {
+            && configuredResolution === localVideoTrack.resolution)) {
         return Promise.resolve();
     }
 


### PR DESCRIPTION
When a local video track is muted, getSettings() on MediaStreamTrack doesn't return capture height. Fixes random torture test failures on beta.