### PR TITLE
fix(video-quality): Fix resolution of simulcast streams.

### DIFF
--- a/modules/RTC/TPCUtils.spec.js
+++ b/modules/RTC/TPCUtils.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
 import { CodecMimeType } from '../../service/RTC/CodecMimeType';
+import { SIM_LAYERS } from '../../service/RTC/StandardVideoSettings';
 import { VideoEncoderScalabilityMode } from '../../service/RTC/VideoEncoderScalabilityMode';
 
 import { MockJitsiLocalTrack, MockPeerConnection } from './MockClasses';
@@ -249,7 +250,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -270,7 +271,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[1].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -291,7 +292,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -336,7 +337,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 1080', () => {
@@ -466,7 +467,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -506,7 +507,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -553,7 +554,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -592,7 +593,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -607,7 +608,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[1].scaleFactor);
             });
 
             it('and requested resolution is 720 again', () => {
@@ -622,7 +623,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -637,7 +638,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -674,7 +675,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -717,7 +718,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -738,7 +739,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[1].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -759,7 +760,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -805,7 +806,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -851,7 +852,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -896,7 +897,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 720', () => {
@@ -1004,7 +1005,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 720', () => {
@@ -1025,7 +1026,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1106,7 +1107,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1121,7 +1122,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[1].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1136,7 +1137,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1173,7 +1174,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1216,9 +1217,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1239,9 +1240,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1262,9 +1263,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1310,9 +1311,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1358,9 +1359,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1399,7 +1400,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1414,7 +1415,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[1].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1429,7 +1430,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1466,7 +1467,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1507,9 +1508,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1528,9 +1529,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1549,9 +1550,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1562,7 +1563,7 @@ describe('TPCUtils', () => {
                 expect(activeState[2]).toBe(false);
             });
 
-            it('and lowest spatial layer is greater than requested resolution', () => {
+            it('and capture resolution is 4k', () => {
                 height = 180;
                 const highResolutiontrack = new MockJitsiLocalTrack(2160, 'video', 'camera');
 
@@ -1580,9 +1581,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(highResolutiontrack, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(12);
+                expect(scaleFactor[1]).toBe(6);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
         });
 
@@ -1618,9 +1619,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1664,9 +1665,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1705,7 +1706,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1720,7 +1721,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[1].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1735,7 +1736,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1772,7 +1773,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1787,7 +1788,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 2160 again', () => {
@@ -1802,7 +1803,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1840,7 +1841,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1910,9 +1911,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -1934,9 +1935,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -1958,9 +1959,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -1982,9 +1983,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
         });
 
@@ -2035,9 +2036,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -2059,9 +2060,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -2083,9 +2084,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -2107,9 +2108,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
         });
 
@@ -2152,9 +2153,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -2174,9 +2175,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -2196,9 +2197,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -2218,9 +2219,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
         });
 
@@ -2263,9 +2264,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -2285,9 +2286,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -2307,9 +2308,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -2329,9 +2330,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
         });
 
@@ -2375,9 +2376,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -2397,9 +2398,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
         });
 
@@ -2443,9 +2444,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -2465,9 +2466,9 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
-                expect(scaleFactor[1]).toBe(tpcUtils.l1ScaleFactor);
-                expect(scaleFactor[2]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
             });
         });
 
