### PR TITLE
fix(SDP) Do not filter out SSRC 'cname' attributes.

### DIFF
--- a/modules/sdp/LocalSdpMunger.js
+++ b/modules/sdp/LocalSdpMunger.js
@@ -96,9 +96,9 @@ export default class LocalSdpMunger {
             }
         }
 
-        // Ignore the 'cname', 'label' and 'mslabel' attributes.
-        mediaSection.ssrcs = mediaSection.ssrcs
-            .filter(ssrc => ssrc.attribute === 'msid' || ssrc.attribute === 'name' || ssrc.attribute === 'videoType');
+        // Ignore the 'label' and 'mslabel' attributes.
+        mediaSection.ssrcs
+            = mediaSection.ssrcs.filter(ssrc => ssrc.attribute !== 'label' && ssrc.attribute !== 'mslabel');
 
         // On FF when the user has started muted create answer will generate a recv only SSRC. We don't want to signal
         // this SSRC in order to reduce the load of the xmpp server for large calls. Therefore the SSRC needs to be


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

fix(SDP) Do not filter out SSRC 'cname' attributes.

<!--- Describe your changes in detail -->

Chrome doesn't generate the a=ssrc line with 'msid' attribute when the track is removed from pc and a renegotiation is triggered. As a result a source-remove is sent to the p2p peer when it shouldn't be causing issues on the receiver when the same source is added back to the conference. Fixes toggleCamera on mobile browser not working as expected.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.