### PR TITLE
fix(connection-quality) Trigger ramp up on codec and session changes.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -41,6 +41,7 @@ import { getJitterDelay } from './modules/util/Retry';
 import ComponentsVersions from './modules/version/ComponentsVersions';
 import VideoSIPGW from './modules/videosipgw/VideoSIPGW';
 import * as VideoSIPGWConstants from './modules/videosipgw/VideoSIPGWConstants';
+import MediaSessionEvents from './modules/xmpp/MediaSessionEvents';
 import SignalingLayerImpl from './modules/xmpp/SignalingLayerImpl';
 import {
     FEATURE_E2EE,
@@ -2279,6 +2280,10 @@ JitsiConference.prototype._acceptJvbIncomingCall = function(jingleSession, jingl
                 if (!this.isP2PActive()) {
                     this.eventEmitter.emit(JitsiConferenceEvents._MEDIA_SESSION_ACTIVE_CHANGED, jingleSession);
                 }
+
+                jingleSession.addEventListener(MediaSessionEvents.VIDEO_CODEC_CHANGED, () => {
+                    this.eventEmitter.emit(JitsiConferenceEvents.VIDEO_CODEC_CHANGED);
+                });
             },
             error => {
                 logger.error('Failed to accept incoming Jingle session', error);
@@ -2998,6 +3003,10 @@ JitsiConference.prototype._acceptP2PIncomingCall = function(jingleSession, jingl
             this.eventEmitter.emit(
                 JitsiConferenceEvents._MEDIA_SESSION_STARTED,
                 jingleSession);
+
+            jingleSession.addEventListener(MediaSessionEvents.VIDEO_CODEC_CHANGED, () => {
+                this.eventEmitter.emit(JitsiConferenceEvents.VIDEO_CODEC_CHANGED);
+            });
         },
         error => {
             logger.error(
@@ -3347,6 +3356,10 @@ JitsiConference.prototype._startP2PSession = function(remoteJid) {
     const localTracks = this.getLocalTracks();
 
     this.p2pJingleSession.invite(localTracks);
+
+    this.p2pJingleSession.addEventListener(MediaSessionEvents.VIDEO_CODEC_CHANGED, () => {
+        this.eventEmitter.emit(JitsiConferenceEvents.VIDEO_CODEC_CHANGED);
+    });
 };
 
 /**

--- a/JitsiConferenceEvents.spec.ts
+++ b/JitsiConferenceEvents.spec.ts
@@ -52,6 +52,7 @@ describe( "/JitsiConferenceEvents members", () => {
         PHONE_NUMBER_CHANGED,
         PROPERTIES_CHANGED,
         RECORDER_STATE_CHANGED,
+        VIDEO_CODEC_CHANGED,
         VIDEO_SIP_GW_AVAILABILITY_CHANGED,
         VIDEO_SIP_GW_SESSION_STATE_CHANGED,
         START_MUTED_POLICY_CHANGED,
@@ -136,6 +137,7 @@ describe( "/JitsiConferenceEvents members", () => {
         expect( PHONE_NUMBER_CHANGED ).toBe( 'conference.phoneNumberChanged' );
         expect( PROPERTIES_CHANGED ).toBe( 'conference.propertiesChanged' );
         expect( RECORDER_STATE_CHANGED ).toBe( 'conference.recorderStateChanged' );
+        expect( VIDEO_CODEC_CHANGED ).toBe( 'conference.videoCodecChanged' );
         expect( VIDEO_SIP_GW_AVAILABILITY_CHANGED ).toBe( 'conference.videoSIPGWAvailabilityChanged' );
         expect( VIDEO_SIP_GW_SESSION_STATE_CHANGED ).toBe( 'conference.videoSIPGWSessionStateChanged' );
         expect( VISITORS_SUPPORTED_CHANGED ).toBe( 'conference.visitorsSupported' );

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -449,6 +449,11 @@ export enum JitsiConferenceEvents {
     USER_STATUS_CHANGED = 'conference.statusChanged',
 
     /**
+     * Indicates that the video codec of the local video track has changed.
+     */
+    VIDEO_CODEC_CHANGED = 'conference.videoCodecChanged',
+
+    /**
      * Indicates that video SIP GW state changed.
      * @param {VideoSIPGWConstants} status.
      */
@@ -579,6 +584,7 @@ export const USER_JOINED = JitsiConferenceEvents.USER_JOINED;
 export const USER_LEFT = JitsiConferenceEvents.USER_LEFT;
 export const USER_ROLE_CHANGED = JitsiConferenceEvents.USER_ROLE_CHANGED;
 export const USER_STATUS_CHANGED = JitsiConferenceEvents.USER_STATUS_CHANGED;
+export const VIDEO_CODEC_CHANGED = JitsiConferenceEvents.VIDEO_CODEC_CHANGED;
 export const VIDEO_SIP_GW_AVAILABILITY_CHANGED = JitsiConferenceEvents.VIDEO_SIP_GW_AVAILABILITY_CHANGED;
 export const VIDEO_SIP_GW_SESSION_STATE_CHANGED = JitsiConferenceEvents.VIDEO_SIP_GW_SESSION_STATE_CHANGED;
 export const VIDEO_UNMUTE_PERMISSIONS_CHANGED = JitsiConferenceEvents.VIDEO_UNMUTE_PERMISSIONS_CHANGED;

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -1424,11 +1424,13 @@ TraceablePeerConnection.prototype.setDesktopSharingFrameRate = function(maxFps) 
  *
  * @param {Array<CodecMimeType>} codecList - Preferred codecs for video.
  * @param {CodecMimeType} screenshareCodec - The preferred codec for screenshare.
- * @returns {void}
+ * @returns {boolean} - Returns true if the codec settings were updated, false otherwise.
  */
 TraceablePeerConnection.prototype.setVideoCodecs = function(codecList, screenshareCodec) {
+    let updated = false;
+
     if (!this.codecSettings || !codecList?.length) {
-        return;
+        return updated;
     }
 
     this.codecSettings.codecList = codecList;
@@ -1437,7 +1439,7 @@ TraceablePeerConnection.prototype.setVideoCodecs = function(codecList, screensha
     }
 
     if (!this.usesCodecSelectionAPI()) {
-        return;
+        return updated;
     }
 
     for (const track of this.getLocalVideoTracks()) {
@@ -1445,10 +1447,14 @@ TraceablePeerConnection.prototype.setVideoCodecs = function(codecList, screensha
 
         if (screenshareCodec && track.getVideoType() === VideoType.DESKTOP && screenshareCodec !== currentCodec) {
             this.configureVideoSenderEncodings(track, screenshareCodec);
+            updated = true;
         } else if (currentCodec !== codecList[0]) {
             this.configureVideoSenderEncodings(track);
+            updated = true;
         }
     }
+
+    return updated;
 };
 
 /**

--- a/modules/connectivity/ConnectionQuality.js
+++ b/modules/connectivity/ConnectionQuality.js
@@ -209,6 +209,11 @@ export default class ConnectionQuality {
                     this._maybeUpdateUnmuteTime();
                 }
             });
+
+        conference.on(ConferenceEvents.VIDEO_CODEC_CHANGED, this._resetVideoUnmuteTime.bind(this));
+
+        conference.on(ConferenceEvents._MEDIA_SESSION_ACTIVE_CHANGED, this._resetVideoUnmuteTime.bind(this));
+
         conference.rtc.on(
             RTCEvents.LOCAL_TRACK_MAX_ENABLED_RESOLUTION_CHANGED,
             track => {
@@ -228,6 +233,17 @@ export default class ConnectionQuality {
                     = Number((properties || {})['bridge-count']);
             }
         );
+    }
+
+    /**
+     * Resets the time video was unmuted and triggers a new ramp-up.
+     *
+     * @private
+     * @returns {void}
+     */
+    _resetVideoUnmuteTime() {
+        this._timeVideoUnmuted = -1;
+        this._maybeUpdateUnmuteTime();
     }
 
     /**

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -2284,7 +2284,11 @@ export default class JingleSessionPC extends JingleSession {
      */
     setVideoCodecs(codecList, screenshareCodec) {
         if (this._assertNotEnded()) {
-            this.peerconnection.setVideoCodecs(codecList, screenshareCodec);
+            const updated = this.peerconnection.setVideoCodecs(codecList, screenshareCodec);
+
+            if (updated) {
+                this.eventEmitter.emit(MediaSessionEvents.VIDEO_CODEC_CHANGED);
+            }
 
             // Browser throws an error when H.264 is set on the encodings. Therefore, munge the SDP when H.264 needs to
             // be selected.
@@ -2300,6 +2304,7 @@ export default class JingleSessionPC extends JingleSession {
                 return;
             }
 
+            this.eventEmitter.emit(MediaSessionEvents.VIDEO_CODEC_CHANGED);
             Statistics.sendAnalytics(
                 VIDEO_CODEC_CHANGED,
                 {

--- a/modules/xmpp/MediaSessionEvents.spec.ts
+++ b/modules/xmpp/MediaSessionEvents.spec.ts
@@ -5,11 +5,13 @@ import { default as exported } from "./MediaSessionEvents";
 describe( "/modules/xmpp/MediaSessionEvents members", () => {
     const {
         REMOTE_SOURCE_CONSTRAINTS_CHANGED,
+        VIDEO_CODEC_CHANGED,
         ...others
     } = exported;
 
     it( "known members", () => {
         expect( REMOTE_SOURCE_CONSTRAINTS_CHANGED ).toBe( 'media_session.REMOTE_SOURCE_CONSTRAINTS_CHANGED' );
+        expect( VIDEO_CODEC_CHANGED ).toBe( 'media_session.VIDEO_CODEC_CHANGED' );
     } );
 
     it( "unknown members", () => {

--- a/modules/xmpp/MediaSessionEvents.ts
+++ b/modules/xmpp/MediaSessionEvents.ts
@@ -3,7 +3,12 @@ enum MediaSessionEvents {
     /**
      * Event triggered when the remote party signals video max frame heights for its local sources.
      */
-    REMOTE_SOURCE_CONSTRAINTS_CHANGED = 'media_session.REMOTE_SOURCE_CONSTRAINTS_CHANGED'
+    REMOTE_SOURCE_CONSTRAINTS_CHANGED = 'media_session.REMOTE_SOURCE_CONSTRAINTS_CHANGED',
+
+    /**
+     * Event triggered when the video codec of the local video track has changed.
+     */
+    VIDEO_CODEC_CHANGED = 'media_session.VIDEO_CODEC_CHANGED'
 }
 
 export default MediaSessionEvents;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Trigger ramp up on codec and session changes.

<!--- Describe your changes in detail -->

This should prevent connection quality GSM bars turning red for video codec changes and when the call switches between jvb and p2p connection.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.