### PR TITLE
fix(JitsiLocalTRack): Calc resolution correctly.

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -47,6 +47,7 @@ let rtcTrackIdCounter = 0;
 function _createLocalTracks(mediaStreamMetaData = []) {
     return mediaStreamMetaData.map(metaData => {
         const {
+            constraints,
             sourceId,
             sourceType,
             stream,
@@ -63,6 +64,7 @@ function _createLocalTracks(mediaStreamMetaData = []) {
         rtcTrackIdCounter = safeCounterIncrement(rtcTrackIdCounter);
 
         return new JitsiLocalTrack({
+            constraints,
             deviceId,
             facingMode,
             mediaType: track.kind,

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -515,6 +515,7 @@ class RTCUtils extends Listenable {
         } = options;
 
         const mediaStreamsMetaData = [];
+        let constraints = {};
 
         // Declare private functions to be used in the promise chain below.
         // These functions are declared in the scope of this function because
@@ -558,7 +559,7 @@ class RTCUtils extends Listenable {
                 }
 
                 const requestedDevices = [ 'video' ];
-                const constraints = {
+                const deviceConstraints = {
                     video: {
                         deviceId: matchingDevice.deviceId
 
@@ -566,7 +567,7 @@ class RTCUtils extends Listenable {
                     }
                 };
 
-                return this._getUserMedia(requestedDevices, constraints, timeout)
+                return this._getUserMedia(requestedDevices, deviceConstraints, timeout)
                     .then(stream => {
                         return {
                             sourceType: 'device',
@@ -637,7 +638,7 @@ class RTCUtils extends Listenable {
                 return Promise.resolve();
             }
 
-            const constraints = getConstraints(requestedCaptureDevices, otherOptions);
+            constraints = getConstraints(requestedCaptureDevices, otherOptions);
 
             logger.info('Got media constraints: ', JSON.stringify(constraints));
 
@@ -664,6 +665,7 @@ class RTCUtils extends Listenable {
                 const audioStream = new MediaStream(audioTracks);
 
                 mediaStreamsMetaData.push({
+                    constraints: constraints.audio,
                     stream: audioStream,
                     track: audioStream.getAudioTracks()[0],
                     effects: otherOptions.effects
@@ -676,6 +678,7 @@ class RTCUtils extends Listenable {
                 const videoStream = new MediaStream(videoTracks);
 
                 mediaStreamsMetaData.push({
+                    constraints: constraints.video,
                     stream: videoStream,
                     track: videoStream.getVideoTracks()[0],
                     videoType: VideoType.CAMERA,

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2208,7 +2208,7 @@ TraceablePeerConnection.prototype.setRemoteDescription = function(description) {
  * @returns {Promise} promise that will be resolved when the operation is successful and rejected otherwise.
  */
 TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeight, localVideoTrack) {
-    if (frameHeight < 0) {
+    if (frameHeight < 0 || isNaN(frameHeight)) {
         throw new Error(`Invalid frameHeight: ${frameHeight}`);
     }
     if (!localVideoTrack) {


### PR DESCRIPTION
If MediaStreamTrack.getSettings() doesn't return the height of the track, use the constraints passed to gUM for calculating the height. Fixes an issue for Firefox/Linux which could result in media not displayed.