### PR TITLE
Allow Electron to use getDisplayMedia

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -46,11 +46,13 @@ const ScreenObtainer = {
      * @private
      */
     _createObtainStreamMethod() {
-        if (browser.isElectron()) {
+        const supportsGetDisplayMedia = browser.supportsGetDisplayMedia();
+
+        if (browser.isElectron() && !this.options.electronUseGetDisplayMedia) {
             return this.obtainScreenOnElectron;
-        } else if (browser.isReactNative() && browser.supportsGetDisplayMedia()) {
+        } else if (browser.isReactNative() && supportsGetDisplayMedia) {
             return this.obtainScreenFromGetDisplayMediaRN;
-        } else if (browser.supportsGetDisplayMedia()) {
+        } else if (supportsGetDisplayMedia) {
             return this.obtainScreenFromGetDisplayMedia;
         }
         logger.log('Screen sharing not supported on ', browser.getName());


### PR DESCRIPTION
This PR allows Electron to use getDisplayMedia, its hidden behind a flag `electronUseGetDisplayMedia`.

If there's a better place for the flag, or naming convention, do let me know.

Later on I assume you will be deprecating the old method, and it'll be a flag to use the old method, before removing it entirely?

Closes #2597 