### PR TITLE
fix(TPC): reconfigure the encodings to suspend/resume media after jvb<->p2p switch.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1388,11 +1388,6 @@ JitsiConference.prototype._setupNewTrack = function(newTrack) {
     this.rtc.addLocalTrack(newTrack);
     newTrack.setConference(this);
 
-    // Suspend media on the inactive media session since it gets automatically enabled for a newly added source.
-    if (this.isP2PActive()) {
-        this._suspendMediaTransferForJvbConnection();
-    }
-
     // Add event handlers.
     newTrack.muteHandler = this._fireMuteChangeEvent.bind(this, newTrack);
     newTrack.addEventListener(JitsiTrackEvents.TRACK_MUTE_CHANGED, newTrack.muteHandler);

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -409,20 +409,23 @@ export class TPCUtils {
         const encodingsState = videoStreamEncodings
         .map(encoding => height / encoding.scaleResolutionDownBy)
         .map((frameHeight, idx) => {
+            let activeState = false;
+
+            // When video is suspended on the media session.
+            if (!this.pc.videoTransferActive) {
+                return activeState;
+            }
+
             // Single video stream.
             if (!this.pc.isSpatialScalabilityOn() || this._isRunningInFullSvcMode(codec)) {
                 const { active } = this._calculateActiveEncodingParams(localVideoTrack, codec, newHeight);
 
-                return idx === 0 ? active : false;
+                return idx === 0 ? active : activeState;
             }
-
-            // Multiple video streams.
-            let active = false;
 
             if (newHeight > 0) {
                 if (localVideoTrack.getVideoType() === VideoType.CAMERA) {
-
-                    active = frameHeight <= newHeight
+                    activeState = frameHeight <= newHeight
 
                         // Keep the LD stream enabled even when the LD stream's resolution is higher than of the
                         // requested resolution. This can happen when camera is captured at high resolutions like 4k
@@ -433,12 +436,12 @@ export class TPCUtils {
                 } else {
                     // For screenshare, keep the HD layer enabled always and the lower layers only for high fps
                     // screensharing.
-                    active = videoStreamEncodings[idx].scaleResolutionDownBy === SIM_LAYERS[2].scaleFactor
+                    activeState = videoStreamEncodings[idx].scaleResolutionDownBy === SIM_LAYERS[2].scaleFactor
                         || !this._isScreenshareBitrateCapped(localVideoTrack);
                 }
             }
 
-            return active;
+            return activeState;
         });
 
         return encodingsState;

--- a/modules/RTC/TPCUtils.spec.js
+++ b/modules/RTC/TPCUtils.spec.js
@@ -224,6 +224,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -311,6 +312,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -441,6 +443,7 @@ describe('TPCUtils', () => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = true;
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -487,6 +490,7 @@ describe('TPCUtils', () => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
                 pc._capScreenshareBitrate = true;
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -528,6 +532,7 @@ describe('TPCUtils', () => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = false;
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -573,6 +578,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -655,6 +661,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -692,6 +699,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -780,6 +788,7 @@ describe('TPCUtils', () => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = true;
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -826,6 +835,7 @@ describe('TPCUtils', () => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = false;
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -871,6 +881,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -979,6 +990,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1087,6 +1099,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1154,6 +1167,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1191,6 +1205,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1285,6 +1300,7 @@ describe('TPCUtils', () => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = true;
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1333,6 +1349,7 @@ describe('TPCUtils', () => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = false;
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1380,6 +1397,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1447,6 +1465,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1484,6 +1503,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1595,6 +1615,7 @@ describe('TPCUtils', () => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = true;
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1641,6 +1662,7 @@ describe('TPCUtils', () => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = false;
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1686,6 +1708,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1753,6 +1776,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1821,6 +1845,7 @@ describe('TPCUtils', () => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
                 pc.options = { videoQuality };
                 pc._capScreenshareBitrate = false;
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -1884,6 +1909,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -2009,6 +2035,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -2128,6 +2155,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -2239,6 +2267,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -2351,6 +2380,7 @@ describe('TPCUtils', () => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
                 pc._capScreenshareBitrate = true;
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -2419,6 +2449,7 @@ describe('TPCUtils', () => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
                 pc._capScreenshareBitrate = false;
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -2486,6 +2517,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -2571,6 +2603,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -2657,6 +2690,7 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc.options = { videoQuality };
+                pc.videoTransferActive = true;
                 tpcUtils = new TPCUtils(pc);
             });
 
@@ -2744,6 +2778,7 @@ describe('TPCUtils', () => {
             pc = new MockPeerConnection('1', true, true /* simulcast */);
             pc.options = { videoQuality };
             pc._capScreenshareBitrate = true;
+            pc.videoTransferActive = true;
             const utils = new TPCUtils(pc);
 
             it('and requested desktop resolution is 2160', () => {
@@ -2861,6 +2896,7 @@ describe('TPCUtils', () => {
             pc = new MockPeerConnection('1', true, true /* simulcast */);
             pc.options = { videoQuality };
             pc._capScreenshareBitrate = true;
+            pc.videoTransferActive = true;
             const utils = new TPCUtils(pc);
 
             it('and requested desktop resolution is 2160', () => {
@@ -2955,6 +2991,86 @@ describe('TPCUtils', () => {
                 height = 0;
 
                 activeState = utils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(false);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+            });
+        });
+
+        describe('for VP9 camera tracks and the jvb connection is suspended', () => {
+            const track = new MockJitsiLocalTrack(720, 'video', 'camera');
+            const codec = CodecMimeType.VP9;
+
+            beforeEach(() => {
+                pc = new MockPeerConnection('1', true, true /* simulcast */);
+                pc.options = {};
+                pc.videoTransferActive = false;
+                tpcUtils = new TPCUtils(pc);
+            });
+
+            afterEach(() => {
+                pc = null;
+                tpcUtils = null;
+            });
+
+            it('and requested resolution is 720', () => {
+                height = 720;
+
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(false);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                bitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(bitrates[0]).toBe(1200000);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[2].scaleFactor);
+            });
+
+            it('and requested resolution is 360', () => {
+                height = 360;
+
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(false);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                bitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(bitrates[0]).toBe(300000);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[1].scaleFactor);
+            });
+
+            it('and requested resolution is 180', () => {
+                height = 180;
+
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
+                expect(activeState[0]).toBe(false);
+                expect(activeState[1]).toBe(false);
+                expect(activeState[2]).toBe(false);
+
+                bitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
+                expect(bitrates[0]).toBe(100000);
+
+                scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
+                expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
+
+                scaleFactor = tpcUtils.calculateEncodingsScaleFactor(track, codec, height);
+                expect(scaleFactor[0]).toBe(SIM_LAYERS[0].scaleFactor);
+            });
+
+            it('and requested resolution is 0', () => {
+                height = 0;
+
+                activeState = tpcUtils.calculateEncodingsActiveState(track, codec, height);
                 expect(activeState[0]).toBe(false);
                 expect(activeState[1]).toBe(false);
                 expect(activeState[2]).toBe(false);


### PR DESCRIPTION
Also fixes the issue with video freezing after video mute and unmute when the user joins the call with `config.startSilent=true`.