### PR TITLE
fix(JitsiConference) handle repeaded calls to leave gracefully

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -671,7 +671,7 @@ JitsiConference.prototype.leave = async function(reason) {
 
     // Leave the conference. If this.room == null we are calling second time leave().
     if (!this.room) {
-        throw new Error('You have already left the conference');
+        return;
     }
 
     const room = this.room;


### PR DESCRIPTION
There is no hardm in calling it twice since we protect against it.