### PR TITLE
Expose `track.conference` field in types

### DIFF
--- a/types/hand-crafted/modules/RTC/JitsiRemoteTrack.d.ts
+++ b/types/hand-crafted/modules/RTC/JitsiRemoteTrack.d.ts
@@ -4,6 +4,7 @@ import JitsiConference from '../../JitsiConference';
 
 export default class JitsiRemoteTrack extends JitsiTrack {
   constructor(rtc: RTC, conference: JitsiConference, ownerEndpointId: string, stream: MediaStream, track: MediaStreamTrack, mediaType: any, videoType: any, ssrc: number, muted: boolean, isP2P: boolean);
+  readonly conference: JitsiConference;
   setMute: ( value: boolean ) => void;
   isMuted: () => boolean;
   getParticipantId: () => string;

--- a/types/hand-crafted/modules/RTC/JitsiTrack.d.ts
+++ b/types/hand-crafted/modules/RTC/JitsiTrack.d.ts
@@ -6,6 +6,7 @@ import TraceablePeerConnection from './TraceablePeerConnection';
 
 export default class JitsiTrack extends EventEmitter {
   constructor( conference: JitsiConference, stream: unknown, track: unknown, streamInactiveHandler: unknown, trackMediaType: MediaType, videoType: VideoType ); // TODO:
+  readonly conference: null | JitsiConference;
   disposed: boolean;
   getVideoType: () => VideoType;
   getType: () => MediaType;


### PR DESCRIPTION
There's a field `jitsiTrack.conference` that keeps a reference to the track's owning conference. It does not have a corresponding TypeScript definition. This PR adds a type definition.

- `JitsiLocalTrack.conference`: `null` if it hasn't been added to a conference yet
- `JitsiRemoteTrack.conference`: non-nullable, always associated with a conference

(We're using this in our application.)