### PR TITLE
fix(JitsiConference): handle mute state updates arriving before track creation

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -3547,9 +3547,15 @@ export default class JitsiConference extends Listenable {
 
         emitter.emit(JitsiConferenceEvents.TRACK_ADDED, track);
 
-        // Emit initial mute state since the track may be created with a mute state
-        // and subsequent setMute() calls won't trigger the event if state doesn't change
-        emitter.emit(JitsiConferenceEvents.TRACK_MUTE_CHANGED, track);
+        // Apply any pending mute state that arrived before the track was created
+        // Always call setMute when there's a pending state, even if it matches current state,
+        // because setMute() is designed to emit on the first call regardless of state change
+        const pendingMutedState = track._getPendingMuteState();
+
+        if (pendingMutedState !== undefined) {
+            track._clearPendingMuteState();
+            track.setMute(pendingMutedState);
+        }
     }
 
 

--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -47,7 +47,9 @@ export default class JitsiRemoteTrack extends JitsiTrack {
     private _rtc: RTC;
     private _muted: boolean;
     private _hasBeenMuted: boolean;
+    private _setMuteCalled: boolean;
     private _ssrc: number;
+    private _pendingMuteState?: boolean;
 
     public ownerEndpointId: string;
     public isP2P: boolean;
@@ -101,6 +103,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         this._ssrc = ssrc;
         this.ownerEndpointId = ownerEndpointId;
         this._muted = muted;
+        this._setMuteCalled = false;
         this.isP2P = isP2P;
         this._sourceName = sourceName;
         this._trackStreamingStatus = null;
@@ -424,6 +427,37 @@ export default class JitsiRemoteTrack extends JitsiTrack {
     }
 
     /**
+     * Sets the pending mute state for this track,
+     * received before the track was fully initialized.
+     *
+     * @param {boolean | undefined} state - The pending mute state
+     * @internal
+     */
+    _setPendingMuteState(state: boolean | undefined): void {
+        this._pendingMuteState = state;
+    }
+
+    /**
+     * Returns the pending mute state for this track,
+     * received before the track was fully initialized.
+     *
+     * @returns {boolean | undefined} the pending mute state
+     * @internal
+     */
+    _getPendingMuteState(): boolean | undefined {
+        return this._pendingMuteState;
+    }
+
+    /**
+     * Clears the pending mute state for this track.
+     *
+     * @internal
+     */
+    _clearPendingMuteState(): void {
+        this._pendingMuteState = undefined;
+    }
+
+    /**
      * Removes attached event listeners and dispose TrackStreamingStatus .
      *
      * @returns {Promise}
@@ -444,9 +478,15 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      * @internal
      */
     setMute(value: boolean): void {
-        if (this._muted === value) {
+        const isFirstCall = !this._setMuteCalled;
+        const stateChanged = this._muted !== value;
+
+        // Skip if state didn't change, unless this is the first call (to emit initial state)
+        if (!stateChanged && !isFirstCall) {
             return;
         }
+
+        this._setMuteCalled = true;
 
         if (value) {
             this._hasBeenMuted = true;

--- a/modules/RTC/TraceablePeerConnection.ts
+++ b/modules/RTC/TraceablePeerConnection.ts
@@ -157,6 +157,7 @@ export default class TraceablePeerConnection {
     private _pcId: string;
     private _remoteUfrag: string;
     private _signalingLayer: SignalingLayer;
+    private _pendingMuteUpdates: Map<string, boolean>;
     /**
      * @internal
      */
@@ -323,6 +324,13 @@ export default class TraceablePeerConnection {
          * @type {Map<string, Map<MediaType, Set<JitsiRemoteTrack>>>}
          */
         this.remoteTracks = new Map();
+
+        /**
+         * Stores pending mute updates for sources that haven't had tracks created yet.
+         * @type {Map<string, boolean>}
+         * @private
+         */
+        this._pendingMuteUpdates = new Map();
 
         /**
          * A map which stores local tracks mapped by {@link JitsiLocalTrack.rtcId}
@@ -1203,11 +1211,14 @@ export default class TraceablePeerConnection {
         const track = this.getRemoteTracks().slice().reverse().find(t => t.getSourceName() === sourceName);
 
         if (!track) {
-            logger.debug(`Remote track not found for source=${sourceName}, mute update failed!`);
+            // Store the pending mute update to be applied when the track is created
+            this._pendingMuteUpdates.set(sourceName, isMuted);
 
             return;
         }
 
+        // Clear any pending mute update since we're applying the current state to an existing track
+        this._pendingMuteUpdates.delete(sourceName);
         track.setMute(isMuted);
     }
 
@@ -1690,6 +1701,14 @@ export default class TraceablePeerConnection {
             this.remoteTracksBySsrc.set(ssrc, remoteTrack);
         } else {
             userTracksByMediaType.add(remoteTrack);
+        }
+
+        // Store pending mute update on the track itself so JitsiConference can apply it after attaching listeners
+        if (this._pendingMuteUpdates.has(sourceName)) {
+            const pendingMutedState = this._pendingMuteUpdates.get(sourceName);
+
+            remoteTrack._setPendingMuteState(pendingMutedState);
+            this._pendingMuteUpdates.delete(sourceName);
         }
 
         this.eventEmitter.emit(RTCEvents.REMOTE_TRACK_ADDED, remoteTrack, this);


### PR DESCRIPTION
## Description
Fixes race condition where mute state updates can arrive via signaling before the corresponding remote track has been created, causing the initial TRACK_MUTE_CHANGED event to never be emitted.

## How Has This Been Tested?

  - Manual testing with multiple sources per participant
  - Verified events fire on mute state transitions
  - Confirmed aggregate logic works correctly (unmuted if ANY source is unmuted)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.