### PR TITLE
ref(TPC) Move all the utility functions to TPCUtils.

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -470,10 +470,10 @@ export class TPCUtils {
             mLine.ssrcs = reorderedSsrcs;
         });
 
-        return new RTCSessionDescription({
+        return {
             type: description.type,
             sdp: transform.write(parsedSdp)
-        });
+        };
     }
 
     /**
@@ -626,10 +626,10 @@ export class TPCUtils {
             }
         });
 
-        return new RTCSessionDescription({
+        return {
             type: desc.type,
             sdp: transform.write(sdp)
-        });
+        };
     }
 
     /**
@@ -703,10 +703,10 @@ export class TPCUtils {
             }
         }
 
-        return new RTCSessionDescription({
+        return {
             type: description.type,
             sdp: transform.write(parsedSdp)
-        });
+        };
     }
 
     /**
@@ -776,10 +776,10 @@ export class TPCUtils {
             fmtpOpus.config = mungedConfig.trim();
         }
 
-        return new RTCSessionDescription({
+        return {
             type: description.type,
             sdp: transform.write(parsedSdp)
-        });
+        };
     }
 
     /**
@@ -842,10 +842,10 @@ export class TPCUtils {
             }
         }
 
-        return new RTCSessionDescription({
+        return {
             type: description.type,
             sdp: transform.write(parsedSdp)
-        });
+        };
     }
 
     /**
@@ -892,9 +892,9 @@ export class TPCUtils {
             }
         });
 
-        return new RTCSessionDescription({
+        return {
             type: description.type,
             sdp: transform.write(parsedSdp)
-        });
+        };
     }
 }

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -31,8 +31,12 @@ export class TPCUtils {
      * Creates a new instance for a given TraceablePeerConnection
      *
      * @param peerconnection - the tpc instance for which we have utility functions.
+     * @param options - additional options that can be passed to the utility functions.
+     * @param options.audioQuality - the audio quality settings that are used to calculate the audio codec parameters.
+     * @param options.isP2P - whether the connection is a P2P connection.
+     * @param options.videoQuality - the video quality settings that are used to calculate the encoding parameters.
      */
