### PR TITLE
fix(JitsiConference,ChatRoom) make isFocus check more resilient

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2325,11 +2325,8 @@ JitsiConference.prototype._rejectIncomingCall = function(jingleSession, options)
     // Terminate the jingle session with a reason
     jingleSession.terminate(
         null /* success callback => we don't care */,
-        error => {
-            logger.warn(
-                'An error occurred while trying to terminate'
-                    + ' invalid Jingle session', error);
-        }, {
+        null, /* error callback => we don't care */
+        {
             reason: options && options.reason,
             reasonDescription: options && options.reasonDescription,
             sendSessionTerminate: true

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -2694,12 +2694,11 @@ JitsiConference.prototype.sendApplicationLog = function() { };
 /**
  * Checks if the user identified by given <tt>mucJid</tt> is the conference focus.
  * @param mucJid the full MUC address of the user to be checked.
- * @returns {boolean|null} <tt>true</tt> if MUC user is the conference focus,
- * <tt>false</tt> when is not. <tt>null</tt> if we're not in the MUC anymore and
- * are unable to figure out the status or if given <tt>mucJid</tt> is invalid.
+ * @returns {boolean} <tt>true</tt> if MUC user is the conference focus,
+ * <tt>false</tt> when is not.
  */
 JitsiConference.prototype.isFocus = function(mucJid) {
-    return this.room ? this.room.isFocus(mucJid) : null;
+    return this.room?.isFocus(mucJid) ?? false;
 };
 
 /**

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -543,7 +543,7 @@ export default class ChatRoom extends Listenable {
         const jid = mucUserItem && mucUserItem.getAttribute('jid');
 
         member.jid = jid;
-        member.isFocus = this.xmpp.moderator.isFocusJid(jid);
+        member.isFocus = this.isFocus(jid);
         member.isHiddenDomain
             = jid && jid.indexOf('@') > 0
                 && this.options.hiddenDomain
@@ -1643,18 +1643,11 @@ export default class ChatRoom extends Listenable {
      * Checks if the user identified by given <tt>mucJid</tt> is the conference
      * focus.
      * @param mucJid the full MUC address of the user to be checked.
-     * @returns {boolean|null} <tt>true</tt> if MUC user is the conference focus
-     * or <tt>false</tt> if is not. When given <tt>mucJid</tt> does not exist in
-     * the MUC then <tt>null</tt> is returned.
+     * @returns {boolean} <tt>true</tt> if MUC user is the conference focus
+     * or <tt>false</tt> if is not.
      */
     isFocus(mucJid) {
-        const member = this.members[mucJid];
-
-        if (member) {
-            return member.isFocus;
-        }
-
-        return null;
+        return this.xmpp.moderator.isFocusJid(mucJid);
     }
 
     /**


### PR DESCRIPTION
Protect against an incoming session that is received before we have processed presence for the focus user.