### PR TITLE
fix(SDP) Inject trackID if missing from signaled source info.

### DIFF
--- a/modules/sdp/SDP.js
+++ b/modules/sdp/SDP.js
@@ -95,8 +95,18 @@ export default class SDP {
             updatedMidIndices.push(idx);
 
             if (isAdd) {
+                let updatedMsid = msid;
+
+                // If the msid is not in the <stream ID> <track ID> format, create msid in that format.
+                // Chrome's older versions (upto 117) expect the msid to be in this format.
+                if (msid.split(' ').length !== 2
+                    && browser.isChromiumBased()
+                    && browser.isEngineVersionLessThan(117)) {
+                    updatedMsid = `${msid} ${msid}-${idx}`;
+                }
+
                 ssrcList.forEach(ssrc => {
-                    this.media[idx] += `a=ssrc:${ssrc} msid:${msid}\r\n`;
+                    this.media[idx] += `a=ssrc:${ssrc} msid:${updatedMsid}\r\n`;
                 });
                 groups?.forEach(group => {
                     this.media[idx] += `a=ssrc-group:${group.semantics} ${group.ssrcs.join(' ')}\r\n`;


### PR DESCRIPTION
Reconstruct the msid to include both streamId and trackId if its missing from the source signaling. Fixes issue on Chromium < 117 where the remote offer gets rejected and the client gets kicked out of the call.