@@ -2506,7 +2507,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -2522,7 +2523,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[1].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -2538,7 +2539,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes).toBe(undefined);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -2593,7 +2594,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -2611,7 +2612,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[1].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -2629,7 +2630,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
@@ -2679,7 +2680,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l2ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
             });
 
             it('and requested resolution is 360', () => {
@@ -2697,7 +2698,7 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l1ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[1].scaleFactor);
             });
 
             it('and requested resolution is 180', () => {
@@ -2715,13 +2716,245 @@ describe('TPCUtils', () => {
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
 
                 scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
-                expect(scaleFactor[0]).toBe(tpcUtils.l0ScaleFactor);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
             });
 
             it('and requested resolution is 0', () => {
                 height = 0;
 
                 activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(false);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+            });
+        });
+
+        describe('for VP9 camera/desktop tracks when simulcast is used', () => {
+            const track = new MockJitsiLocalTrack(720, 'video', 'camera');
+            const desktop = new MockJitsiLocalTrack(1440, 'video', 'desktop');
+            const codec = CodecMimeType.VP9;
+
+            // Configure VP9 to use SVC mode instead of the K-SVC mode.
+            const videoQuality = {
+                vp9: {
+                    useSimulcast: true
+                }
+            };
+
+            pc = new MockPeerConnection('1', true, true /* simulcast */);
+            pc.options = { videoQuality };
+            pc._capScreenshareBitrate = true;
+            const utils = new TPCUtils(pc);
+
+            it('and requested desktop resolution is 2160', () => {
+                height = 2160;
+
+                activeState = utils.calculateEncodingsActiveState(desktop, codec, height);
+                expect(activeState[0]).toBe(false);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(true);
+
+                bitrates = utils.calculateEncodingsBitrates(desktop, codec, height);
+                expect(bitrates[0]).toBe(2500000);
+                expect(bitrates[1]).toBe(2500000);
+                expect(bitrates[2]).toBe(2500000);
+
+                scalabilityModes = utils.calculateEncodingsScalabilityMode(desktop, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
+                expect(scalabilityModes[1]).toBe(VideoEncoderScalabilityMode.L1T3);
+                expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
+
+                scaleFactor = utils.calculateEncodingsScaleFactor(desktop, codec, height);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
+            });
+
+            it('and requested camera resolution is 720', () => {
+                height = 720;
+
+                activeState = utils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(true);
+                expect(activeState[2]).toBe(true);
+
+                bitrates = utils.calculateEncodingsBitrates(track, codec, height);
+                expect(bitrates[0]).toBe(100000);
+                expect(bitrates[1]).toBe(300000);
+                expect(bitrates[2]).toBe(1200000);
+
+                scalabilityModes = utils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
+                expect(scalabilityModes[1]).toBe(VideoEncoderScalabilityMode.L1T3);
+                expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
+
+                scaleFactor = utils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
+            });
+
+            it('and requested camera resolution is 360', () => {
+                height = 360;
+
+                activeState = utils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(true);
+                expect(activeState[2]).toBe(false);
+
+                bitrates = utils.calculateEncodingsBitrates(track, codec, height);
+                expect(bitrates[0]).toBe(100000);
+                expect(bitrates[1]).toBe(300000);
+                expect(bitrates[2]).toBe(1200000);
+
+                scalabilityModes = utils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
+                expect(scalabilityModes[1]).toBe(VideoEncoderScalabilityMode.L1T3);
+                expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
+
+                scaleFactor = utils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
+            });
+
+            it('and requested camera resolution is 180', () => {
+                height = 180;
+
+                activeState = utils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                bitrates = utils.calculateEncodingsBitrates(track, codec, height);
+                expect(bitrates[0]).toBe(100000);
+                expect(bitrates[1]).toBe(300000);
+                expect(bitrates[2]).toBe(1200000);
+
+                scalabilityModes = utils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
+                expect(scalabilityModes[1]).toBe(VideoEncoderScalabilityMode.L1T3);
+                expect(scalabilityModes[2]).toBe(VideoEncoderScalabilityMode.L1T3);
+
+                scaleFactor = utils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
+            });
+
+            it('and requested camera resolution is 0', () => {
+                height = 0;
+
+                activeState = utils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(false);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+            });
+        });
+
+        describe('for VP8 camera/desktop tracks when simulcast is used', () => {
+            const track = new MockJitsiLocalTrack(2160, 'video', 'camera');
+            const desktop = new MockJitsiLocalTrack(1440, 'video', 'desktop');
+            const codec = CodecMimeType.VP8;
+            const videoQuality = {};
+
+            pc = new MockPeerConnection('1', true, true /* simulcast */);
+            pc.options = { videoQuality };
+            pc._capScreenshareBitrate = true;
+            const utils = new TPCUtils(pc);
+
+            it('and requested desktop resolution is 2160', () => {
+                height = 2160;
+
+                activeState = utils.calculateEncodingsActiveState(desktop, codec, height);
+                expect(activeState[0]).toBe(false);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(true);
+
+                bitrates = utils.calculateEncodingsBitrates(desktop, codec, height);
+                expect(bitrates[0]).toBe(2500000);
+                expect(bitrates[1]).toBe(2500000);
+                expect(bitrates[2]).toBe(2500000);
+
+                scalabilityModes = utils.calculateEncodingsScalabilityMode(desktop, codec, height);
+                expect(scalabilityModes).toBe(undefined);
+
+                scaleFactor = utils.calculateEncodingsScaleFactor(desktop, codec, height);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+                expect(scaleFactor[1]).toBe(SIM_LAYERS[1].scaleFactor);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
+            });
+
+            it('and requested camera resolution is 2160', () => {
+                height = 2160;
+
+                activeState = utils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(true);
+                expect(activeState[2]).toBe(true);
+
+                bitrates = utils.calculateEncodingsBitrates(track, codec, height);
+                expect(bitrates[0]).toBe(200000);
+                expect(bitrates[1]).toBe(500000);
+                expect(bitrates[2]).toBe(6000000);
+
+                scalabilityModes = utils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes).toBe(undefined);
+
+                scaleFactor = utils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(12);
+                expect(scaleFactor[1]).toBe(6);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
+            });
+
+            it('and requested camera resolution is 360', () => {
+                height = 360;
+
+                activeState = utils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(true);
+                expect(activeState[2]).toBe(false);
+
+                bitrates = utils.calculateEncodingsBitrates(track, codec, height);
+                expect(bitrates[0]).toBe(200000);
+                expect(bitrates[1]).toBe(500000);
+                expect(bitrates[2]).toBe(6000000);
+
+                scalabilityModes = utils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes).toBe(undefined);
+
+                scaleFactor = utils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(12);
+                expect(scaleFactor[1]).toBe(6);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
+            });
+
+            it('and requested camera resolution is 180', () => {
+                height = 180;
+
+                activeState = utils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(true);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                bitrates = utils.calculateEncodingsBitrates(track, codec, height);
+                expect(bitrates[0]).toBe(200000);
+                expect(bitrates[1]).toBe(500000);
+                expect(bitrates[2]).toBe(6000000);
+
+                scalabilityModes = utils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes).toBe(undefined);
+
+                scaleFactor = utils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(12);
+                expect(scaleFactor[1]).toBe(6);
+                expect(scaleFactor[2]).toBe(SIM_LAYERS[2].scaleFactor);
+            });
+
+            it('and requested camera resolution is 0', () => {
+                height = 0;
+
+                activeState = utils.calculateEncodingsActiveState(track, codec, height);
                 expect(activeState[0]).toBe(false);
                 expect(activeState[1]).toBe(false);
                 expect(activeState[2]).toBe(false);


### PR DESCRIPTION
When both the camera and screenshare tracks are present. Add unit tests.