### PR TITLE
feat(typedoc) document all related types even if not explciitly exported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "karma-webpack": "5.0.0",
         "process": "0.11.10",
         "typedoc": "0.28.1",
+        "typedoc-plugin-missing-exports": "4.1.0",
         "typedoc-plugin-no-inherit": "1.6.1",
         "typedoc-plugin-rename-defaults": "0.7.3",
         "typescript": "5.7.2",
@@ -8432,6 +8433,16 @@
         "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
       }
     },
+    "node_modules/typedoc-plugin-missing-exports": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-4.1.0.tgz",
+      "integrity": "sha512-p1M5jXnEbQ4qqy0erJz41BBZEDb8XDrbLjndlH4RhYEcymbdQr0xLF6yUw1GWBrhSIfkU98m3BELMAiQh+R1zA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typedoc": "^0.28.1"
+      }
+    },
     "node_modules/typedoc-plugin-no-inherit": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.6.1.tgz",
@@ -15024,6 +15035,13 @@
           }
         }
       }
+    },
+    "typedoc-plugin-missing-exports": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-4.1.0.tgz",
+      "integrity": "sha512-p1M5jXnEbQ4qqy0erJz41BBZEDb8XDrbLjndlH4RhYEcymbdQr0xLF6yUw1GWBrhSIfkU98m3BELMAiQh+R1zA==",
+      "dev": true,
+      "requires": {}
     },
     "typedoc-plugin-no-inherit": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "karma-webpack": "5.0.0",
     "process": "0.11.10",
     "typedoc": "0.28.1",
+    "typedoc-plugin-missing-exports": "4.1.0",
     "typedoc-plugin-no-inherit": "1.6.1",
     "typedoc-plugin-rename-defaults": "0.7.3",
     "typescript": "5.7.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,11 +44,8 @@
       "JitsiTrackError.ts",
       "JitsiTrackErrors.ts",
       "JitsiTrackEvents.ts",
-      "modules/RTC/JitsiTrack.ts",
-      "modules/RTC/JitsiLocalTrack.ts",
-      "modules/RTC/JitsiRemoteTrack.ts",
-      "modules/util/Listenable.ts",
     ],
+    "excludeExternals": true,
     "excludePrivate": true,
     "excludeProtected": true,
     "blockTags": [
@@ -58,10 +55,14 @@
       "@returns",
       "@see",
       "@throws",
-      "@deprecated"
+      "@deprecated",
+      "@code",
+      "@property",
+      "@type",
     ],
     "readme": "none",
     "plugin": [
+      "typedoc-plugin-missing-exports",
       "typedoc-plugin-no-inherit",
       "typedoc-plugin-rename-defaults"
     ]


### PR DESCRIPTION
In JitsiMeetJS for example, we expose a lot of this which we are not listing as entrypoints so TypeDoc is not documenting them.

It will now.

We shall now go through the exported symbols gradually and annotate the properties we think should be internal / private.
