### PR TITLE
fix(JingleSession) Remove ice restart option and functionality.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -106,8 +106,6 @@ function _getCodecMimeType(codec) {
  * @param {number} [options.config.avgRtpStatsN=15] how many samples are to be
  * collected by {@link AvgRTPStatsReporter}, before arithmetic mean is
  * calculated and submitted to the analytics module.
- * @param {boolean} [options.config.enableIceRestart=false] - enables the ICE
- * restart logic.
  * @param {boolean} [options.config.p2p.enabled] when set to <tt>true</tt>
  * the peer to peer mode will be enabled. It means that when there are only 2
  * participants in the conference an attempt to make direct connection will be

--- a/modules/proxyconnection/ProxyConnectionPC.js
+++ b/modules/proxyconnection/ProxyConnectionPC.js
@@ -225,8 +225,7 @@ export default class ProxyConnectionPC {
             connectionTimes: [],
             eventEmitter: { emit: emitter },
             removeEventListener: () => { /* no op */ },
-            removePresenceListener: () => { /* no-op */ },
-            supportsRestartByTerminate: () => false
+            removePresenceListener: () => { /* no-op */ }
         };
 
         /**

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -816,13 +816,6 @@ export default class ChatRoom extends Listenable {
                     }
 
                     this.eventEmitter.emit(XMPPEvents.CONFERENCE_PROPERTIES_CHANGED, properties);
-
-                    // Log if Jicofo supports restart by terminate only once. This conference property does not change
-                    // during the call.
-                    if (typeof this.restartByTerminateSupported === 'undefined') {
-                        this.restartByTerminateSupported = properties['support-terminate-restart'] === 'true';
-                        logger.info(`Jicofo supports restart by terminate: ${this.supportsRestartByTerminate()}`);
-                    }
                 }
                 break;
             case 'transcription-status': {
@@ -911,14 +904,6 @@ export default class ChatRoom extends Listenable {
      */
     setParticipantPropertyListener(listener) {
         this.participantPropertyListener = listener;
-    }
-
-    /**
-     * Checks if Jicofo supports restarting Jingle session after 'session-terminate'.
-     * @returns {boolean}
-     */
-    supportsRestartByTerminate() {
-        return this.restartByTerminateSupported;
     }
 
     /**

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -4,13 +4,7 @@ import { cloneDeep } from 'lodash-es';
 import { $iq, Strophe } from 'strophe.js';
 
 import { MediaType } from '../../service/RTC/MediaType';
-import {
-    ACTION_JINGLE_TR_RECEIVED,
-    ACTION_JINGLE_TR_SUCCESS,
-    createJingleEvent
-} from '../../service/statistics/AnalyticsEvents';
 import { XMPPEvents } from '../../service/xmpp/XMPPEvents';
-import Statistics from '../statistics/statistics';
 import RandomUtil from '../util/RandomUtil';
 
 import ConnectionPlugin from './ConnectionPlugin';
@@ -253,40 +247,6 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
             logger.debug(`Received ${action} from ${fromJid} disconnect reason=${reasonText}`);
             this.terminate(sess.sid, reasonCondition, reasonText);
             this.eventEmitter.emit(XMPPEvents.CALL_ENDED, sess, reasonCondition, reasonText);
-            break;
-        }
-        case 'transport-replace': {
-            logger.info('(TIME) Start transport replace:\t', now);
-            const transport = $(iq).find('jingle>content>transport');
-            const candidates = _parseIceCandidates(transport);
-            const iceUfrag = $(transport).attr('ufrag');
-            const icePwd = $(transport).attr('pwd');
-            const dtlsFingerprint = $(transport).find('>fingerprint')?.text();
-
-            logger.debug(`Received ${action} from ${fromJid} with iceUfrag=${iceUfrag},`
-            + ` icePwd=${icePwd}, DTLS fingerprint=${dtlsFingerprint}, candidates=${candidates.join(', ')}`);
-
-            Statistics.sendAnalytics(createJingleEvent(
-                ACTION_JINGLE_TR_RECEIVED,
-                {
-                    p2p: isP2P,
-                    value: now
-                }));
-
-            sess.replaceTransport($(iq).find('>jingle'), () => {
-                const successTime = window.performance.now();
-
-                logger.info('(TIME) Transport replace success:\t', successTime);
-                Statistics.sendAnalytics(createJingleEvent(
-                    ACTION_JINGLE_TR_SUCCESS,
-                    {
-                        p2p: isP2P,
-                        value: successTime
-                    }));
-            }, error => {
-                logger.error('Transport replace failed', error);
-                sess.sendTransportReject();
-            });
             break;
         }
         case 'source-add':

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -249,6 +249,9 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
             this.eventEmitter.emit(XMPPEvents.CALL_ENDED, sess, reasonCondition, reasonText);
             break;
         }
+        case 'transport-replace':
+            logger.error(`Ignoring ${action} from ${fromJid} as it is not supported by the client.`);
+            break;
         case 'source-add':
             sess.addRemoteStream($(iq).find('>jingle>content'));
             break;

--- a/service/statistics/AnalyticsEvents.spec.ts
+++ b/service/statistics/AnalyticsEvents.spec.ts
@@ -13,8 +13,6 @@ describe( "/service/statistics/AnalyticsEvents members", () => {
         ACTION_JINGLE_SI_RECEIVED,
         ACTION_JINGLE_SI_TIMEOUT,
         ACTION_JINGLE_TERMINATE,
-        ACTION_JINGLE_TR_RECEIVED,
-        ACTION_JINGLE_TR_SUCCESS,
         ACTION_P2P_DECLINED,
         ACTION_P2P_ESTABLISHED,
         ACTION_P2P_FAILED,
@@ -61,8 +59,6 @@ describe( "/service/statistics/AnalyticsEvents members", () => {
         expect( ACTION_JINGLE_SI_RECEIVED ).toBe( 'session-initiate.received' );
         expect( ACTION_JINGLE_SI_TIMEOUT ).toBe( 'session-initiate.timeout' );
         expect( ACTION_JINGLE_TERMINATE ).toBe( 'terminate' );
-        expect( ACTION_JINGLE_TR_RECEIVED ).toBe( 'transport-replace.received' );
-        expect( ACTION_JINGLE_TR_SUCCESS ).toBe( 'transport-replace.success' );
         expect( ACTION_P2P_DECLINED ).toBe( 'decline' );
         expect( ACTION_P2P_ESTABLISHED ).toBe( 'established' );
         expect( ACTION_P2P_FAILED ).toBe( 'failed' );
@@ -88,8 +84,6 @@ describe( "/service/statistics/AnalyticsEvents members", () => {
         expect( AnalyticsEvents.ACTION_JINGLE_SI_RECEIVED ).toBe( 'session-initiate.received' );
         expect( AnalyticsEvents.ACTION_JINGLE_SI_TIMEOUT ).toBe( 'session-initiate.timeout' );
         expect( AnalyticsEvents.ACTION_JINGLE_TERMINATE ).toBe( 'terminate' );
-        expect( AnalyticsEvents.ACTION_JINGLE_TR_RECEIVED ).toBe( 'transport-replace.received' );
-        expect( AnalyticsEvents.ACTION_JINGLE_TR_SUCCESS ).toBe( 'transport-replace.success' );
         expect( AnalyticsEvents.ACTION_P2P_DECLINED ).toBe( 'decline' );
         expect( AnalyticsEvents.ACTION_P2P_ESTABLISHED ).toBe( 'established' );
         expect( AnalyticsEvents.ACTION_P2P_FAILED ).toBe( 'failed' );

--- a/service/statistics/AnalyticsEvents.ts
+++ b/service/statistics/AnalyticsEvents.ts
@@ -75,18 +75,6 @@ export enum AnalyticsEvents {
     ACTION_JINGLE_TERMINATE = 'terminate',
 
     /**
-     * The "action" value for Jingle events which indicates that a transport-replace
-     * was received.
-     */
-    ACTION_JINGLE_TR_RECEIVED = 'transport-replace.received',
-
-    /**
-     * The "action" value for Jingle events which indicates that a transport-replace
-     * succeeded (TODO: verify/fix the documentation)
-     */
-    ACTION_JINGLE_TR_SUCCESS = 'transport-replace.success',
-
-    /**
      * The "action" value for P2P events which indicates that P2P session initiate message has been rejected by the client
      * because the mandatory requirements were not met.
      */
@@ -233,8 +221,6 @@ export const ACTION_JINGLE_SA_TIMEOUT = AnalyticsEvents.ACTION_JINGLE_SA_TIMEOUT
 export const ACTION_JINGLE_SI_RECEIVED = AnalyticsEvents.ACTION_JINGLE_SI_RECEIVED;
 export const ACTION_JINGLE_SI_TIMEOUT = AnalyticsEvents.ACTION_JINGLE_SI_TIMEOUT;
 export const ACTION_JINGLE_TERMINATE = AnalyticsEvents.ACTION_JINGLE_TERMINATE;
-export const ACTION_JINGLE_TR_RECEIVED = AnalyticsEvents.ACTION_JINGLE_TR_RECEIVED;
-export const ACTION_JINGLE_TR_SUCCESS = AnalyticsEvents.ACTION_JINGLE_TR_SUCCESS;
 export const ACTION_P2P_DECLINED = AnalyticsEvents.ACTION_P2P_DECLINED;
 export const ACTION_P2P_ESTABLISHED = AnalyticsEvents.ACTION_P2P_ESTABLISHED;
 export const ACTION_P2P_FAILED = AnalyticsEvents.ACTION_P2P_FAILED;

--- a/service/xmpp/XMPPEvents.spec.ts
+++ b/service/xmpp/XMPPEvents.spec.ts
@@ -36,8 +36,6 @@ describe( "/service/xmpp/XMPPEvents members", () => {
         expect( XMPPEvents.FOCUS_DISCONNECTED ).toBe( 'xmpp.focus_disconnected' );
         expect( XMPPEvents.FOCUS_LEFT ).toBe( 'xmpp.focus_left' );
         expect( XMPPEvents.GRACEFUL_SHUTDOWN ).toBe( 'xmpp.graceful_shutdown' );
-        expect( XMPPEvents.ICE_RESTARTING ).toBe( 'rtc.ice_restarting' );
-        expect( XMPPEvents.ICE_RESTART_SUCCESS ).toBe( 'rtc.ice_restart_success' );
         expect( XMPPEvents.KICKED ).toBe( 'xmpp.kicked' );
         expect( XMPPEvents.LOCAL_ROLE_CHANGED ).toBe( 'xmpp.localrole_changed' );
         expect( XMPPEvents.MEETING_ID_SET ).toBe( 'xmpp.meeting_id_set' );

--- a/service/xmpp/XMPPEvents.ts
+++ b/service/xmpp/XMPPEvents.ts
@@ -88,18 +88,6 @@ export enum XMPPEvents {
     GRACEFUL_SHUTDOWN = 'xmpp.graceful_shutdown',
 
     /**
-     * Event fired when 'transport-replace' Jingle message has been received,
-     * before the new offer is set on the PeerConnection.
-     */
-    ICE_RESTARTING = 'rtc.ice_restarting',
-
-    /**
-     * Event fired after the 'transport-replace' message has been processed
-     * and the new offer has been set successfully.
-     */
-    ICE_RESTART_SUCCESS = 'rtc.ice_restart_success',
-
-    /**
      * Designates an event indicating that we were kicked from the XMPP MUC.
      * @param {boolean} isSelfPresence - whether it is for local participant
      * or another participant.

--- a/types/hand-crafted/JitsiConference.d.ts
+++ b/types/hand-crafted/JitsiConference.d.ts
@@ -14,7 +14,6 @@ export default class JitsiConference {
     name: string;
     config: {
       avgRtpStatsN?: number,
-      enableIceRestart?: boolean,
       p2p?: {
         enabled: boolean,
         backToP2PDelay?: number

--- a/types/hand-crafted/modules/xmpp/ChatRoom.d.ts
+++ b/types/hand-crafted/modules/xmpp/ChatRoom.d.ts
@@ -21,7 +21,6 @@ export default class ChatRoom extends Listenable {
   onConnStatusChanged: ( status: Strophe.Status ) => void;
   onPresence: ( pres: unknown ) => void; // TODO:
   setParticipantPropertyListener: ( listener: unknown ) => void; // TODO:
-  supportsRestartByTerminate: () => boolean;
   processNode: ( node: unknown, from: unknown ) => void; // TODO:
   sendMessage: ( message: unknown, elementName: string ) => void; // TODO:
   sendPrivateMessage: ( id: unknown, message: unknown, elementName: string ) => void; // TODO:

--- a/types/hand-crafted/modules/xmpp/JingleSessionPC.d.ts
+++ b/types/hand-crafted/modules/xmpp/JingleSessionPC.d.ts
@@ -11,7 +11,6 @@ export default class JingleSessionPC extends JingleSession {
   getRemoteRecvMaxFrameHeight: () => number | undefined;
   sendIceCandidate: ( candidate: RTCIceCandidate ) => void;
   sendIceCandidates: ( candidates: RTCIceCandidate[] ) => void;
-  sendIceFailedNotification: () => void;
   addIceCandidates: ( elem: unknown ) => void; // TODO:
   readSsrcInfo: ( contents: unknown ) => void; // TODO:
   getConfiguredVideoCodec: () => CodecMimeType;
@@ -21,12 +20,9 @@ export default class JingleSessionPC extends JingleSession {
   setAnswer: ( jingleAnswer: unknown ) => void; // TODO:
   setOfferAnswerCycle: ( jingleOfferAnswerIq: JQuery, success: ( params: unknown ) => unknown, failure: ( params: unknown ) => unknown, localTracks?: JitsiLocalTrack[] ) => void; // TODO:
   setVideoCodecs: ( preferred?: CodecMimeType, disabled?: CodecMimeType ) => void;
-  replaceTransport: ( jingleOfferElem: unknown, success: ( params: unknown ) => unknown, failure: ( params: unknown ) => unknown ) => void; // TODO:
   sendSessionAccept: ( success: ( params: unknown ) => unknown, failure: ( params: unknown ) => unknown ) => void; // TODO:
   sendContentModify: () => void;
   setReceiverVideoConstraint: ( maxFrameHeight: number ) => void;
-  sendTransportAccept: ( localSDP: unknown, success: ( params: unknown ) => unknown, failure: ( params: unknown ) => unknown ) => void; // TODO:
-  sendTransportReject: ( success: ( params: unknown ) => unknown, failure: ( params: unknown ) => unknown ) => void; // TODO:
   setSenderMaxBitrates: () => Promise<void>;
   setSenderVideoConstraint: ( maxFrameHeight: number ) => Promise<unknown>; // TODO:
   setSenderVideoDegradationPreference: () => Promise<void>;

--- a/types/hand-crafted/service/statistics/AnalyticsEvents.d.ts
+++ b/types/hand-crafted/service/statistics/AnalyticsEvents.d.ts
@@ -10,8 +10,6 @@ export enum AnalyticsEvents {
   ACTION_JINGLE_SI_RECEIVED = 'session-initiate.received',
   ACTION_JINGLE_SI_TIMEOUT = 'session-initiate.timeout',
   ACTION_JINGLE_TERMINATE = 'terminate',
-  ACTION_JINGLE_TR_RECEIVED = 'transport-replace.received',
-  ACTION_JINGLE_TR_SUCCESS = 'transport-replace.success',
   ACTION_P2P_DECLINED = 'decline',
   ACTION_P2P_ESTABLISHED = 'established',
   ACTION_P2P_FAILED = 'failed',

--- a/types/hand-crafted/service/xmpp/XMPPEvents.d.ts
+++ b/types/hand-crafted/service/xmpp/XMPPEvents.d.ts
@@ -23,8 +23,6 @@
   FOCUS_DISCONNECTED = 'xmpp.focus_disconnected',
   FOCUS_LEFT = 'xmpp.focus_left',
   GRACEFUL_SHUTDOWN = 'xmpp.graceful_shutdown',
-  ICE_RESTARTING = 'rtc.ice_restarting',
-  ICE_RESTART_SUCCESS = 'rtc.ice_restart_success',
   KICKED = 'xmpp.kicked',
   LOCAL_ROLE_CHANGED = 'xmpp.localrole_changed',
   MEETING_ID_SET = 'xmpp.meeting_id_set',


### PR DESCRIPTION
Reinvite method in Jicofo is set to restart-jingle (terminate and recreate the whole jingle session) instead of sending 'transport-replace'. The replaceTransport option has never worked because of a bug in Chrome related to TCC sequence numbering after the DTLS transport layer is reset to start a new DTLS handshake with fresh transport on the bride.