### PR TITLE
fixed selectEndpoints resets constraints properly

### DIFF
--- a/modules/qualitycontrol/ReceiveVideoController.js
+++ b/modules/qualitycontrol/ReceiveVideoController.js
@@ -219,6 +219,11 @@ export default class ReceiveVideoController {
             this._receiverVideoConstraints.lastN = this._lastN;
             this._receiveResolutionLimitedByCpu && this._updateIndividualConstraints();
 
+            if (constraints.selectedEndpoints && constraints.selectedEndpoints.length === 0) {
+                this._receiverVideoConstraints.selectedEndpoints = undefined;
+            }
+            this._rtc.setReceiverVideoConstraints(this._receiverVideoConstraints);
+
             // Send the contraints on the bridge channel.
             this._rtc.setReceiverVideoConstraints(this._receiverVideoConstraints);
 

--- a/modules/qualitycontrol/ReceiveVideoController.js
+++ b/modules/qualitycontrol/ReceiveVideoController.js
@@ -222,7 +222,6 @@ export default class ReceiveVideoController {
             if (constraints.selectedEndpoints && constraints.selectedEndpoints.length === 0) {
                 this._receiverVideoConstraints.selectedEndpoints = undefined;
             }
-            this._rtc.setReceiverVideoConstraints(this._receiverVideoConstraints);
 
             // Send the contraints on the bridge channel.
             this._rtc.setReceiverVideoConstraints(this._receiverVideoConstraints);


### PR DESCRIPTION
Fixes #2134 

When calling selectEndpoints, previously selected participants were still present instead of being removed.

Modified setReceiverConstraints() in ReceiveVideoController.js
If selectedEndpoints is an empty array, it now resets the constraints properly instead of keeping old values.

**this._receiverVideoConstraints.selectedEndpoints = undefined;**

 This ensures that when selectEndpoints is called

It completely resets selectedEndpoints instead of keeping old data.

