### PR TITLE
WIP: Add deafen function and ReceiverAudioSubscription

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -832,24 +832,27 @@ JitsiConference.prototype._sendBridgeVideoTypeMessage = function(localtrack) {
     localtrack && this.rtc.sendSourceVideoType(localtrack.getSourceName(), videoType);
 };
 
+/**
+ * Set deafened state of the local participant.
+ * 
+ * @param {bool} deafened - whether the local participant is deafened or not.
+ */
 JitsiConference.prototype.setIsDeafened = function(deafened) {
     this._sendReceiverAudioSubscriptionMessage(
-        deafened ? [] : ['*'],
-        deafened ? ['*'] : []
+        deafened ? { mode: 'None' } : { mode: 'All' },
     );
 };
 
 /**
  * Sends the "ReceiverAudioSubscriptionMessage" to the bridge on the bridge channel
  *
- * @param {string[]} include - The source names to include in the subscription.
- * @param {string[]} exclude - The source names to exclude from the subscription.
+ * @param {ReceiverAudioSubscriptionMessage} message - The audio subscription message to send.
  * @returns {void}
  * @private
  */
-JitsiConference.prototype._sendReceiverAudioSubscriptionMessage = function(include, exclude) {
+JitsiConference.prototype._sendReceiverAudioSubscriptionMessage = function(message) {
     if (this.rtc) {
-        this.rtc.sendReceiverAudioSubscription(include, exclude);
+        this.rtc.sendReceiverAudioSubscription(message);
     }
 };
 

--- a/modules/RTC/BridgeChannel.ts
+++ b/modules/RTC/BridgeChannel.ts
@@ -9,6 +9,7 @@ import { SourceName } from '../../service/RTC/SignalingLayer';
 import { createBridgeChannelClosedEvent } from '../../service/statistics/AnalyticsEvents';
 import ReceiverVideoConstraints from '../qualitycontrol/ReceiveVideoController';
 import Statistics from '../statistics/statistics';
+import { ReceiverAudioSubscriptionMessage } from '../../service/RTC/ReceiverAudioSubscription';
 
 
 const logger = getLogger('modules/RTC/BridgeChannel');
@@ -290,16 +291,14 @@ export default class BridgeChannel {
     /**
      * Sends a 'ReceiverAudioSubscriptionMessage' message via the bridge channel.
      *
-     * @param {SourceName[]} include - the source names of the audio tracks to include. '*' means all included.
-     * @param {SourceName[]} exclude - the source names of the audio tracks to exclude. '*' means all excluded.
+     * @param {ReceiverAudioSubscriptionMessage} message - the audio subscription message.
      * @returns {void}
      */
-    sendReceiverAudioSubscriptionMessage(include: SourceName[], exclude: SourceName[]): void {
-        logger.info(`Sending ReceiverAudioSubscriptionMessage with include: ${include}, exclude: ${exclude}`);
+    sendReceiverAudioSubscriptionMessage(message: ReceiverAudioSubscriptionMessage): void {
+        logger.info(`Sending ReceiverAudioSubscriptionMessage with mode: ${message.mode}`);
         this._send({
             colibriClass: 'ReceiverAudioSubscription',
-            include,
-            exclude
+            ...message
         });
     }
 

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -325,12 +325,11 @@ export default class RTC extends Listenable {
 
     /**
      * Sends the audio subscription message to the JVB.
-     * @param {SourceName[]} include - the source names of the audio tracks to include.
-     * @param {SourceName[]} exclude - the source names of the audio tracks to exclude.
+     * @param {ReceiverAudioSubscriptionMessage} message - The subscription message to send.
      */
-    sendReceiverAudioSubscription(include, exclude) {
+    sendReceiverAudioSubscription(message) {
         if (this._channel && this._channel.isOpen()) {
-            this._channel.sendReceiverAudioSubscriptionMessage(include, exclude);
+            this._channel.sendReceiverAudioSubscriptionMessage(message);
         }
     }
 

--- a/service/RTC/ReceiverAudioSubscription.ts
+++ b/service/RTC/ReceiverAudioSubscription.ts
@@ -1,0 +1,8 @@
+export type ReceiverAudioSubscriptionMessage =
+	| { mode: "All" }
+	| { mode: "None" }
+	| {
+      mode: "Custom"
+      include: string[]
+      exclude: string[]
+    };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds new bridge message "ReceiverAudioSubscription", which notifies the bridge about the receiver's audio source selection. As the first step, I'm adding "deafen" feature to jitsi-meet and add its handler and ReceiverAudioSubscription sender to lib-jitsi-meet.

TODO:
- Add test

## Related Issue

None

## Motivation and Context

This is going to be one of PRs for the [Audio Switchboard API](https://summerofcode.withgoogle.com/myprojects/details/aBy319rB).

ReceiverAudioSubscriptionMessage is new bridge message to notify selected audio sources from the receiver.

## How Has This Been Tested?

I've also modified jitsi-meet to send this message from the web, and modified JVB to receive this message.
Tested on Chrome 136 and made sure the message was sent and received properly (actual subscription handler is yet to be implemented).

Also existing test was success. (the headless chrome used is version 137)

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.