### PR TITLE
ref(ssrc-rewriting): Fire track removed/added instead of owner changed.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1882,12 +1882,12 @@ JitsiConference.prototype.onMemberLeft = function(jid, reason) {
     }
 
     tracksToBeRemoved.forEach(track => {
+        // Fire the event before renegotiation is done so that the thumbnails can be removed immediately.
+        this.eventEmitter.emit(JitsiConferenceEvents.TRACK_REMOVED, track);
+
         if (FeatureFlags.isSsrcRewritingSupported()) {
             track.setSourceName(null);
             track.setOwner(null);
-        } else {
-            // Fire the event before renegotiation is done so that the thumbnails can be removed immediately.
-            this.eventEmitter.emit(JitsiConferenceEvents.TRACK_REMOVED, track);
         }
     });
 
@@ -2946,9 +2946,7 @@ JitsiConference.prototype._addRemoteP2PTracks = function() {
  */
 JitsiConference.prototype._addRemoteTracks = function(logName, remoteTracks) {
     for (const track of remoteTracks) {
-        // There will be orphan (with no owner) tracks when ssrc-rewriting is enabled and all of them need to be addded
-        // back to the conference.
-        if (FeatureFlags.isSsrcRewritingSupported() || this.participants.has(track.ownerEndpointId)) {
+        if (this.participants.has(track.ownerEndpointId)) {
             logger.info(`Adding remote ${logName} track: ${track}`);
             this.onRemoteTrackAdded(track);
         }

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -173,7 +173,10 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
         }
     });
 
-    chatRoom.addListener(JitsiTrackEvents.TRACK_REMOVED, track => {
+    chatRoom.addListener(JitsiTrackEvents.TRACK_OWNER_ADDED, track => {
+        conference.eventEmitter.emit(JitsiConferenceEvents.TRACK_ADDED, track);
+    });
+    chatRoom.addListener(JitsiTrackEvents.TRACK_OWNER_REMOVED, track => {
         conference.eventEmitter.emit(JitsiConferenceEvents.TRACK_REMOVED, track);
     });
 

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -173,11 +173,16 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
         }
     });
 
