### PR TITLE
fix(quality) Do not set b:AS line in SDP for SVC codecs when codec selection API is used.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2129,7 +2129,12 @@ TraceablePeerConnection.prototype._setMaxBitrates = function(description, isLoca
         const localTrack = this.getLocalVideoTracks()
             .find(track => this._localTrackTransceiverMids.get(track.rtcId) === mLine.mid.toString());
 
-        if ((isDoingVp9KSvc || this.tpcUtils._isRunningInFullSvcMode(currentCodec)) && localTrack) {
+        if (localTrack
+            && (isDoingVp9KSvc
+
+                // Setting bitrates in the SDP for SVC codecs is no longer needed in the newer versions where
+                // maxBitrates from the RTCRtpEncodingParameters directly affect the target bitrate for the encoder.
+                || (this.tpcUtils._isRunningInFullSvcMode(currentCodec) && !this.usesCodecSelectionAPI()))) {
             let maxBitrate;
 
             if (localTrack.getVideoType() === VideoType.DESKTOP) {


### PR DESCRIPTION

This was needed in older versions since the browser didn't apply maxBitrates from RTCRtpEncoderParameters on the encoder. In the newer versions this seems to be no longer the case. Also, when the codec selection API is used, we no longer renegotiate locally so if we switched codec from AV1->VP9-VP9, the AV1 bitrate setting in the SDP will still be effective resulting in a lower send resolution because of b/w limitation.