### PR TITLE
feat(codec-selection): Use the new codec selection API

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -390,14 +390,20 @@ JitsiConference.prototype._init = function(options = {}) {
                 ? config.videoQuality.mobileCodecPreferenceOrder
                 : config.videoQuality?.codecPreferenceOrder,
             disabledCodec: _getCodecMimeType(config.videoQuality?.disabledCodec),
-            preferredCodec: _getCodecMimeType(config.videoQuality?.preferredCodec)
+            preferredCodec: _getCodecMimeType(config.videoQuality?.preferredCodec),
+            screenshareCodec: browser.isMobileDevice()
+                ? _getCodecMimeType(config.videoQuality?.mobileScreenshareCodec)
+                : _getCodecMimeType(config.videoQuality?.screenshareCodec)
         },
         p2p: {
             preferenceOrder: browser.isMobileDevice() && config.p2p?.mobileCodecPreferenceOrder
                 ? config.p2p.mobileCodecPreferenceOrder
                 : config.p2p?.codecPreferenceOrder,
             disabledCodec: _getCodecMimeType(config.p2p?.disabledCodec),
-            preferredCodec: _getCodecMimeType(config.p2p?.preferredCodec)
+            preferredCodec: _getCodecMimeType(config.p2p?.preferredCodec),
+            screenshareCodec: browser.isMobileDevice()
+                ? _getCodecMimeType(config.p2p?.mobileScreenshareCodec)
+                : _getCodecMimeType(config.p2p?.screenshareCodec)
         }
     };
 
@@ -2198,7 +2204,8 @@ JitsiConference.prototype._acceptJvbIncomingCall = function(jingleSession, jingl
                 ...this.options.config,
                 codecSettings: {
                     mediaType: MediaType.VIDEO,
-                    codecList: this.codecSelection.getCodecPreferenceList('jvb')
+                    codecList: this.codecSelection.getCodecPreferenceList('jvb'),
+                    screenshareCodec: this.codecSelection.getScreenshareCodec('jvb')
                 },
                 enableInsertableStreams: this.isE2EEEnabled() || FeatureFlags.isRunInLiteModeEnabled()
             });
@@ -2908,7 +2915,8 @@ JitsiConference.prototype._acceptP2PIncomingCall = function(jingleSession, jingl
             ...this.options.config,
             codecSettings: {
                 mediaType: MediaType.VIDEO,
-                codecList: this.codecSelection.getCodecPreferenceList('p2p')
+                codecList: this.codecSelection.getCodecPreferenceList('p2p'),
+                screenshareCodec: this.codecSelection.getScreenshareCodec('p2p')
             },
             enableInsertableStreams: this.isE2EEEnabled() || FeatureFlags.isRunInLiteModeEnabled()
         });
@@ -3263,7 +3271,8 @@ JitsiConference.prototype._startP2PSession = function(remoteJid) {
             ...this.options.config,
             codecSettings: {
                 mediaType: MediaType.VIDEO,
-                codecList: this.codecSelection.getCodecPreferenceList('p2p')
+                codecList: this.codecSelection.getCodecPreferenceList('p2p'),
+                screenshareCodec: this.codecSelection.getScreenshareCodec('p2p')
             },
             enableInsertableStreams: this.isE2EEEnabled() || FeatureFlags.isRunInLiteModeEnabled()
         });

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -734,6 +734,11 @@ JitsiConferenceEventManager.prototype.setupStatisticsListeners = function() {
             JitsiConferenceEvents.BEFORE_STATISTICS_DISPOSED);
     });
 
