### PR TITLE
fix(typedoc) fix warnings 

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -221,7 +221,7 @@ function _getCodecMimeType(codec: string): Nullable<CodecMimeType> {
  * @param options.connection the JitsiConnection object for this
  * JitsiConference.
  * @param {number} [options.config.avgRtpStatsN=15] how many samples are to be
- * collected by {@link AvgRTPStatsReporter}, before arithmetic mean is
+ * collected by `AvgRTPStatsReporter`, before arithmetic mean is
  * calculated and submitted to the analytics module.
  * @param {boolean} [options.config.p2p.enabled] when set to <tt>true</tt>
  * the peer to peer mode will be enabled. It means that when there are only 2
@@ -3639,8 +3639,7 @@ export default class JitsiConference extends Listenable {
     /**
      * Starts recording the current conference.
      *
-     * @param {IRecordingOptions} options - Configuration for the recording. See
-     * {@link Chatroom#startRecording} for more info.
+     * @param {IRecordingOptions} options - Configuration for the recording.
      * @returns {Promise} Resolves when recording starts successfully, rejects otherwise.
      */
     public startRecording(options: IRecordingOptions): Promise<JibriSession> {
@@ -4155,7 +4154,7 @@ export default class JitsiConference extends Listenable {
     /**
      * Creates a video SIP GW session and returns it if service is enabled. Before
      * creating a session one need to check whether video SIP GW service is
-     * available in the system {@link JitsiConference.isVideoSIPGWAvailable}. Even
+     * available in the system. Even
      * if there are available nodes to serve this request, after creating the
      * session those nodes can be taken and the request about using the
      * created session can fail.
@@ -4341,7 +4340,7 @@ export default class JitsiConference extends Listenable {
      * Sends a message to a lobby room.
      * When id is specified it sends a private message.
      * Otherwise it sends the message to all moderators.
-     * @param {message} Object The message to send
+     * @param {object} message The message to send
      * @param {string} id The participant id.
      *
      * @returns {void}

--- a/JitsiMediaDevices.ts
+++ b/JitsiMediaDevices.ts
@@ -19,7 +19,7 @@ export default class JitsiMediaDevices extends Listenable {
     private _permissionsApiSupported: Promise<boolean>;
 
     /**
-     * Initializes a {@code JitsiMediaDevices} object. There will be a single
+     * Initializes a `JitsiMediaDevices` object. There will be a single
      * instance of this class.
      */
     constructor() {
@@ -49,7 +49,7 @@ export default class JitsiMediaDevices extends Listenable {
     /**
      * Updates the local granted/denied permissions cache. A permissions might be
      * granted, denied, or undefined. This is represented by having its media
-     * type key set to {@code true} or {@code false} respectively.
+     * type key set to `true` or `false` respectively.
      *
      * @param {Object} permissions - Object with the permissions.
      */

--- a/JitsiMeetJS.ts
+++ b/JitsiMeetJS.ts
@@ -123,13 +123,13 @@ export interface IJoinConferenceOptions {
 const mediaDevices = new JitsiMediaDevices();
 
 /**
- * The public API of the Jitsi Meet library (a.k.a. {@code JitsiMeetJS}).
+ * The public API of the Jitsi Meet library (a.k.a. `JitsiMeetJS`).
  */
 const JitsiMeetJS = {
     JitsiConnection,
 
     /**
-     * {@code ProxyConnectionService} is used to connect a remote peer to a local Jitsi participant without going
+     * `ProxyConnectionService` is used to connect a remote peer to a local Jitsi participant without going
      * through a Jitsi conference. It is currently used for room integration development, specifically wireless
      * screensharing. Its API is experimental and will likely change; usage of it is advised against.
      */
@@ -425,8 +425,8 @@ const JitsiMeetJS = {
      * Returns whether the current execution environment supports WebRTC (for
      * use within this library).
      *
-     * @returns {boolean} {@code true} if WebRTC is supported in the current
-     * execution environment (for use within this library); {@code false},
+     * @returns {boolean} `true` if WebRTC is supported in the current
+     * execution environment (for use within this library); `false`,
      * otherwise.
      */
     isWebRtcSupported() {
@@ -631,7 +631,7 @@ const JitsiMeetJS = {
      * Informs lib-jitsi-meet about the current network status.
      *
      * @param {object} state - The network info state.
-     * @param {boolean} state.isOnline - {@code true} if the internet connectivity is online or {@code false}
+     * @param {boolean} state.isOnline - `true` if the internet connectivity is online or `false`
      * otherwise.
      */
     setNetworkInfo({ isOnline }) {

--- a/JitsiParticipant.ts
+++ b/JitsiParticipant.ts
@@ -391,8 +391,8 @@ export default class JitsiParticipant {
     /**
      * Sets the value of a property of this participant, and fires an event if
      * the value has changed.
-     * @name the name of the property.
-     * @value the value to set.
+     * @param {string} name the name of the property.
+     * @param {any} value the value to set.
      */
     setProperty(name: string, value: any): void {
         const oldValue = this._properties.get(name);

--- a/modules/util/ScriptUtil.ts
+++ b/modules/util/ScriptUtil.ts
@@ -18,18 +18,18 @@ export interface ILoadScriptOptions {
 const ScriptUtil = {
     /**
      * Loads a script from a specific source.
-     *
-     * @param src the source from the which the script is to be (down)loaded
-     * @param async true to asynchronously load the script or false to
+     * @param options
+     * @param options.src the source from the which the script is to be (down)loaded
+     * @param options.async true to asynchronously load the script or false to
      * synchronously load the script
-     * @param prepend true to schedule the loading of the script as soon as
+     * @param options.prepend true to schedule the loading of the script as soon as
      * possible or false to schedule the loading of the script at the end of the
      * scripts known at the time
-     * @param relativeURL whether we need load the library from url relative
+     * @param options.relativeURL whether we need load the library from url relative
      * to the url that lib-jitsi-meet was loaded. Useful when sourcing the
      * library from different location than the app that is using it
-     * @param loadCallback on load callback function
-     * @param errorCallback callback to be called on error loading the script
+     * @param options.loadCallback on load callback function
+     * @param options.errorCallback callback to be called on error loading the script
      */
     loadScript({
         src,


### PR DESCRIPTION
I have leave the warnings of kind `...  but not included in the documentation`as for them they need to be in  as i don't think they are meant to be public
and I also leave the warnings like `Encountered an unknown block tag @static @constructor @noInheritDoc` as i believe they should be there.