### PR TITLE
fix(xmpp) unescape HTML entities in JSON messages

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -1,6 +1,7 @@
 import { safeJsonParse } from '@jitsi/js-utils/json';
 import { getLogger } from '@jitsi/logger';
 import $ from 'jquery';
+import { unescape } from 'lodash-es';
 import { $msg, Strophe } from 'strophe.js';
 import 'strophejs-plugin-disco';
 
@@ -1019,7 +1020,9 @@ export default class XMPP extends Listenable {
         }
 
         try {
-            const json = safeJsonParse(jsonString);
+            // Note: we use `unescape` to also convert HTML entities to UTF-8 since
+            // Jigasi seems to encode them like that in some circumstances.
+            const json = safeJsonParse(unescape(jsonString));
 
             // Handle non-exception-throwing cases:
             // Neither JSON.parse(false) or JSON.parse(1234) throw errors,


### PR DESCRIPTION
Jigasi / Jitsi (desktop) seems to encode apostrophes like (&apos or &#39) for instance.

This is notably visible in the subtitles.

Normalize it so it's plain UTF-8.