### PR TITLE
fix(xmpp) catch errors in XMPP session resumption

### DIFF
--- a/modules/xmpp/ResumeTask.js
+++ b/modules/xmpp/ResumeTask.js
@@ -155,7 +155,11 @@ export default class ResumeTask {
 
         this._stropheConn.service = url.toString();
 
-        streamManagement.resume();
+        try {
+            streamManagement.resume();
+        } catch (e) {
+            logger.error('Failed to resume XMPP connnection', e);
+        }
     }
 
     /**


### PR DESCRIPTION
In RN, an uncaught exception causes the app to crash in release builds. We sidestep that on the native side, but RN SDK users usually don't, so be gracefull.

Fixes: https://github.com/jitsi/jitsi-meet/issues/14728
Fixes: https://github.com/jitsi/jitsi-meet/issues/14399