### PR TITLE
feat(build) remove export from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "scripts": {
     "build": "npm run build:webpack && npm run build:tsc",
-    "build:webpack": "LIB_JITSI_MEET_COMMIT_HASH=$(git rev-parse --short HEAD 2>/dev/null) webpack",
+    "build:webpack": "webpack",
     "build:webpack-dev": "webpack --mode development",
     "build:tsc": "tsc --build --clean && tsc",
     "gen-types": "tsc --declaration --emitDeclarationOnly --out types/index.d.ts",

--- a/webpack-shared-config.js
+++ b/webpack-shared-config.js
@@ -1,10 +1,16 @@
 /* global __dirname */
 
+const { execSync } = require('child_process');
 const path = require('path');
 const process = require('process');
 const { IgnorePlugin, ProvidePlugin } = require('webpack');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
+const devNull = process.platform === 'win32' ? 'nul' : '/dev/null';
+const commitHash = process.env.LIB_JITSI_MEET_COMMIT_HASH
+    || execSync(`git rev-parse --short HEAD 2>${devNull} || echo development`)
+        .toString()
+        .trim();
 
 module.exports = (minimize, analyzeBundle) => {
     return {
@@ -24,8 +30,7 @@ module.exports = (minimize, analyzeBundle) => {
                 loader: 'string-replace-loader',
                 options: {
                     flags: 'g',
-                    replace:
-                        process.env.LIB_JITSI_MEET_COMMIT_HASH || 'development',
+                    replace: commitHash,
                     search: '{#COMMIT_HASH#}'
                 },
                 test: path.join(__dirname, 'JitsiMeetJS.ts')


### PR DESCRIPTION
this moves the determination of the git commit to webpack-shared-config LIB_JITSI_MEET_COMMIT_HASH is still kept for backward compatibility

fix(build) in case git fails use development