-    constructor(peerconnection, options) {
+    constructor(peerconnection, options = {}) {
         this.pc = peerconnection;
         this.options = options;
         this.codecSettings = cloneDeep(STANDARD_CODEC_SETTINGS);

--- a/modules/RTC/TPCUtils.spec.js
+++ b/modules/RTC/TPCUtils.spec.js
@@ -99,7 +99,7 @@ describe('TPCUtils', () => {
 
         it('sort ssrcs in case the first ssrc in the SIM group is not present at the top', () => {
             const pc = new MockPeerConnection();
-            const tpcUtils = new TPCUtils(pc, { });
+            const tpcUtils = new TPCUtils(pc);
             const source = new RTCSessionDescription({
                 type: 'offer',
                 sdp: getSourceSdp()
@@ -163,7 +163,7 @@ describe('TPCUtils', () => {
 
         it('sort ssrcs in case there is a single FID group', () => {
             const pc = new MockPeerConnection();
-            const tpcUtils = new TPCUtils(pc, { });
+            const tpcUtils = new TPCUtils(pc);
             const source = new RTCSessionDescription({
                 type: 'offer',
                 sdp: getSourceSdp()

--- a/modules/RTC/TPCUtils.spec.js
+++ b/modules/RTC/TPCUtils.spec.js
@@ -35,7 +35,7 @@ describe('TPCUtils', () => {
 
         it('sort ssrcs associated with all FID ssrc-groups', () => {
             const pc = new MockPeerConnection();
-            const tpcUtils = new TPCUtils(pc);
+            const tpcUtils = new TPCUtils(pc, { });
             const source = new RTCSessionDescription({
                 type: 'offer',
                 sdp: getSourceSdp()
@@ -99,7 +99,7 @@ describe('TPCUtils', () => {
 
         it('sort ssrcs in case the first ssrc in the SIM group is not present at the top', () => {
             const pc = new MockPeerConnection();
-            const tpcUtils = new TPCUtils(pc);
+            const tpcUtils = new TPCUtils(pc, { });
             const source = new RTCSessionDescription({
                 type: 'offer',
                 sdp: getSourceSdp()
@@ -163,7 +163,7 @@ describe('TPCUtils', () => {
 
         it('sort ssrcs in case there is a single FID group', () => {
             const pc = new MockPeerConnection();
-            const tpcUtils = new TPCUtils(pc);
+            const tpcUtils = new TPCUtils(pc, { });
             const source = new RTCSessionDescription({
                 type: 'offer',
                 sdp: getSourceSdp()
@@ -223,9 +223,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -311,9 +310,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -442,9 +440,8 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = true;
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -489,9 +486,8 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
                 pc._capScreenshareBitrate = true;
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -531,9 +527,8 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = false;
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -577,9 +572,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -660,9 +654,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -698,9 +691,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -787,9 +779,8 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = true;
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -834,9 +825,8 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = false;
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -880,9 +870,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -989,9 +978,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1098,9 +1086,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1166,9 +1153,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1204,9 +1190,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1299,9 +1284,8 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = true;
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1348,9 +1332,8 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = false;
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1396,9 +1379,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1464,9 +1446,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1502,9 +1483,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1614,9 +1594,8 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = true;
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1661,9 +1640,8 @@ describe('TPCUtils', () => {
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
                 pc._capScreenshareBitrate = false;
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1707,9 +1685,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1775,9 +1752,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1843,10 +1819,9 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
-                pc.options = { videoQuality };
                 pc._capScreenshareBitrate = false;
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -1908,9 +1883,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -2034,9 +2008,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -2154,9 +2127,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -2266,9 +2238,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -2378,10 +2349,9 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc._capScreenshareBitrate = true;
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -2447,10 +2417,9 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc._capScreenshareBitrate = false;
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -2516,9 +2485,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, false /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -2602,9 +2570,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -2689,9 +2656,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = { videoQuality };
                 pc.videoTransferActive = true;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality });
             });
 
             afterEach(() => {
@@ -2776,10 +2742,9 @@ describe('TPCUtils', () => {
             };
 
             pc = new MockPeerConnection('1', true, true /* simulcast */);
-            pc.options = { videoQuality };
             pc._capScreenshareBitrate = true;
             pc.videoTransferActive = true;
-            const utils = new TPCUtils(pc);
+            const utils = new TPCUtils(pc, { videoQuality });
 
             it('and requested desktop resolution is 2160', () => {
                 height = 2160;
@@ -2894,10 +2859,9 @@ describe('TPCUtils', () => {
             const videoQuality = {};
 
             pc = new MockPeerConnection('1', true, true /* simulcast */);
-            pc.options = { videoQuality };
             pc._capScreenshareBitrate = true;
             pc.videoTransferActive = true;
-            const utils = new TPCUtils(pc);
+            const utils = new TPCUtils(pc, { videoQuality });
 
             it('and requested desktop resolution is 2160', () => {
                 height = 2160;
@@ -3003,9 +2967,8 @@ describe('TPCUtils', () => {
 
             beforeEach(() => {
                 pc = new MockPeerConnection('1', true, true /* simulcast */);
-                pc.options = {};
                 pc.videoTransferActive = false;
-                tpcUtils = new TPCUtils(pc);
+                tpcUtils = new TPCUtils(pc, { videoQuality: {} });
             });
 
             afterEach(() => {

--- a/modules/RTC/TPCUtils.spec.js
+++ b/modules/RTC/TPCUtils.spec.js
@@ -35,7 +35,7 @@ describe('TPCUtils', () => {
 
         it('sort ssrcs associated with all FID ssrc-groups', () => {
             const pc = new MockPeerConnection();
-            const tpcUtils = new TPCUtils(pc, { });
+            const tpcUtils = new TPCUtils(pc);
             const source = new RTCSessionDescription({
                 type: 'offer',
                 sdp: getSourceSdp()

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1210,7 +1210,7 @@ const getters = {
         this.trace('getLocalDescription::preTransform', dumpSDP(desc));
 
         if (!this.isP2P) {
-            desc = this.tpcUtils.injectSsrcGroupForUnifiedSimulcast(desc);
+            desc = this.tpcUtils.injectSsrcGroupForSimulcast(desc);
             this.trace('getLocalDescription::postTransform (inject ssrc group)', dumpSDP(desc));
         }
 

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1233,10 +1233,10 @@ TraceablePeerConnection.prototype._injectSsrcGroupForUnifiedSimulcast = function
         }
     }
 
-    return new RTCSessionDescription({
+    return {
         type: desc.type,
         sdp: transform.write(sdp)
-    });
+    };
 };
 
 /* eslint-disable-next-line vars-on-top */
@@ -1797,10 +1797,10 @@ TraceablePeerConnection.prototype._adjustRemoteMediaDirection = function(remoteD
         });
     });
 
-    return new RTCSessionDescription({
+    return {
         type: remoteDescription.type,
         sdp: transformer.toRawSDP()
-    });
+    };
 };
 
 /**
@@ -2458,10 +2458,10 @@ TraceablePeerConnection.prototype._createOfferOrAnswer = function(isOffer, const
 
             if (!this.options.disableRtx && browser.usesSdpMungingForSimulcast()) {
                 // eslint-disable-next-line no-param-reassign
-                resultSdp = new RTCSessionDescription({
+                resultSdp = {
                     type: resultSdp.type,
                     sdp: this.rtxModifier.modifyRtxSsrcs(resultSdp.sdp)
-                });
+                };
 
                 this.trace(
                     `create${logName}`

--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -144,9 +144,9 @@ export default class LocalSdpMunger {
             this._transformMediaIdentifiers(videoMLine, ssrcMap);
         }
 
-        return new RTCSessionDescription({
+        return {
             type: sessionDesc.type,
             sdp: transformer.toRawSDP()
-        });
+        };
     }
 }

--- a/modules/sdp/SdpSimulcast.ts
+++ b/modules/sdp/SdpSimulcast.ts
@@ -227,9 +227,9 @@ export default class SdpSimulcast {
             }
         }
 
-        return new RTCSessionDescription({
+        return {
             type: description.type,
             sdp: transform.write(session)
-        });
+        };
     }
 }

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -2103,7 +2103,7 @@ export default class JingleSessionPC extends JingleSession {
             return Promise.resolve();
         }
 
-        return this.peerconnection.tpcUtils.setMediaTransferActive(active)
+        return this.peerconnection.setMediaTransferActive(active)
             .then(() => {
                 this.peerconnection.audioTransferActive = active;
                 this.peerconnection.videoTransferActive = active;

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -655,10 +655,10 @@ export default class JingleSessionPC extends JingleSession {
             return Promise.reject(error);
         }
 
-        const remoteDescription = new RTCSessionDescription({
+        const remoteDescription = {
             type: 'offer',
             sdp: remoteSdp
-        });
+        };
 
         const oldLocalSDP = this.peerconnection.localDescription.sdp;
 
@@ -2062,10 +2062,10 @@ export default class JingleSessionPC extends JingleSession {
 
         const newRemoteSdp = this._processNewJingleOfferIq(jingleAnswer);
         const oldLocalSdp = new SDP(this.peerconnection.localDescription.sdp);
-        const remoteDescription = new RTCSessionDescription({
+        const remoteDescription = {
             type: 'answer',
             sdp: newRemoteSdp.raw
-        });
+        };
 
         this.peerconnection.setRemoteDescription(remoteDescription)
             .then(() => {

--- a/types/hand-crafted/modules/RTC/TPCUtils.d.ts
+++ b/types/hand-crafted/modules/RTC/TPCUtils.d.ts
@@ -9,7 +9,6 @@ export default class TPCUtils {
   getLocalStreamHeightConstraints: ( localTrack: JitsiLocalTrack ) => number[];
   removeTrackMute: ( localTrack: JitsiLocalTrack ) => Promise<void>;
   replaceTrack: ( oldTrack: JitsiLocalTrack, newTrack: JitsiLocalTrack ) => Promise<void>;
-  setEncodings: ( track: JitsiLocalTrack ) => Promise<void>;
   setMediaTransferActive: ( active: boolean ) => void;
   setVideoTransferActive: ( active: boolean ) => void;
   updateEncodingsResolution: ( parameters: RTCRtpEncodingParameters ) => void;


### PR DESCRIPTION
Move all utility functions to TPCUtils that include
1. munging the SDP.
2. getting current codecs
3. getting expected transceiver direction.
4. getting expected settings for video encodings.

Move all functions that call RTCPeerConnection APIs directly back to TPC.