### PR TITLE
fix(statistics) initialize LocalStatsCollector on Statistics.init

### DIFF
--- a/modules/statistics/LocalStatsCollector.js
+++ b/modules/statistics/LocalStatsCollector.js
@@ -137,6 +137,13 @@ LocalStatsCollector.prototype.stop = function() {
 };
 
 /**
+ * Initialize collector.
+ */
+LocalStatsCollector.init = function() {
+    LocalStatsCollector.connectAudioContext();
+};
+
+/**
  * Checks if the environment has the necessary conditions to support
  * collecting stats from local streams.
  *
@@ -170,8 +177,3 @@ LocalStatsCollector.connectAudioContext = function() {
 
     context.suspend();
 };
-
-/**
- * Initialize the audio context on startup.
- */
-LocalStatsCollector.connectAudioContext();

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -40,6 +40,8 @@ Statistics.init = function(options) {
 
     Statistics.disableThirdPartyRequests = options.disableThirdPartyRequests;
 
+    LocalStats.init();
+
     // WatchRTC is not required to work for react native
     browser.isReactNative()
         ? logger.warn('Cannot initialize WatchRTC in a react native environment!')


### PR DESCRIPTION
Creating the AudioContext at import time means a warning line is printed in the JS console even before the user has a chance of initializing the library, which is weird.

There is no harm in initializing it in init since it's the first thing the user needs to do in order to use the library.