+    conference.statistics.addEncodeTimeStatsListener((tpc, stats) => {
+        conference.eventEmitter.emit(
+            JitsiConferenceEvents.ENCODE_TIME_STATS_RECEIVED, tpc, stats);
+    });
+
     // if we are in startSilent mode we will not be sending/receiving so nothing to detect
     if (!conference.options.config.startSilent) {
         conference.statistics.addByteSentStatsListener((tpc, stats) => {

--- a/JitsiConferenceEvents.spec.ts
+++ b/JitsiConferenceEvents.spec.ts
@@ -27,6 +27,7 @@ describe( "/JitsiConferenceEvents members", () => {
         E2EE_VERIFICATION_AVAILABLE,
         E2EE_VERIFICATION_READY,
         E2EE_VERIFICATION_COMPLETED,
+        ENCODE_TIME_STATS_RECEIVED,
         ENDPOINT_MESSAGE_RECEIVED,
         ENDPOINT_STATS_RECEIVED,
         JVB121_STATUS,
@@ -166,6 +167,7 @@ describe( "/JitsiConferenceEvents members", () => {
         expect( BREAKOUT_ROOMS_MOVE_TO_ROOM ).toBe( 'conference.breakout-rooms.move-to-room' );
         expect( BREAKOUT_ROOMS_UPDATED ).toBe( 'conference.breakout-rooms.updated' );
         expect( METADATA_UPDATED ).toBe( 'conference.metadata.updated' );
+        expect( ENCODE_TIME_STATS_RECEIVED ).toBe( 'conference.encode_time_stats_received' );
 
         expect( JitsiConferenceEvents ).toBeDefined();
 
@@ -188,6 +190,7 @@ describe( "/JitsiConferenceEvents members", () => {
         expect( JitsiConferenceEvents.DOMINANT_SPEAKER_CHANGED ).toBe( 'conference.dominantSpeaker' );
         expect( JitsiConferenceEvents.CONFERENCE_CREATED_TIMESTAMP ).toBe( 'conference.createdTimestamp' );
         expect( JitsiConferenceEvents.DTMF_SUPPORT_CHANGED ).toBe( 'conference.dtmfSupportChanged' );
+        expect( JitsiConferenceEvents.ENCODE_TIME_STATS_RECEIVED ).toBe( 'conference.encode_time_stats_received' );
         expect( JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED ).toBe( 'conference.endpoint_message_received' );
         expect( JitsiConferenceEvents.ENDPOINT_STATS_RECEIVED ).toBe( 'conference.endpoint_stats_received' );
         expect( JitsiConferenceEvents.JVB121_STATUS ).toBe( 'conference.jvb121Status' );

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -194,6 +194,11 @@ export enum JitsiConferenceEvents {
     E2EE_VERIFICATION_READY = 'conference.e2ee.verification.ready',
 
     /**
+     * Indicates that the encode time stats for the local video sources has been received.
+     */
+    ENCODE_TIME_STATS_RECEIVED = 'conference.encode_time_stats_received',
+
+    /**
      * Indicates that a message from another participant is received on data
      * channel.
      */
@@ -518,6 +523,7 @@ export const DTMF_SUPPORT_CHANGED = JitsiConferenceEvents.DTMF_SUPPORT_CHANGED;
 export const E2EE_VERIFICATION_AVAILABLE = JitsiConferenceEvents.E2EE_VERIFICATION_AVAILABLE;
 export const E2EE_VERIFICATION_COMPLETED = JitsiConferenceEvents.E2EE_VERIFICATION_COMPLETED;
 export const E2EE_VERIFICATION_READY = JitsiConferenceEvents.E2EE_VERIFICATION_READY;
+export const ENCODE_TIME_STATS_RECEIVED = JitsiConferenceEvents.ENCODE_TIME_STATS_RECEIVED;
 export const ENDPOINT_MESSAGE_RECEIVED = JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED;
 export const ENDPOINT_STATS_RECEIVED = JitsiConferenceEvents.ENDPOINT_STATS_RECEIVED;
 export const FORWARDED_SOURCES_CHANGED = JitsiConferenceEvents.FORWARDED_SOURCES_CHANGED;

--- a/modules/RTC/CodecSelection.js
+++ b/modules/RTC/CodecSelection.js
@@ -148,7 +148,7 @@ export class CodecSelection {
         const activeSession = this.conference.getActiveMediaSession();
 
         // Process stats only for the active media session.
-        if (activeSession.peerconnection.id !== tpc.id) {
+        if (activeSession.peerconnection !== tpc) {
             return;
         }
 

--- a/modules/RTC/CodecSelection.js
+++ b/modules/RTC/CodecSelection.js
@@ -166,13 +166,14 @@ export class CodecSelection {
             };
 
             if (existingStats) {
-                existingStats.trackStats.push(ssrcStats);
+                existingStats.codec = codec;
                 existingStats.timestamp = timestamp;
+                existingStats.trackStats.push(ssrcStats);
             } else {
                 existingStats = {
-                    trackStats: [ ssrcStats ],
-                    currentCodec: codec,
-                    timestamp
+                    codec,
+                    timestamp,
+                    trackStats: [ ssrcStats ]
                 };
 
                 statsPerTrack.set(track.rtcId, existingStats);
@@ -181,7 +182,7 @@ export class CodecSelection {
 
         // Aggregate the stats for multiple simulcast streams with different SSRCs but for the same video stream.
         for (const trackId of statsPerTrack.keys()) {
-            const { currentCodec, timestamp, trackStats } = statsPerTrack.get(trackId);
+            const { codec, timestamp, trackStats } = statsPerTrack.get(trackId);
             const totalEncodeTime = trackStats
                 .map(stat => stat.encodeTime)
                 .reduce((totalValue, currentValue) => totalValue + currentValue, 0);
@@ -196,7 +197,7 @@ export class CodecSelection {
             const exisitingStats = this.encodeTimeStats.get(trackId);
             const sourceStats = {
                 avgEncodeTime,
-                currentCodec,
+                codec,
                 encodeResolution,
                 qualityLimitationReason,
                 localTrack,
@@ -209,7 +210,7 @@ export class CodecSelection {
                 this.encodeTimeStats.set(trackId, [ sourceStats ]);
             }
 
-            logger.debug(`Encode stats for ${localTrack}: codec=${currentCodec}, time=${avgEncodeTime},`
+            logger.debug(`Encode stats for ${localTrack}: codec=${codec}, time=${avgEncodeTime},`
                 + `resolution=${encodeResolution}, qualityLimitationReason=${qualityLimitationReason}`);
         }
     }

--- a/modules/RTC/CodecSelection.spec.js
+++ b/modules/RTC/CodecSelection.spec.js
@@ -135,7 +135,7 @@ describe('Codec Selection', () => {
             participant1 = new MockParticipant('remote-1');
             conference.addParticipant(participant1, [ 'vp9', 'vp8' ]);
 
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(0);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(1);
 
             // Add a third user joining the call with a subset of codecs.
             participant2 = new MockParticipant('remote-2');
@@ -145,7 +145,7 @@ describe('Codec Selection', () => {
 
             // Make p2 leave the call
             conference.removeParticipant(participant2);
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(1);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(3);
         });
 
         it('and remote endpoints use the old codec selection logic (RN)', () => {
@@ -163,7 +163,7 @@ describe('Codec Selection', () => {
 
             // Make p1 leave the call
             conference.removeParticipant(participant1);
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(2);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(3);
         });
     });
 
@@ -185,7 +185,7 @@ describe('Codec Selection', () => {
             participant1 = new MockParticipant('remote-1');
             conference.addParticipant(participant1, [ 'vp9', 'vp8', 'h264' ]);
 
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(0);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(1);
 
             // Add a third user joining the call with a subset of codecs.
             participant2 = new MockParticipant('remote-2');
@@ -195,7 +195,7 @@ describe('Codec Selection', () => {
 
             // Make p2 leave the call
             conference.removeParticipant(participant2);
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(1);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(3);
         });
 
         it('and remote endpoint prefers a codec that is locally disabled', () => {
@@ -221,7 +221,7 @@ describe('Codec Selection', () => {
 
             // Make p1 leave the call
             conference.removeParticipant(participant1);
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(2);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(3);
         });
     });
 });

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1601,6 +1601,18 @@ TraceablePeerConnection.prototype._assertTrackBelongs = function(
  * video in the local SDP.
  */
 TraceablePeerConnection.prototype.getConfiguredVideoCodec = function() {
+    const localVideoTrack = this.getLocalVideoTracks()[0];
+
+    if (this._usesCodecSelectionAPI && localVideoTrack) {
+        const rtpSender = this.findSenderForTrack(localVideoTrack.getTrack());
+
+        if (rtpSender) {
+            const { codecs } = rtpSender.getParameters();
+
+            return codecs[0].mimeType.split('/')[1].toLowerCase();
+        }
+    }
+
     const sdp = this.peerconnection.remoteDescription?.sdp;
     const defaultCodec = CodecMimeType.VP8;
 

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -141,6 +141,18 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
+     * Checks if the browser supports the new codec selection API, i.e., checks if dictionary member
+     * RTCRtpEncodingParameters.codec as defined in
+     * https://w3c.github.io/webrtc-extensions/#dom-rtcrtpencodingparameters-codec is supported by the browser. It
+     * allows the application to change the current codec used by each RTCRtpSender without a renegotiation.
+     *
+     * @returns {boolean}
+     */
+    supportsCodecSelectionAPI() {
+        return this.isChromiumBased() && this.isEngineVersionGreaterThan(125);
+    }
+
+    /**
      * Returns true if the browser supports Dependency Descriptor header extension.
      *
      * @returns {boolean}

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -658,7 +658,9 @@ StatsCollector.prototype.processStatsReport = function() {
                     && track?.isVideoTrack()
                     && this.peerconnection.usesCodecSelectionAPI()
                     && before?.totalEncodeTime
-                    && before?.framesEncoded) {
+                    && before?.framesEncoded
+                    && now.frameHeight
+                    && now.frameWidth) {
                     const encodeTimeDelta = now.totalEncodeTime - before.totalEncodeTime;
                     const framesEncodedDelta = now.framesEncoded - before.framesEncoded;
                     const encodeTimePerFrameInMs = 1000 * encodeTimeDelta / framesEncodedDelta;

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -651,7 +651,7 @@ StatsCollector.prototype.processStatsReport = function() {
                 codecShortType && ssrcStats.setCodec(codecShortType);
 
                 // Calculate the encodeTime stat for outbound video streams.
-                const track = this.peerconnection.getTrackBySSRC(ssrc, false);
+                const track = this.peerconnection.getTrackBySSRC(ssrc);
 
                 if (now.type === 'outbound-rtp'
                     && now.active
@@ -667,7 +667,7 @@ StatsCollector.prototype.processStatsReport = function() {
                     const encodeTimeStats = {
                         codec: codecShortType,
                         encodeTime: encodeTimePerFrameInMs,
-                        isBandwidthLimited: now.qualityLimitationReason === 'bandwidth',
+                        qualityLimitationReason: now.qualityLimitationReason,
                         resolution,
                         timestamp: now.timestamp
                     };

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -84,6 +84,10 @@ SsrcStats.prototype.setCodec = function(codec) {
     this.codec = codec || '';
 };
 
+SsrcStats.prototype.setEncodeStats = function(encodeStats) {
+    this.encodeStats = encodeStats || {};
+};
+
 /**
  *
  */
@@ -493,6 +497,7 @@ StatsCollector.prototype._calculateFps = function(now, before, fieldName) {
  */
 StatsCollector.prototype.processStatsReport = function() {
     const byteSentStats = {};
+    const encodedTimeStatsPerSsrc = new Map();
 
     this.currentStatsReport.forEach(now => {
         const before = this.previousStatsReport ? this.previousStatsReport.get(now.id) : null;
@@ -638,13 +643,36 @@ StatsCollector.prototype.processStatsReport = function() {
 
             if (codec) {
                 /**
-                 * The mime type has the following form: video/VP8 or audio/ISAC,
-                 * so we what to keep just the type after the '/', audio and video
-                 * keys will be added on the processing side.
+                 * The mime type has the following form: video/VP8 or audio/ISAC, so we what to keep just the type
+                 * after the '/', audio and video keys will be added on the processing side.
                  */
                 const codecShortType = codec.mimeType.split('/')[1];
 
                 codecShortType && ssrcStats.setCodec(codecShortType);
+
+                // Calculate the encodeTime stat for outbound video streams.
+                const track = this.peerconnection.getTrackBySSRC(ssrc, false);
+
+                if (now.type === 'outbound-rtp'
+                    && now.active
+                    && track?.isVideoTrack()
+                    && this.peerconnection.usesCodecSelectionAPI()
+                    && before?.totalEncodeTime
+                    && before?.framesEncoded) {
+                    const encodeTimeDelta = now.totalEncodeTime - before.totalEncodeTime;
+                    const framesEncodedDelta = now.framesEncoded - before.framesEncoded;
+                    const encodeTimePerFrameInMs = 1000 * encodeTimeDelta / framesEncodedDelta;
+                    const encodeTimeStats = {
+                        codec: codecShortType,
+                        encodeTime: encodeTimePerFrameInMs,
+                        isBandwidthLimited: now.qualityLimitationReason === 'bandwidth',
+                        resolution,
+                        timestamp: now.timestamp
+                    };
+
+                    encodedTimeStatsPerSsrc.set(ssrc, encodeTimeStats);
+                    ssrcStats.setEncodeStats(encodedTimeStatsPerSsrc);
+                }
             }
 
         // Continue to use the 'track' based stats for Firefox and Safari and older versions of Chromium.
@@ -690,6 +718,10 @@ StatsCollector.prototype.processStatsReport = function() {
 
     if (Object.keys(byteSentStats).length) {
         this.eventEmitter.emit(StatisticsEvents.BYTE_SENT_STATS, this.peerconnection, byteSentStats);
+    }
+
+    if (encodedTimeStatsPerSsrc.size) {
+        this.eventEmitter.emit(StatisticsEvents.ENCODE_TIME_STATS, this.peerconnection, encodedTimeStatsPerSsrc);
     }
 
     this._processAndEmitReport();

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -203,6 +203,14 @@ Statistics.prototype.removeConnectionStatsListener = function(listener) {
         listener);
 };
 
+Statistics.prototype.addEncodeTimeStatsListener = function(listener) {
+    this.eventEmitter.on(StatisticsEvents.ENCODE_TIME_STATS, listener);
+};
+
+Statistics.prototype.removeEncodeTimeStatsListener = function(listener) {
+    this.eventEmitter.removeListener(StatisticsEvents.ENCODE_TIME_STATS, listener);
+};
+
 Statistics.prototype.addByteSentStatsListener = function(listener) {
     this.eventEmitter.on(StatisticsEvents.BYTE_SENT_STATS, listener);
 };

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1192,6 +1192,13 @@ export default class JingleSessionPC extends JingleSession {
                 return;
             }
 
+            // Skip renegotiation when the selected codec order matches with that of the remote SDP.
+            const currentCodecOrder = this.peerconnection.getConfiguredVideoCodecs();
+
+            if (codecList.every((val, index) => val === currentCodecOrder[index])) {
+                return;
+            }
+
             // Initiate a renegotiate for the codec setting to take effect.
             const workFunction = finishedCallback => {
                 this._renegotiate()

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import { $build, $iq, Strophe } from 'strophe.js';
 
 import { JitsiTrackEvents } from '../../JitsiTrackEvents';
+import { CodecMimeType } from '../../service/RTC/CodecMimeType';
 import { MediaDirection } from '../../service/RTC/MediaDirection';
 import { MediaType } from '../../service/RTC/MediaType';
 import {
@@ -1184,7 +1185,10 @@ export default class JingleSessionPC extends JingleSession {
             logger.info(`${this} setVideoCodecs: ${codecList}`);
             this.peerconnection.setVideoCodecs(codecList);
 
-            if (this.usesCodecSelectionAPI) {
+            // Browser throws an error when H.264 is set on the encodings. Therefore, munge the SDP when H.264 needs to
+            // be selected.
+            // TODO: Remove this check when the above issue is fixed.
+            if (this.usesCodecSelectionAPI && codecList[0] !== CodecMimeType.H264) {
                 return;
             }
 

--- a/service/statistics/Events.spec.ts
+++ b/service/statistics/Events.spec.ts
@@ -8,6 +8,7 @@ describe( "/service/statistics/Events members", () => {
         BEFORE_DISPOSED,
         BYTE_SENT_STATS,
         CONNECTION_STATS,
+        ENCODE_TIME_STATS,
         LONG_TASKS_STATS,
         Events,
         ...others
@@ -18,6 +19,7 @@ describe( "/service/statistics/Events members", () => {
         expect( BEFORE_DISPOSED ).toBe( 'statistics.before_disposed' );
         expect( BYTE_SENT_STATS ).toBe( 'statistics.byte_sent_stats' );
         expect( CONNECTION_STATS ).toBe( 'statistics.connectionstats' );
+        expect( ENCODE_TIME_STATS ).toBe( 'statistics.encode_time_stats' );
         expect( LONG_TASKS_STATS ).toBe( 'statistics.long_tasks_stats' );
 
         expect( Events ).toBeDefined();
@@ -26,6 +28,7 @@ describe( "/service/statistics/Events members", () => {
         expect( Events.BEFORE_DISPOSED ).toBe( 'statistics.before_disposed' );
         expect( Events.BYTE_SENT_STATS ).toBe( 'statistics.byte_sent_stats' );
         expect( Events.CONNECTION_STATS ).toBe( 'statistics.connectionstats' );
+        expect( Events.ENCODE_TIME_STATS ).toBe( 'statistics.encode_time_stats' );
         expect( Events.LONG_TASKS_STATS ).toBe( 'statistics.long_tasks_stats' );
     } );
 

--- a/service/statistics/Events.ts
+++ b/service/statistics/Events.ts
@@ -32,6 +32,11 @@ export enum Events {
     CONNECTION_STATS = 'statistics.connectionstats',
 
     /**
+     * An event carrying the encode time stats for all the local video sources.
+     */
+    ENCODE_TIME_STATS = 'statistics.encode_time_stats',
+
+    /**
      * An event carrying performance stats.
      */
     LONG_TASKS_STATS = 'statistics.long_tasks_stats'
@@ -42,4 +47,5 @@ export const AUDIO_LEVEL = Events.AUDIO_LEVEL;
 export const BEFORE_DISPOSED = Events.BEFORE_DISPOSED;
 export const BYTE_SENT_STATS = Events.BYTE_SENT_STATS;
 export const CONNECTION_STATS = Events.CONNECTION_STATS;
+export const ENCODE_TIME_STATS = Events.ENCODE_TIME_STATS;
 export const LONG_TASKS_STATS = Events.LONG_TASKS_STATS;


### PR DESCRIPTION
https://github.com/w3ctag/design-reviews/issues/836. This allows the client to seamlessly switch between the codecs without having to trigger a renegotiation. This feature is behind the flag testing.enableCodecSelectionAPI in config.js

This is marked WIP since we need a JVB change for this feature to work as expected for all codecs. When the DD header extension headers are negotiated, Chrome includes the layer information for VP8 in the DD extension headers but the bridge currently reads this from the VP8 packet headers. Since renegotiation cycle is not triggered when this feature is enabled, client doesn't have a way of removing the DDs from being sent by Chrome when we switch to VP8. - this has been fixed in https://github.com/jitsi/jitsi-videobridge/pull/2136