### PR TITLE
Avoid adding multiple NETWORK_INFO_EVENT events causing memory leak.

### DIFF
--- a/modules/xmpp/ResumeTask.js
+++ b/modules/xmpp/ResumeTask.js
@@ -47,6 +47,7 @@ export default class ResumeTask {
      */
     schedule() {
         this._cancelResume();
+        this._removeNetworkOnlineListener();
 
         this._resumeRetryN += 1;
 
@@ -98,16 +99,24 @@ export default class ResumeTask {
      * @returns {void}
      */
     _cancelResume() {
-        if (this._networkOnlineListener) {
-            this._networkOnlineListener();
-            this._networkOnlineListener = null;
-        }
-
         if (this._resumeTimeout) {
             logger.info('Canceling connection resume task');
             clearTimeout(this._resumeTimeout);
             this._resumeTimeout = undefined;
             this._retryDelay = undefined;
+        }
+    }
+
+    /**
+     * Removes network online listener for the NETWORK_INFO_EVENT event.
+     *
+     * @private
+     * @returns {void}
+     */
+    _removeNetworkOnlineListener() {
+        if (this._networkOnlineListener) {
+            this._networkOnlineListener();
+            this._networkOnlineListener = null;
         }
     }
 
@@ -157,6 +166,7 @@ export default class ResumeTask {
      */
     cancel() {
         this._cancelResume();
+        this._removeNetworkOnlineListener();
         this._resumeRetryN = 0;
     }
 }

--- a/modules/xmpp/ResumeTask.js
+++ b/modules/xmpp/ResumeTask.js
@@ -49,7 +49,9 @@ export default class ResumeTask {
         this._cancelResume();
 
         this._resumeRetryN += 1;
-
+        if (this._networkOnlineListener) {
+            this._networkOnlineListener();
+        }
         this._networkOnlineListener
             = NetworkInfo.addCancellableListener(
                 NETWORK_INFO_EVENT,

--- a/modules/xmpp/ResumeTask.js
+++ b/modules/xmpp/ResumeTask.js
@@ -49,9 +49,7 @@ export default class ResumeTask {
         this._cancelResume();
 
         this._resumeRetryN += 1;
-        if (this._networkOnlineListener) {
-            this._networkOnlineListener();
-        }
+
         this._networkOnlineListener
             = NetworkInfo.addCancellableListener(
                 NETWORK_INFO_EVENT,
@@ -100,6 +98,11 @@ export default class ResumeTask {
      * @returns {void}
      */
     _cancelResume() {
+        if (this._networkOnlineListener) {
+            this._networkOnlineListener();
+            this._networkOnlineListener = null;
+        }
+
         if (this._resumeTimeout) {
             logger.info('Canceling connection resume task');
             clearTimeout(this._resumeTimeout);
@@ -155,9 +158,5 @@ export default class ResumeTask {
     cancel() {
         this._cancelResume();
         this._resumeRetryN = 0;
-        if (this._networkOnlineListener) {
-            this._networkOnlineListener();
-            this._networkOnlineListener = null;
-        }
     }
 }


### PR DESCRIPTION
This fixes #2505.