### PR TITLE
fix(gDM) handle NotReadableError

### DIFF
--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -21,7 +21,7 @@ TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.NOT_FOUND]
 TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.CONSTRAINT_FAILED]
     = 'Constraint could not be satisfied: ';
 TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.TIMEOUT]
-    = 'Could not start media source. Timeout occured!';
+    = 'Could not start media source. Timeout occurred!';
 TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.TRACK_IS_DISPOSED]
     = 'Track has been already disposed';
 TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.TRACK_NO_STREAM_FOUND]

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -286,17 +286,24 @@ const ScreenObtainer = {
             })
             .catch(error => {
                 const errorDetails = {
-                    errorName: error && error.name,
-                    errorMsg: error && error.message,
-                    errorStack: error && error.stack
+                    errorName: error?.name,
+                    errorMsg: error?.message,
+                    errorStack: error?.stack
                 };
 
                 logger.error('getDisplayMedia error', JSON.stringify(constraints), JSON.stringify(errorDetails));
 
-                if (errorDetails.errorMsg && errorDetails.errorMsg.indexOf('denied by system') !== -1) {
+                if (errorDetails.errorMsg?.indexOf('denied by system') !== -1) {
                     // On Chrome this is the only thing different between error returned when user cancels
                     // and when no permission was given on the OS level.
                     errorCallback(new JitsiTrackError(JitsiTrackErrors.PERMISSION_DENIED));
+
+                    return;
+                } else if (errorDetails.errorMsg === 'NotReadableError') {
+                    // This can happen under some weird conditions:
+                    //  - https://issues.chromium.org/issues/369103607
+                    //  - https://issues.chromium.org/issues/353555347
+                    errorCallback(new JitsiTrackError(JitsiTrackErrors.SCREENSHARING_GENERIC_ERROR));
 
                     return;
                 }

--- a/modules/proxyconnection/ProxyConnectionPC.js
+++ b/modules/proxyconnection/ProxyConnectionPC.js
@@ -285,7 +285,7 @@ export default class ProxyConnectionPC {
      * Invoked when a connection related issue has been encountered.
      *
      * @param {string} errorType - The constant indicating the type of the error
-     * that occured.
+     * that occurred.
      * @param {string} details - Optional additional data about the error.
      * @private
      * @returns {void}

--- a/modules/proxyconnection/ProxyConnectionService.js
+++ b/modules/proxyconnection/ProxyConnectionService.js
@@ -218,7 +218,7 @@ export default class ProxyConnectionService {
      * attempted or started, and to which an iq with error details should be
      * sent.
      * @param {string} errorType - The constant indicating the type of the error
-     * that occured.
+     * that occurred.
      * @param {string} details - Optional additional data about the error.
      * @private
      * @returns {void}


### PR DESCRIPTION
Don't show the misleading "user cancelled" error, there are corner cases in which a different error can be manifested.