### PR TITLE
fix(browser-support): Impl a min. version check for Firefox.

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -622,13 +622,8 @@ export class TPCUtils {
             }
         ];
 
-        // Firefox 72 has stopped parsing the legacy rid= parameters in simulcast attributes.
-        // eslint-disable-next-line max-len
-        // https://www.fxsitecompat.dev/en-CA/docs/2019/pt-and-rid-in-webrtc-simulcast-attributes-are-no-longer-supported/
         const ridLine = rids.map(val => val.id).join(';');
-        const simulcastLine = browser.isFirefox() && browser.isVersionGreaterThan(71)
-            ? `recv ${ridLine}`
-            : `recv rid=${ridLine}`;
+        const simulcastLine = `recv ${ridLine}`;
         const sdp = transform.parse(desc.sdp);
         const mLines = sdp.media.filter(m => m.type === MediaType.VIDEO);
         const senderMids = Array.from(this.pc._localTrackTransceiverMids.values());

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -2,6 +2,7 @@ import { BrowserDetection } from '@jitsi/js-utils';
 
 /* Minimum required Chrome / Chromium version. This applies also to derivatives. */
 const MIN_REQUIRED_CHROME_VERSION = 72;
+const MIN_REQUIRED_FIREFOX_VERSION = 91;
 const MIN_REQUIRED_SAFARI_VERSION = 14;
 const MIN_REQUIRED_IOS_VERSION = 14;
 
@@ -71,7 +72,7 @@ export default class BrowserCapabilities extends BrowserDetection {
         }
 
         return (this.isChromiumBased() && this.isEngineVersionGreaterThan(MIN_REQUIRED_CHROME_VERSION - 1))
-            || this.isFirefox()
+            || (this.isFirefox() && this.isVersionGreaterThan(MIN_REQUIRED_FIREFOX_VERSION - 1))
             || this.isReactNative()
             || this.isWebKitBased();
     }


### PR DESCRIPTION
Set the min. required version for Firefox to 91 so that the last 3 ESR versions are supported.