### PR TITLE
Ref/move feature flags init

### DIFF
--- a/JitsiConnection.js
+++ b/JitsiConnection.js
@@ -1,5 +1,6 @@
 import JitsiConference from './JitsiConference';
 import * as JitsiConnectionEvents from './JitsiConnectionEvents';
+import FeatureFlags from './modules/flags/FeatureFlags';
 import Statistics from './modules/statistics/statistics';
 import XMPP from './modules/xmpp/xmpp';
 import {
@@ -21,6 +22,10 @@ export default function JitsiConnection(appID, token, options) {
     this.appID = appID;
     this.token = token;
     this.options = options;
+
+    // Initialize the feature flags so that they are advertised through the disco-info.
+    FeatureFlags.init(options.flags || {});
+
     this.xmpp = new XMPP(options, token);
 
     /* eslint-disable max-params */

--- a/JitsiMeetJS.ts
+++ b/JitsiMeetJS.ts
@@ -150,10 +150,6 @@ export default {
 
         Settings.init(options.externalStorage);
         Statistics.init(options);
-        const flags = options.flags || {};
-
-        // Configure the feature flags.
-        FeatureFlags.init(flags);
 
         // Initialize global window.connectionTimes
         // FIXME do not use 'window'

--- a/modules/flags/FeatureFlags.js
+++ b/modules/flags/FeatureFlags.js
@@ -11,12 +11,10 @@ class FeatureFlags {
      * @param {object} flags - The feature flags.
      * @param {boolean=} flags.runInLiteMode - Enables lite mode for testing to disable media decoding.
      * @param {boolean=} flags.ssrcRewritingEnabled - Use SSRC rewriting.
-     * @param {boolean=} flags.enableJoinAsVisitor - Enable joining as a visitor.
      */
     init(flags) {
         this._runInLiteMode = Boolean(flags.runInLiteMode);
         this._ssrcRewriting = Boolean(flags.ssrcRewritingEnabled);
-        this._joinAsVisitor = Boolean(flags.enableJoinAsVisitor ?? true);
     }
 
     /**
@@ -36,14 +34,6 @@ class FeatureFlags {
      */
     isSsrcRewritingSupported() {
         return this._ssrcRewriting;
-    }
-
-    /**
-     * Checks if the clients supports joining as a visitor.
-     * @returns {boolean}
-     */
-    isJoinAsVisitorSupported() {
-        return this._joinAsVisitor;
     }
 }
 

--- a/modules/flags/FeatureFlags.ts
+++ b/modules/flags/FeatureFlags.ts
@@ -1,10 +1,12 @@
-
 import browser from '../browser';
 
 /**
  * A global module for accessing information about different feature flags state.
  */
 class FeatureFlags {
+    private _runInLiteMode: boolean;
+    private _ssrcRewriting: boolean;
+    
     /**
      * Configures the module.
      *
@@ -12,7 +14,7 @@ class FeatureFlags {
      * @param {boolean=} flags.runInLiteMode - Enables lite mode for testing to disable media decoding.
      * @param {boolean=} flags.ssrcRewritingEnabled - Use SSRC rewriting.
      */
-    init(flags) {
+    init(flags: { runInLiteMode?: boolean | undefined; ssrcRewritingEnabled?: boolean | undefined; }) {
         this._runInLiteMode = Boolean(flags.runInLiteMode);
         this._ssrcRewriting = Boolean(flags.ssrcRewritingEnabled);
     }
@@ -24,7 +26,7 @@ class FeatureFlags {
      *
      * @returns {boolean}
      */
-    isRunInLiteModeEnabled() {
+    isRunInLiteModeEnabled(): boolean {
         return this._runInLiteMode && browser.supportsInsertableStreams();
     }
 
@@ -32,7 +34,7 @@ class FeatureFlags {
      * Checks if the clients supports re-writing of the SSRCs on the media streams by the bridge.
      * @returns {boolean}
      */
-    isSsrcRewritingSupported() {
+    isSsrcRewritingSupported(): boolean {
         return this._ssrcRewriting;
     }
 }

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -4,7 +4,6 @@ import $ from 'jquery';
 import { $iq } from 'strophe.js';
 
 import { CONNECTION_REDIRECTED } from '../../JitsiConnectionEvents';
-import FeatureFlags from '../flags/FeatureFlags';
 import Settings from '../settings/Settings';
 import Listenable from '../util/Listenable';
 
@@ -190,7 +189,7 @@ export default class Moderator extends Listenable {
             conferenceRequest.sessionId = sessionId;
         }
 
-        if (FeatureFlags.isJoinAsVisitorSupported() && !config.iAmRecorder && !config.iAmSipGateway) {
+        if (!config.iAmRecorder && !config.iAmSipGateway) {
             conferenceRequest.properties['visitors-version'] = 1;
 
             if (this.options.preferVisitor) {

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -263,9 +263,7 @@ export default class XMPP extends Listenable {
         // the version added in moderator.js, this one here is mostly defined
         // for keeping stats, since it is not made available to jocofo at
         // the time of the initial conference-request.
-        if (FeatureFlags.isJoinAsVisitorSupported()) {
-            this.caps.addFeature('http://jitsi.org/visitors-1');
-        }
+        this.caps.addFeature('http://jitsi.org/visitors-1');
     }
 
     /**


### PR DESCRIPTION
The feature flags need to be initialized before the xmpp connection is created so that the capabilities are advertised to Jicofo through disco-info.
See https://github.com/jitsi/jitsi-meet/pull/14567