### PR TITLE
fix(typedoc) improve generated TypeDoc documentation

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -234,14 +234,8 @@ function _getCodecMimeType(codec: string): Nullable<CodecMimeType> {
  * @param {number} [options.config.channelLastN=-1] The requested amount of
  * videos are going to be delivered after the value is in effect. Set to -1 for
  * unlimited or all available videos.
- * @constructor
  *
- * FIXME Make all methods which are called from lib-internal classes
- *       to non-public (use _). To name a few:
- *       {@link JitsiConference.onLocalRoleChanged}
- *       {@link JitsiConference.onUserRoleChanged}
- *       {@link JitsiConference.onMemberLeft}
- *       and so on...
+ * @noInheritDoc
  */
 export default class JitsiConference extends Listenable {
     private _transcribingEnabled?: boolean;

--- a/JitsiMeetJS.ts
+++ b/JitsiMeetJS.ts
@@ -120,10 +120,12 @@ export interface IJoinConferenceOptions {
     tracks?: JitsiLocalTrack[];
 }
 
+const mediaDevices = new JitsiMediaDevices();
+
 /**
  * The public API of the Jitsi Meet library (a.k.a. {@code JitsiMeetJS}).
  */
-export default {
+const JitsiMeetJS = {
     JitsiConnection,
 
     /**
@@ -373,7 +375,7 @@ export default {
         // @ts-ignore
         logger.info(`This appears to be ${browser.getName()}, ver: ${browser.getVersion()}`);
 
-        JitsiMediaDevices.init();
+        mediaDevices.init();
         Settings.init(options.externalStorage);
         Statistics.init(options);
 
@@ -521,7 +523,7 @@ export default {
     },
 
     logLevels: Logger.levels,
-    mediaDevices: JitsiMediaDevices as unknown,
+    mediaDevices,
 
     /**
      * Removes global logging transport from the library logging framework.
@@ -646,3 +648,5 @@ export default {
     },
     version: COMMIT_HASH
 };
+
+export default JitsiMeetJS;

--- a/modules/util/Listenable.ts
+++ b/modules/util/Listenable.ts
@@ -6,7 +6,10 @@ import EventEmitter, { EventListener } from './EventEmitter';
  * this functionality to other classes.
  */
 export default class Listenable {
-    public eventEmitter: EventEmitter;
+    /**
+     * @internal
+     */
+    eventEmitter: EventEmitter;
 
     /**
      * Creates new instance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,8 @@
         "karma-webpack": "5.0.0",
         "process": "0.11.10",
         "typedoc": "0.28.1",
+        "typedoc-plugin-no-inherit": "1.6.1",
+        "typedoc-plugin-rename-defaults": "0.7.3",
         "typescript": "5.7.2",
         "webpack": "5.98.0",
         "webpack-bundle-analyzer": "4.4.2",
@@ -3481,6 +3483,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -8417,6 +8432,29 @@
         "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
       }
     },
+    "node_modules/typedoc-plugin-no-inherit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.6.1.tgz",
+      "integrity": "sha512-+qf0RkO5YR9kUBBS1HqzzDOsWOnLcXTtGL0f2ia4jDQAjGrtF0+po/0R8k3UNtBqyDzL273aaV3FIGHEX+U/tg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typedoc": "0.26.x || 0.27.x || 0.28.x"
+      }
+    },
+    "node_modules/typedoc-plugin-rename-defaults": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-rename-defaults/-/typedoc-plugin-rename-defaults-0.7.3.tgz",
+      "integrity": "sha512-fDtrWZ9NcDfdGdlL865GW7uIGQXlthPscURPOhDkKUe4DBQSRRFUf33fhWw41FLlsz8ZTeSxzvvuNmh54MynFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^8.0.0"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.22.x <0.29.x"
+      }
+    },
     "node_modules/typedoc/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -11543,6 +11581,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
       "dev": true
     },
     "caniuse-lite": {
@@ -14979,6 +15023,22 @@
             "brace-expansion": "^2.0.1"
           }
         }
+      }
+    },
+    "typedoc-plugin-no-inherit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.6.1.tgz",
+      "integrity": "sha512-+qf0RkO5YR9kUBBS1HqzzDOsWOnLcXTtGL0f2ia4jDQAjGrtF0+po/0R8k3UNtBqyDzL273aaV3FIGHEX+U/tg==",
+      "dev": true,
+      "requires": {}
+    },
+    "typedoc-plugin-rename-defaults": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-rename-defaults/-/typedoc-plugin-rename-defaults-0.7.3.tgz",
+      "integrity": "sha512-fDtrWZ9NcDfdGdlL865GW7uIGQXlthPscURPOhDkKUe4DBQSRRFUf33fhWw41FLlsz8ZTeSxzvvuNmh54MynFA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^8.0.0"
       }
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "karma-webpack": "5.0.0",
     "process": "0.11.10",
     "typedoc": "0.28.1",
+    "typedoc-plugin-no-inherit": "1.6.1",
+    "typedoc-plugin-rename-defaults": "0.7.3",
     "typescript": "5.7.2",
     "webpack": "5.98.0",
     "webpack-bundle-analyzer": "4.4.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,9 +43,14 @@
       "JitsiTrackError.ts",
       "JitsiTrackErrors.ts",
       "JitsiTrackEvents.ts",
+      "modules/util/Listenable.ts",
     ],
     "excludePrivate": true,
     "excludeProtected": true,
     "readme": "none",
+    "plugin": [
+      "typedoc-plugin-no-inherit",
+      "typedoc-plugin-rename-defaults"
+    ]
   }
 }


### PR DESCRIPTION
- Avoid "default" named constants due to our use of default exports
- Fix JitsiMediaDevices docs not showing up
- Export Listenable since many objects inherit from it
- Hide Listenable members in descendant classes
- Tweak visibility of JitsiMediaDevices members

Some samples about the "default" variables:

Before:
<img width="433" height="527" alt="Screenshot 2025-08-20 at 11 09 27" src="https://github.com/user-attachments/assets/0119fdd4-5b80-43c9-b7dd-00db603e449d" />
<img width="364" height="409" alt="Screenshot 2025-08-20 at 10 41 58" src="https://github.com/user-attachments/assets/c2aad055-e2d6-436b-af1d-dea5113ff163" />


After:
<img width="439" height="478" alt="Screenshot 2025-08-20 at 11 10 12" src="https://github.com/user-attachments/assets/05a72859-6d04-43f9-8b34-60c3a1e03b7a" />
<img width="458" height="503" alt="Screenshot 2025-08-20 at 11 09 41" src="https://github.com/user-attachments/assets/5a88aee9-7a29-4978-bb6d-4e2cbab2b9ab" />
