### PR TITLE
fix(flags) don't enable SSRC rewriting by default

### DIFF
--- a/modules/flags/FeatureFlags.js
+++ b/modules/flags/FeatureFlags.js
@@ -10,12 +10,12 @@ class FeatureFlags {
      *
      * @param {object} flags - The feature flags.
      * @param {boolean=} flags.runInLiteMode - Enables lite mode for testing to disable media decoding.
-     * @param {boolean=} flags.ssrcRewritingEnabled - Use SSRC rewriting. Requires sourceNameSignaling to be enabled.
+     * @param {boolean=} flags.ssrcRewritingEnabled - Use SSRC rewriting.
      * @param {boolean=} flags.enableJoinAsVisitor - Enable joining as a visitor.
      */
     init(flags) {
         this._runInLiteMode = Boolean(flags.runInLiteMode);
-        this._ssrcRewriting = flags.ssrcRewritingEnabled ?? true;
+        this._ssrcRewriting = Boolean(flags.ssrcRewritingEnabled);
         this._joinAsVisitor = Boolean(flags.enableJoinAsVisitor ?? true);
     }
 


### PR DESCRIPTION
We are going to work on making the tracks API backwards compatible and
re-enable it in the near future.
