### PR TITLE
feat(lobby): Reads lobby muc meeting id and starts rtc stats.

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -359,6 +359,22 @@ export default class ChatRoom extends Listenable {
                 .c('query', { xmlns: Strophe.NS.DISCO_INFO });
 
         this.connection.sendIQ(getInfo, result => {
+            const meetingIdValEl
+                = $(result).find('>query>x[type="result"]>field[var="muc#roominfo_meetingId"]>value');
+
+            if (meetingIdValEl.length) {
+                this.setMeetingId(meetingIdValEl.text());
+            } else {
+                logger.warn('No meeting ID from backend');
+            }
+
+            if (!this.lobby) {
+                // if this is in the lobby room, we need just the meetingId
+                // only the main room has this.lobby
+
+                return;
+            }
+
             const locked
                 = $(result).find('>query>feature[var="muc_passwordprotected"]')
                     .length
@@ -369,14 +385,6 @@ export default class ChatRoom extends Listenable {
                 this.locked = locked;
             }
 
-            const meetingIdValEl
-                = $(result).find('>query>x[type="result"]>field[var="muc#roominfo_meetingId"]>value');
-
-            if (meetingIdValEl.length) {
-                this.setMeetingId(meetingIdValEl.text());
-            } else {
-                logger.warn('No meeting ID from backend');
-            }
 
             const meetingCreatedTSValEl
                 = $(result).find('>query>x[type="result"]>field[var="muc#roominfo_created_timestamp"]>value');

--- a/modules/xmpp/Lobby.js
+++ b/modules/xmpp/Lobby.js
@@ -251,7 +251,6 @@ export default class Lobby {
         this.lobbyRoom = this.xmpp.createRoom(
             roomName, {
                 customDomain,
-                disableDiscoInfo: true,
                 disableFocus: true,
                 enableLobby: false
             }
@@ -379,6 +378,8 @@ export default class Lobby {
                     this.lobbyRoom.addOrReplaceInPresence(EMAIL_COMMAND, { value: email })
                         && this.lobbyRoom.sendPresence();
                 }
+
+                this.mainRoom.emit(XMPPEvents.MUC_LOBBY_JOINED, this.lobbyRoom);
             });
             this.lobbyRoom.addEventListener(XMPPEvents.ROOM_JOIN_ERROR, reject);
             this.lobbyRoom.addEventListener(XMPPEvents.ROOM_CONNECT_NOT_ALLOWED_ERROR, reject);

--- a/service/xmpp/XMPPEvents.ts
+++ b/service/xmpp/XMPPEvents.ts
@@ -152,6 +152,9 @@ export enum XMPPEvents {
     // Designates an event indicating that a participant left the XMPP MUC.
     MUC_MEMBER_LEFT = 'xmpp.muc_member_left',
 
+    // Designates an event indicating that the lobby XMPP MUC is joined.
+    MUC_LOBBY_JOINED = 'xmpp.muc_lobby_joined',
+
     // Designates an event indicating that a participant joined the lobby XMPP MUC.
     MUC_LOBBY_MEMBER_JOINED = 'xmpp.muc_lobby_member_joined',
 


### PR DESCRIPTION
Starts rtc stats when joining lobby room, to gather logs before joining the room.