### PR TITLE
fix(ScreenObtainer) fix using gDM with old Electron clients

### DIFF
--- a/JitsiTrackError.js
+++ b/JitsiTrackError.js
@@ -8,6 +8,8 @@ TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.SCREENSHARING_USER_CANCELED]
     = 'User canceled screen sharing prompt';
 TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.SCREENSHARING_GENERIC_ERROR]
     = 'Unknown error from screensharing';
+TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.SCREENSHARING_NOT_SUPPORTED_ERROR]
+    = 'Not supported';
 TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_ERROR]
     = 'Unkown error from desktop picker';
 TRACK_ERROR_TO_MESSAGE_MAP[JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_NOT_FOUND]

--- a/JitsiTrackErrors.spec.ts
+++ b/JitsiTrackErrors.spec.ts
@@ -11,6 +11,7 @@ describe( "/JitsiTrackErrors members", () => {
         NOT_FOUND,
         PERMISSION_DENIED,
         SCREENSHARING_GENERIC_ERROR,
+        SCREENSHARING_NOT_SUPPORTED_ERROR,
         SCREENSHARING_USER_CANCELED,
         TIMEOUT,
         TRACK_IS_DISPOSED,
@@ -30,6 +31,7 @@ describe( "/JitsiTrackErrors members", () => {
         expect( NOT_FOUND ).toBe( 'gum.not_found' );
         expect( PERMISSION_DENIED ).toBe( 'gum.permission_denied' );
         expect( SCREENSHARING_GENERIC_ERROR ).toBe( 'gum.screensharing_generic_error' );
+        expect( SCREENSHARING_NOT_SUPPORTED_ERROR ).toBe( 'gdm.screen_sharing_not_supported' );
         expect( SCREENSHARING_USER_CANCELED ).toBe( 'gum.screensharing_user_canceled' );
         expect( TIMEOUT ).toBe( 'gum.timeout' );
         expect( TRACK_IS_DISPOSED ).toBe( 'track.track_is_disposed' );
@@ -47,6 +49,7 @@ describe( "/JitsiTrackErrors members", () => {
         expect( JitsiTrackErrors.NOT_FOUND ).toBe( 'gum.not_found' );
         expect( JitsiTrackErrors.PERMISSION_DENIED ).toBe( 'gum.permission_denied' );
         expect( JitsiTrackErrors.SCREENSHARING_GENERIC_ERROR ).toBe( 'gum.screensharing_generic_error' );
+        expect( JitsiTrackErrors.SCREENSHARING_NOT_SUPPORTED_ERROR ).toBe( 'gdm.screen_sharing_not_supported' );
         expect( JitsiTrackErrors.SCREENSHARING_USER_CANCELED ).toBe( 'gum.screensharing_user_canceled' );
         expect( JitsiTrackErrors.TIMEOUT ).toBe( 'gum.timeout' );
         expect( JitsiTrackErrors.TRACK_IS_DISPOSED ).toBe( 'track.track_is_disposed' );

--- a/JitsiTrackErrors.ts
+++ b/JitsiTrackErrors.ts
@@ -43,6 +43,12 @@ export enum JitsiTrackErrors {
     SCREENSHARING_GENERIC_ERROR = 'gum.screensharing_generic_error',
 
     /**
+     * Error in getDisplayMedia when not supported. Can happen in Electron if no
+     * permission handler was set.
+     */
+    SCREENSHARING_NOT_SUPPORTED_ERROR = 'gdm.screen_sharing_not_supported',
+
+    /**
      * An error which indicates that user canceled screen sharing window
      * selection dialog.
      */
@@ -89,6 +95,7 @@ export const GENERAL = JitsiTrackErrors.GENERAL;
 export const NOT_FOUND = JitsiTrackErrors.NOT_FOUND;
 export const PERMISSION_DENIED = JitsiTrackErrors.PERMISSION_DENIED;
 export const SCREENSHARING_GENERIC_ERROR = JitsiTrackErrors.SCREENSHARING_GENERIC_ERROR;
+export const SCREENSHARING_NOT_SUPPORTED_ERROR = JitsiTrackErrors.SCREENSHARING_NOT_SUPPORTED_ERROR;
 export const SCREENSHARING_USER_CANCELED = JitsiTrackErrors.SCREENSHARING_USER_CANCELED;
 export const TIMEOUT = JitsiTrackErrors.TIMEOUT;
 export const TRACK_IS_DISPOSED = JitsiTrackErrors.TRACK_IS_DISPOSED;


### PR DESCRIPTION
Detect if gDM support has been enabled and fallback to the previous gUM flow otherwise.