### PR TITLE
fix(JitsiLocalTrack) handle broken constraints more gracefully

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -107,7 +107,8 @@ export default class JitsiLocalTrack extends JitsiTrack {
         if (mediaType === MediaType.VIDEO) {
             if (videoType === VideoType.CAMERA) {
                 // Safari returns an empty constraints object, construct the constraints using getSettings.
-                if (!Object.keys(this._constraints).length) {
+                // Firefox in "fingerprint resistance mode" does a similar thing, except a `mediaSource` key is set.
+                if (!this._constraints.height || !this._constraints.width) {
                     this._constraints = {
                         height: { ideal: this.getHeight() },
                         width: { ideal: this.getWidth() }


### PR DESCRIPTION
We are already handling Safari, which provides an empty constraints object. Handle any type of broken constraints object which doesn't have at least a `width` and `height` properties. This is the case of Firefox when "fingerprint resistence" is enabled.

Fixes: https://github.com/jitsi/jitsi-meet/issues/14609