### PR TITLE
fix(xmpp): add React Native DOM compatibility to StropheErrorHandler

### DIFF
--- a/modules/xmpp/StropheErrorHandler.ts
+++ b/modules/xmpp/StropheErrorHandler.ts
@@ -34,24 +34,32 @@ export function handleStropheError(errResponse: any, context: IStropheErrorConte
     }
 
     if (errorEl) {
-        errorObj.code = errorEl.getAttribute('code') || undefined;
+        try {
+            errorObj.code = errorEl.getAttribute('code') || undefined;
 
-        // Get first child element as reason
-        const reasonEl = Array.from(errorEl.children)[0];
+            // Get first child element as reason
+            const reasonEl = Array.from(errorEl.children || [])[0];
 
-        if (reasonEl) {
-            errorObj.reason = reasonEl.tagName;
+            if (reasonEl) {
+                errorObj.reason = reasonEl.tagName;
+            }
+
+            // Get <text> child element
+            const msgEl = Array.from(errorEl.getElementsByTagName('text') || [])[0];
+
+            if (msgEl?.textContent) {
+                errorObj.msg = msgEl.textContent;
+            }
+
+            // Raw XML string for debugging
+            if (errorEl.outerHTML) {
+                errorObj.raw = errorEl.outerHTML;
+            }
+        } catch (e: any) {
+            // React Native doesn't have full DOM API - fall back to basic error info
+            errorObj.reason = 'parse-error';
+            errorObj.parseError = e.message;
         }
-
-        // Get <text> child element
-        const msgEl = Array.from(errorEl.getElementsByTagName('text'))[0];
-
-        if (msgEl?.textContent) {
-            errorObj.msg = msgEl.textContent;
-        }
-
-        // Raw XML string for debugging
-        errorObj.raw = errorEl.outerHTML;
 
     // if the connection is not established we directly return a string as error from sendIQ method
     } else if (typeof errResponse === 'string') {


### PR DESCRIPTION
## Description

Adds try/catch and null safety for React Native environments where the full DOM API may not be available.

Previously, StropheErrorHandler would crash in React Native when accessing DOM properties like errorEl.children, errorEl.outerHTML, or getElementsByTagName without null checks.

Changes:
- Wrap DOM operations in try/catch block
- Add null coalescing to errorEl.children and getElementsByTagName
- Add conditional check for errorEl.outerHTML before accessing
- Fall back to parse-error on exception with error message captured

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.