### PR TITLE
fix(TPC) Use videoType from 'source-add' for remote track creation.

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -971,10 +971,10 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track, tr
         stream,
         track,
         ssrc: trackSsrc,
-        videoType: mediaType === MediaType.VIDEO ? VideoType.CAMERA : undefined
+        videoType: peerMediaInfo?.videoType
     };
 
-    if (this._remoteSsrcMap.has(sourceName)) {
+    if (this._remoteSsrcMap.has(sourceName) && mediaType === MediaType.VIDEO) {
         trackDetails.videoType = this._remoteSsrcMap.get(sourceName).videoType;
     }
 

--- a/modules/xmpp/JingleHelperFunctions.js
+++ b/modules/xmpp/JingleHelperFunctions.js
@@ -5,6 +5,7 @@ import { $build } from 'strophe.js';
 
 import { MediaType } from '../../service/RTC/MediaType';
 import { SSRC_GROUP_SEMANTICS } from '../../service/RTC/StandardVideoQualitySettings';
+import { VideoType } from '../../service/RTC/VideoType';
 import { XEP } from '../../service/xmpp/XMPPExtensioProtocols';
 
 const logger = getLogger(__filename);
@@ -13,13 +14,23 @@ const logger = getLogger(__filename);
  * Creates a "source" XML element for the source described in compact JSON format in [sourceCompactJson].
  * @param {*} owner the endpoint ID of the owner of the source.
  * @param {*} sourceCompactJson the compact JSON representation of the source.
+ * @param {boolean} isVideo whether the source is a video source
  * @returns the created "source" XML element.
  */
-function _createSourceExtension(owner, sourceCompactJson) {
+function _createSourceExtension(owner, sourceCompactJson, isVideo = false) {
+    let videoType = sourceCompactJson.v ? VideoType.DESKTOP : undefined;
+
+    // If the video type is not specified, it is assumed to be a camera for video sources.
+    // Jicofo adds the video type only for desktop sharing sources.
+    if (!videoType && isVideo) {
+        videoType = VideoType.CAMERA;
+    }
+
     const node = $build('source', {
         xmlns: XEP.SOURCE_ATTRIBUTES,
         ssrc: sourceCompactJson.s,
-        name: sourceCompactJson.n
+        name: sourceCompactJson.n,
+        videoType
     });
 
     if (sourceCompactJson.m) {
@@ -157,7 +168,7 @@ export function expandSourcesFromJson(iq, jsonMessageXml) {
 
             if (videoSources?.length) {
                 for (let i = 0; i < videoSources.length; i++) {
-                    videoRtpDescription.appendChild(_createSourceExtension(owner, videoSources[i]));
+                    videoRtpDescription.appendChild(_createSourceExtension(owner, videoSources[i], true));
                     ssrcs.push(videoSources[i]?.s);
                 }
             }

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -73,7 +73,8 @@ function _addSourceElement(description, s, ssrc_, msid) {
     description.c('source', {
         xmlns: XEP.SOURCE_ATTRIBUTES,
         ssrc: ssrc_,
-        name: s.source
+        name: s.source,
+        videoType: s.videoType?.toLowerCase()
     })
         .c('parameter', {
             name: 'msid',
@@ -561,6 +562,7 @@ export default class JingleSessionPC extends JingleSession {
                     const msid = $(source)
                         .find('>parameter[name="msid"]')
                         .attr('value');
+                    const videoType = $(source).attr('videoType');
 
                     if (sourceDescription.has(sourceName)) {
                         sourceDescription.get(sourceName).ssrcList?.push(ssrc);
@@ -569,7 +571,8 @@ export default class JingleSessionPC extends JingleSession {
                             groups: [],
                             mediaType,
                             msid,
-                            ssrcList: [ ssrc ]
+                            ssrcList: [ ssrc ],
+                            videoType
                         });
                     }
 


### PR DESCRIPTION
If 'source-add' for a remote video source is received before presence for that source, videoType will default to 'camera' and the client wouldn't be able to create the virtual participant tile for rendering the desktop track.