### PR TITLE
fix(connectivity) Do not overwrite the packet loss value when video muted.

### DIFF
--- a/modules/connectivity/ConnectionQuality.js
+++ b/modules/connectivity/ConnectionQuality.js
@@ -257,27 +257,8 @@ export default class ConnectionQuality {
         let packetLoss;
 
         // TODO: take into account packet loss for received streams
-
         if (this._localStats.packetLoss) {
             packetLoss = this._localStats.packetLoss.upload;
-
-            // Ugly Hack Alert (UHA):
-            // The packet loss for the upload direction is calculated based on
-            // incoming RTCP Receiver Reports. Since we don't have RTCP
-            // termination for audio, these reports come from the actual
-            // receivers in the conference and therefore the reported packet
-            // loss includes loss from the bridge to the receiver.
-            // When we are sending video this effect is small, because the
-            // number of video packets is much larger than the number of audio
-            // packets (and our calculation is based on the total number of
-            // received and lost packets).
-            // When video is muted, however, the effect might be significant,
-            // but we don't know what it is. We do know that it is positive, so
-            // as a temporary solution, until RTCP termination is implemented
-            // for the audio streams, we relax the packet loss checks here.
-            if (isMuted) {
-                packetLoss *= 0.5;
-            }
         }
 
         if (isMuted || !resolution || videoType === VideoType.DESKTOP


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

Do not overwrite the packet loss value when video muted. RTCP termination for audio was implemented a while back. This hack is no longer needed.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.