### PR TITLE
fix(remoteControl): Failure to start

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -312,9 +312,15 @@ const ScreenObtainer = {
                     }
                 }
 
+                const videoTracks = stream?.getVideoTracks();
+                const track = videoTracks?.length > 0 ? videoTracks[0] : undefined;
+                const { deviceId } = track?.getSettings() ?? {};
+
                 callback({
                     stream,
-                    sourceId: stream.id
+
+                    // Used by remote-control to identify the display that is currently shared.
+                    sourceId: deviceId ?? stream.id
                 });
             })
             .catch(error => {


### PR DESCRIPTION
It appears that when the gDM flow is used we do not set properly the sourceId of the shared stream.  When the user has multiple screens we use the sourceId to identify the display that is currently shared. Therefore in electron we can't identify the display that is used and we fail.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.