-    chatRoom.addListener(JitsiTrackEvents.TRACK_OWNER_ADDED, track => {
-        conference.eventEmitter.emit(JitsiConferenceEvents.TRACK_ADDED, track);
-    });
-    chatRoom.addListener(JitsiTrackEvents.TRACK_OWNER_REMOVED, track => {
-        conference.eventEmitter.emit(JitsiConferenceEvents.TRACK_REMOVED, track);
+    chatRoom.addListener(JitsiTrackEvents.TRACK_OWNER_SET, (track, owner, sourceName, videoType) => {
+        if (track.getParticipantId() !== owner || track.getSourceName() !== sourceName) {
+            conference.eventEmitter.emit(JitsiConferenceEvents.TRACK_REMOVED, track);
+
+            // Update the owner and other properties on the track.
+            track.setOwner(owner);
+            track.setSourceName(sourceName);
+            track._setVideoType(videoType);
+            owner && conference.eventEmitter.emit(JitsiConferenceEvents.TRACK_ADDED, track);
+        }
     });
 
     this.chatRoomForwarder.forward(XMPPEvents.ROOM_JOIN_ERROR,

--- a/JitsiTrackEvents.spec.ts
+++ b/JitsiTrackEvents.spec.ts
@@ -8,12 +8,12 @@ describe( "/JitsiTrackEvents members", () => {
         TRACK_AUDIO_LEVEL_CHANGED,
         TRACK_AUDIO_OUTPUT_CHANGED,
         TRACK_MUTE_CHANGED,
+        TRACK_OWNER_ADDED,
+        TRACK_OWNER_REMOVED,
         TRACK_STREAMING_STATUS_CHANGED,
         TRACK_VIDEOTYPE_CHANGED,
         NO_DATA_FROM_SOURCE,
         NO_AUDIO_INPUT,
-        TRACK_OWNER_CHANGED,
-        TRACK_REMOVED,
         JitsiTrackEvents,
         ...others
     } = exported;
@@ -23,12 +23,12 @@ describe( "/JitsiTrackEvents members", () => {
         expect( TRACK_AUDIO_LEVEL_CHANGED ).toBe( 'track.audioLevelsChanged' );
         expect( TRACK_AUDIO_OUTPUT_CHANGED ).toBe( 'track.audioOutputChanged' );
         expect( TRACK_MUTE_CHANGED ).toBe( 'track.trackMuteChanged' );
+        expect( TRACK_OWNER_ADDED ).toBe( 'track.owner_added' );
+        expect( TRACK_OWNER_REMOVED ).toBe( 'track.owner_removed' );
         expect( TRACK_STREAMING_STATUS_CHANGED ).toBe( 'track.streaming_status_changed' );
         expect( TRACK_VIDEOTYPE_CHANGED ).toBe( 'track.videoTypeChanged' );
         expect( NO_DATA_FROM_SOURCE ).toBe( 'track.no_data_from_source' );
         expect( NO_AUDIO_INPUT ).toBe( 'track.no_audio_input' );
-        expect( TRACK_OWNER_CHANGED ).toBe( 'track.owner_changed' );
-        expect( TRACK_REMOVED ).toBe( 'track.removed' );
 
         expect( JitsiTrackEvents ).toBeDefined();
 
@@ -36,12 +36,12 @@ describe( "/JitsiTrackEvents members", () => {
         expect( JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED ).toBe( 'track.audioLevelsChanged' );
         expect( JitsiTrackEvents.TRACK_AUDIO_OUTPUT_CHANGED ).toBe( 'track.audioOutputChanged' );
         expect( JitsiTrackEvents.TRACK_MUTE_CHANGED ).toBe( 'track.trackMuteChanged' );
+        expect( JitsiTrackEvents.TRACK_OWNER_ADDED ).toBe( 'track.owner_added' );
+        expect( JitsiTrackEvents.TRACK_OWNER_REMOVED ).toBe( 'track.owner_removed' );
         expect( JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED ).toBe( 'track.streaming_status_changed' );
         expect( JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED ).toBe( 'track.videoTypeChanged' );
         expect( JitsiTrackEvents.NO_DATA_FROM_SOURCE ).toBe( 'track.no_data_from_source' );
         expect( JitsiTrackEvents.NO_AUDIO_INPUT ).toBe( 'track.no_audio_input' );
-        expect( JitsiTrackEvents.TRACK_OWNER_CHANGED ).toBe( 'track.owner_changed' );
-        expect( JitsiTrackEvents.TRACK_REMOVED ).toBe( 'track.removed' );
     } );
 
     it( "unknown members", () => {

--- a/JitsiTrackEvents.spec.ts
+++ b/JitsiTrackEvents.spec.ts
@@ -8,8 +8,7 @@ describe( "/JitsiTrackEvents members", () => {
         TRACK_AUDIO_LEVEL_CHANGED,
         TRACK_AUDIO_OUTPUT_CHANGED,
         TRACK_MUTE_CHANGED,
-        TRACK_OWNER_ADDED,
-        TRACK_OWNER_REMOVED,
+        TRACK_OWNER_SET,
         TRACK_STREAMING_STATUS_CHANGED,
         TRACK_VIDEOTYPE_CHANGED,
         NO_DATA_FROM_SOURCE,
@@ -23,8 +22,7 @@ describe( "/JitsiTrackEvents members", () => {
         expect( TRACK_AUDIO_LEVEL_CHANGED ).toBe( 'track.audioLevelsChanged' );
         expect( TRACK_AUDIO_OUTPUT_CHANGED ).toBe( 'track.audioOutputChanged' );
         expect( TRACK_MUTE_CHANGED ).toBe( 'track.trackMuteChanged' );
-        expect( TRACK_OWNER_ADDED ).toBe( 'track.owner_added' );
-        expect( TRACK_OWNER_REMOVED ).toBe( 'track.owner_removed' );
+        expect( TRACK_OWNER_SET ).toBe( 'track.owner_set' );
         expect( TRACK_STREAMING_STATUS_CHANGED ).toBe( 'track.streaming_status_changed' );
         expect( TRACK_VIDEOTYPE_CHANGED ).toBe( 'track.videoTypeChanged' );
         expect( NO_DATA_FROM_SOURCE ).toBe( 'track.no_data_from_source' );
@@ -36,8 +34,7 @@ describe( "/JitsiTrackEvents members", () => {
         expect( JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED ).toBe( 'track.audioLevelsChanged' );
         expect( JitsiTrackEvents.TRACK_AUDIO_OUTPUT_CHANGED ).toBe( 'track.audioOutputChanged' );
         expect( JitsiTrackEvents.TRACK_MUTE_CHANGED ).toBe( 'track.trackMuteChanged' );
-        expect( JitsiTrackEvents.TRACK_OWNER_ADDED ).toBe( 'track.owner_added' );
-        expect( JitsiTrackEvents.TRACK_OWNER_REMOVED ).toBe( 'track.owner_removed' );
+        expect( JitsiTrackEvents.TRACK_OWNER_SET ).toBe( 'track.owner_set' );
         expect( JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED ).toBe( 'track.streaming_status_changed' );
         expect( JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED ).toBe( 'track.videoTypeChanged' );
         expect( JitsiTrackEvents.NO_DATA_FROM_SOURCE ).toBe( 'track.no_data_from_source' );

--- a/JitsiTrackEvents.ts
+++ b/JitsiTrackEvents.ts
@@ -48,12 +48,7 @@ export enum JitsiTrackEvents {
     /**
      * Indicates that a new owner has been assigned to a remote track when SSRC rewriting is enabled.
      */
-    TRACK_OWNER_ADDED = 'track.owner_added',
-
-    /**
-     * Indicates that an owner has been removed from a remote track when SSRC rewriting is enabled.
-     */
-    TRACK_OWNER_REMOVED = 'track.owner_removed',
+    TRACK_OWNER_SET = 'track.owner_set',
 
     /**
      * Event fired whenever video track's streaming changes.
@@ -77,6 +72,5 @@ export const TRACK_MUTE_CHANGED = JitsiTrackEvents.TRACK_MUTE_CHANGED;
 export const TRACK_VIDEOTYPE_CHANGED = JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED;
 export const NO_DATA_FROM_SOURCE = JitsiTrackEvents.NO_DATA_FROM_SOURCE;
 export const NO_AUDIO_INPUT = JitsiTrackEvents.NO_AUDIO_INPUT;
-export const TRACK_OWNER_ADDED = JitsiTrackEvents.TRACK_OWNER_ADDED;
-export const TRACK_OWNER_REMOVED = JitsiTrackEvents.TRACK_OWNER_REMOVED;
+export const TRACK_OWNER_SET = JitsiTrackEvents.TRACK_OWNER_SET;
 export const TRACK_STREAMING_STATUS_CHANGED = JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED;

--- a/JitsiTrackEvents.ts
+++ b/JitsiTrackEvents.ts
@@ -46,6 +46,16 @@ export enum JitsiTrackEvents {
     NO_AUDIO_INPUT = 'track.no_audio_input',
 
     /**
+     * Indicates that a new owner has been assigned to a remote track when SSRC rewriting is enabled.
+     */
+    TRACK_OWNER_ADDED = 'track.owner_added',
+
+    /**
+     * Indicates that an owner has been removed from a remote track when SSRC rewriting is enabled.
+     */
+    TRACK_OWNER_REMOVED = 'track.owner_removed',
+
+    /**
      * Event fired whenever video track's streaming changes.
      * First argument is the sourceName of the track and the second is a string indicating if the connection is currently
      * - active - the connection is active.
@@ -57,17 +67,6 @@ export enum JitsiTrackEvents {
      * The current status value can be obtained by calling JitsiRemoteTrack.getTrackStreamingStatus().
      */
     TRACK_STREAMING_STATUS_CHANGED = 'track.streaming_status_changed',
-
-    /**
-     * An SSRC has been remapped. The track is now associated with a new participant.
-     */
-    TRACK_OWNER_CHANGED = 'track.owner_changed',
-
-    /**
-     * A track is being removed. Fired when a session terminates for tracks
-     * that persist in ssrc-rewriting mode.
-     */
-    TRACK_REMOVED = 'track.removed',
 };
 
 // exported for backward compatibility
@@ -78,6 +77,6 @@ export const TRACK_MUTE_CHANGED = JitsiTrackEvents.TRACK_MUTE_CHANGED;
 export const TRACK_VIDEOTYPE_CHANGED = JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED;
 export const NO_DATA_FROM_SOURCE = JitsiTrackEvents.NO_DATA_FROM_SOURCE;
 export const NO_AUDIO_INPUT = JitsiTrackEvents.NO_AUDIO_INPUT;
+export const TRACK_OWNER_ADDED = JitsiTrackEvents.TRACK_OWNER_ADDED;
+export const TRACK_OWNER_REMOVED = JitsiTrackEvents.TRACK_OWNER_REMOVED;
 export const TRACK_STREAMING_STATUS_CHANGED = JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED;
-export const TRACK_OWNER_CHANGED = JitsiTrackEvents.TRACK_OWNER_CHANGED;
-export const TRACK_REMOVED = JitsiTrackEvents.TRACK_REMOVED;

--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -280,7 +280,6 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      */
     setOwner(owner) {
         this.ownerEndpointId = owner;
-        this.emit(JitsiTrackEvents.TRACK_OWNER_CHANGED, owner);
     }
 
     /**

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1081,26 +1081,6 @@ TraceablePeerConnection.prototype._remoteTrackRemoved = function(stream, track) 
 };
 
 /**
- * Removes all JitsiRemoteTracks associated with given MUC nickname (resource part of the JID).
- *
- * @param {string} owner - The resource part of the MUC JID.
- * @returns {JitsiRemoteTrack[]} - The array of removed tracks.
- */
-TraceablePeerConnection.prototype.removeRemoteTracks = function(owner) {
-    let removedTracks = [];
-    const remoteTracksByMedia = this.remoteTracks.get(owner);
-
-    if (remoteTracksByMedia) {
-        removedTracks = removedTracks.concat(Array.from(remoteTracksByMedia.get(MediaType.AUDIO)));
-        removedTracks = removedTracks.concat(Array.from(remoteTracksByMedia.get(MediaType.VIDEO)));
-        this.remoteTracks.delete(owner);
-    }
-    logger.debug(`${this} removed remote tracks[endpoint=${owner},count=${removedTracks.length}`);
-
-    return removedTracks;
-};
-
-/**
  * Removes and disposes given <tt>JitsiRemoteTrack</tt> instance. Emits {@link RTCEvents.REMOTE_TRACK_REMOVED}.
  *
  * @param {JitsiRemoteTrack} toBeRemoved - The remote track to be removed.

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1777,32 +1777,21 @@ export default class JingleSessionPC extends JingleSession {
                     const track = this.peerconnection.getTrackBySSRC(oldSsrc);
 
                     if (track) {
-                        track.setSourceName(null);
-                        track.setOwner(null);
-                        track._setVideoType(null);
-                        this.room.eventEmitter.emit(JitsiTrackEvents.TRACK_OWNER_REMOVED, track);
+                        this.room.eventEmitter.emit(JitsiTrackEvents.TRACK_OWNER_SET, track);
                     }
                 }
             } else {
                 logger.debug(`Existing SSRC re-mapped ${ssrc}: new owner=${owner}, source-name=${source}`);
                 const track = this.peerconnection.getTrackBySSRC(ssrc);
 
-                this.room.eventEmitter.emit(JitsiTrackEvents.TRACK_OWNER_REMOVED, track);
-
                 this._signalingLayer.setSSRCOwner(ssrc, owner, source);
-                track.setSourceName(source);
-                track.setOwner(owner);
-
-                this.room.eventEmitter.emit(JitsiTrackEvents.TRACK_OWNER_ADDED, track);
 
                 // Update the muted state and the video type on the track since the presence for this track could have
                 // been received before the updated source map is received on the bridge channel.
-                const peerMediaInfo = this._signalingLayer.getPeerMediaInfo(owner, mediaType, source);
+                const { muted, videoType } = this._signalingLayer.getPeerMediaInfo(owner, mediaType, source);
 
-                if (peerMediaInfo) {
-                    track._setVideoType(peerMediaInfo.videoType);
-                    this.peerconnection._sourceMutedChanged(source, peerMediaInfo.muted);
-                }
+                muted && this.peerconnection._sourceMutedChanged(source, muted);
+                this.room.eventEmitter.emit(JitsiTrackEvents.TRACK_OWNER_SET, track, owner, source, videoType);
             }
         }
 

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1777,18 +1777,23 @@ export default class JingleSessionPC extends JingleSession {
                     const track = this.peerconnection.getTrackBySSRC(oldSsrc);
 
                     if (track) {
-                        track.setSourceName(undefined);
-                        track.setOwner(undefined);
-                        track._setVideoType(undefined);
+                        track.setSourceName(null);
+                        track.setOwner(null);
+                        track._setVideoType(null);
+                        this.room.eventEmitter.emit(JitsiTrackEvents.TRACK_OWNER_REMOVED, track);
                     }
                 }
             } else {
                 logger.debug(`Existing SSRC re-mapped ${ssrc}: new owner=${owner}, source-name=${source}`);
                 const track = this.peerconnection.getTrackBySSRC(ssrc);
 
+                this.room.eventEmitter.emit(JitsiTrackEvents.TRACK_OWNER_REMOVED, track);
+
                 this._signalingLayer.setSSRCOwner(ssrc, owner, source);
                 track.setSourceName(source);
                 track.setOwner(owner);
+
+                this.room.eventEmitter.emit(JitsiTrackEvents.TRACK_OWNER_ADDED, track);
 
                 // Update the muted state and the video type on the track since the presence for this track could have
                 // been received before the updated source map is received on the bridge channel.


### PR DESCRIPTION
When an existing SSRC for a remote track gets re-mapped from one source to another, fire a TRACK_REMOVED event followed by TRACK_ADDED event instead of TRACK_OWNER_CHANGED event. This should simplify the application logic for track handling when SSRC rewriting is enabled.