### PR TITLE
fix(RTC) improve bridge channel not being available error

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -727,7 +727,7 @@ export default class RTC extends Listenable {
         if (this._channel) {
             this._channel.sendMessage(to, payload);
         } else {
-            throw new Error('Channel support is disabled!');
+            throw new Error('BridgeChannel has not been initialized yet');
         }
     }
 


### PR DESCRIPTION
Claiming there is no support for it is misleading, the user might have called the function before the channel was initialized.