### PR TITLE
fix(TPC): Do not reconfigure the encodings for Safari audio.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1829,10 +1829,9 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
                     = newTrack || browser.isFirefox() ? MediaDirection.SENDRECV : MediaDirection.RECVONLY;
             }
 
-            // Avoid configuring the video encodings on Chromium/Safari until simulcast is configured
-            // for the newly added video track using SDP munging which happens during the renegotiation.
+            // Avoid re-configuring the encodings on Chromium/Safari, this is needed only on Firefox.
             const configureEncodingsPromise
-                = !newTrack || (newTrack.getType() === MediaType.VIDEO && browser.usesSdpMungingForSimulcast())
+                = !newTrack || browser.usesSdpMungingForSimulcast()
                     ? Promise.resolve()
                     : this.tpcUtils.setEncodings(newTrack);
 


### PR DESCRIPTION
Fixes an issues where microphone change for Safari fails.