### PR TITLE
fix(codec) Fix AV1/VP9 support on Firefox.

### DIFF
--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -222,7 +222,9 @@ export class TPCUtils {
         // https://hg.mozilla.org/mozilla-central/rev/b0348f1f8d7197fb87158ba74542d28d46133997
         // This revert seems to be applied only to camera tracks, the desktop stream encodings still have the
         // resolution order of 4:2:1.
-        if (browser.isFirefox() && (videoType === VideoType.DESKTOP || browser.isVersionLessThan(117))) {
+        if (browser.isFirefox()
+            && !browser.supportsScalabilityModeAPI()
+            && (videoType === VideoType.DESKTOP || browser.isVersionLessThan(117))) {
             effectiveBitrates = effectiveBitrates.reverse();
             effectiveScaleFactors = effectiveScaleFactors.reverse();
         }

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -177,7 +177,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     supportsDDExtHeaders() {
-        return !this.isFirefox();
+        return !(this.isFirefox() && this.isVersionLessThan('136'));
     }
 
     /**
@@ -233,7 +233,8 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     supportsScalabilityModeAPI() {
-        return this.isChromiumBased() && this.isEngineVersionGreaterThan(112);
+        return (this.isChromiumBased() && this.isEngineVersionGreaterThan(112))
+            || (this.isFirefox() && this.isVersionGreaterThan(135));
     }
 
     /**
@@ -246,12 +247,12 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
-     * Returns true if VP9 is supported by the client on the browser. VP9 is currently disabled on Firefox and Safari
-     * because of issues with rendering. Please check https://bugzilla.mozilla.org/show_bug.cgi?id=1492500,
-     * https://bugs.webkit.org/show_bug.cgi?id=231071 and https://bugs.webkit.org/show_bug.cgi?id=231074 for details.
+     * Returns true if VP9 is supported by the client on the browser. VP9 is currently disabled on Safari
+     * and older versions of Firefox because of issues. Please check https://bugs.webkit.org/show_bug.cgi?id=231074 for
+     * details.
      */
     supportsVP9() {
-        return this.isChromiumBased() || this.isReactNative();
+        return !(this.isWebKitBased() || (this.isFirefox() && this.isVersionLessThan('136')));
     }
 
     /**

--- a/modules/qualitycontrol/CodecSelection.js
+++ b/modules/qualitycontrol/CodecSelection.js
@@ -72,11 +72,10 @@ export class CodecSelection {
             }
 
             // Push VP9 to the end of the list so that the client continues to decode VP9 even if its not
-            // preferable to encode VP9 (because of browser bugs on the encoding side or added complexity on mobile
-            // devices). Currently, VP9 encode is supported on Chrome and on Safari (only for p2p).
+            // preferable to encode VP9 (because of browser bugs on the encoding side or other reasons).
             const isVp9EncodeSupported = browser.supportsVP9() || (browser.isWebKitBased() && connectionType === 'p2p');
 
-            if (!isVp9EncodeSupported || this.conference.isE2EEEnabled()) {
+            if (!isVp9EncodeSupported) {
                 const index = selectedOrder.findIndex(codec => codec === CodecMimeType.VP9);
 
                 if (index !== -1) {


### PR DESCRIPTION
Firefox added support for AV1 with DD and VP9 SVC is also working as expected in Firefox 136.