### PR TITLE
Migrate `modules\videosipgw\JitsiVideoSIPGWSession.ts`

### DIFF
--- a/modules/videosipgw/JitsiVideoSIPGWSession.ts
+++ b/modules/videosipgw/JitsiVideoSIPGWSession.ts
@@ -1,13 +1,11 @@
 import { getLogger } from '@jitsi/logger';
 import { $iq } from 'strophe.js';
-
+import ChatRoom from '../xmpp/ChatRoom';
 import Listenable from '../util/Listenable';
 
 import * as VideoSIPGWConstants from './VideoSIPGWConstants';
 
 const logger = getLogger('modules/videosipgw/JitsiVideoSIPGWSession');
-
-import ChatRoom from '../xmpp/ChatRoom';
 
 /**
  * The event name for current sip video session state changed.

--- a/modules/videosipgw/JitsiVideoSIPGWSession.ts
+++ b/modules/videosipgw/JitsiVideoSIPGWSession.ts
@@ -6,7 +6,8 @@ import Listenable from '../util/Listenable';
 import * as VideoSIPGWConstants from './VideoSIPGWConstants';
 
 const logger = getLogger('modules/videosipgw/JitsiVideoSIPGWSession');
-import ChatRoom  from '../xmpp/ChatRoom';
+
+import ChatRoom from '../xmpp/ChatRoom';
 
 /**
  * The event name for current sip video session state changed.
@@ -22,7 +23,7 @@ export default class JitsiVideoSIPGWSession extends Listenable {
     sipAddress: string;
     displayName: string;
     chatRoom: ChatRoom;
-    state: string | undefined;
+    state?: string;
 
     /**
      * Creates new session with the desired sip address and display name.
@@ -33,7 +34,7 @@ export default class JitsiVideoSIPGWSession extends Listenable {
      * that participant.
      * @param {ChatRoom} chatRoom - The chat room this session is bound to.
      */
-    constructor(sipAddress: string, displayName: string, chatRoom: any) {
+    constructor(sipAddress: string, displayName: string, chatRoom: ChatRoom) {
         super();
 
         this.sipAddress = sipAddress;
@@ -136,10 +137,10 @@ export default class JitsiVideoSIPGWSession extends Listenable {
      */
     private _sendJibriIQ(action: string): void {
         const attributes: {
-            xmlns: string;
             action: string;
-            sipaddress: string;
             displayname?: string;
+            sipaddress: string;
+            xmlns: string;
         } = {
             'xmlns': 'http://jitsi.org/protocol/jibri',
             'action': action,
@@ -157,7 +158,7 @@ export default class JitsiVideoSIPGWSession extends Listenable {
         logger.debug(`${action} video SIP GW session`, iq.nodeTree);
         this.chatRoom.connection.sendIQ(
             iq,
-            () => {}, // eslint-disable-line no-empty-function
+            () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
             (error: any) => {
                 logger.error(
                     `Failed to ${action} video SIP GW session, error: `, error);

--- a/modules/videosipgw/JitsiVideoSIPGWSession.ts
+++ b/modules/videosipgw/JitsiVideoSIPGWSession.ts
@@ -136,18 +136,12 @@ export default class JitsiVideoSIPGWSession extends Listenable {
      * @param {string} action - The action to send ('start' or 'stop').
      */
     private _sendJibriIQ(action: string): void {
-        const attributes: {
-            action: string;
-            displayname?: string;
-            sipaddress: string;
-            xmlns: string;
-        } = {
+        const attributes = {
             'xmlns': 'http://jitsi.org/protocol/jibri',
             'action': action,
-            sipaddress: this.sipAddress
+            'sipaddress': this.sipAddress,
+            'displayname': this.displayName
         };
-
-        attributes.displayname = this.displayName;
 
         const iq = $iq({
             to: this.chatRoom.focusMucJid,

--- a/modules/videosipgw/JitsiVideoSIPGWSession.ts
+++ b/modules/videosipgw/JitsiVideoSIPGWSession.ts
@@ -113,18 +113,18 @@ export default class JitsiVideoSIPGWSession extends Listenable {
      * Subscribes the passed listener to the event for state change of this
      * session.
      *
-     * @param {Function} listener - The function that will receive the event.
+     * @param {EventListener} listener - The function that will receive the event.
      */
-    addStateListener(listener: Function): void {
+    addStateListener(listener: EventListener): void {
         this.addListener(STATE_CHANGED, listener);
     }
 
     /**
      * Unsubscribes the passed handler.
      *
-     * @param {Function} listener - The function to be removed.
+     * @param {EventListener} listener - The function to be removed.
      */
-    removeStateListener(listener: Function): void {
+    removeStateListener(listener: EventListener): void {
         this.removeListener(STATE_CHANGED, listener);
     }
 
@@ -162,6 +162,7 @@ export default class JitsiVideoSIPGWSession extends Listenable {
                 logger.error(
                     `Failed to ${action} video SIP GW session, error: `, error);
                 this.setState(VideoSIPGWConstants.STATE_FAILED);
-            });
+            },
+            undefined);
     }
 }


### PR DESCRIPTION
Fixes #2637 

- Changed type of listener from function to EventListener 
`Argument of type 'Function' is not assignable to parameter of type 'EventListener'.
  Type 'Function' provides no match for the signature '(...args: any[]): void'.ts(`

![image](https://github.com/user-attachments/assets/c271a923-bf33-4d2d-a740-401335a50dd3)
