### PR TITLE
fix(RTC): Fix capture resolution for Safari desktop tracks.

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -668,6 +668,19 @@ export default class JitsiLocalTrack extends JitsiTrack {
     }
 
     /**
+     * Returns the capture resolution of the video track.
+     *
+     * @returns {Number}
+     */
+    getCaptureResolution() {
+        if (this.videoType === VideoType.CAMERA || !browser.isWebKitBased()) {
+            return this.resolution;
+        }
+
+        return this.getHeight();
+    }
+
+    /**
      * Returns device id associated with track.
      *
      * @returns {string}

--- a/modules/RTC/MockClasses.js
+++ b/modules/RTC/MockClasses.js
@@ -330,6 +330,14 @@ export class MockJitsiLocalTrack {
     }
 
     /**
+     * Returns the capture resolution.
+     * @returns {number}
+     */
+    getCaptureResolution() {
+        return this.getHeight();
+    }
+
+    /**
      * Returns track.
      * @returns {MockTrack}
      */

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -84,7 +84,7 @@ export class TPCUtils {
      */
     _calculateActiveEncodingParams(localVideoTrack, codec, newHeight) {
         const codecBitrates = this.codecSettings[codec].maxBitratesVideo;
-        const trackCaptureHeight = localVideoTrack.resolution;
+        const trackCaptureHeight = localVideoTrack.getCaptureResolution();
         const effectiveNewHeight = newHeight > trackCaptureHeight ? trackCaptureHeight : newHeight;
         const desktopShareBitrate = this.pc.options?.videoQuality?.desktopbitrate || codecBitrates.ssHigh;
         const isScreenshare = localVideoTrack.getVideoType() === VideoType.DESKTOP;
@@ -177,7 +177,7 @@ export class TPCUtils {
      * @param {String} codec
      */
     _getVideoStreamEncodings(localTrack, codec) {
-        const captureResolution = localTrack.resolution;
+        const captureResolution = localTrack.getCaptureResolution();
         const codecBitrates = this.codecSettings[codec].maxBitratesVideo;
         const videoType = localTrack.getVideoType();
         let effectiveScaleFactors = SIM_LAYERS.map(sim => sim.scaleFactor);
@@ -360,7 +360,7 @@ export class TPCUtils {
      * @returns {Array<boolean>}
      */
     calculateEncodingsActiveState(localVideoTrack, codec, newHeight) {
-        const height = localVideoTrack.resolution;
+        const height = localVideoTrack.getCaptureResolution();
         const videoStreamEncodings = this._getVideoStreamEncodings(localVideoTrack, codec);
         const encodingsState = videoStreamEncodings
         .map(encoding => height / encoding.scaleResolutionDownBy)
@@ -543,7 +543,7 @@ export class TPCUtils {
      * @returns {number|null} The max encoded resolution for the given video track.
      */
     getConfiguredEncodeResolution(localVideoTrack, codec) {
-        const height = localVideoTrack.resolution;
+        const height = localVideoTrack.getCaptureResolution();
         const videoSender = this.pc.findSenderForTrack(localVideoTrack.getTrack());
         let maxHeight = 0;
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2062,7 +2062,7 @@ TraceablePeerConnection.prototype._setMaxBitrates = function(description, isLoca
             if (localTrack.getVideoType() === VideoType.DESKTOP) {
                 maxBitrate = codecScalabilityModeSettings.maxBitratesVideo.ssHigh;
             } else {
-                const { level } = VIDEO_QUALITY_LEVELS.find(lvl => lvl.height <= localTrack.resolution);
+                const { level } = VIDEO_QUALITY_LEVELS.find(lvl => lvl.height <= localTrack.getCaptureResolution());
 
                 maxBitrate = codecScalabilityModeSettings.maxBitratesVideo[level];
             }
@@ -2240,7 +2240,7 @@ TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeig
     if ((localVideoTrack.getVideoType() === VideoType.CAMERA && configuredResolution === frameHeight)
         || (localVideoTrack.getVideoType() === VideoType.DESKTOP
             && frameHeight > 0
-            && configuredResolution === localVideoTrack.resolution)) {
+            && configuredResolution === localVideoTrack.getCaptureResolution())) {
         return Promise.resolve();
     }
 


### PR DESCRIPTION
The browser returns height as 0 at track creation time. Fixes an issue where Safari's screenshare shows as black.