### PR TITLE
fix(ICE) remove force reload option on ICE failures.

### DIFF
--- a/JitsiConferenceErrors.spec.ts
+++ b/JitsiConferenceErrors.spec.ts
@@ -42,7 +42,6 @@ describe( "/JitsiConferenceErrors members", () => {
         expect( CONFERENCE_DESTROYED ).toBe( 'conference.destroyed' );
         expect( CONFERENCE_MAX_USERS ).toBe( 'conference.max_users' );
         expect( CONNECTION_ERROR ).toBe( 'conference.connectionError' );
-        expect( CONFERENCE_RESTARTED ).toBe( 'conference.restarted' );
         expect( DISPLAY_NAME_REQUIRED ).toBe( 'conference.display_name_required' );
         expect( NOT_ALLOWED_ERROR ).toBe( 'conference.connectionError.notAllowed' );
         expect( MEMBERS_ONLY_ERROR ).toBe( 'conference.connectionError.membersOnly' );
@@ -66,7 +65,6 @@ describe( "/JitsiConferenceErrors members", () => {
         expect( JitsiConferenceErrors.CONFERENCE_DESTROYED ).toBe( 'conference.destroyed' );
         expect( JitsiConferenceErrors.CONFERENCE_MAX_USERS ).toBe( 'conference.max_users' );
         expect( JitsiConferenceErrors.CONNECTION_ERROR ).toBe( 'conference.connectionError' );
-        expect( JitsiConferenceErrors.CONFERENCE_RESTARTED ).toBe( 'conference.restarted' );
         expect( JitsiConferenceErrors.DISPLAY_NAME_REQUIRED ).toBe( 'conference.display_name_required' );
         expect( JitsiConferenceErrors.NOT_ALLOWED_ERROR ).toBe( 'conference.connectionError.notAllowed' );
         expect( JitsiConferenceErrors.MEMBERS_ONLY_ERROR ).toBe( 'conference.connectionError.membersOnly' );

--- a/JitsiConferenceErrors.ts
+++ b/JitsiConferenceErrors.ts
@@ -31,12 +31,6 @@ export enum JitsiConferenceErrors {
     CONFERENCE_MAX_USERS = 'conference.max_users',
 
     /**
-     * Indicates that the client has been forced to restart by jicofo when the
-     * conference was migrated from one bridge to another.
-     */
-    CONFERENCE_RESTARTED = 'conference.restarted',
-
-    /**
      * Indicates that a connection error occurred when trying to join a conference.
      */
     CONNECTION_ERROR = 'conference.connectionError',
@@ -135,7 +129,6 @@ export const SETTINGS_ERROR = JitsiConferenceErrors.SETTINGS_ERROR;
 export const CONFERENCE_DESTROYED = JitsiConferenceErrors.CONFERENCE_DESTROYED;
 export const CONFERENCE_MAX_USERS = JitsiConferenceErrors.CONFERENCE_MAX_USERS;
 export const CONNECTION_ERROR = JitsiConferenceErrors.CONNECTION_ERROR;
-export const CONFERENCE_RESTARTED = JitsiConferenceErrors.CONFERENCE_RESTARTED;
 export const NOT_ALLOWED_ERROR = JitsiConferenceErrors.NOT_ALLOWED_ERROR;
 export const MEMBERS_ONLY_ERROR = JitsiConferenceErrors.MEMBERS_ONLY_ERROR;
 export const CONFERENCE_ACCESS_DENIED = JitsiConferenceErrors.CONFERENCE_ACCESS_DENIED;

--- a/modules/connectivity/IceFailedHandling.spec.js
+++ b/modules/connectivity/IceFailedHandling.spec.js
@@ -89,21 +89,4 @@ describe('IceFailedHandling', () => {
                 });
         });
     });
-    describe('when forced reloads are enabled', () => {
-        beforeEach(() => {
-            mockConference.options.config.enableForcedReload = true;
-
-            mockConference.room = {};
-        });
-
-        it('emits conference restarted when force reloads are enabled', () => {
-            iceFailedHandling.start();
-
-            return nextTick() // tick for ping
-                .then(() => nextTick(2500)) // tick for ice timeout
-                .then(() => {
-                    expect(emitEventSpy).toHaveBeenCalled();
-                });
-        });
-    });
 });

--- a/modules/connectivity/IceFailedHandling.ts
+++ b/modules/connectivity/IceFailedHandling.ts
@@ -1,8 +1,6 @@
 import { getLogger } from '@jitsi/logger';
 
 import JitsiConference from '../../JitsiConference';
-import * as JitsiConferenceErrors from '../../JitsiConferenceErrors';
-import * as JitsiConferenceEvents from '../../JitsiConferenceEvents';
 
 const logger = getLogger('modules/connectivity/IceFailedHandling');
 
@@ -11,8 +9,7 @@ const logger = getLogger('modules/connectivity/IceFailedHandling');
  *
  * If ICE connection is not re-established within 2 secs after the internet comes back online, the client will initiate
  * a session restart via 'session-terminate'. This results in Jicofo re-inviting the participant into the conference by
- * recreating the jvb media session so that there is minimla disruption to the user by default. However, if the
- * 'enableForcedReload' option is set in config.js, the conference will be forcefully reloaded.
+ * recreating the jvb media session so that there is minimla disruption to the user by default.
  */
 export default class IceFailedHandling {
     private _conference: JitsiConference;
@@ -35,19 +32,6 @@ export default class IceFailedHandling {
      */
     _actOnIceFailed(): void {
         if (!this._conference.room) {
-            return;
-        }
-
-        const { enableForcedReload } = this._conference.options.config;
-
-        logger.info(`ICE failed, enableForcedReload: ${enableForcedReload}`);
-
-        if (enableForcedReload) {
-            logger.info('ICE failed, force reloading the conference');
-            this._conference.eventEmitter.emit(
-                JitsiConferenceEvents.CONFERENCE_FAILED,
-                JitsiConferenceErrors.CONFERENCE_RESTARTED);
-
             return;
         }
 

--- a/types/hand-crafted/JitsiConferenceErrors.d.ts
+++ b/types/hand-crafted/JitsiConferenceErrors.d.ts
@@ -4,7 +4,6 @@ export enum JitsiConferenceErrors {
   CONFERENCE_DESTROYED = 'conference.destroyed',
   CONFERENCE_MAX_USERS = 'conference.max_users',
   CONNECTION_ERROR = 'conference.connectionError',
-  CONFERENCE_RESTARTED = 'conference.restarted',
   NOT_ALLOWED_ERROR = 'conference.connectionError.notAllowed',
   MEMBERS_ONLY_ERROR = 'conference.connectionError.membersOnly',
   CONFERENCE_ACCESS_DENIED = 'conference.connectionError.accessDenied',


### PR DESCRIPTION
Restarting media session when ICE fails has been working well for some time now.