### PR TITLE
fix(codec) Debounce the call that calc codec intersection set.

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -512,10 +512,10 @@ export class TPCUtils {
         const rtpSender = this.pc.findSenderForTrack(localVideoTrack.getTrack());
 
         if (this.pc.usesCodecSelectionAPI() && rtpSender) {
-            const { codecs } = rtpSender.getParameters();
+            const { encodings } = rtpSender.getParameters();
 
-            if (codecs?.length) {
-                return codecs[0].mimeType.split('/')[1].toLowerCase();
+            if (encodings[0].codec) {
+                return encodings[0].codec.mimeType.split('/')[1].toLowerCase();
             }
         }
 

--- a/modules/qualitycontrol/CodecSelection.spec.js
+++ b/modules/qualitycontrol/CodecSelection.spec.js
@@ -50,43 +50,57 @@ describe('Codec Selection', () => {
             };
 
             qualityController = new QualityController(conference, options);
+            jasmine.clock().install();
             spyOn(jingleSession, 'setVideoCodecs');
         });
 
-        it('and remote endpoints use the new codec selection logic', () => {
+        afterEach(() => {
+            jasmine.clock().uninstall();
+        });
+
+        it('and remote endpoints use the new codec selection logic', async () => {
             // Add a second user joining the call.
             participant1 = new MockParticipant('remote-1');
             conference.addParticipant(participant1, [ 'vp9', 'vp8' ]);
 
+            await nextTick(1000);
+
             expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(1);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp9', 'vp8' ], 'vp9');
 
             // Add a third user joining the call with a subset of codecs.
             participant2 = new MockParticipant('remote-2');
             conference.addParticipant(participant2, [ 'vp8' ]);
 
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp8' ], 'vp9');
-
-            // Make p2 leave the call
+            // Make p2 leave the call.
             conference.removeParticipant(participant2);
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(3);
+
+            await nextTick(1000);
+
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(2);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp9', 'vp8' ], 'vp9');
         });
 
-        it('and remote endpoints use the old codec selection logic (RN)', () => {
+        it('and remote endpoints use the old codec selection logic (RN)', async () => {
             // Add a second user joining the call.
             participant1 = new MockParticipant('remote-1');
             conference.addParticipant(participant1, null, 'vp8');
 
+            await nextTick(1000);
+
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(1);
             expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp8' ], 'vp9');
 
             // Add a third user (newer) to the call.
             participant2 = new MockParticipant('remote-2');
             conference.addParticipant(participant2, [ 'vp9', 'vp8' ]);
 
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp8' ], 'vp9');
-
             // Make p1 leave the call
             conference.removeParticipant(participant1);
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(3);
+
+            await nextTick(1000);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(2);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp9', 'vp8' ], 'vp9');
         });
     });
 
@@ -102,50 +116,61 @@ describe('Codec Selection', () => {
 
             qualityController = new QualityController(conference, options);
             spyOn(jingleSession, 'setVideoCodecs');
+            jasmine.clock().install();
         });
 
-        it('and remote endpoints use the new codec selection logic', () => {
+        afterEach(() => {
+            jasmine.clock().uninstall();
+        });
+
+        it('and remote endpoints use the new codec selection logic', async () => {
             // Add a second user joining the call.
             participant1 = new MockParticipant('remote-1');
             conference.addParticipant(participant1, [ 'vp9', 'vp8', 'h264' ]);
 
+            await nextTick(1000);
             expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(1);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp9', 'vp8' ], undefined);
 
             // Add a third user joining the call with a subset of codecs.
             participant2 = new MockParticipant('remote-2');
             conference.addParticipant(participant2, [ 'vp8' ]);
 
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp8' ], undefined);
-
             // Make p2 leave the call
             conference.removeParticipant(participant2);
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(3);
+
+            await nextTick(1000);
+
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(2);
         });
 
-        it('and remote endpoint prefers a codec that is locally disabled', () => {
+        it('and remote endpoint prefers a codec that is locally disabled', async () => {
             // Add a second user joining the call the prefers H.264 and VP8.
             participant1 = new MockParticipant('remote-1');
             conference.addParticipant(participant1, [ 'h264', 'vp8' ]);
 
+            await nextTick(1200);
             expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp8' ], undefined);
         });
 
-        it('and remote endpoints use the old codec selection logic (RN)', () => {
+        it('and remote endpoints use the old codec selection logic (RN)', async () => {
             // Add a second user joining the call.
             participant1 = new MockParticipant('remote-1');
             conference.addParticipant(participant1, null, 'vp8');
 
+            await nextTick(1000);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(1);
             expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp8' ], undefined);
 
             // Add a third user (newer) to the call.
             participant2 = new MockParticipant('remote-2');
             conference.addParticipant(participant2, [ 'vp9', 'vp8', 'h264' ]);
 
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp8' ], undefined);
-
             // Make p1 leave the call
             conference.removeParticipant(participant1);
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(3);
+
+            jasmine.clock().tick(1000);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(2);
         });
     });
 
@@ -171,11 +196,14 @@ describe('Codec Selection', () => {
 
             participant1 = new MockParticipant('remote-1');
             conference.addParticipant(participant1, [ 'av1', 'vp9', 'vp8' ]);
+
+            await nextTick(1000);
+
             expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'av1', 'vp9', 'vp8' ], undefined);
 
             participant2 = new MockParticipant('remote-2');
             conference.addParticipant(participant2, [ 'av1', 'vp9', 'vp8' ]);
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'av1', 'vp9', 'vp8' ], undefined);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(1);
 
             qualityController.codecController.changeCodecPreferenceOrder(localTrack, 'av1');
 
@@ -187,6 +215,7 @@ describe('Codec Selection', () => {
 
             // Expect the local endpoint to continue sending VP9.
             expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp9', 'av1', 'vp8' ], undefined);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(3);
         });
 
         it('and does not change codec if the current codec is already the lowest complexity codec', async () => {
@@ -196,6 +225,8 @@ describe('Codec Selection', () => {
 
             participant1 = new MockParticipant('remote-1');
             conference.addParticipant(participant1, [ 'av1', 'vp9', 'vp8' ]);
+
+            await nextTick(1000);
             expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp8', 'vp9', 'av1' ], undefined);
 
             participant2 = new MockParticipant('remote-2');
@@ -239,11 +270,14 @@ describe('Codec Selection', () => {
 
             participant1 = new MockParticipant('remote-1');
             conference.addParticipant(participant1, [ 'av1', 'vp9', 'vp8' ]);
+
+            await nextTick(1000);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(1);
             expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'av1', 'vp9', 'vp8' ], undefined);
 
             participant2 = new MockParticipant('remote-2');
             conference.addParticipant(participant2, [ 'av1', 'vp9', 'vp8' ]);
-            expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'av1', 'vp9', 'vp8' ], undefined);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(1);
 
             const sourceStats = {
                 avgEncodeTime: 12,
@@ -268,6 +302,8 @@ describe('Codec Selection', () => {
 
             participant3 = new MockParticipant('remote-3');
             conference.addParticipant(participant3, [ 'av1', 'vp9', 'vp8' ]);
+
+            await nextTick(1000);
 
             // Expect the local endpoint to continue sending VP9.
             expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp9', 'av1', 'vp8' ], undefined);
@@ -326,6 +362,43 @@ describe('Codec Selection', () => {
             await nextTick(60000);
 
             expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe('When multiple joins and leaves happen in a quick burst', () => {
+        beforeEach(() => {
+            options = {
+                jvb: {
+                    preferenceOrder: [ 'AV1', 'VP9', 'VP8' ],
+                    screenshareCodec: 'VP9'
+                },
+                p2p: {}
+            };
+            jasmine.clock().install();
+            qualityController = new QualityController(conference, options);
+            spyOn(jingleSession, 'setVideoCodecs');
+        });
+
+        afterEach(() => {
+            jasmine.clock().uninstall();
+        });
+
+        it('should call setVideoCodecs only once within the same tick', async () => {
+            participant1 = new MockParticipant('remote-1');
+            conference.addParticipant(participant1, [ 'vp9', 'vp8' ]);
+
+            // Add a third user joining the call with a subset of codecs.
+            participant2 = new MockParticipant('remote-2');
+            conference.addParticipant(participant2, [ 'vp8' ]);
+
+            // Make p1 and p2 leave the call.
+            conference.removeParticipant(participant2);
+            conference.removeParticipant(participant1);
+
+            await nextTick(1000);
+
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledTimes(1);
+            expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'av1', 'vp9', 'vp8' ], 'vp9');
         });
     });
 });

--- a/modules/qualitycontrol/QualityController.spec.js
+++ b/modules/qualitycontrol/QualityController.spec.js
@@ -33,7 +33,7 @@ describe('QualityController', () => {
                 p2p: {}
             };
             localTrack = new MockLocalTrack('1', 720, 'camera');
-            qualityController = new QualityController(conference, options, true);
+            qualityController = new QualityController(conference, options);
             sourceStats = {
                 avgEncodeTime: 12,
                 codec: 'VP8',
@@ -165,7 +165,7 @@ describe('QualityController', () => {
                 p2p: {}
             };
             localTrack = new MockLocalTrack('1', 720, 'camera');
-            qualityController = new QualityController(conference, options, true);
+            qualityController = new QualityController(conference, options);
             sourceStats = {
                 avgEncodeTime: 12,
                 codec: 'VP8',

--- a/modules/qualitycontrol/QualityController.ts
+++ b/modules/qualitycontrol/QualityController.ts
@@ -1,4 +1,3 @@
-import { throttle } from 'lodash-es';
 import { getLogger } from '@jitsi/logger';
 
 import JitsiConference from "../../JitsiConference";
@@ -174,8 +173,8 @@ export class QualityController {
         return function (...args) {
             if (!this._timer) {
                 this._timer = setTimeout(() => {
-                    func.apply(this, args);
                     this._timer = null;
+                    func.apply(this, args);
                 }, delay);
             }
         };

--- a/modules/qualitycontrol/QualityController.ts
+++ b/modules/qualitycontrol/QualityController.ts
@@ -1,3 +1,4 @@
+import { throttle } from 'lodash-es';
 import { getLogger } from '@jitsi/logger';
 
 import JitsiConference from "../../JitsiConference";
@@ -145,18 +146,39 @@ export class QualityController {
         this._conference.on(
             JitsiConferenceEvents.CONFERENCE_VISITOR_CODECS_CHANGED,
             (codecList: CodecMimeType[]) => this._codecController.updateVisitorCodecs(codecList));
-        this._conference.on(
-            JitsiConferenceEvents.USER_JOINED,
-            () => this._codecController.selectPreferredCodec(this._conference.jvbJingleSession));
-        this._conference.on(
-            JitsiConferenceEvents.USER_LEFT,
-            () => this._codecController.selectPreferredCodec(this._conference.jvbJingleSession));
+
+        // Debounce the calls to codec selection when there is a burst of joins and leaves.
+        const debouncedSelectCodec = this._debounce(
+            () => this._codecController.selectPreferredCodec(this._conference.jvbJingleSession),
+            1000);
+        this._conference.on(JitsiConferenceEvents.USER_JOINED, debouncedSelectCodec.bind(this));
+        this._conference.on(JitsiConferenceEvents.USER_LEFT, debouncedSelectCodec.bind(this));
         this._conference.rtc.on(
             RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED,
             (videoConstraints: IVideoConstraints) => this._sendVideoController.onSenderConstraintsReceived(videoConstraints));
         this._conference.on(
             JitsiConferenceEvents.ENCODE_TIME_STATS_RECEIVED,
             (tpc: TraceablePeerConnection, stats: Map<number, IOutboundRtpStats>) => this._processOutboundRtpStats(tpc, stats));
+    }
+
+    /**
+     * Creates a debounced function that delays the execution of the provided function until after the specified delay
+     * has elapsed. Unlike typical debounce implementations, the timer does not reset when the function is called again
+     * within the delay period.
+     *
+     * @param {Function} func - The function to be debounced.
+     * @param {number} delay - The delay in milliseconds.
+     * @returns {Function} - The debounced function.
+     */
+    _debounce(func: Function, delay: number) {
+        return function (...args) {
+            if (!this._timer) {
+                this._timer = setTimeout(() => {
+                    func.apply(this, args);
+                    this._timer = null;
+                }, delay);
+            }
+        };
     }
 
     /**

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -2283,7 +2283,6 @@ export default class JingleSessionPC extends JingleSession {
      */
     setVideoCodecs(codecList, screenshareCodec) {
         if (this._assertNotEnded()) {
-            logger.info(`${this} setVideoCodecs: codecList=${codecList}, screenshareCodec=${screenshareCodec}`);
             this.peerconnection.setVideoCodecs(codecList, screenshareCodec);
 
             // Browser throws an error when H.264 is set on the encodings. Therefore, munge the SDP when H.264 needs to
@@ -2306,6 +2305,8 @@ export default class JingleSessionPC extends JingleSession {
                     value: codecList[0],
                     videoType: VideoType.CAMERA
                 });
+
+            logger.info(`${this} setVideoCodecs: codecList=${codecList}, screenshareCodec=${screenshareCodec}`);
 
             // Initiate a renegotiate for the codec setting to take effect.
             const workFunction = finishedCallback => {


### PR DESCRIPTION
Calculate codec intersection set only once per second even when there is a burst of joins/leaves. Also, check for current codec before chaining a codec change operation when codec selection API is used.