### PR TITLE
fix(logging): Set default logging level as early as possible.

### DIFF
--- a/JitsiMeetJS.ts
+++ b/JitsiMeetJS.ts
@@ -38,6 +38,9 @@ import { VideoType } from './service/RTC/VideoType';
 
 const logger = Logger.getLogger(__filename);
 
+// Settin the default log levels to info early so that we avoid overriding a log level set externally.
+Logger.setLogLevel(Logger.levels.INFO);
+
 /**
  * Indicates whether GUM has been executed or not.
  */
@@ -136,8 +139,6 @@ export default {
     mediaDevices: JitsiMediaDevices as unknown,
     analytics: Statistics.analytics as unknown,
     init(options: IJitsiMeetJSOptions = {}) {
-        Logger.setLogLevel(Logger.levels.INFO);
-
         // @ts-ignore
         logger.info(`This appears to be ${browser.getName()}, ver: ${browser.getVersion()}`);
 


### PR DESCRIPTION
We were setting the logging level in JitsiMeetJS.init which potentially would have overriden all external calls for setting the log level before the JitsiMeetJS.init is called. In fact this was happening for jitsi-meet.