### PR TITLE
fix(CodecSelection): disable AV1 for Safari.

### DIFF
--- a/modules/qualitycontrol/CodecSelection.js
+++ b/modules/qualitycontrol/CodecSelection.js
@@ -90,6 +90,12 @@ export class CodecSelection {
                 }
             });
 
+            // Safari retports AV1 as supported on M3+ macs. Because of some decoder/encoder issues reported AV1 should
+            // be disabled until all issues are resolved.
+            if (browser.isWebKitBased()) {
+                selectedOrder = selectedOrder.filter(codec => codec !== CodecMimeType.AV1);
+            }
+
             logger.info(`Codec preference order for ${connectionType} connection is ${selectedOrder}`);
             this.codecPreferenceOrder[connectionType] = selectedOrder;
 


### PR DESCRIPTION
Encoder/decoder issues were noticed with AV1 for Safari. This includes no scalability for the stream that is send, not decoded videos on the receiver side, etc. This should be disable until all issues are resolved.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.