### PR TITLE
fix(chat-features): Add messageId and change id to participantId

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -368,12 +368,12 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
         XMPPEvents.MESSAGE_RECEIVED,
 
         // eslint-disable-next-line max-params
-        (jid, txt, myJid, ts, nick, isGuest) => {
-            const id = Strophe.getResourceFromJid(jid);
+        (jid, txt, myJid, ts, nick, isGuest, messageId) => {
+            const participantId = Strophe.getResourceFromJid(jid);
 
             conference.eventEmitter.emit(
                 JitsiConferenceEvents.MESSAGE_RECEIVED,
-                id, txt, ts, nick, isGuest);
+                participantId, txt, ts, nick, isGuest, messageId);
         });
 
     chatRoom.addListener(

--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -380,12 +380,12 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
         XMPPEvents.PRIVATE_MESSAGE_RECEIVED,
 
         // eslint-disable-next-line max-params
-        (jid, txt, myJid, ts) => {
-            const id = Strophe.getResourceFromJid(jid);
+        (jid, txt, myJid, ts, messageId) => {
+            const participantId = Strophe.getResourceFromJid(jid);
 
             conference.eventEmitter.emit(
                 JitsiConferenceEvents.PRIVATE_MESSAGE_RECEIVED,
-                id, txt, ts);
+                participantId, txt, ts, messageId);
         });
 
     chatRoom.addListener(XMPPEvents.PRESENCE_STATUS,

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1218,11 +1218,13 @@ export default class ChatRoom extends Listenable {
                     nick = nickEl.text();
                 }
 
+                const messageId = $(msg).attr('id');
+                
                 // we will fire explicitly that this is a guest(isGuest:true) to the conference
                 // informing that this is probably a message from a guest to the conference (visitor)
                 // a message with explicit name set
                 this.eventEmitter.emit(XMPPEvents.MESSAGE_RECEIVED,
-                    from, txt, this.myroomjid, stamp, nick, Boolean(nick));
+                    from, txt, this.myroomjid, stamp, nick, Boolean(nick), messageId);
             }
         }
     }

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1219,7 +1219,7 @@ export default class ChatRoom extends Listenable {
                 }
 
                 const messageId = $(msg).attr('id');
-                
+
                 // we will fire explicitly that this is a guest(isGuest:true) to the conference
                 // informing that this is probably a message from a guest to the conference (visitor)
                 // a message with explicit name set

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1,10 +1,9 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import { safeJsonParse } from '@jitsi/js-utils/json';
 import { getLogger } from '@jitsi/logger';
 import $ from 'jquery';
 import isEqual from 'lodash.isequal';
 import { $iq, $msg, $pres, Strophe } from 'strophe.js';
+import { v4 as uuidv4 } from 'uuid';
 
 import { AUTH_ERROR_TYPES } from '../../JitsiConferenceErrors';
 import * as JitsiTranscriptionStatus from '../../JitsiTranscriptionStatus';

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1209,9 +1209,12 @@ export default class ChatRoom extends Listenable {
         }
 
         if (txt) {
+
+            const messageId = $(msg).attr('id') || uuidv4();
+
             if (type === 'chat') {
                 this.eventEmitter.emit(XMPPEvents.PRIVATE_MESSAGE_RECEIVED,
-                        from, txt, this.myroomjid, stamp);
+                        from, txt, this.myroomjid, stamp, messageId);
             } else if (type === 'groupchat') {
                 const nickEl = $(msg).find('>nick');
                 let nick;
@@ -1219,8 +1222,6 @@ export default class ChatRoom extends Listenable {
                 if (nickEl.length > 0) {
                     nick = nickEl.text();
                 }
-
-                const messageId = $(msg).attr('id') || uuidv4();
 
                 // we will fire explicitly that this is a guest(isGuest:true) to the conference
                 // informing that this is probably a message from a guest to the conference (visitor)

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import { safeJsonParse } from '@jitsi/js-utils/json';
 import { getLogger } from '@jitsi/logger';
 import $ from 'jquery';
@@ -1218,7 +1220,7 @@ export default class ChatRoom extends Listenable {
                     nick = nickEl.text();
                 }
 
-                const messageId = $(msg).attr('id');
+                const messageId = $(msg).attr('id') || uuidv4();
 
                 // we will fire explicitly that this is a guest(isGuest:true) to the conference
                 // informing that this is probably a message from a guest to the conference (visitor)


### PR DESCRIPTION
- messageId needs to be added to be able to attach reactions to specific messages
- participantId indicates that it is the participant's id rather than the message's id