### PR TITLE
fix(ResumeTask) reset resume timeout after running timer

### DIFF
--- a/modules/xmpp/ResumeTask.js
+++ b/modules/xmpp/ResumeTask.js
@@ -127,6 +127,8 @@ export default class ResumeTask {
      * @returns {void}
      */
     _resumeConnection() {
+        this._resumeTimeout = undefined;
+
         const { streamManagement } = this._stropheConn;
         const resumeToken = streamManagement.getResumeToken();
 


### PR DESCRIPTION
It will avoid having an extra "Canceling connection resume task" log line every time we schedule a timer.