### PR TITLE
fix(rtc) use exact deviceId constraints

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -122,7 +122,7 @@ function getConstraints(um = [], options = {}) {
             }
         }
         if (options.cameraDeviceId) {
-            constraints.video.deviceId = options.cameraDeviceId;
+            constraints.video.deviceId = { exact: options.cameraDeviceId };
         } else {
             const facingMode = options.facingMode || CameraFacingMode.USER;
 
@@ -139,10 +139,13 @@ function getConstraints(um = [], options = {}) {
 
         constraints.audio = {
             autoGainControl: !disableAGC && !disableAP,
-            deviceId: options.micDeviceId,
             echoCancellation: !disableAEC && !disableAP,
             noiseSuppression: !disableNS && !disableAP
         };
+
+        if (options.micDeviceId) {
+            constraints.audio.deviceId = { exact: options.micDeviceId };
+        }
 
         if (stereo) {
             Object.assign(constraints.audio, { channelCount: 2 });


### PR DESCRIPTION
webrtc-adapter transforms "deviceId": "foo" to "deviceId": { ideal: "foo"}.

This makes the camera non-selectable if the resolution constraints are not met.

Setting the constraint to exact will sidestep that adapter behavior, and express stronger intent.