### PR TITLE
Avoid finally in promise chain. Log error if error happen in _l_lastVideoSenderUpdatePromise.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2261,7 +2261,7 @@ TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeig
 TraceablePeerConnection.prototype._updateVideoSenderParameters = function(nextFunction) {
     const nextPromise = this._lastVideoSenderUpdatePromise.catch(
       error => {
-          logger.error('[TraceablePeerConnection] Failed to proceed with last video sender update promise', error);
+          logger.error('Failed to proceed with last video sender update promise', error);
       }
     ).then(nextFunction);
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2259,8 +2259,11 @@ TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeig
  * @returns {Promise}
  */
 TraceablePeerConnection.prototype._updateVideoSenderParameters = function(nextFunction) {
-    const nextPromise = this._lastVideoSenderUpdatePromise
-        .finally(nextFunction);
+    const nextPromise = this._lastVideoSenderUpdatePromise.catch(
+      error => {
+          logger.error('[TraceablePeerConnection] Failed to proceed with last video sender update promise', error);
+      }
+    ).then(nextFunction);
 
     this._lastVideoSenderUpdatePromise = nextPromise;
 


### PR DESCRIPTION
Fixes #2464 _lastVideoSenderUpdatePromise.finally is not a function issue. Add more information about occurred errors.