### PR TITLE
fix(Conference) Do not kick endpoint out on renegotiation errors.

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -144,13 +144,6 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
             });
         });
 
-    chatRoom.addListener(XMPPEvents.RENEGOTIATION_FAILED, (e, session) => {
-        if (!session.isP2P) {
-            conference.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_FAILED,
-                JitsiConferenceErrors.OFFER_ANSWER_FAILED, e);
-        }
-    });
-
     chatRoom.addListener(JitsiTrackEvents.TRACK_OWNER_SET, (track, owner, sourceName, videoType) => {
         if (track.getParticipantId() !== owner || track.getSourceName() !== sourceName) {
             conference.eventEmitter.emit(JitsiConferenceEvents.TRACK_REMOVED, track);
@@ -521,38 +514,6 @@ JitsiConferenceEventManager.prototype.setupRTCListeners = function() {
                 conference.eventEmitter.emit(JitsiConferenceEvents.ENDPOINT_STATS_RECEIVED, participant, payload);
             } else {
                 logger.warn(`Ignoring ENDPOINT_STATS_RECEIVED for a non-existant participant: ${from}`);
-            }
-        });
-
-    rtc.addListener(RTCEvents.CREATE_ANSWER_FAILED,
-        (e, tpc) => {
-            if (!tpc.isP2P) {
-                conference.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_FAILED,
-                    JitsiConferenceErrors.OFFER_ANSWER_FAILED, e);
-            }
-        });
-
-    rtc.addListener(RTCEvents.CREATE_OFFER_FAILED,
-        (e, tpc) => {
-            if (!tpc.isP2P) {
-                conference.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_FAILED,
-                    JitsiConferenceErrors.OFFER_ANSWER_FAILED, e);
-            }
-        });
-
-    rtc.addListener(RTCEvents.SET_LOCAL_DESCRIPTION_FAILED,
-        (e, tpc) => {
-            if (!tpc.isP2P) {
-                conference.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_FAILED,
-                    JitsiConferenceErrors.OFFER_ANSWER_FAILED, e);
-            }
-        });
-
-    rtc.addListener(RTCEvents.SET_REMOTE_DESCRIPTION_FAILED,
-        (e, tpc) => {
-            if (!tpc.isP2P) {
-                conference.eventEmitter.emit(JitsiConferenceEvents.CONFERENCE_FAILED,
-                    JitsiConferenceErrors.OFFER_ANSWER_FAILED, e);
             }
         });
 };

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -2008,7 +2008,6 @@ TraceablePeerConnection.prototype.setLocalDescription = function(description) {
                 resolve();
             }, err => {
                 this.trace('setLocalDescriptionOnFailure', err);
-                this.eventEmitter.emit(RTCEvents.SET_LOCAL_DESCRIPTION_FAILED, err, this);
                 reject(err);
             });
     });
@@ -2046,9 +2045,9 @@ TraceablePeerConnection.prototype.setRemoteDescription = function(description) {
                 this._initializeDtlsTransport();
 
                 resolve();
-            }, err => {
+            })
+            .catch(err => {
                 this.trace('setRemoteDescriptionOnFailure', err);
-                this.eventEmitter.emit(RTCEvents.SET_REMOTE_DESCRIPTION_FAILED, err, this);
                 reject(err);
             });
     });
