### PR TITLE
feat(createLocalTracks) drop unused slow gUM event

### DIFF
--- a/JitsiMediaDevicesEvents.spec.ts
+++ b/JitsiMediaDevicesEvents.spec.ts
@@ -7,7 +7,6 @@ describe( "/JitsiMediaDevicesEvents members", () => {
         DEVICE_LIST_CHANGED,
         PERMISSIONS_CHANGED,
         PERMISSION_PROMPT_IS_SHOWN,
-        SLOW_GET_USER_MEDIA,
         JitsiMediaDevicesEvents,
         ...others
     } = exported;
@@ -16,14 +15,12 @@ describe( "/JitsiMediaDevicesEvents members", () => {
         expect( DEVICE_LIST_CHANGED ).toBe( 'mediaDevices.devicechange' );
         expect( PERMISSIONS_CHANGED ).toBe( 'rtc.permissions_changed' );
         expect( PERMISSION_PROMPT_IS_SHOWN ).toBe( 'mediaDevices.permissionPromptIsShown' );
-        expect( SLOW_GET_USER_MEDIA ).toBe( 'mediaDevices.slowGetUserMedia' );
 
         expect( JitsiMediaDevicesEvents ).toBeDefined();
 
         expect( JitsiMediaDevicesEvents.DEVICE_LIST_CHANGED ).toBe( 'mediaDevices.devicechange' );
         expect( JitsiMediaDevicesEvents.PERMISSIONS_CHANGED ).toBe( 'rtc.permissions_changed' );
         expect( JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN ).toBe( 'mediaDevices.permissionPromptIsShown' );
-        expect( JitsiMediaDevicesEvents.SLOW_GET_USER_MEDIA ).toBe( 'mediaDevices.slowGetUserMedia' );
     } );
 
     it( "unknown members", () => {

--- a/JitsiMediaDevicesEvents.ts
+++ b/JitsiMediaDevicesEvents.ts
@@ -29,13 +29,10 @@ export enum JitsiMediaDevicesEvents {
      *  |'react-native'|'android'} environmentType - type of browser or
      *  other execution environment.
      */
-    PERMISSION_PROMPT_IS_SHOWN = 'mediaDevices.permissionPromptIsShown',
-
-    SLOW_GET_USER_MEDIA = 'mediaDevices.slowGetUserMedia'
+    PERMISSION_PROMPT_IS_SHOWN = 'mediaDevices.permissionPromptIsShown'
 };
 
 // exported for backward compatibility
 export const DEVICE_LIST_CHANGED = JitsiMediaDevicesEvents.DEVICE_LIST_CHANGED;
 export const PERMISSIONS_CHANGED = JitsiMediaDevicesEvents.PERMISSIONS_CHANGED;
 export const PERMISSION_PROMPT_IS_SHOWN = JitsiMediaDevicesEvents.PERMISSION_PROMPT_IS_SHOWN;
-export const SLOW_GET_USER_MEDIA = JitsiMediaDevicesEvents.SLOW_GET_USER_MEDIA;

--- a/types/hand-crafted/JitsiMediaDevicesEvents.d.ts
+++ b/types/hand-crafted/JitsiMediaDevicesEvents.d.ts
@@ -1,6 +1,5 @@
 export enum JitsiMediaDevicesEvents {
   DEVICE_LIST_CHANGED = 'mediaDevices.devicechange',
   PERMISSIONS_CHANGED = 'rtc.permissions_changed',
-  PERMISSION_PROMPT_IS_SHOWN = 'mediaDevices.permissionPromptIsShown',
-  SLOW_GET_USER_MEDIA = 'mediaDevices.slowGetUserMedia'
+  PERMISSION_PROMPT_IS_SHOWN = 'mediaDevices.permissionPromptIsShown'
 }


### PR DESCRIPTION
It's better handled by the application layer anyway.