### PR TITLE
fix(TPC): Run the DD ext header check on all browsers.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1425,10 +1425,6 @@ TraceablePeerConnection.prototype._mungeCodecOrder = function(description) {
  * @returns {RTCSessionDescription} the munged description.
  */
 TraceablePeerConnection.prototype._updateAv1DdHeaders = function(description) {
-    if (!browser.supportsScalabilityModeAPI()) {
-        return description;
-    }
-
     const parsedSdp = transform.parse(description.sdp);
     const mLines = parsedSdp.media.filter(m => m.type === MediaType.VIDEO);
 


### PR DESCRIPTION
We do not want non Chromium browsers to negotiate DD ext headers when VP8/VP9 is the selected codec. Fixes poor video quality issue for Safari when Av1 is offered by Jicofo.