### PR TITLE
feat: Set AV1 as the preferred video codec.

### DIFF
--- a/modules/qualitycontrol/CodecSelection.js
+++ b/modules/qualitycontrol/CodecSelection.js
@@ -10,7 +10,7 @@ import browser from '../browser';
 const logger = getLogger(__filename);
 
 // Default video codec preferences on mobile and desktop endpoints.
-const DESKTOP_VIDEO_CODEC_ORDER = [ CodecMimeType.VP9, CodecMimeType.VP8, CodecMimeType.H264, CodecMimeType.AV1 ];
+const DESKTOP_VIDEO_CODEC_ORDER = [ CodecMimeType.AV1, CodecMimeType.VP9, CodecMimeType.VP8, CodecMimeType.H264 ];
 const MOBILE_P2P_VIDEO_CODEC_ORDER = [ CodecMimeType.H264, CodecMimeType.VP8, CodecMimeType.VP9, CodecMimeType.AV1 ];
 const MOBILE_VIDEO_CODEC_ORDER = [ CodecMimeType.VP8, CodecMimeType.VP9, CodecMimeType.H264, CodecMimeType.AV1 ];
 

--- a/modules/qualitycontrol/QualityController.ts
+++ b/modules/qualitycontrol/QualityController.ts
@@ -131,7 +131,7 @@ export class QualityController {
 
         this._codecController = new CodecSelection(conference, { jvb,
             p2p });
-        this._enableAdaptiveMode = options.enableAdaptiveMode;
+        this._enableAdaptiveMode = options.enableAdaptiveMode ?? true;
         this._encodeTimeStats = new Map();
         this._isLastNRampupBlocked = false;
         this._lastNRampupTime = options.lastNRampupTime;

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1250,7 +1250,9 @@ export default class JingleSessionPC extends JingleSession {
         pcOptions.codecSettings = options.codecSettings;
         pcOptions.enableInsertableStreams = options.enableInsertableStreams;
         pcOptions.usesCodecSelectionAPI = this.usesCodecSelectionAPI
-            = browser.supportsCodecSelectionAPI() && options.testing?.enableCodecSelectionAPI && !this.isP2P;
+            = browser.supportsCodecSelectionAPI()
+            && (options.testing?.enableCodecSelectionAPI ?? true)
+            && !this.isP2P;
 
         if (options.videoQuality) {
             const settings = Object.entries(options.videoQuality)


### PR DESCRIPTION
This is done in code for desktop clients. Mobile clients will continue to encode VP8 by default

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.