### PR TITLE
fix(e2ee) avoid restarting media sessions more than once

### DIFF
--- a/modules/e2ee/Context.spec.js
+++ b/modules/e2ee/Context.spec.js
@@ -67,7 +67,9 @@ describe('E2EE Context', () => {
 
     beforeEach(() => {
         sender = new Context('sender');
+        sender.setEnabled(true);
         receiver = new Context('receiver');
+        receiver.setEnabled(true);
     });
 
     describe('encode function', () => {

--- a/modules/e2ee/E2EEContext.js
+++ b/modules/e2ee/E2EEContext.js
@@ -151,6 +151,18 @@ export default class E2EEcontext {
     }
 
     /**
+     * Set the E2EE enabled state.
+     *
+     * @param {boolean} enabled - whether E2EE is enabled or not.
+     */
+    setEnabled(enabled) {
+        this._worker.postMessage({
+            operation: 'setEnabled',
+            enabled
+        });
+    }
+
+    /**
      * Set the E2EE key for the specified participant.
      *
      * @param {string} participantId - the ID of the participant who's key we are setting.

--- a/modules/e2ee/ManagedKeyHandler.js
+++ b/modules/e2ee/ManagedKeyHandler.js
@@ -209,7 +209,6 @@ export class ManagedKeyHandler extends KeyHandler {
         this.conference.eventEmitter.emit(JitsiConferenceEvents.E2EE_VERIFICATION_AVAILABLE, pId);
     }
 
-
     /**
      * Handles the SAS completed event.
      *

--- a/modules/e2ee/Worker.js
+++ b/modules/e2ee/Worker.js
@@ -8,6 +8,8 @@ const contexts = new Map(); // Map participant id => context
 
 let sharedContext;
 
+let enabled = false;
+
 /**
  * Retrieves the participant {@code Context}, creating it if necessary.
  *
@@ -20,7 +22,10 @@ function getParticipantContext(participantId) {
     }
 
     if (!contexts.has(participantId)) {
-        contexts.set(participantId, new Context());
+        const context = new Context();
+
+        context.setEnabled(enabled);
+        contexts.set(participantId, context);
     }
 
     return contexts.get(participantId);
@@ -63,6 +68,9 @@ onmessage = event => {
         const context = getParticipantContext(participantId);
 
         handleTransform(context, operation, readableStream, writableStream);
+    } else if (operation === 'setEnabled') {
+        enabled = event.data.enabled;
+        contexts.forEach(context => context.setEnabled(enabled));
     } else if (operation === 'setKey') {
         const { participantId, key, keyIndex } = event.data;
         const context = getParticipantContext(participantId);


### PR DESCRIPTION
After enabling E2EE for the first time, keep the media transform inplace, but make it a no-op.

This simplifies the flow a little since it doesn't require a media session restart.

Way back when, there were performance concerns when having a transform, which is what prompted us to implement the restar mechanism, but a lot has changed since and both audio and video frames don't need to jump threads these days. We are still not enabling an empty transform at all times out of precaution.
