### PR TITLE
fix(video-quality): Bump up the default bitrates for 1080p and 4k.

### DIFF
--- a/modules/RTC/TPCUtils.spec.js
+++ b/modules/RTC/TPCUtils.spec.js
@@ -326,7 +326,7 @@ describe('TPCUtils', () => {
                 expect(activeState[2]).toBe(false);
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
-                expect(maxBitrates[0]).toBe(2500000);
+                expect(maxBitrates[0]).toBe(3600000);
                 expect(maxBitrates[1]).toBe(0);
                 expect(maxBitrates[2]).toBe(0);
 
@@ -347,7 +347,7 @@ describe('TPCUtils', () => {
                 expect(activeState[2]).toBe(false);
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
-                expect(maxBitrates[0]).toBe(1200000);
+                expect(maxBitrates[0]).toBe(1800000);
                 expect(maxBitrates[1]).toBe(0);
                 expect(maxBitrates[2]).toBe(0);
 
@@ -863,7 +863,7 @@ describe('TPCUtils', () => {
             });
         });
 
-        describe('VP9 camera tracks with 1080p resolutions ', () => {
+        describe('VP9 camera tracks with 1080p resolutions', () => {
             const codec = CodecMimeType.VP9;
             const track = new MockJitsiLocalTrack(1080, 'video', 'camera');
 
@@ -886,7 +886,7 @@ describe('TPCUtils', () => {
                 expect(activeState[2]).toBe(false);
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
-                expect(maxBitrates[0]).toBe(1500000);
+                expect(maxBitrates[0]).toBe(2000000);
                 expect(maxBitrates[1]).toBe(0);
                 expect(maxBitrates[2]).toBe(0);
 
@@ -1574,7 +1574,7 @@ describe('TPCUtils', () => {
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(highResolutiontrack, codec, height);
                 expect(maxBitrates[0]).toBe(200000);
                 expect(maxBitrates[1]).toBe(500000);
-                expect(maxBitrates[2]).toBe(4000000);
+                expect(maxBitrates[2]).toBe(5000000);
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(highResolutiontrack, codec, height);
                 expect(scalabilityModes).toBe(undefined);

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1582,7 +1582,7 @@ TraceablePeerConnection.prototype._assertTrackBelongs = function(
  * video in the local SDP.
  */
 TraceablePeerConnection.prototype.getConfiguredVideoCodec = function() {
-    const sdp = this.peerconnection.localDescription?.sdp;
+    const sdp = this.peerconnection.remoteDescription?.sdp;
     const defaultCodec = CodecMimeType.VP8;
 
     if (!sdp) {

--- a/service/RTC/StandardVideoSettings.ts
+++ b/service/RTC/StandardVideoSettings.ts
@@ -25,8 +25,8 @@ export const STANDARD_CODEC_SETTINGS = {
             low: 100000,
             standard: 300000,
             high: 1000000,
-            fullHd: 1200000,
-            ultraHd: 2500000,
+            fullHd: 1800000,
+            ultraHd: 3600000,
             ssHigh: 2500000,
             none: 0
         },
@@ -39,8 +39,8 @@ export const STANDARD_CODEC_SETTINGS = {
             low: 200000,
             standard: 500000,
             high: 1500000,
-            fullHd: 2000000,
-            ultraHd: 4000000,
+            fullHd: 2500000,
+            ultraHd: 5000000,
             ssHigh: 2500000,
             none: 0
         },
@@ -51,8 +51,8 @@ export const STANDARD_CODEC_SETTINGS = {
             low: 200000,
             standard: 500000,
             high: 1500000,
-            fullHd: 2000000,
-            ultraHd: 4000000,
+            fullHd: 2500000,
+            ultraHd: 5000000,
             ssHigh: 2500000,
             none: 0
         },
@@ -63,8 +63,8 @@ export const STANDARD_CODEC_SETTINGS = {
             low: 100000,
             standard: 300000,
             high: 1200000,
-            fullHd: 1500000,
-            ultraHd: 3000000,
+            fullHd: 2000000,
+            ultraHd: 4000000,
             ssHigh: 2500000,
             none: 0
         },


### PR DESCRIPTION
Check the first payload type of the m-line in remote description to get the codec used for encoding the local video source.