### PR TITLE
fix(browser) detect WebRTC APIs and mark browser unsupported if not

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -71,6 +71,12 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean} true if the browser is supported, false otherwise.
      */
     isSupported() {
+        // First check for WebRTC APIs because some "security" extensions are dumb.
+        if (typeof RTCPeerConnection === 'undefined'
+                || !navigator?.mediaDevices?.enumerateDevices || !navigator?.mediaDevices?.getUserMedia) {
+            return false;
+        }
+
         if (this.isSafari() && this._getSafariVersion() < MIN_REQUIRED_SAFARI_VERSION) {
             return false;
         }


### PR DESCRIPTION
Some so called "security" browser extensions override WebRTC APIs so even if the UA string suggests the browser is supported, it won't work.

Coincidentally, this should also mark Safari in Lockdown Mode as unsupported, since the WebRTC APIs are not available in that case.