### PR TITLE
fix(JitsiTranscriptionStatus): the status values are upper case

### DIFF
--- a/JitsiTranscriptionStatus.spec.ts
+++ b/JitsiTranscriptionStatus.spec.ts
@@ -11,13 +11,13 @@ describe( "/JitsiTranscriptionStatus members", () => {
     } = exported;
 
     it( "known members", () => {
-        expect( ON ).toBe( 'on' );
-        expect( OFF ).toBe( 'off' );
+        expect( ON ).toBe( 'ON' );
+        expect( OFF ).toBe( 'OFF' );
 
         expect( JitsiTranscriptionStatus ).toBeDefined();
 
-        expect( JitsiTranscriptionStatus.ON ).toBe( 'on' );
-        expect( JitsiTranscriptionStatus.OFF ).toBe( 'off' );
+        expect( JitsiTranscriptionStatus.ON ).toBe( 'ON' );
+        expect( JitsiTranscriptionStatus.OFF ).toBe( 'OFF' );
     } );
 
     it( "unknown members", () => {

--- a/JitsiTranscriptionStatus.ts
+++ b/JitsiTranscriptionStatus.ts
@@ -2,12 +2,12 @@ export enum JitsiTranscriptionStatus {
     /**
      * The transcription is on.
      */
-    ON = 'on',
+    ON = 'ON',
 
     /**
      * The transcription is off.
      */
-    OFF = 'off'
+    OFF = 'OFF'
 }
 
 // exported for backward compatibility

--- a/types/hand-crafted/JitsiTranscriptionStatus.d.ts
+++ b/types/hand-crafted/JitsiTranscriptionStatus.d.ts
@@ -1,4 +1,4 @@
 export enum JitsiTranscriptionStatus {
-  ON = 'on',
-  OFF = 'off'
+  ON = 'ON',
+  OFF = 'OFF'
 }


### PR DESCRIPTION
The backend really sends upper case values:

https://github.com/jitsi/jitsi-xmpp-extensions/blob/3816e5a154160056290c2a2fbff1ab63cbac95e0/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/TranscriptionStatusExtension.java#L82