### PR TITLE
feat(xmpp): Switch unload to pagehide event listener

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -216,7 +216,7 @@ export default class XMPP extends Listenable {
         // they wanted to utilize the connected connection in an unload handler
         // of their own. However, it should be fairly easy for them to do that
         // by registering their unload handler before us.
-        $(window).on(`${this.options.disableBeforeUnloadHandlers ? '' : 'beforeunload '}unload`, ev => {
+        $(window).on('pagehide', ev => {
             this.disconnect(ev).catch(() => {
                 // ignore errors in order to not brake the unload.
             });
@@ -810,7 +810,7 @@ export default class XMPP extends Listenable {
      * Disconnects this from the XMPP server (if this is connected).
      *
      * @param {Object} ev - Optionally, the event which triggered the necessity to
-     * disconnect from the XMPP server (e.g. beforeunload, unload).
+     * disconnect from the XMPP server (e.g. beforeunload, pagehide).
      * @returns {Promise} - Resolves when the disconnect process is finished or rejects with an error.
      */
     disconnect(ev) {
@@ -843,7 +843,7 @@ export default class XMPP extends Listenable {
      * participant will be removed from the conference XMPP MUC, so that it doesn't leave a "ghost" participant behind.
      *
      * @param {Object} ev - Optionally, the event which triggered the necessity to disconnect from the XMPP server
-     * (e.g. beforeunload, unload).
+     * (e.g. beforeunload, pagehide).
      * @private
      * @returns {void}
      */
@@ -861,7 +861,7 @@ export default class XMPP extends Listenable {
         if (!this.connection.isUsingWebSocket && ev !== null && typeof ev !== 'undefined') {
             const evType = ev.type;
 
-            if (evType === 'beforeunload' || evType === 'unload') {
+            if (evType === 'beforeunload' || evType === 'pagehide') {
                 // XXX Whatever we said above, synchronous sending is the best (known) way to properly disconnect from
                 // the XMPP server. Consequently, it may be fine to have the source code and comment it in or out
                 // depending on whether we want to run with it for some time.


### PR DESCRIPTION
## Description

Switched the [beforeunload](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event) event listener to a [pagehide](https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event) event listener which is now baseline and well supported.

The `config.disableBeforeUnloadHandlers` is no longer needed. This simplifies configuration for maintainers, while following specification best practices.

This change allows the use of beforeunload handler in a more appropriate manner.

## Related Issue

https://github.com/jitsi/jitsi-meet/issues/15890
https://community.jitsi.org/t/prompt-before-closing-during-a-call/20081
https://community.jitsi.org/t/prevent-refresh-or-back-during-call-give-some-confirmation-prompt/84949/2

## Motivation and Context

The `unload` and `beforeunload` event handlers have been [marked deprecated](https://developer.chrome.com/docs/web-platform/page-lifecycle-api#legacy_lifecycle_apis_to_avoid) and websites are recommended to switch to better supported events.

The MDN docs mention
> If you're specifically trying to detect page unload events, the pagehide event is the best option.

This change allows the implementation of a confirmation dialog before meetings are exited.
> It is therefore recommended that developers listen for beforeunload only when users have unsaved changes so that the dialog mentioned above can be used to warn them about impending data loss, and remove the listener again when it is not needed. Listening for beforeunload sparingly can minimize the effect on performance.

## How Has This Been Tested?

- All `npm run test` pass.
- Deployed to jitsi-meet instance and connected to conference with no issues.
- meeting ends gracefully when page closed/navigated away.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

no effect on UI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.