### PR TITLE
fix(tracks): Do not filter the tracks for p2p.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2910,7 +2910,7 @@ JitsiConference.prototype._acceptP2PIncomingCall = function(jingleSession, jingl
             enableInsertableStreams: this.isE2EEEnabled() || FeatureFlags.isRunInLiteModeEnabled()
         });
 
-    const localTracks = this._getInitialLocalTracks();
+    const localTracks = this.getLocalTracks();
 
     this.p2pJingleSession.acceptOffer(
         jingleOffer,
@@ -3253,7 +3253,7 @@ JitsiConference.prototype._startP2PSession = function(remoteJid) {
             enableInsertableStreams: this.isE2EEEnabled() || FeatureFlags.isRunInLiteModeEnabled()
         });
 
-    const localTracks = this._getInitialLocalTracks();
+    const localTracks = this.getLocalTracks();
 
     this.p2pJingleSession.invite(localTracks);
 };


### PR DESCRIPTION
The tracks should get removed if the startAudioMuted/startVideoMuted flags are set for the conference. Fixes the failing startMuted testcase.