### PR TITLE
This line triggered the _scheduleResume function even when the network was offline.

### DIFF
--- a/modules/xmpp/ResumeTask.js
+++ b/modules/xmpp/ResumeTask.js
@@ -56,7 +56,6 @@ export default class ResumeTask {
         this._cancelResume();
         this._removeNetworkOnlineListener();
 
-        this._resumeRetryN += 1;
 
         this._networkOnlineListener
             = NetworkInfo.addCancellableListener(
@@ -82,6 +81,8 @@ export default class ResumeTask {
             // NO-OP
             return;
         }
+
+        this._resumeRetryN += 1;
 
         // The retry delay will be:
         //   1st retry: 1.5s - 3s


### PR DESCRIPTION
This line triggered the _scheduleResume function even when the network was offline. Given the presence of the listener mechanism, this line is redundant and its removal is recommended to avoid unnecessary operations.