### PR TITLE
fix(FF): scalability.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -457,7 +457,8 @@ JitsiConference.prototype._init = function(options = {}) {
             preferredCodec: _getCodecMimeType(config.videoQuality?.preferredCodec),
             screenshareCodec: browser.isMobileDevice()
                 ? _getCodecMimeType(config.videoQuality?.mobileScreenshareCodec)
-                : _getCodecMimeType(config.videoQuality?.screenshareCodec)
+                : _getCodecMimeType(config.videoQuality?.screenshareCodec),
+            enableAV1ForFF: config.testing?.enableAV1ForFF
         },
         p2p: {
             preferenceOrder: browser.isMobileDevice()
@@ -467,7 +468,8 @@ JitsiConference.prototype._init = function(options = {}) {
             preferredCodec: _getCodecMimeType(config.p2p?.preferredCodec),
             screenshareCodec: browser.isMobileDevice()
                 ? _getCodecMimeType(config.p2p?.mobileScreenshareCodec)
-                : _getCodecMimeType(config.p2p?.screenshareCodec)
+                : _getCodecMimeType(config.p2p?.screenshareCodec),
+            enableAV1ForFF: true // For P2P no simulcast is needed, therefore AV1 can be used.
         }
     };
 

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -723,8 +723,9 @@ export class TPCUtils {
 
         return videoCodec === CodecMimeType.VP8 // VP8 always
 
-            // K-SVC mode for VP9 when no scalability mode is set. Though only one outbound-rtp stream is present,
-            // three separate encodings have to be configured.
+            // For FF: scalabilityModeEnabled is not supported and we have to use simulcast.
+            // For other browsers we use K-SVC mode for VP9 when no scalability mode is set. Although
+            // only one outbound-rtp stream is present, three separate encodings have to be configured.
             || (!this.codecSettings[videoCodec].scalabilityModeEnabled && videoCodec === CodecMimeType.VP9)
 
             // When scalability is enabled, always for H.264, and only when simulcast is explicitly enabled via

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -942,7 +942,10 @@ export class TPCUtils {
 
             if (isSender && mLine.ext?.length) {
                 const headerIndex = mLine.ext.findIndex(ext => ext.uri === DD_HEADER_EXT_URI);
-                const shouldNegotiateHeaderExts = codec === CodecMimeType.AV1 || codec === CodecMimeType.H264;
+                const shouldNegotiateHeaderExts = codec === CodecMimeType.AV1 || codec === CodecMimeType.H264
+
+                    // Removing DD ext header lines from the sdp breaks the scalability for FF with version 136+.
+                    || (codec === CodecMimeType.VP8 && browser.isFirefox());
 
                 if (!this.supportsDDHeaderExt && headerIndex >= 0) {
                     this.supportsDDHeaderExt = true;

--- a/modules/RTC/TPCUtils.js
+++ b/modules/RTC/TPCUtils.js
@@ -728,6 +728,11 @@ export class TPCUtils {
             // only one outbound-rtp stream is present, three separate encodings have to be configured.
             || (!this.codecSettings[videoCodec].scalabilityModeEnabled && videoCodec === CodecMimeType.VP9)
 
+            // FF uses simulcast with AV1.
+            || (!this.codecSettings[videoCodec].scalabilityModeEnabled
+                && this.codecSettings[videoCodec].useSimulcast
+                && videoCodec === CodecMimeType.AV1)
+
             // When scalability is enabled, always for H.264, and only when simulcast is explicitly enabled via
             // config.js for VP9 and AV1 since full SVC is the default mode for these 2 codecs.
             || (this.codecSettings[videoCodec].scalabilityModeEnabled

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2149,7 +2149,7 @@ TraceablePeerConnection.prototype._updateVideoSenderEncodings = function(frameHe
     // case they were set when the endpoint was encoding video using the other codecs before switching over to VP9
     // K-SVC codec.
     if (codec === CodecMimeType.VP9
-        && browser.supportsKSVCForVP9()
+        && browser.supportsSVC()
         && this.isSpatialScalabilityOn()
         && !this.tpcUtils.codecSettings[codec].scalabilityModeEnabled) {
         scaleFactors = scaleFactors.map(() => undefined);

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2149,6 +2149,7 @@ TraceablePeerConnection.prototype._updateVideoSenderEncodings = function(frameHe
     // case they were set when the endpoint was encoding video using the other codecs before switching over to VP9
     // K-SVC codec.
     if (codec === CodecMimeType.VP9
+        && browser.supportsKSVCForVP9()
         && this.isSpatialScalabilityOn()
         && !this.tpcUtils.codecSettings[codec].scalabilityModeEnabled) {
         scaleFactors = scaleFactors.map(() => undefined);

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -246,15 +246,6 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
-     * Returns true if K-SVC is supported for AV1.
-     *
-     * @returns {boolean}
-     */
-    supportsKSVCForAV1() {
-        return !this.isFirefox();
-    }
-
-    /**
      * Returns true if VP9 is supported by the client on the browser. VP9 is currently disabled on Safari
      * and older versions of Firefox because of issues. Please check https://bugs.webkit.org/show_bug.cgi?id=231074 for
      * details.
@@ -267,11 +258,11 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
-     * Returns true if K-SVC is supported for VP9.
+     * Returns true if SVC is supported.
      *
      * @returns {boolean}
      */
-    supportsKSVCForVP9() {
+    supportsSVC() {
         return !this.isFirefox();
     }
 

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -233,8 +233,7 @@ export default class BrowserCapabilities extends BrowserDetection {
      * @returns {boolean}
      */
     supportsScalabilityModeAPI() {
-        return (this.isChromiumBased() && this.isEngineVersionGreaterThan(112))
-            || (this.isFirefox() && this.isVersionGreaterThan(135));
+        return this.isChromiumBased() && this.isEngineVersionGreaterThan(112);
     }
 
     /**

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -246,6 +246,15 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
+     * Returns true if K-SVC is supported for AV1.
+     *
+     * @returns {boolean}
+     */
+    supportsKSVCForAV1() {
+        return !this.isFirefox();
+    }
+
+    /**
      * Returns true if VP9 is supported by the client on the browser. VP9 is currently disabled on Safari
      * and older versions of Firefox because of issues. Please check https://bugs.webkit.org/show_bug.cgi?id=231074 for
      * details.

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -251,7 +251,19 @@ export default class BrowserCapabilities extends BrowserDetection {
      * details.
      */
     supportsVP9() {
-        return !(this.isWebKitBased() || (this.isFirefox() && this.isVersionLessThan('136')));
+        // Keep this disabled for FF because simulcast is disabled by default.
+        // For versions 136+ if the media.webrtc.simulcast.vp9.enabled config is set to true it will work.
+        // TODO: enable for FF with version 136+ once media.webrtc.simulcast.vp9.enabled is set to true by default.
+        return !(this.isWebKitBased() || this.isFirefox());
+    }
+
+    /**
+     * Returns true if K-SVC is supported for VP9.
+     *
+     * @returns {boolean}
+     */
+    supportsKSVCForVP9() {
+        return !this.isFirefox();
     }
 
     /**

--- a/modules/qualitycontrol/CodecSelection.js
+++ b/modules/qualitycontrol/CodecSelection.js
@@ -39,8 +39,8 @@ export class CodecSelection {
         this.visitorCodecs = [];
 
         for (const connectionType of Object.keys(options)) {
-            // eslint-disable-next-line prefer-const
-            let { disabledCodec, preferredCodec, preferenceOrder, screenshareCodec } = options[connectionType];
+            let { disabledCodec, preferredCodec, preferenceOrder } = options[connectionType];
+            const { enableAV1ForFF = false, screenshareCodec } = options[connectionType];
             const supportedCodecs = new Set(this._getSupportedVideoCodecs(connectionType));
 
             // Default preference codec order when no codec preferences are set in config.js
@@ -86,6 +86,20 @@ export class CodecSelection {
                     if (!this.conference.isE2EEEnabled()) {
                         selectedOrder.push(CodecMimeType.VP9);
                     }
+                }
+            }
+
+            // Adding this flag for testing purposes since AV1 is not properly supported by FF (it doesn't support SVC
+            // and it doesn't send temporal layers with simulcast).
+            if (browser.isFirefox() && !enableAV1ForFF) {
+                // By default moving AV1 to the end of the list. This way AV1 won't be used for encoding but can be
+                // used for decoding.
+                const index = selectedOrder.findIndex(codec => codec === CodecMimeType.AV1);
+
+                if (index !== -1) {
+                    selectedOrder.splice(index, 1);
+
+                    selectedOrder.push(CodecMimeType.AV1);
                 }
             }
 

--- a/service/RTC/StandardVideoQualitySettings.ts
+++ b/service/RTC/StandardVideoQualitySettings.ts
@@ -57,8 +57,8 @@ export const STANDARD_CODEC_SETTINGS = {
             none: 0
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI(),
-        useSimulcast: !browser.supportsKSVCForAV1(),
-        useKSVC: browser.supportsKSVCForAV1()
+        useSimulcast: !browser.supportsSVC(),
+        useKSVC: browser.supportsSVC()
     },
     h264: {
         maxBitratesVideo: {
@@ -95,8 +95,8 @@ export const STANDARD_CODEC_SETTINGS = {
             none: 0
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI(),
-        useSimulcast: !browser.supportsKSVCForVP9(),
-        useKSVC: browser.supportsKSVCForVP9()
+        useSimulcast: !browser.supportsSVC(),
+        useKSVC: browser.supportsSVC()
     }
 };
 

--- a/service/RTC/StandardVideoQualitySettings.ts
+++ b/service/RTC/StandardVideoQualitySettings.ts
@@ -57,8 +57,8 @@ export const STANDARD_CODEC_SETTINGS = {
             none: 0
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI(),
-        useSimulcast: false, // defaults to SVC.
-        useKSVC: true // defaults to L3T3_KEY for SVC mode.
+        useSimulcast: !browser.supportsKSVCForAV1(),
+        useKSVC: browser.supportsKSVCForAV1()
     },
     h264: {
         maxBitratesVideo: {

--- a/service/RTC/StandardVideoQualitySettings.ts
+++ b/service/RTC/StandardVideoQualitySettings.ts
@@ -95,8 +95,8 @@ export const STANDARD_CODEC_SETTINGS = {
             none: 0
         },
         scalabilityModeEnabled: browser.supportsScalabilityModeAPI(),
-        useSimulcast: false, // defaults to SVC.
-        useKSVC: true // defaults to L3T3_KEY for SVC mode.
+        useSimulcast: !browser.supportsKSVCForVP9(),
+        useKSVC: browser.supportsKSVCForVP9()
     }
 };
 


### PR DESCRIPTION
Disables AV1 and VP9 for FF due to scalability not working. Also in order to make VP8 scalability to work, DD extension headers had to be disabled.