### PR TITLE
fix(codec-selection): Include visitor codecs.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -3087,6 +3087,20 @@ JitsiConference.prototype._updateProperties = function(properties = {}) {
             }
         });
 
+        // Handle changes to aggregate list of visitor codecs.
+        let publishedCodecs = this.properties['visitor-codecs']?.split(',');
+
+        if (publishedCodecs?.length) {
+            publishedCodecs = publishedCodecs.filter(codec => typeof codec === 'string'
+                && codec.trim().length
+                && Object.values(CodecMimeType).find(val => val === codec));
+        }
+
+        if (this._visitorCodecs !== publishedCodecs) {
+            this._visitorCodecs = publishedCodecs;
+            this.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_VISITOR_CODECS_CHANGED, this._visitorCodecs);
+        }
+
         const oldValue = this._hasVisitors;
 
         this._hasVisitors = this.properties['visitor-count'] > 0;

--- a/JitsiConferenceEvents.spec.ts
+++ b/JitsiConferenceEvents.spec.ts
@@ -14,6 +14,7 @@ describe( "/JitsiConferenceEvents members", () => {
         CONFERENCE_JOINED,
         CONFERENCE_LEFT,
         CONFERENCE_UNIQUE_ID_SET,
+        CONFERENCE_VISITOR_CODECS_CHANGED,
         CONNECTION_ESTABLISHED,
         CONNECTION_INTERRUPTED,
         CONNECTION_RESTORED,
@@ -98,6 +99,7 @@ describe( "/JitsiConferenceEvents members", () => {
         expect( CONFERENCE_JOINED ).toBe( 'conference.joined' );
         expect( CONFERENCE_LEFT ).toBe( 'conference.left' );
         expect( CONFERENCE_UNIQUE_ID_SET ).toBe( 'conference.unique_id_set' );
+        expect( CONFERENCE_VISITOR_CODECS_CHANGED ).toBe( 'conference.visitor_codecs_changed' );
         expect( CONNECTION_ESTABLISHED ).toBe( 'conference.connectionEstablished' );
         expect( CONNECTION_INTERRUPTED ).toBe( 'conference.connectionInterrupted' );
         expect( CONNECTION_RESTORED ).toBe( 'conference.connectionRestored' );

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -137,6 +137,11 @@ export enum JitsiConferenceEvents {
     CONFERENCE_UNIQUE_ID_SET = 'conference.unique_id_set',
 
     /**
+     * Indicates that the aggregate set of codecs supported by the visitors has changed.
+     */
+    CONFERENCE_VISITOR_CODECS_CHANGED = 'conference.visitor_codecs_changed',
+
+    /**
      * Indicates that the connection to the conference has been established
      * XXX This is currently fired when the *ICE* connection enters 'connected'
      * state for the first time.
@@ -501,6 +506,7 @@ export const CONFERENCE_JOIN_IN_PROGRESS = JitsiConferenceEvents.CONFERENCE_JOIN
 export const CONFERENCE_JOINED = JitsiConferenceEvents.CONFERENCE_JOINED;
 export const CONFERENCE_LEFT = JitsiConferenceEvents.CONFERENCE_LEFT;
 export const CONFERENCE_UNIQUE_ID_SET = JitsiConferenceEvents.CONFERENCE_UNIQUE_ID_SET;
+export const CONFERENCE_VISITOR_CODECS_CHANGED = JitsiConferenceEvents.CONFERENCE_VISITOR_CODECS_CHANGED;
 export const CONNECTION_ESTABLISHED = JitsiConferenceEvents.CONNECTION_ESTABLISHED;
 export const CONNECTION_INTERRUPTED = JitsiConferenceEvents.CONNECTION_INTERRUPTED;
 export const CONNECTION_RESTORED = JitsiConferenceEvents.CONNECTION_RESTORED;


### PR DESCRIPTION
Include visitor codecs published by Jicofo while calculating the intersection set for the conference.