### PR TITLE
fix: Sends conference requests on retries of errors.

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -649,9 +649,6 @@ export default class ChatRoom extends Listenable {
                     this.sendPresence();
                 }
 
-                // we need to reset it because of breakout rooms which will reuse connection but will invite jicofo
-                this.xmpp.moderator.conferenceRequestSent = false;
-
                 this.eventEmitter.emit(XMPPEvents.MUC_JOINED);
 
                 // Now let's check the disco-info to retrieve the

--- a/modules/xmpp/moderator.js
+++ b/modules/xmpp/moderator.js
@@ -288,16 +288,6 @@ export default class Moderator extends Listenable {
      * rejected, and it'll keep on pinging Jicofo forever.
      */
     sendConferenceRequest(roomJid) {
-        // there is no point of sending conference iq when in visitor mode (disableFocus)
-        // when we have sent early the conference request via http
-        // we want to skip sending it here, or visitors can loop
-        if (this.conferenceRequestSent) {
-            return Promise.resolve();
-        }
-
-        // to mark whether we have already sent a conference request
-        this.conferenceRequestSent = false;
-
         return new Promise(resolve => {
             if (this.mode === 'xmpp') {
                 logger.info(`Sending conference request over XMPP to ${this.targetJid}`);
@@ -349,8 +339,6 @@ export default class Moderator extends Listenable {
                         this._handleError(roomJid);
                     });
             }
-        }).then(() => {
-            this.conferenceRequestSent = true;
         });
     }
 


### PR DESCRIPTION
This changes the behavior of retires when Room creation restricted error is received, we will always send the conference request to jicofo when retrying.
Also, after error for password protected rooms and providing password, a conference request was not send which can result jicofo left the room and error is received.
