### PR TITLE
Fix firefox issues

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1428,7 +1428,7 @@ TraceablePeerConnection.prototype._updateAv1DdHeaders = function(description) {
     const parsedSdp = transform.parse(description.sdp);
     const mLines = parsedSdp.media.filter(m => m.type === MediaType.VIDEO);
 
-    if (!mLines.length) {
+    if (!mLines.length || !browser.supportsDDExtHeaders()) {
         return description;
     }
 

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -141,6 +141,15 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
+     * Returns true if the browser supports Dependency Descriptor header extension.
+     *
+     * @returns {boolean}
+     */
+    supportsDDExtHeaders() {
+        return !this.isFirefox();
+    }
+
+    /**
      * Checks if the current browser support the device change event.
      * @return {boolean}
      */


### PR DESCRIPTION
1. fix(TPCUtils): Chain both RTCRtpSender getParameters and setParameters call properly.

Firefox 123 started throwing an error when the transaction ids for getParameters and setParameters don't match. This can result in Firefox not establishing a p2p connection with a remote peer when it is the offerer.

2. fix(TPC): Do not run the DD Header Ext check on Firefox as it doesn't support it currently.