### PR TITLE
fix(quality-control) Check only for cpu limitation

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -1,5 +1,5 @@
 import { getLogger } from '@jitsi/logger';
-import { cloneDeep } from 'lodash-es';
+import { cloneDeep, isEqual } from 'lodash-es';
 
 import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 import { MediaType } from '../../service/RTC/MediaType';
@@ -301,6 +301,10 @@ export default class RTC extends Listenable {
      * @param {*} constraints
      */
     setReceiverVideoConstraints(constraints) {
+        if (isEqual(this._receiverVideoConstraints, constraints)) {
+            return;
+        }
+
         this._receiverVideoConstraints = constraints;
 
         if (this._channel && this._channel.isOpen()) {

--- a/modules/qualitycontrol/QualityController.ts
+++ b/modules/qualitycontrol/QualityController.ts
@@ -319,10 +319,7 @@ export class QualityController {
         // 2. Switch to a lower lastN value, cutting the receive videos by half in every iteration until
         // MIN_LAST_N value is reached.
         // 3. Lower the receive resolution of individual streams up to 180p.
-        if (qualityLimitationReason === QualityLimitationReason.CPU
-            || (encodeResolution < tpc.calculateExpectedSendResolution(localTrack)
-                && qualityLimitationReason !== QualityLimitationReason.BANDWIDTH)) {
-
+        if (qualityLimitationReason === QualityLimitationReason.CPU) {
             if (this._lastNRampupTimeout) {
                 window.clearTimeout(this._lastNRampupTimeout);
                 this._lastNRampupTimeout = undefined;


### PR DESCRIPTION
Checking for send resolution vs expected resolution was unnecessarily limiting lastN and receive resolution when local camera has issues and stops sending video. Also, do not send redundant receiver constraints on the bridge channel.