### PR TITLE
fix(JitsiLocalTrack) Keep a reference to SSRC.

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -182,6 +182,10 @@ export default class JitsiLocalTrack extends JitsiTrack {
         // The source name that will be signaled for this track.
         this._sourceName = null;
 
+        // The primary SSRC associated with the local media track. This will be set after the local desc
+        // is processed once the track is added to the peerconnection.
+        this._ssrc = null;
+
         this._trackMutedTS = 0;
 
         this._onDeviceListWillChange = devices => {
@@ -713,6 +717,14 @@ export default class JitsiLocalTrack extends JitsiTrack {
     }
 
     /**
+     * Returns the primary SSRC associated with the track.
+     * @returns {number}
+     */
+    getSsrc() {
+        return this._ssrc;
+    }
+
+    /**
      * Returns if associated MediaStreamTrack is in the 'ended' state
      *
      * @returns {boolean}
@@ -911,6 +923,17 @@ export default class JitsiLocalTrack extends JitsiTrack {
      */
     setSourceName(name) {
         this._sourceName = name;
+    }
+
+    /**
+     * Sets the primary SSRC for the track.
+     *
+     * @param {number} ssrc The SSRC.
+     */
+    setSsrc(ssrc) {
+        if (!isNaN(ssrc)) {
+            this._ssrc = ssrc;
+        }
     }
 
     /**

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -299,6 +299,14 @@ export default class JitsiTrack extends EventEmitter {
     }
 
     /**
+     * Returns the primary SSRC associated with the track.
+     * @returns {number}
+     */
+    getSsrc() { // eslint-disable-line no-unused-vars
+        // Should be defined by the classes that are extending JitsiTrack
+    }
+
+    /**
      * Returns the ID of the underlying WebRTC Media Stream(if any)
      * @returns {String|null}
      */

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1809,6 +1809,9 @@ TraceablePeerConnection.prototype.replaceTrack = function(oldTrack, newTrack) {
                 if (oldTrackSSRC) {
                     this.localSSRCs.delete(oldTrack.rtcId);
                     this.localSSRCs.set(newTrack.rtcId, oldTrackSSRC);
+                    const oldSsrcNum = this._extractPrimarySSRC(oldTrackSSRC);
+
+                    newTrack.setSsrc(oldSsrcNum);
                 }
             }
 
@@ -2654,6 +2657,7 @@ TraceablePeerConnection.prototype._processLocalSSRCsMap = function(ssrcMap) {
             if (newSSRCNum !== oldSSRCNum) {
                 oldSSRCNum && logger.error(`${this} Overwriting SSRC for track=${track}] with ssrc=${newSSRC}`);
                 this.localSSRCs.set(track.rtcId, newSSRC);
+                track.setSsrc(newSSRCNum);
                 this.eventEmitter.emit(RTCEvents.LOCAL_TRACK_SSRC_UPDATED, track, newSSRCNum);
             }
         } else if (!track.isVideoTrack() && !track.isMuted()) {


### PR DESCRIPTION
This helps us in identifying the video codec associated with a local video track for codec selection torture tests.