### PR TITLE
fix(TPC): Reset the scalabilityMode for VP8.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2324,6 +2324,8 @@ TraceablePeerConnection.prototype._updateVideoSenderEncodings = function(frameHe
             // Configure scalability mode when its supported and enabled.
             if (scalabilityModes) {
                 parameters.encodings[encoding].scalabilityMode = scalabilityModes[encoding];
+            } else {
+                parameters.encodings[encoding].scalabilityMode = undefined;
             }
         }
     }


### PR DESCRIPTION
Set the scalabilityMode to undefined for VP8 after a VP9->VP8 switch even though the browser returns L1T2 in the RTCRtpSender.getParameters() call. Fixes an issue where the bridge stops forwarding video for some participants after vp8->vp9 switch.