### PR TITLE
Fixes #2458 Circular dependency issue

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -655,39 +655,6 @@ export default class RTC extends Listenable {
     }
 
     /**
-     * Returns <tt>true<tt/> if given WebRTC MediaStream is considered a valid
-     * "user" stream which means that it's not a "receive only" stream nor a
-     * "mixed" JVB stream.
-     *
-     * Clients that implement Unified Plan, such as Firefox use recvonly
-     * "streams/channels/tracks" for receiving remote stream/tracks, as opposed
-     * to Plan B where there are only 3 channels: audio, video and data.
-     *
-     * @param {MediaStream} stream The WebRTC MediaStream instance.
-     * @returns {boolean}
-     */
-    static isUserStream(stream) {
-        return RTC.isUserStreamById(stream.id);
-    }
-
-    /**
-     * Returns <tt>true<tt/> if a WebRTC MediaStream identified by given stream
-     * ID is considered a valid "user" stream which means that it's not a
-     * "receive only" stream nor a "mixed" JVB stream.
-     *
-     * Clients that implement Unified Plan, such as Firefox use recvonly
-     * "streams/channels/tracks" for receiving remote stream/tracks, as opposed
-     * to Plan B where there are only 3 channels: audio, video and data.
-     *
-     * @param {string} streamId The id of WebRTC MediaStream.
-     * @returns {boolean}
-     */
-    static isUserStreamById(streamId) {
-        return streamId && streamId !== 'mixedmslabel'
-            && streamId !== 'default';
-    }
-
-    /**
      * Allows to receive list of available cameras/microphones.
      * @param {function} callback Would receive array of devices as an
      *      argument.

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -834,15 +834,31 @@ class RTCUtils extends Listenable {
     getEventDataForActiveDevice(device) {
         const deviceList = [];
         const deviceData = {
-            'deviceId': device.deviceId,
-            'kind': device.kind,
-            'label': device.label,
-            'groupId': device.groupId
+            deviceId: device.deviceId,
+            kind: device.kind,
+            label: device.label,
+            groupId: device.groupId
         };
 
         deviceList.push(deviceData);
 
         return { deviceList };
+    }
+
+    /**
+     * Returns <tt>true<tt/> if a WebRTC MediaStream identified by given stream
+     * ID is considered a valid "user" stream which means that it's not a
+     * "receive only" stream nor a "mixed" JVB stream.
+     *
+     * Clients that implement Unified Plan, such as Firefox use recvonly
+     * "streams/channels/tracks" for receiving remote stream/tracks, as opposed
+     * to Plan B where there are only 3 channels: audio, video and data.
+     *
+     * @param {string} streamId The id of WebRTC MediaStream.
+     * @returns {boolean}
+     */
+    isUserStreamById(streamId) {
+        return streamId && streamId !== 'mixedmslabel' && streamId !== 'default';
     }
 }
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -21,7 +21,7 @@ import SdpSimulcast from '../sdp/SdpSimulcast';
 import { SdpTransformWrap } from '../sdp/SdpTransformUtil';
 
 import JitsiRemoteTrack from './JitsiRemoteTrack';
-import RTC from './RTC';
+import RTCUtils from './RTCUtils';
 import { TPCUtils } from './TPCUtils';
 
 // FIXME SDP tools should end up in some kind of util module
@@ -857,7 +857,7 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track, tr
     const mediaType = track.kind;
 
     // Do not create remote tracks for 'mixed' JVB SSRCs (used by JVB for RTCP termination).
-    if (!this.isP2P && !RTC.isUserStreamById(streamId)) {
+    if (!this.isP2P && !RTCUtils.isUserStreamById(streamId)) {
         return;
     }
     logger.info(`${this} Received track event for remote stream[id=${streamId},type=${mediaType}]`);
@@ -1016,7 +1016,7 @@ TraceablePeerConnection.prototype._remoteTrackRemoved = function(stream, track) 
     const trackId = track?.id;
 
     // Ignore stream removed events for JVB "mixed" sources (used for RTCP termination).
-    if (!RTC.isUserStreamById(streamId)) {
+    if (!RTCUtils.isUserStreamById(streamId)) {
         return;
     }
 
@@ -2454,7 +2454,7 @@ TraceablePeerConnection.prototype.close = function() {
     this._dtmfTonesQueue = [];
 
     if (!this.rtc._removePeerConnection(this)) {
-        logger.error(`${this} RTC._removePeerConnection returned false`);
+        logger.error(`${this} rtc._removePeerConnection returned false`);
     }
     if (this.statsinterval !== null) {
         window.clearInterval(this.statsinterval);

--- a/types/hand-crafted/modules/RTC/RTC.d.ts
+++ b/types/hand-crafted/modules/RTC/RTC.d.ts
@@ -32,8 +32,6 @@ export default class RTC extends Listenable {
   static getCurrentlyAvailableMediaDevices: () => unknown[]; // TODO:
   static getEventDataForActiveDevice: () => MediaDeviceInfo;
   static setAudioOutputDevice: ( deviceId: string ) => Promise<unknown>; // TODO:
-  static isUserStream: ( stream: MediaStream ) => boolean;
-  static isUserStreamById: ( streamId: string ) => boolean;
   static enumerateDevices: ( callback: () => unknown ) => void; // TODO:
   static stopMediaStream: ( mediaStream: MediaStream ) => void;
   static isDesktopSharingEnabled: () => boolean;

--- a/types/hand-crafted/modules/RTC/RTCUtils.d.ts
+++ b/types/hand-crafted/modules/RTC/RTCUtils.d.ts
@@ -15,6 +15,7 @@ declare class RTCUtils extends Listenable {
   getCurrentlyAvailableMediaDevices: () => unknown[]; // TODO:
   getEventDataForActiveDevice: ( device: MediaDeviceInfo ) => unknown; // TODO:
   arePermissionsGrantedForAvailableDevices: () => boolean;
+  isUserStreamById: ( streamId: string ) => boolean;
 }
 
 declare const rtcUtils: RTCUtils;


### PR DESCRIPTION
Closes #2458 
Move isUserStreamById into RTCUtils and remove not used isUserStream RTC method.

Require cycle: lib/lib-jitsi-meet/modules/RTC/RTC.js -> lib/lib-jitsi-meet/modules/RTC/TraceablePeerConnection.js -> lib/lib-jitsi-meet/modules/RTC/RTC.js