### PR TITLE
fix(ICE): treat completed as connected

### DIFF
--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -536,6 +536,7 @@ export default class JingleSessionPC extends JingleSession {
                 this._iceCheckingStartedTimestamp = now;
                 break;
             case 'connected':
+            case 'completed':
                 // Informs interested parties that the connection has been restored. This includes the case when
                 // media connection to the bridge has been restored after an ICE failure by using session-terminate.
                 if (this.peerconnection.signalingState === 'stable') {


### PR DESCRIPTION
When WebRTC ICE gathering policy is set to gather once instead of continually, the controlling agent goes to completed instead of connected (no more candidates to check). This doesn't happen in Chrome or other browsers, but is reproducible with node.js wrapper around WebRTC which runs with the default settings.

This is causing a bug where the initiator side of a P2P connection does not fully switch to P2P mode and keeps on sending data on both P2P and JVB connections.