### PR TITLE
fix(JitsiTrack) Return correct SSRC, fixes missing remote stats.

### DIFF
--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -262,9 +262,10 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      * Returns the synchronization source identifier (SSRC) of this remote
      * track.
      *
+     * @override
      * @returns {number} the SSRC of this remote track.
      */
-    getSSRC() {
+    getSsrc() {
         return this.ssrc;
     }
 
@@ -272,6 +273,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
     /**
      * Returns the tracks source name
      *
+     * @override
      * @returns {string} the track's source name
      */
     getSourceName() {
@@ -288,8 +290,9 @@ export default class JitsiRemoteTrack extends JitsiTrack {
     }
 
     /**
-     * Sets the name of the source associated with the remtoe track.
+     * Sets the name of the source associated with the remote track.
      *
+     * @override
      * @param {string} name - The source name to be associated with the track.
      */
     setSourceName(name) {
@@ -357,6 +360,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      * @param container the HTML container which can be 'video' or 'audio'
      * element.
      * @private
+     * @override
      */
     _attachTTFMTracker(container) {
         if ((ttfmTrackerAudioAttached && this.isAudioTrack())
@@ -379,6 +383,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      *
      * @param {HTMLElement} container the HTML container which can be 'video' or 'audio' element.
      * @private
+     * @override
      */
     _onTrackAttach(container) {
         containerEvents.forEach(event => {
@@ -391,6 +396,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      *
      * @param {HTMLElement} container the HTML container which can be 'video' or 'audio' element.
      * @private
+     * @override
      */
     _onTrackDetach(container) {
         containerEvents.forEach(event => {
@@ -515,6 +521,6 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      */
     toString() {
         return `RemoteTrack[userID: ${this.getParticipantId()}, type: ${this.getType()}, ssrc: ${
-            this.getSSRC()}, p2p: ${this.isP2P}, sourceName: ${this._sourceName}, status: {${this._getStatus()}}]`;
+            this.getSsrc()}, p2p: ${this.isP2P}, sourceName: ${this._sourceName}, status: {${this._getStatus()}}]`;
     }
 }

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -782,7 +782,7 @@ export default class TraceablePeerConnection {
         if (!remoteTracks?.length) {
             return removeSsrcInfo;
         }
-        const primarySsrcs = remoteTracks.map(track => track.getSSRC());
+        const primarySsrcs = remoteTracks.map(track => track.getSsrc());
 
         for (const [ sourceName, sourceInfo ] of this._remoteSsrcMap) {
             if (sourceInfo.ssrcList?.some(ssrc => primarySsrcs.includes(Number(ssrc)))) {
@@ -828,7 +828,7 @@ export default class TraceablePeerConnection {
         }
 
         for (const remoteTrack of this.getRemoteTracks()) {
-            if (remoteTrack.getSSRC() === ssrc) {
+            if (remoteTrack.getSsrc() === ssrc) {
                 return remoteTrack;
             }
         }
@@ -854,7 +854,7 @@ export default class TraceablePeerConnection {
         const remoteTrack = this.getRemoteTracks().find(findTrackById);
 
         if (remoteTrack) {
-            return remoteTrack.getSSRC();
+            return remoteTrack.getSsrc();
         }
 
         return null;

--- a/modules/statistics/AvgRTPStatsReporter.ts
+++ b/modules/statistics/AvgRTPStatsReporter.ts
@@ -848,7 +848,7 @@ export default class AvgRTPStatsReporter {
                         ssrc => videoTracks.find(
                             track =>
                                 !track.isMuted()
-                                    && track.getSSRC() === ssrc
+                                    && track.getSsrc() === ssrc
                                     && track.videoType === videoType));
             }
         } else {
@@ -943,7 +943,7 @@ export default class AvgRTPStatsReporter {
                     = ssrcs.filter(
                         ssrc => videoTracks.find(
                             track => !track.isMuted()
-                                && track.getSSRC() === ssrc
+                                && track.getSsrc() === ssrc
                                 && track.videoType === videoType));
             }
         } else {


### PR DESCRIPTION
Regression caused by https://github.com/jitsi/lib-jitsi-meet/commit/b6142c7078637b8c24d0a7e2039c2e1dec96e230. Ideally, JitsiRemoteTrack should be overriding 'getSsrc'.

