### PR TITLE
fix(ReceiveVideoController) fix setting lastN to 0

### DIFF
--- a/modules/qualitycontrol/ReceiveVideoController.js
+++ b/modules/qualitycontrol/ReceiveVideoController.js
@@ -213,7 +213,8 @@ export default class ReceiveVideoController {
             this._receiverVideoConstraints = constraints;
 
             this._assumedBandwidthBps = constraints.assumedBandwidthBps ?? this._assumedBandwidthBps;
-            this._lastN = constraints.lastN && !this._lastNLimitedByCpu ? constraints.lastN : this._lastN;
+            this._lastN = typeof constraints.lastN !== 'undefined' && !this._lastNLimitedByCpu
+                ? constraints.lastN : this._lastN;
             this._receiverVideoConstraints.lastN = this._lastN;
             this._receiveResolutionLimitedByCpu && this._updateIndividualConstraints();
 


### PR DESCRIPTION
When lastN is first set to some truty value and then 0, it wouldn't be set because we relied on a "truthyness" check.

Check if the value is undefined so it can be set to 0.