### PR TITLE
fix(TPC) Fix H.264 simulcast.

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -917,7 +917,7 @@ export class TPCUtils {
      * @returns {string} the munged SDP.
      */
     updateAv1DdHeaders(parsedSdp) {
-        if (!this.supportsDDHeaderExt) {
+        if (!browser.supportsDDExtHeaders()) {
             return parsedSdp;
         }
         const mungedSdp = parsedSdp;

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -542,7 +542,7 @@ TraceablePeerConnection.prototype._getReceiversByEndpointIds = function(endpoint
  */
 TraceablePeerConnection.prototype.isSpatialScalabilityOn = function() {
     const h264SimulcastEnabled = this.tpcUtils.codecSettings[CodecMimeType.H264].scalabilityModeEnabled
-        && this._supportsDDHeaderExt;
+        && this.tpcUtils.supportsDDHeaderExt;
 
     return !this.options.disableSimulcast
         && (this.codecSettings.codecList[0] !== CodecMimeType.H264 || h264SimulcastEnabled);

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -630,7 +630,6 @@ StatsCollector.prototype.processStatsReport = function() {
                 if (now.type === 'outbound-rtp'
                     && now.active
                     && track?.isVideoTrack()
-                    && this.peerconnection.usesCodecSelectionAPI()
                     && before?.totalEncodeTime
                     && before?.framesEncoded
                     && now.frameHeight


### PR DESCRIPTION
Regression was introduced in https://github.com/jitsi/lib-jitsi-meet/commit/07f037e12ed7ced3ba5b1bc6be1cb58dff61789d. Also process encodeTime stats when H.264 is selected