### PR TITLE
fix(JitsiConference): Fix participant features type handling in onMemberJoined

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -3257,13 +3257,13 @@ export default class JitsiConference extends Listenable {
      * @param identity the member identity, if any
      * @param botType the member botType, if any
      * @param fullJid the member full jid, if any
-     * @param features the member botType, if any
+     * @param features the member features, if any.
      * @param isReplaceParticipant whether this join replaces a participant with
      * the same jwt.
      * @internal
      */
     onMemberJoined(
-            jid: string, nick: string, role: string, isHidden: boolean, statsID: string, status: string, identity: object, botType: string, fullJid: string, features: string, isReplaceParticipant: boolean
+            jid: string, nick: string, role: string, isHidden: boolean, statsID: string, status: string, identity: object, botType: string, fullJid: string, features: Set<string> | undefined, isReplaceParticipant: boolean
     ): void {
         const id = Strophe.getResourceFromJid(jid);
 
@@ -3275,7 +3275,7 @@ export default class JitsiConference extends Listenable {
         participant.setConnectionJid(fullJid);
         participant.setRole(role);
         participant.setBotType(botType);
-        participant.setFeatures(features ? new Set([ features ]) : undefined);
+        participant.setFeatures(features);
         participant.setIsReplacing(isReplaceParticipant);
 
         // Set remote tracks on the participant if source signaling was received before presence.


### PR DESCRIPTION
## Summary
- Fixes incorrect type handling for the `features` parameter in `onMemberJoined`
- The parameter was typed as `string` but actually receives a `Set<string>` from ChatRoom
- The code `new Set([ features ])` was wrapping the Set inside another Set, corrupting the features

## Problem
When participant A (e.g., Electron app with remote control) joins first and participant B (browser) joins later, B could not detect A's features (like remote control capability). This is because:

1. ChatRoom emits `MUC_MEMBER_JOINED` with `member.features` as `Set<string>`
2. `onMemberJoined` had `features: string` type and did `new Set([ features ])`
3. This created a Set containing the original Set object as a single element
4. `features.has('http://jitsi.org/meet/remotecontrol')` would return `false` because the Set contained a Set object, not strings

## Fix
- Changed type from `features: string` to `features: Set<string> | undefined`
- Changed assignment from `new Set([ features ])` to just `features`
- Fixed JSDoc comment that incorrectly said "botType"

## Test plan
- [x] Tested with Electron app (remote control receiver) joining first, browser joining second
- [x] Verified the remote control button now appears correctly
- [x] Verified existing behavior still works when browser joins first