### PR TITLE
fix(ScreenObtainer) Fix echo issues with audio share.

### DIFF
--- a/modules/RTC/ScreenObtainer.ts
+++ b/modules/RTC/ScreenObtainer.ts
@@ -32,10 +32,11 @@ interface IResolutionConfig {
  * Interface for audio quality configuration.
  */
 interface IAudioQuality {
-    autogainControl?: boolean;
+    autoGainControl?: boolean;
     channelCount?: number;
     echoCancellation?: boolean;
     noiseSuppression?: boolean;
+    restrictOwnAudio?: boolean;
     stereo?: boolean;
 }
 
@@ -220,12 +221,37 @@ class ScreenObtainer {
      */
     private _getAudioConstraints(): boolean | IAudioQuality {
         const { audioQuality } = this.options;
-        const audio = audioQuality?.stereo ? {
-            autoGainControl: false,
-            channelCount: 2,
-            echoCancellation: false,
-            noiseSuppression: false
-        } : true;
+
+        // Chrome 140+ requires 'restrictOwnAudio' for proper audio sharing when not using stereo.
+        // Starting Chrome 137 'echoCancellation' was turned off by default for screen share audio and needs to be
+        // enabled explicity to avoid echo issues.
+        // See https://issues.chromium.org/issues/422611724 and https://chromestatus.com/feature/5128140732760064 for more details.
+        const supportsRestrictOwnAudio = browser.isChromiumBased() && browser.isEngineVersionGreaterThan(140);
+        const needsEchoCancellation = !audioQuality?.stereo
+            && browser.isChromiumBased()
+            && browser.isEngineVersionGreaterThan(136)
+            && !supportsRestrictOwnAudio;
+
+        const defaultAudioConstraints: IAudioQuality = {
+            autoGainControl: !audioQuality?.stereo,
+            channelCount: audioQuality?.stereo ? 2 : 1,
+            echoCancellation: !audioQuality?.stereo,
+            noiseSuppression: !audioQuality?.stereo
+        };
+
+        let audio: boolean | IAudioQuality = (audioQuality?.stereo || needsEchoCancellation)
+            ? defaultAudioConstraints
+            : true;
+
+        if (supportsRestrictOwnAudio) {
+            if (typeof audio === 'boolean') {
+                audio = {
+                    restrictOwnAudio: true
+                };
+            } else {
+                audio.restrictOwnAudio = true;
+            }
+        }
 
         return audio;
     }


### PR DESCRIPTION
Starting Chromium 137, echo cancellation is getting disabled automatically for desktop audio tracks.
Explicitly enable echo cancellation if "restrictOwnAudio" is not supported (Chrome 140+)