### PR TITLE
fix(JitsiMediaDevices) prevent multiple listeners when reinitializing

### DIFF
--- a/JitsiMediaDevices.js
+++ b/JitsiMediaDevices.js
@@ -19,6 +19,7 @@ class JitsiMediaDevices extends Listenable {
      */
     constructor() {
         super();
+        this._initialized = false;
         this._permissions = {};
     }
 
@@ -26,6 +27,11 @@ class JitsiMediaDevices extends Listenable {
      * Initialize. Start listening for device changes and initialize permissions checks.
      */
     init() {
+        if (this._initialized) {
+            return;
+        }
+        this._initialized = true;
+
         RTC.addListener(
             RTCEvents.DEVICE_LIST_CHANGED,
             devices =>


### PR DESCRIPTION
Initializing JitsiMediaDevices doesn't rely on any settings / config passed on to JitsiMeetJS.init, so make sure it's initialized only once.
