### PR TITLE
fix(ssrc-rewriting): Check for track owner/sourceName before calling TRACK_OWNER_SET.

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -528,15 +528,11 @@ JitsiConferenceEventManager.prototype.setupRTCListeners = function() {
     });
 
     rtc.addListener(RTCEvents.VIDEO_SSRCS_REMAPPED, msg => {
-        for (const session of this.conference.getMediaSessions()) {
-            session.processSourceMap(msg, MediaType.VIDEO);
-        }
+        this.conference.jvbJingleSession.processSourceMap(msg, MediaType.VIDEO);
     });
 
     rtc.addListener(RTCEvents.AUDIO_SSRCS_REMAPPED, msg => {
-        for (const session of this.conference.getMediaSessions()) {
-            session.processSourceMap(msg, MediaType.AUDIO);
-        }
+        this.conference.jvbJingleSession.processSourceMap(msg, MediaType.AUDIO);
     });
 
     rtc.addListener(RTCEvents.ENDPOINT_MESSAGE_RECEIVED,

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1781,8 +1781,12 @@ export default class JingleSessionPC extends JingleSession {
                     }
                 }
             } else {
-                logger.debug(`Existing SSRC re-mapped ${ssrc}: new owner=${owner}, source-name=${source}`);
                 const track = this.peerconnection.getTrackBySSRC(ssrc);
+
+                if (track.getParticipantId() === owner && track.getSourceName() === source) {
+                    continue; // eslint-disable-line no-continue
+                }
+                logger.debug(`Existing SSRC re-mapped ${ssrc}: new owner=${owner}, source-name=${source}`);
 
                 this._signalingLayer.setSSRCOwner(ssrc, owner, source);
 


### PR DESCRIPTION
When the bridge WS is re-established, JVB sends the full map of audio and video sources. Without the check, the library will end up firing TRACK_REMOVED and TRACK_ADDED for all the exiting tracks. Also, process audio and video source maps only on JVB sessions.