@@ -2448,13 +2447,6 @@ TraceablePeerConnection.prototype._createOfferOrAnswer = function(isOffer, const
 
     const handleFailure = (err, rejectFn) => {
         this.trace(`create${logName}OnFailure`, err);
-        const eventType
-            = isOffer
-                ? RTCEvents.CREATE_OFFER_FAILED
-                : RTCEvents.CREATE_ANSWER_FAILED;
-
-        this.eventEmitter.emit(eventType, err, this);
-
         rejectFn(err);
     };
 

--- a/service/RTC/RTCEvents.spec.ts
+++ b/service/RTC/RTCEvents.spec.ts
@@ -5,8 +5,6 @@ import * as exported from "./RTCEvents";
 describe( "/service/RTC/RTCEvents members", () => {
     const {
         BRIDGE_BWE_STATS_RECEIVED,
-        CREATE_ANSWER_FAILED,
-        CREATE_OFFER_FAILED,
         DATA_CHANNEL_OPEN,
         DATA_CHANNEL_CLOSED,
         ENDPOINT_CONN_STATUS_CHANGED,
@@ -20,8 +18,6 @@ describe( "/service/RTC/RTCEvents members", () => {
         REMOTE_TRACK_MUTE,
         REMOTE_TRACK_REMOVED,
         REMOTE_TRACK_UNMUTE,
-        SET_LOCAL_DESCRIPTION_FAILED,
-        SET_REMOTE_DESCRIPTION_FAILED,
         AUDIO_OUTPUT_DEVICE_CHANGED,
         DEVICE_LIST_CHANGED,
         DEVICE_LIST_WILL_CHANGE,
@@ -39,8 +35,6 @@ describe( "/service/RTC/RTCEvents members", () => {
 
     it( "known members", () => {
         expect( BRIDGE_BWE_STATS_RECEIVED ).toBe( 'rtc.bridge_bwe_stats_received' );
-        expect( CREATE_ANSWER_FAILED ).toBe( 'rtc.create_answer_failed' );
-        expect( CREATE_OFFER_FAILED ).toBe( 'rtc.create_offer_failed' );
         expect( DATA_CHANNEL_OPEN ).toBe( 'rtc.data_channel_open' );
         expect( DATA_CHANNEL_CLOSED ).toBe( 'rtc.data_channel_closed' );
         expect( ENDPOINT_CONN_STATUS_CHANGED ).toBe( 'rtc.endpoint_conn_status_changed' );
@@ -54,8 +48,6 @@ describe( "/service/RTC/RTCEvents members", () => {
         expect( REMOTE_TRACK_MUTE ).toBe( 'rtc.remote_track_mute' );
         expect( REMOTE_TRACK_REMOVED ).toBe( 'rtc.remote_track_removed' );
         expect( REMOTE_TRACK_UNMUTE ).toBe( 'rtc.remote_track_unmute' );
-        expect( SET_LOCAL_DESCRIPTION_FAILED ).toBe( 'rtc.set_local_description_failed' );
-        expect( SET_REMOTE_DESCRIPTION_FAILED ).toBe( 'rtc.set_remote_description_failed' );
         expect( AUDIO_OUTPUT_DEVICE_CHANGED ).toBe( 'rtc.audio_output_device_changed' );
         expect( DEVICE_LIST_CHANGED ).toBe( 'rtc.device_list_changed' );
         expect( DEVICE_LIST_WILL_CHANGE ).toBe( 'rtc.device_list_will_change' );
@@ -69,8 +61,6 @@ describe( "/service/RTC/RTCEvents members", () => {
 
         if ( RTCEvents ) {
             expect( RTCEvents.BRIDGE_BWE_STATS_RECEIVED ).toBe( 'rtc.bridge_bwe_stats_received' );
-            expect( RTCEvents.CREATE_ANSWER_FAILED ).toBe( 'rtc.create_answer_failed' );
-            expect( RTCEvents.CREATE_OFFER_FAILED ).toBe( 'rtc.create_offer_failed' );
             expect( RTCEvents.DATA_CHANNEL_OPEN ).toBe( 'rtc.data_channel_open' );
             expect( RTCEvents.DATA_CHANNEL_CLOSED ).toBe( 'rtc.data_channel_closed' );
             expect( RTCEvents.ENDPOINT_CONN_STATUS_CHANGED ).toBe( 'rtc.endpoint_conn_status_changed' );
@@ -83,8 +73,6 @@ describe( "/service/RTC/RTCEvents members", () => {
             expect( RTCEvents.REMOTE_TRACK_MUTE ).toBe( 'rtc.remote_track_mute' );
             expect( RTCEvents.REMOTE_TRACK_REMOVED ).toBe( 'rtc.remote_track_removed' );
             expect( RTCEvents.REMOTE_TRACK_UNMUTE ).toBe( 'rtc.remote_track_unmute' );
-            expect( RTCEvents.SET_LOCAL_DESCRIPTION_FAILED ).toBe( 'rtc.set_local_description_failed' );
-            expect( RTCEvents.SET_REMOTE_DESCRIPTION_FAILED ).toBe( 'rtc.set_remote_description_failed' );
             expect( RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED ).toBe( 'rtc.audio_output_device_changed' );
             expect( RTCEvents.DEVICE_LIST_CHANGED ).toBe( 'rtc.device_list_changed' );
             expect( RTCEvents.DEVICE_LIST_WILL_CHANGE ).toBe( 'rtc.device_list_will_change' );
@@ -99,8 +87,6 @@ describe( "/service/RTC/RTCEvents members", () => {
 
         if ( RTCEventsDefault ) {
             expect( RTCEventsDefault.BRIDGE_BWE_STATS_RECEIVED ).toBe( 'rtc.bridge_bwe_stats_received' );
-            expect( RTCEventsDefault.CREATE_ANSWER_FAILED ).toBe( 'rtc.create_answer_failed' );
-            expect( RTCEventsDefault.CREATE_OFFER_FAILED ).toBe( 'rtc.create_offer_failed' );
             expect( RTCEventsDefault.DATA_CHANNEL_OPEN ).toBe( 'rtc.data_channel_open' );
             expect( RTCEventsDefault.DATA_CHANNEL_CLOSED ).toBe( 'rtc.data_channel_closed' );
             expect( RTCEventsDefault.ENDPOINT_CONN_STATUS_CHANGED ).toBe( 'rtc.endpoint_conn_status_changed' );
@@ -113,8 +99,6 @@ describe( "/service/RTC/RTCEvents members", () => {
             expect( RTCEventsDefault.REMOTE_TRACK_MUTE ).toBe( 'rtc.remote_track_mute' );
             expect( RTCEventsDefault.REMOTE_TRACK_REMOVED ).toBe( 'rtc.remote_track_removed' );
             expect( RTCEventsDefault.REMOTE_TRACK_UNMUTE ).toBe( 'rtc.remote_track_unmute' );
-            expect( RTCEventsDefault.SET_LOCAL_DESCRIPTION_FAILED ).toBe( 'rtc.set_local_description_failed' );
-            expect( RTCEventsDefault.SET_REMOTE_DESCRIPTION_FAILED ).toBe( 'rtc.set_remote_description_failed' );
             expect( RTCEventsDefault.AUDIO_OUTPUT_DEVICE_CHANGED ).toBe( 'rtc.audio_output_device_changed' );
             expect( RTCEventsDefault.DEVICE_LIST_CHANGED ).toBe( 'rtc.device_list_changed' );
             expect( RTCEventsDefault.DEVICE_LIST_WILL_CHANGE ).toBe( 'rtc.device_list_will_change' );

--- a/service/RTC/RTCEvents.ts
+++ b/service/RTC/RTCEvents.ts
@@ -16,16 +16,6 @@ export enum RTCEvents {
     BRIDGE_BWE_STATS_RECEIVED = 'rtc.bridge_bwe_stats_received',
 
     /**
-     * Indicates error while create answer call.
-     */
-    CREATE_ANSWER_FAILED = 'rtc.create_answer_failed',
-
-    /**
-     * Indicates error while create offer call.
-     */
-    CREATE_OFFER_FAILED = 'rtc.create_offer_failed',
-
-    /**
      * Indicates that the data channel has been closed.
      */
     DATA_CHANNEL_CLOSED = 'rtc.data_channel_closed',
@@ -135,16 +125,6 @@ export enum RTCEvents {
     SENDER_VIDEO_CONSTRAINTS_CHANGED = 'rtc.sender_video_constraints_changed',
 
     /**
-     * Indicates error while set local description.
-     */
-    SET_LOCAL_DESCRIPTION_FAILED = 'rtc.set_local_description_failed',
-
-    /**
-     * Indicates error while set remote description.
-     */
-    SET_REMOTE_DESCRIPTION_FAILED = 'rtc.set_remote_description_failed',
-
-    /**
      * Designates an event indicating that some video SSRCs that have already been signaled will now map to new remote
      * sources.
      */
@@ -152,8 +132,6 @@ export enum RTCEvents {
 }
 
 export const BRIDGE_BWE_STATS_RECEIVED = RTCEvents.BRIDGE_BWE_STATS_RECEIVED;
-export const CREATE_ANSWER_FAILED = RTCEvents.CREATE_ANSWER_FAILED;
-export const CREATE_OFFER_FAILED = RTCEvents.CREATE_OFFER_FAILED;
 export const DATA_CHANNEL_OPEN = RTCEvents.DATA_CHANNEL_OPEN;
 export const DATA_CHANNEL_CLOSED = RTCEvents.DATA_CHANNEL_CLOSED;
 export const ENDPOINT_CONN_STATUS_CHANGED = RTCEvents.ENDPOINT_CONN_STATUS_CHANGED;
@@ -167,8 +145,6 @@ export const REMOTE_TRACK_ADDED = RTCEvents.REMOTE_TRACK_ADDED;
 export const REMOTE_TRACK_MUTE = RTCEvents.REMOTE_TRACK_MUTE;
 export const REMOTE_TRACK_REMOVED = RTCEvents.REMOTE_TRACK_REMOVED;
 export const REMOTE_TRACK_UNMUTE = RTCEvents.REMOTE_TRACK_UNMUTE;
-export const SET_LOCAL_DESCRIPTION_FAILED = RTCEvents.SET_LOCAL_DESCRIPTION_FAILED;
-export const SET_REMOTE_DESCRIPTION_FAILED = RTCEvents.SET_REMOTE_DESCRIPTION_FAILED;
 export const AUDIO_OUTPUT_DEVICE_CHANGED = RTCEvents.AUDIO_OUTPUT_DEVICE_CHANGED;
 export const DEVICE_LIST_CHANGED = RTCEvents.DEVICE_LIST_CHANGED;
 export const DEVICE_LIST_WILL_CHANGE = RTCEvents.DEVICE_LIST_WILL_CHANGE;

--- a/service/xmpp/XMPPEvents.spec.ts
+++ b/service/xmpp/XMPPEvents.spec.ts
@@ -69,8 +69,6 @@ describe( "/service/xmpp/XMPPEvents members", () => {
         expect( XMPPEvents.READY_TO_JOIN ).toBe( 'xmpp.ready_to_join' );
         expect( XMPPEvents.RECORDER_STATE_CHANGED ).toBe( 'xmpp.recorderStateChanged' );
         expect( XMPPEvents.REMOTE_STATS ).toBe( 'xmpp.remote_stats' );
-        expect( XMPPEvents.RENEGOTIATION_FAILED ).toBe( 'xmpp.renegotiation_failed' );
-        expect( XMPPEvents.RESERVATION_ERROR ).toBe( 'xmpp.room_reservation_error' );
         expect( XMPPEvents.ROOM_CONNECT_ERROR ).toBe( 'xmpp.room_connect_error' );
         expect( XMPPEvents.ROOM_CONNECT_NOT_ALLOWED_ERROR ).toBe( 'xmpp.room_connect_error.not_allowed' );
         expect( XMPPEvents.ROOM_JOIN_ERROR ).toBe( 'xmpp.room_join_error' );

--- a/service/xmpp/XMPPEvents.ts
+++ b/service/xmpp/XMPPEvents.ts
@@ -278,11 +278,6 @@ export enum XMPPEvents {
     // participant in the MUC.
     REMOTE_STATS = 'xmpp.remote_stats',
 
-    /**
-     * Indicates that the offer / answer renegotiation has failed.
-     */
-    RENEGOTIATION_FAILED = 'xmpp.renegotiation_failed',
-
     RESERVATION_ERROR = 'xmpp.room_reservation_error',
 
     ROOM_CONNECT_ERROR = 'xmpp.room_connect_error',

--- a/types/hand-crafted/service/RTC/RTCEvents.d.ts
+++ b/types/hand-crafted/service/RTC/RTCEvents.d.ts
@@ -1,6 +1,4 @@
 export enum RTCEvents {
-  CREATE_ANSWER_FAILED = 'rtc.create_answer_failed',
-  CREATE_OFFER_FAILED = 'rtc.create_offer_failed',
   DATA_CHANNEL_OPEN = 'rtc.data_channel_open',
   ENDPOINT_CONN_STATUS_CHANGED = 'rtc.endpoint_conn_status_changed',
   DOMINANT_SPEAKER_CHANGED = 'rtc.dominant_speaker_changed',
@@ -13,8 +11,6 @@ export enum RTCEvents {
   REMOTE_TRACK_MUTE = 'rtc.remote_track_mute',
   REMOTE_TRACK_REMOVED = 'rtc.remote_track_removed',
   REMOTE_TRACK_UNMUTE = 'rtc.remote_track_unmute',
-  SET_LOCAL_DESCRIPTION_FAILED = 'rtc.set_local_description_failed',
-  SET_REMOTE_DESCRIPTION_FAILED = 'rtc.set_remote_description_failed',
   AUDIO_OUTPUT_DEVICE_CHANGED = 'rtc.audio_output_device_changed',
   DEVICE_LIST_CHANGED = 'rtc.device_list_changed',
   DEVICE_LIST_WILL_CHANGE = 'rtc.device_list_will_change',

--- a/types/hand-crafted/service/xmpp/XMPPEvents.d.ts
+++ b/types/hand-crafted/service/xmpp/XMPPEvents.d.ts
@@ -54,7 +54,6 @@
   READY_TO_JOIN = 'xmpp.ready_to_join',
   RECORDER_STATE_CHANGED = 'xmpp.recorderStateChanged',
   REMOTE_STATS = 'xmpp.remote_stats',
-  RENEGOTIATION_FAILED = 'xmpp.renegotiation_failed',
   RESERVATION_ERROR = 'xmpp.room_reservation_error',
   ROOM_CONNECT_ERROR = 'xmpp.room_connect_error',
   ROOM_CONNECT_NOT_ALLOWED_ERROR = 'xmpp.room_connect_error.not_allowed',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Once the session has been established, reneg errors are not fatal. Any reneg failure resulting in failure to add local devices will be notified to the end user anyways.
Also, reload the client when Jicofo rejects the session-accept from a client so that it doesn't stay in the conference with no media.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.