### PR TITLE
fix(conference) Fix different bugs with startMuted policy.

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -1246,6 +1246,9 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
  * @returns {Array<JitsiLocalTrack>} - list of local tracks that are unmuted.
  */
 JitsiConference.prototype._getInitialLocalTracks = function() {
+    logger.debug('Adding tracks to the conference based on the startMutedPolicy='
+        + `${JSON.stringify(this.startMutedPolicy)}`);
+
     // Always add the audio track on certain platforms:
     //  * Safari / WebKit: because of a known issue where audio playout doesn't happen
     //    if the user joins audio and video muted.
@@ -1504,6 +1507,13 @@ JitsiConference.prototype._addLocalTrackToPc = function(track) {
         // If the track hasn't been added to the conference yet because of start muted by focus, add it to the
         // conference instead of adding it only to the media sessions.
         addPromises.push(this.addTrack(track));
+    }
+
+    // Update the start muted policy to reflect the fact that the track is now added to the conference by the user.
+    if (track.getType() === MediaType.VIDEO) {
+        this.startMutedPolicy.video = false;
+    } else {
+        this.startMutedPolicy.audio = false;
     }
 
     return Promise.allSettled(addPromises);

--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -187,8 +187,6 @@ export default function JitsiConference(options) {
     this.dtmfManager = null;
     this.somebodySupportsDTMF = false;
     this.authEnabled = false;
-    this.startAudioMuted = false;
-    this.startVideoMuted = false;
     this.startMutedPolicy = {
         audio: false,
         video: false
@@ -1239,41 +1237,6 @@ JitsiConference.prototype._fireMuteChangeEvent = function(track) {
 };
 
 /**
- * Returns the list of local tracks that need to be added to the peerconnection on join.
- * This takes the startAudioMuted/startVideoMuted flags into consideration since we do not
- * want to add the tracks if the user joins the call audio/video muted. The tracks will be
- * added when the user unmutes for the first time.
- * @returns {Array<JitsiLocalTrack>} - list of local tracks that are unmuted.
- */
-JitsiConference.prototype._getInitialLocalTracks = function() {
-    logger.debug('Adding tracks to the conference based on the startMutedPolicy='
-        + `${JSON.stringify(this.startMutedPolicy)}`);
-
-    // Always add the audio track on certain platforms:
-    //  * Safari / WebKit: because of a known issue where audio playout doesn't happen
-    //    if the user joins audio and video muted.
-    //  * React Native: after iOS 15, if a user joins muted they won't be able to unmute.
-    return this.getLocalTracks()
-        .filter(track => {
-            const trackType = track.getType();
-
-            if (trackType === MediaType.AUDIO
-                    && (!(this.isStartAudioMuted() || this.startMutedPolicy.audio)
-                    || browser.isWebKitBased()
-                    || browser.isReactNative())) {
-                return true;
-            } else if (trackType === MediaType.VIDEO && !this.isStartVideoMuted() && !this.startMutedPolicy.video) {
-                return true;
-            }
-
-            // Remove the track from the conference.
-            this.onLocalTrackRemoved(track);
-
-            return false;
-        });
-};
-
-/**
  * Clear JitsiLocalTrack properties and listeners.
  * @param track the JitsiLocalTrack object.
  */
@@ -1507,13 +1470,6 @@ JitsiConference.prototype._addLocalTrackToPc = function(track) {
         // If the track hasn't been added to the conference yet because of start muted by focus, add it to the
         // conference instead of adding it only to the media sessions.
         addPromises.push(this.addTrack(track));
-    }
-
-    // Update the start muted policy to reflect the fact that the track is now added to the conference by the user.
-    if (track.getType() === MediaType.VIDEO) {
-        this.startMutedPolicy.video = false;
-    } else {
-        this.startMutedPolicy.audio = false;
     }
 
     return Promise.allSettled(addPromises);
@@ -1844,6 +1800,31 @@ JitsiConference.prototype.onMemberJoined = function(
     }
 
     this._maybeSetSITimeout();
+    const { startAudioMuted, startVideoMuted } = this.options.config;
+
+    // Ignore startAudio/startVideoMuted settings if the media session has already been established.
+    // Apply the policy if the number of participants exceeds the startMuted thresholds.
+    if ((this.jvbJingleSession && this.getActiveMediaSession() === this.jvbJingleSession)
+        || ((typeof startAudioMuted === 'undefined' || startAudioMuted === -1)
+            && (typeof startVideoMuted === 'undefined' || startVideoMuted === -1))) {
+        return;
+    }
+
+    let audioMuted = false;
+    let videoMuted = false;
+    const numberOfParticipants = this.getParticipantCount();
+
+    if (numberOfParticipants > this.options.config.startAudioMuted) {
+        audioMuted = true;
+    }
+
+    if (numberOfParticipants > this.options.config.startVideoMuted) {
+        videoMuted = true;
+    }
+
+    if ((audioMuted && !this.startMutedPolicy.audio) || (videoMuted && !this.startMutedPolicy.video)) {
+        this._updateStartMutedPolicy(audioMuted, videoMuted);
+    }
 };
 
 /* eslint-enable max-params */
@@ -2292,7 +2273,7 @@ JitsiConference.prototype._acceptJvbIncomingCall = function(jingleSession, jingl
     // Open a channel with the videobridge.
     this._setBridgeChannel(jingleOffer, jingleSession.peerconnection);
 
-    const localTracks = this._getInitialLocalTracks();
+    const localTracks = this.getLocalTracks();
 
     try {
         jingleSession.acceptOffer(
@@ -2663,11 +2644,9 @@ JitsiConference.prototype.setStartMutedPolicy = function(policy) {
         return;
     }
 
-    // Do not apply the startMutedPolicy locally on the moderator, the moderator should join with available local
-    // sources and the policy needs to be applied only on users that join the call after.
-    // this.startMutedPolicy = policy;
-    // TODO: to remove using presence for startmuted policy after old clients update
-    // we keep presence to update UI of old clients
+    logger.info(`Setting start muted policy: ${JSON.stringify(policy)} in presence and in conference metadata`);
+
+    // TODO: to remove using presence for startmuted policy after old clients update to using metadata always.
     this.room.addOrReplaceInPresence('startmuted', {
         attributes: {
             audio: policy.audio,
@@ -2675,9 +2654,6 @@ JitsiConference.prototype.setStartMutedPolicy = function(policy) {
             xmlns: 'http://jitsi.org/jitmeet/start-muted'
         }
     }) && this.room.sendPresence();
-
-    // we want to ignore applying startMutedPolicy locally when we set it
-    this._ignoreFirstStartMutedPolicyUpdate = true;
 
     this.getMetadataHandler().setMetadata('startMuted', {
         audio: policy.audio,
@@ -2692,9 +2668,8 @@ JitsiConference.prototype.setStartMutedPolicy = function(policy) {
  * @param {boolean} video if video should be muted.
  */
 JitsiConference.prototype._updateStartMutedPolicy = function(audio, video) {
-    if (this._ignoreFirstStartMutedPolicyUpdate) {
-        this._ignoreFirstStartMutedPolicyUpdate = false;
-
+    // Update the start muted policy for the conference only if the meta data is received before conference join.
+    if (this.isJoined()) {
         return;
     }
 
@@ -2724,20 +2699,6 @@ JitsiConference.prototype._updateStartMutedPolicy = function(audio, video) {
  */
 JitsiConference.prototype.getStartMutedPolicy = function() {
     return this.startMutedPolicy;
-};
-
-/**
- * Check if audio is muted on join.
- */
-JitsiConference.prototype.isStartAudioMuted = function() {
-    return this.startAudioMuted;
-};
-
-/**
- * Check if video is muted on join.
- */
-JitsiConference.prototype.isStartVideoMuted = function() {
-    return this.startVideoMuted;
 };
 
 /**

--- a/JitsiConferenceEvents.spec.ts
+++ b/JitsiConferenceEvents.spec.ts
@@ -58,7 +58,6 @@ describe( "/JitsiConferenceEvents members", () => {
         VIDEO_SIP_GW_AVAILABILITY_CHANGED,
         VIDEO_SIP_GW_SESSION_STATE_CHANGED,
         START_MUTED_POLICY_CHANGED,
-        STARTED_MUTED,
         SUBJECT_CHANGED,
         SUSPEND_DETECTED,
         TALK_WHILE_MUTED,
@@ -146,7 +145,6 @@ describe( "/JitsiConferenceEvents members", () => {
         expect( VIDEO_SIP_GW_SESSION_STATE_CHANGED ).toBe( 'conference.videoSIPGWSessionStateChanged' );
         expect( VISITORS_SUPPORTED_CHANGED ).toBe( 'conference.visitorsSupported' );
         expect( START_MUTED_POLICY_CHANGED ).toBe( 'conference.start_muted_policy_changed' );
-        expect( STARTED_MUTED ).toBe( 'conference.started_muted' );
         expect( SUBJECT_CHANGED ).toBe( 'conference.subjectChanged' );
         expect( SUSPEND_DETECTED ).toBe( 'conference.suspendDetected' );
         expect( TALK_WHILE_MUTED ).toBe( 'conference.talk_while_muted' );
@@ -227,7 +225,6 @@ describe( "/JitsiConferenceEvents members", () => {
         expect( JitsiConferenceEvents.VIDEO_SIP_GW_AVAILABILITY_CHANGED ).toBe( 'conference.videoSIPGWAvailabilityChanged' );
         expect( JitsiConferenceEvents.VIDEO_SIP_GW_SESSION_STATE_CHANGED ).toBe( 'conference.videoSIPGWSessionStateChanged' );
         expect( JitsiConferenceEvents.START_MUTED_POLICY_CHANGED ).toBe( 'conference.start_muted_policy_changed' );
-        expect( JitsiConferenceEvents.STARTED_MUTED ).toBe( 'conference.started_muted' );
         expect( JitsiConferenceEvents.SUBJECT_CHANGED ).toBe( 'conference.subjectChanged' );
         expect( JitsiConferenceEvents.SUSPEND_DETECTED ).toBe( 'conference.suspendDetected' );
         expect( JitsiConferenceEvents.TALK_WHILE_MUTED ).toBe( 'conference.talk_while_muted' );

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -372,11 +372,6 @@ export enum JitsiConferenceEvents {
     SILENT_STATUS_CHANGED = 'conference.silentStatusChanged',
 
     /**
-     * Indicates that the local user has started muted.
-     */
-    STARTED_MUTED = 'conference.started_muted',
-
-    /**
      * Indicates that start muted settings changed.
      */
     START_MUTED_POLICY_CHANGED = 'conference.start_muted_policy_changed',
@@ -582,7 +577,6 @@ export const RECORDER_STATE_CHANGED = JitsiConferenceEvents.RECORDER_STATE_CHANG
 export const SERVER_REGION_CHANGED = JitsiConferenceEvents.SERVER_REGION_CHANGED;
 export const SILENT_STATUS_CHANGED = JitsiConferenceEvents.SILENT_STATUS_CHANGED;
 export const START_MUTED_POLICY_CHANGED = JitsiConferenceEvents.START_MUTED_POLICY_CHANGED;
-export const STARTED_MUTED = JitsiConferenceEvents.STARTED_MUTED;
 export const SUBJECT_CHANGED = JitsiConferenceEvents.SUBJECT_CHANGED;
 export const SUSPEND_DETECTED = JitsiConferenceEvents.SUSPEND_DETECTED;
 export const TALK_WHILE_MUTED = JitsiConferenceEvents.TALK_WHILE_MUTED;

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -406,11 +406,6 @@ export default class JitsiLocalTrack extends JitsiTrack {
             } else if (this.track) {
                 this.track.enabled = !muted;
             }
-
-            // Override the start muted policy for the conference if the track has been unmuted.
-            if (!muted) {
-                this.conference.startMutedPolicy.audio = false;
-            }
         } else if (muted) {
             promise = new Promise((resolve, reject) => {
                 logMuteInfo();

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -406,6 +406,11 @@ export default class JitsiLocalTrack extends JitsiTrack {
             } else if (this.track) {
                 this.track.enabled = !muted;
             }
+
+            // Override the start muted policy for the conference if the track has been unmuted.
+            if (!muted) {
+                this.conference.startMutedPolicy.audio = false;
+            }
         } else if (muted) {
             promise = new Promise((resolve, reject) => {
                 logMuteInfo();

--- a/modules/xmpp/RoomMetadata.ts
+++ b/modules/xmpp/RoomMetadata.ts
@@ -95,6 +95,7 @@ export default class RoomMetadata {
         }
 
         this._metadata = metadata;
+        logger.debug('Received metadata update', metadata);
         this.room.eventEmitter.emit(XMPPEvents.ROOM_METADATA_UPDATED, metadata);
     }
 

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -3,7 +3,6 @@ import $ from 'jquery';
 import { cloneDeep } from 'lodash-es';
 import { $iq, Strophe } from 'strophe.js';
 
-import { MediaType } from '../../service/RTC/MediaType';
 import { XMPPEvents } from '../../service/xmpp/XMPPEvents';
 import RandomUtil from '../util/RandomUtil';
 
@@ -179,18 +178,8 @@ export default class JingleConnectionPlugin extends ConnectionPlugin {
         switch (action) {
         case 'session-initiate': {
             logger.info('(TIME) received session-initiate:\t', now);
-            const startMuted = $(iq).find('jingle>startmuted');
 
             isP2P && logger.debug(`Received ${action} from ${fromJid}`);
-            if (startMuted?.length) {
-                const audioMuted = startMuted.attr(MediaType.AUDIO);
-                const videoMuted = startMuted.attr(MediaType.VIDEO);
-
-                this.eventEmitter.emit(
-                    XMPPEvents.START_MUTED_FROM_FOCUS,
-                    audioMuted === 'true',
-                    videoMuted === 'true');
-            }
             const pcConfig = isP2P ? this.p2pIceConfig : this.jvbIceConfig;
 
             sess

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -284,6 +284,9 @@ export default class XMPP extends Listenable {
         // for keeping stats, since it is not made available to jocofo at
         // the time of the initial conference-request.
         this.caps.addFeature('http://jitsi.org/visitors-1');
+
+        // Advertise support for startMuted policy through room metadata.
+        this.caps.addFeature('http://jitsi.org/start-muted-room-metadata');
     }
 
     /**

--- a/service/xmpp/XMPPEvents.spec.ts
+++ b/service/xmpp/XMPPEvents.spec.ts
@@ -96,7 +96,6 @@ describe( "/service/xmpp/XMPPEvents members", () => {
         expect( XMPPEvents.BREAKOUT_ROOMS_UPDATED ).toBe( 'xmpp.breakout-rooms.updated' );
         expect( XMPPEvents.ROOM_METADATA_EVENT ).toBe( 'xmpp.room-metadata.event' );
         expect( XMPPEvents.ROOM_METADATA_UPDATED ).toBe( 'xmpp.room-metadata.updated' );
-        expect( XMPPEvents.START_MUTED_FROM_FOCUS ).toBe( 'xmpp.start_muted_from_focus' );
         expect( XMPPEvents.SUBJECT_CHANGED ).toBe( 'xmpp.subject_changed' );
         expect( XMPPEvents.SUSPEND_DETECTED ).toBe( 'xmpp.suspend_detected' );
         expect( XMPPEvents.TRANSCRIPTION_STATUS_CHANGED ).toBe( 'xmpp.transcription_status_changed' );

--- a/service/xmpp/XMPPEvents.ts
+++ b/service/xmpp/XMPPEvents.ts
@@ -371,10 +371,6 @@ export enum XMPPEvents {
      */
     SPEAKER_STATS_RECEIVED = 'xmpp.speaker_stats_received',
 
-    // Designates an event indicating that we should join the conference with
-    // audio and/or video muted.
-    START_MUTED_FROM_FOCUS = 'xmpp.start_muted_from_focus',
-
     // Designates an event indicating that the subject of the XMPP MUC has
     // changed.
     SUBJECT_CHANGED = 'xmpp.subject_changed',

--- a/types/hand-crafted/JitsiConference.d.ts
+++ b/types/hand-crafted/JitsiConference.d.ts
@@ -105,8 +105,6 @@ export default class JitsiConference {
   getConnectionState: () => string | null;
   setStartMutedPolicy: ( policy: { audio: boolean, video: boolean } ) => void;
   getStartMutedPolicy: () => { audio: boolean, video: boolean };
-  isStartAudioMuted: () => boolean;
-  isStartVideoMuted: () => boolean;
   getConnectionTimes: () => unknown;
   setLocalParticipantProperty: ( name: string, value: unknown ) => void;
   removeLocalParticipantProperty: ( name: string ) => void;

--- a/types/hand-crafted/JitsiConferenceEvents.d.ts
+++ b/types/hand-crafted/JitsiConferenceEvents.d.ts
@@ -41,7 +41,6 @@ export enum JitsiConferenceEvents {
   VIDEO_SIP_GW_AVAILABILITY_CHANGED = 'conference.videoSIPGWAvailabilityChanged',
   VIDEO_SIP_GW_SESSION_STATE_CHANGED = 'conference.videoSIPGWSessionStateChanged',
   START_MUTED_POLICY_CHANGED = 'conference.start_muted_policy_changed',
-  STARTED_MUTED = 'conference.started_muted',
   SUBJECT_CHANGED = 'conference.subjectChanged',
   SUSPEND_DETECTED = 'conference.suspendDetected',
   TALK_WHILE_MUTED = 'conference.talk_while_muted',

--- a/types/hand-crafted/service/xmpp/XMPPEvents.d.ts
+++ b/types/hand-crafted/service/xmpp/XMPPEvents.d.ts
@@ -69,7 +69,6 @@
   AV_MODERATION_RECEIVED = 'xmpp.av_moderation.received',
   AV_MODERATION_CHANGED = 'xmpp.av_moderation.changed',
   AV_MODERATION_PARTICIPANT_APPROVED = 'xmpp.av_moderation.participant.approved',
-  START_MUTED_FROM_FOCUS = 'xmpp.start_muted_from_focus',
   SUBJECT_CHANGED = 'xmpp.subject_changed',
   SUSPEND_DETECTED = 'xmpp.suspend_detected',
   TRANSCRIPTION_STATUS_CHANGED = 'xmpp.transcription_status_changed',


### PR DESCRIPTION
If the user changes mute state after joining the call and before the other participats join the call, make sure those state changes are honored.
