### PR TITLE
feat(ScreenObtainer) add fallback option for Electron

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -298,24 +298,20 @@ const ScreenObtainer = {
                     errorStack: error?.stack
                 };
 
-                logger.error('getDisplayMedia error', JSON.stringify(constraints), JSON.stringify(errorDetails));
+                logger.warn('getDisplayMedia error', JSON.stringify(constraints), JSON.stringify(errorDetails));
 
                 if (errorDetails.errorMsg?.indexOf('denied by system') !== -1) {
                     // On Chrome this is the only thing different between error returned when user cancels
                     // and when no permission was given on the OS level.
                     errorCallback(new JitsiTrackError(JitsiTrackErrors.PERMISSION_DENIED));
-
-                    return;
                 } else if (errorDetails.errorMsg === 'NotReadableError') {
                     // This can happen under some weird conditions:
                     //  - https://issues.chromium.org/issues/369103607
                     //  - https://issues.chromium.org/issues/353555347
                     errorCallback(new JitsiTrackError(JitsiTrackErrors.SCREENSHARING_GENERIC_ERROR));
-
-                    return;
+                } else {
+                    errorCallback(new JitsiTrackError(JitsiTrackErrors.SCREENSHARING_USER_CANCELED));
                 }
-
-                errorCallback(new JitsiTrackError(JitsiTrackErrors.SCREENSHARING_USER_CANCELED));
             });
     },
 

--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -94,7 +94,12 @@ const ScreenObtainer = {
      * @param {Object} options - Optional parameters.
      */
     obtainScreenOnElectron(onSuccess, onFailure, options = {}) {
-        if (window.JitsiMeetScreenObtainer && window.JitsiMeetScreenObtainer.openDesktopPicker) {
+        if (typeof window.JitsiMeetScreenObtainer?.openDesktopPicker === 'function') {
+            // Detect if we have the fallback option.
+            if (window.JitsiMeetScreenObtainer?.gDMSupported) {
+                return this.obtainScreenFromGetDisplayMedia(onSuccess, onFailure);
+            }
+
             const { desktopSharingFrameRate, desktopSharingResolution, desktopSharingSources } = this.options;
 
             window.JitsiMeetScreenObtainer.openDesktopPicker(


### PR DESCRIPTION
If the enclosing Jitsi Meet app declares gDM in Electron is supported, ignore the `electronUseGetDisplayMedia` config flag and use the gDM flow. This facilitates having backwards compatibility since the Electron app won't know if the deployment it's about to join has the gDM flow support or not.