### PR TITLE
feat(pkg) add react-native key to pakage.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "browser": "dist/umd/lib-jitsi-meet.min.js",
   "module": "dist/esm/JitsiMeetJS.js",
+  "react-native": "./dist/esm/JitsiMeetJS.js",
   "files": [
     "dist",
     "types",


### PR DESCRIPTION
This makes it use the ESM build rather than the UMD one.
