### PR TITLE
fix(codecs) Continue to munge SDP for p2p codec.

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -401,7 +401,7 @@ export default class JingleSessionPC extends JingleSession {
         pcOptions.codecSettings = options.codecSettings;
         pcOptions.enableInsertableStreams = options.enableInsertableStreams;
         pcOptions.usesCodecSelectionAPI = this.usesCodecSelectionAPI
-            = browser.supportsCodecSelectionAPI() && options.testing?.enableCodecSelectionAPI;
+            = browser.supportsCodecSelectionAPI() && options.testing?.enableCodecSelectionAPI && !this.isP2P;
 
         if (options.videoQuality) {
             const settings = Object.entries(options.videoQuality)


### PR DESCRIPTION
We need the initial invite/answer to have the codecs in the correct order so codec selection API for selecting codecs is not useful in this case.