### PR TITLE
fix(xmpp): Moves event local user role changed after muc joined.

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -638,12 +638,6 @@ export default class ChatRoom extends Listenable {
             const newRole
                 = member.affiliation === 'owner' ? member.role : 'none';
 
-            if (this.role !== newRole) {
-                this.role = newRole;
-                this.eventEmitter.emit(
-                    XMPPEvents.LOCAL_ROLE_CHANGED,
-                    this.role);
-            }
             if (!this.joined) {
                 this.joined = true;
                 const now = this.connectionTimes['muc.joined']
@@ -675,6 +669,13 @@ export default class ChatRoom extends Listenable {
                 // Now let's check the disco-info to retrieve the
                 // meeting Id if any
                 !this.options.disableDiscoInfo && this.discoRoomInfo();
+            }
+
+            if (this.role !== newRole) {
+                this.role = newRole;
+                this.eventEmitter.emit(
+                    XMPPEvents.LOCAL_ROLE_CHANGED,
+                    this.role);
             }
 
             if (xElement && $(xElement).find('>status[code="110"]').length) {


### PR DESCRIPTION
Having it before can result in iframeAPI receiving this event for unknown user as the local user id is sent after that with videoconferenceJoined which is based on MUC_JOINED.