### PR TITLE
feat(rtcstats): early rtcstats initialization

### DIFF
--- a/JitsiConnection.js
+++ b/JitsiConnection.js
@@ -68,7 +68,7 @@ export default function JitsiConnection(appID, token, options) {
  */
 JitsiConnection.prototype.connect = function(options = {}) {
 
-    RTCStats.startWithConnection(options.name, this.options);
+    RTCStats.startWithConnection(this);
 
     // if we get redirected, we set disableFocus to skip sending the conference request twice
     if (this.xmpp.moderator.targetUrl && !this.options.disableFocus && options.name) {

--- a/JitsiConnection.js
+++ b/JitsiConnection.js
@@ -33,9 +33,6 @@ export default function JitsiConnection(appID, token, options) {
 
     this.xmpp = new XMPP(options, token);
 
-
-    RTCStats.attachToConnection(options);
-
     /* eslint-disable max-params */
     this.addEventListener(JitsiConnectionEvents.CONNECTION_FAILED,
         (errType, msg, credentials, details) => {
@@ -70,6 +67,9 @@ export default function JitsiConnection(appID, token, options) {
  * to be used.
  */
 JitsiConnection.prototype.connect = function(options = {}) {
+
+    RTCStats.startWithConnection(options.name, this.options);
+
     // if we get redirected, we set disableFocus to skip sending the conference request twice
     if (this.xmpp.moderator.targetUrl && !this.options.disableFocus && options.name) {
         this.xmpp.moderator.sendConferenceRequest(this.xmpp.getRoomJid(options.name))

--- a/JitsiConnection.js
+++ b/JitsiConnection.js
@@ -2,6 +2,7 @@ import { getLogger } from '@jitsi/logger';
 
 import JitsiConference from './JitsiConference';
 import * as JitsiConnectionEvents from './JitsiConnectionEvents';
+import RTCStats from './modules/RTCStats/RTCStats';
 import FeatureFlags from './modules/flags/FeatureFlags';
 import Statistics from './modules/statistics/statistics';
 import XMPP from './modules/xmpp/xmpp';
@@ -31,6 +32,9 @@ export default function JitsiConnection(appID, token, options) {
     FeatureFlags.init(options.flags || {});
 
     this.xmpp = new XMPP(options, token);
+
+
+    RTCStats.attachToConnection(options);
 
     /* eslint-disable max-params */
     this.addEventListener(JitsiConnectionEvents.CONNECTION_FAILED,

--- a/JitsiMeetJS.ts
+++ b/JitsiMeetJS.ts
@@ -84,8 +84,8 @@ type desktopSharingSourceType = 'screen' | 'window';
 
 interface IJitsiMeetJSOptions {
     analytics?: {
-        rtcstatsStoreLogs?: boolean;
         rtcstatsLogFlushSizeBytes?: number;
+        rtcstatsStoreLogs?: boolean;
     };
     desktopSharingSources?: Array<desktopSharingSourceType>;
     enableAnalyticsLogging?: boolean;

--- a/modules/RTCStats/DefaulLogStorage.ts
+++ b/modules/RTCStats/DefaulLogStorage.ts
@@ -22,7 +22,7 @@ export default class DefaultLogStorage {
      * <tt>false</tt> otherwise.
      */
     isReady() {
-        return this.rtcStats._initialized;
+        return this.rtcStats.isTraceAvailable();
     }
 
     /**

--- a/modules/RTCStats/RTCStats.ts
+++ b/modules/RTCStats/RTCStats.ts
@@ -3,6 +3,7 @@ import rtcstatsInit from '@jitsi/rtcstats/rtcstats';
 import traceInit from '@jitsi/rtcstats/trace-ws';
 
 import JitsiConference from '../../JitsiConference';
+import JitsiConnection from '../../JitsiConnection';
 import {
     BEFORE_STATISTICS_DISPOSED,
     CONFERENCE_CREATED_TIMESTAMP,
@@ -71,16 +72,17 @@ class RTCStats {
     }
 
     /**
-     * A JitsiConnection instance is created before the conference is joined, so even though
+      * A JitsiConnection instance is created before the conference is joined, so even though
      * we don't have any conference specific data yet, we can initialize the trace module and
      * send any logs that might of otherwise be missed in case an error occurs between the connection
      * and conference initialization.
      *
-     * @param name - The name of the conference.
-     * @param options - The config options available at JitsiConnection level.
+     * @param connection - The JitsiConnection instance.
      * @returns {void}
      */
-    startWithConnection(name: string, options: any) {
+    startWithConnection(connection: JitsiConnection) {
+        const { options } = connection;
+        const name = options?.name ?? '';
         const {
             analytics: {
                 rtcstatsUseLegacy: useLegacy = false,

--- a/modules/RTCStats/RTCStats.ts
+++ b/modules/RTCStats/RTCStats.ts
@@ -75,7 +75,7 @@ class RTCStats {
      * we don't have any conference specific data yet, we can initialize the trace module and
      * send any logs that might of otherwise be missed in case an error occurs between the connection
      * and conference initialization.
-     * 
+     *
      * @param name - The name of the conference.
      * @param options - The config options available at JitsiConnection level.
      * @returns {void}
@@ -117,15 +117,15 @@ class RTCStats {
             ...options
         });
 
-        // This module is tightly tied with the ljm JitsiConnection and JitsiConference flows, technically 
-        // the connection isn't associated with a conference, but we still need to have some association for 
+        // This module is tightly tied with the ljm JitsiConnection and JitsiConference flows, technically
+        // the connection isn't associated with a conference, but we still need to have some association for
         // data that is logged before the conference is joined.
         // In short the flow is as follows:
         // 1. Connection is created.
         // 2. The trace module is initialized and connected to the rtcstats server, so data starts being sent.
         // 3. Conference is created.
         // 4. If the trace wasn't already initialized from the connection creation, it will be initialized again.
-        // this will take care of the cases where the connection is created and then multiple conferences are 
+        // this will take care of the cases where the connection is created and then multiple conferences are
         // sequentially joined and left, such as breakout rooms.
         this._startedWithNewConnection = true;
     }
@@ -246,9 +246,9 @@ class RTCStats {
      */
     _connectTrace(traceOptions: ITraceOptions) {
 
-         const traceOptionsComplete = { 
+        const traceOptionsComplete = {
             ...traceOptions,
-            onCloseCallback: (event) => this.events.emit(RTC_STATS_WC_DISCONNECTED, event)
+            onCloseCallback: event => this.events.emit(RTC_STATS_WC_DISCONNECTED, event)
         };
 
         const { isBreakoutRoom } = traceOptionsComplete;

--- a/modules/RTCStats/RTCStats.ts
+++ b/modules/RTCStats/RTCStats.ts
@@ -42,7 +42,6 @@ class RTCStats {
     init(initConfig: IRTCStatsConfiguration) {
         const {
             analytics: {
-                rtcstatsUseLegacy: useLegacy = false,
                 rtcstatsPollInterval: pollInterval = 10000,
                 rtcstatsSendSdp: sendSdp = false,
                 rtcstatsEnabled = false
@@ -59,7 +58,7 @@ class RTCStats {
         rtcstatsInit(
             { statsEntry: this.sendStatsEntry.bind(this) },
             { pollInterval,
-                useLegacy,
+                useLegacy: false,
                 sendSdp,
                 eventCallback: event => this.events.emit(RTC_STATS_PC_EVENT, event) }
         );
@@ -85,7 +84,6 @@ class RTCStats {
         const name = options?.name ?? '';
         const {
             analytics: {
-                rtcstatsUseLegacy: useLegacy = false,
                 rtcstatsEndpoint: endpoint = '',
                 rtcstatsEnabled = false
             } = {},
@@ -105,7 +103,6 @@ class RTCStats {
         const traceOptions: ITraceOptions = {
             endpoint,
             meetingFqn: name,
-            useLegacy,
             isBreakoutRoom: false
         };
 
@@ -153,8 +150,7 @@ class RTCStats {
         const {
             analytics: {
                 rtcstatsEnabled = false,
-                rtcstatsEndpoint: endpoint = '',
-                rtcstatsUseLegacy: useLegacy = false
+                rtcstatsEndpoint: endpoint = ''
             } = {}
         } = confConfig;
 
@@ -194,7 +190,6 @@ class RTCStats {
                 const traceOptions = {
                     endpoint,
                     meetingFqn: confName,
-                    useLegacy,
                     isBreakoutRoom
                 };
 
@@ -250,6 +245,7 @@ class RTCStats {
 
         const traceOptionsComplete = {
             ...traceOptions,
+            useLegacy: false,
             onCloseCallback: event => this.events.emit(RTC_STATS_WC_DISCONNECTED, event)
         };
 

--- a/modules/RTCStats/RTCStats.ts
+++ b/modules/RTCStats/RTCStats.ts
@@ -95,7 +95,7 @@ class RTCStats {
 
         // If rtcstats proxy module is not initialized, do nothing (should never happen).
         if (!this._initialized) {
-            logger.error('Calling attachToConnection before RTCStats proxy module is initialized.');
+            logger.error('Calling startWithConnection before RTCStats proxy module is initialized.');
 
             return;
         }

--- a/modules/RTCStats/interfaces.ts
+++ b/modules/RTCStats/interfaces.ts
@@ -7,7 +7,7 @@ export interface IRTCStatsConfiguration {
         rtcstatsSendSdp?: boolean;
         rtcstatsStoreLogs?: boolean;
         rtcstatsUseLegacy?: boolean;
-    },
+    };
 }
 
 export interface ITraceOptions {

--- a/modules/RTCStats/interfaces.ts
+++ b/modules/RTCStats/interfaces.ts
@@ -6,7 +6,6 @@ export interface IRTCStatsConfiguration {
         rtcstatsPollInterval?: number;
         rtcstatsSendSdp?: boolean;
         rtcstatsStoreLogs?: boolean;
-        rtcstatsUseLegacy?: boolean;
     };
 }
 
@@ -14,5 +13,4 @@ export interface ITraceOptions {
     endpoint: string;
     isBreakoutRoom: boolean;
     meetingFqn: string;
-    useLegacy: boolean;
 }

--- a/modules/RTCStats/interfaces.ts
+++ b/modules/RTCStats/interfaces.ts
@@ -8,7 +8,6 @@ export interface IRTCStatsConfiguration {
         rtcstatsStoreLogs?: boolean;
         rtcstatsUseLegacy?: boolean;
     },
-    confName: string;
 }
 
 export interface ITraceOptions {

--- a/modules/RTCStats/interfaces.ts
+++ b/modules/RTCStats/interfaces.ts
@@ -7,5 +7,13 @@ export interface IRTCStatsConfiguration {
         rtcstatsSendSdp?: boolean;
         rtcstatsStoreLogs?: boolean;
         rtcstatsUseLegacy?: boolean;
-    };
+    },
+    confName: string;
+}
+
+export interface ITraceOptions {
+    endpoint: string;
+    isBreakoutRoom: boolean;
+    meetingFqn: string;
+    useLegacy: boolean;
 }

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -69,7 +69,7 @@ export default function Statistics(conference, options) {
 
     Statistics.instances.add(this);
 
-    RTCStats.start(this.conference);
+    RTCStats.attachToConference(this.conference);
 
     // WatchRTC is not required to work for react native
     if (!browser.isReactNative()) {


### PR DESCRIPTION
## Description

Push rtcstats initialization when JitsiConnection is created.
This will allow us to capture logs occurring before the JitsiConference has actually connected.
Depends on https://github.com/jitsi/jitsi-meet/pull/15838
