### PR TITLE
Add `monitorTypeSurfaces` option to Chromium

### DIFF
--- a/modules/RTC/ScreenObtainer.js
+++ b/modules/RTC/ScreenObtainer.js
@@ -247,6 +247,10 @@ class ScreenObtainer {
             browser.isEngineVersionGreaterThan(111)
                 && (constraintOpts.selfBrowserSurface = screenShareSettings?.desktopSelfBrowserSurface || 'exclude');
 
+            // Allow users to include/exclude display monitors from the capture sources, default: include
+            browser.isEngineVersionGreaterThan(118)
+                && (constraintOpts.monitorTypeSurfaces = screenShareSettings?.desktopMonitorTypeSurfaces || 'include');
+
             // Set bogus resolution constraints to work around
             // https://bugs.chromium.org/p/chromium/issues/detail?id=1056311 for low fps screenshare. Capturing SS at
             // very high resolutions restricts the framerate. Therefore, skip this hack when capture fps > 5 fps.


### PR DESCRIPTION
## Description

This adds the experimental (Chromium 119+) option `monitorTypeSurfaces`. By default its `include`

https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia#monitortypesurfaces

## Related Issue

https://github.com/jitsi/lib-jitsi-meet/issues/2780

## Motivation and Context

It allows developers to control inclusion/exclusion of display monitors

## How Has This Been Tested?

1. Opened a browser
2. Selected screen to share
3. Checked that display monitors are excluded/included

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.