### PR TITLE
fix(SDP) Include the trackId in the signaled msid for the source.

### DIFF
--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -38,6 +38,7 @@ export default class LocalSdpMunger {
         const mediaType = mediaSection.mLine.type;
         const mediaDirection = mediaSection.mLine.direction;
         const sources = [ ...new Set(mediaSection.mLine.ssrcs?.map(s => s.id)) ];
+        let trackId = mediaSection.mLine.msid?.split(' ')[1];
         let sourceName;
 
         if (ssrcMap.size) {
@@ -51,8 +52,12 @@ export default class LocalSdpMunger {
             for (const source of sources) {
                 if ((mediaDirection === MediaDirection.SENDONLY || mediaDirection === MediaDirection.SENDRECV)
                     && sourceName) {
-                    const msid = ssrcMap.get(sourceName).msid;
-                    const generatedMsid = `${msid}-${this.tpc.id}`;
+                    const msid = mediaSection.ssrcs.find(ssrc => ssrc.id === source && ssrc.attribute === 'msid');
+
+                    if (msid) {
+                        trackId = msid.value.split(' ')[1];
+                    }
+                    const generatedMsid = `${ssrcMap.get(sourceName).msid}-${this.tpc.id} ${trackId}-${this.tpc.id}`;
                     const existingMsid = mediaSection.ssrcs
                         .find(ssrc => ssrc.id === source && ssrc.attribute === 'msid');
 

--- a/modules/sdp/LocalSdpMunger.spec.js
+++ b/modules/sdp/LocalSdpMunger.spec.js
@@ -109,7 +109,8 @@ describe('TransformSdpsForUnifiedPlan', () => {
                 if (ssrcLine.attribute === 'msid') {
                     const msid = ssrcLine.value;
 
-                    expect(msid).toBe(`${localEndpointId}-video-0-${tpc.id}`);
+                    expect(msid)
+                        .toBe(`${localEndpointId}-video-0-${tpc.id} bdbd2c0a-7959-4578-8db5-9a6a1aec4ecf-${tpc.id}`);
                 }
             }
         });


### PR DESCRIPTION
Without the trackID in a=ssrc lines in SDP, older versions of Chrome (108) reject the remote description resulting in endpoint getting kicked out of the conference.