### PR TITLE
feat(rtcstats): move rtcstats init

### DIFF
--- a/JitsiConnection.ts
+++ b/JitsiConnection.ts
@@ -2,6 +2,7 @@ import { getLogger } from '@jitsi/logger';
 
 import JitsiConference from './JitsiConference';
 import { JitsiConnectionEvents } from './JitsiConnectionEvents';
+import RTCStats from './modules/RTCStats/RTCStats';
 import FeatureFlags from './modules/flags/FeatureFlags';
 import Statistics from './modules/statistics/statistics';
 import XMPP from './modules/xmpp/xmpp';
@@ -95,6 +96,9 @@ export default class JitsiConnection {
      * to be used.
      */
     connect(options: IConnectOptions = {}): void {
+
+        RTCStats.startWithConnection(this);
+
         // if we get redirected, we set disableFocus to skip sending the conference request twice
         if (this.xmpp.moderator.targetUrl && !this.options.disableFocus && options.name) {
             // The domain (optional) will uses this.options.hosts.muc.toLowerCase() if not provided

--- a/modules/RTCStats/RTCStats.ts
+++ b/modules/RTCStats/RTCStats.ts
@@ -16,7 +16,7 @@ import EventEmitter from '../util/EventEmitter';
 
 import DefaultLogStorage from './DefaulLogStorage';
 import { RTC_STATS_PC_EVENT, RTC_STATS_WC_DISCONNECTED } from './RTCStatsEvents';
-import { IRTCStatsConfiguration, ITraceOptions } from './interfaces';
+import { ITraceOptions } from './interfaces';
 
 const logger = getLogger('modules/RTCStats/RTCStats');
 

--- a/modules/RTCStats/interfaces.ts
+++ b/modules/RTCStats/interfaces.ts
@@ -1,14 +1,3 @@
-export interface IRTCStatsConfiguration {
-    analytics?: {
-        obfuscateRoomName?: boolean;
-        rtcstatsEnabled?: boolean;
-        rtcstatsEndpoint?: string;
-        rtcstatsPollInterval?: number;
-        rtcstatsSendSdp?: boolean;
-        rtcstatsStoreLogs?: boolean;
-    };
-}
-
 export interface ITraceOptions {
     endpoint: string;
     isBreakoutRoom: boolean;

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -2,7 +2,6 @@ import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 import { JitsiTrackEvents } from '../../JitsiTrackEvents';
 import { FEEDBACK } from '../../service/statistics/AnalyticsEvents';
 import * as StatisticsEvents from '../../service/statistics/Events';
-import RTCStats from '../RTCStats/RTCStats';
 import browser from '../browser';
 import EventEmitter from '../util/EventEmitter';
 import WatchRTC from '../watchRTC/WatchRTC';
@@ -42,7 +41,6 @@ Statistics.init = function(options) {
 
     LocalStats.init();
     WatchRTC.init(options);
-    RTCStats.init(options);
 };
 
 /**

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -2,6 +2,7 @@ import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 import { JitsiTrackEvents } from '../../JitsiTrackEvents';
 import { FEEDBACK } from '../../service/statistics/AnalyticsEvents';
 import * as StatisticsEvents from '../../service/statistics/Events';
+import RTCStats from '../RTCStats/RTCStats';
 import browser from '../browser';
 import EventEmitter from '../util/EventEmitter';
 import WatchRTC from '../watchRTC/WatchRTC';


### PR DESCRIPTION
LJM no longer proxies RTCPeerConnection so we can move the rtcstats initialization process in a more convenient place.
Also it seems that the recent migration to .ts of the JitsiConnection module removed the       `RTCStats.startWithConnection(this)` call, disabling rtcstats, re added that.