### PR TITLE
chore: improve type safety in getResolutionFromFailedConstraint using…

### DIFF
--- a/JitsiTrackError.ts
+++ b/JitsiTrackError.ts
@@ -29,7 +29,7 @@ const TRACK_ERROR_TO_MESSAGE_MAP: { [key: string]: string; } = {
     [JitsiTrackErrors.SCREENSHARING_USER_CANCELED]: 'User canceled screen sharing prompt',
     [JitsiTrackErrors.SCREENSHARING_GENERIC_ERROR]: 'Unknown error from screensharing',
     [JitsiTrackErrors.SCREENSHARING_NOT_SUPPORTED_ERROR]: 'Not supported',
-    [JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_ERROR]: 'Unkown error from desktop picker',
+    [JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_ERROR]: 'Unknown error from desktop picker',
     [JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_NOT_FOUND]: 'Failed to detect desktop picker',
     [JitsiTrackErrors.GENERAL]: 'Generic getUserMedia error',
     [JitsiTrackErrors.PERMISSION_DENIED]: 'User denied permission to use device(s): ',
@@ -140,14 +140,14 @@ export default class JitsiTrackError extends Error {
      */
     private getResolutionFromFailedConstraint(failedConstraintName: string, constraints: IGumOptions): string | number {
         if (constraints?.video?.mandatory) {
-            switch (failedConstraintName) {
-            case 'width':
-                return constraints.video.mandatory.minWidth;
-            case 'height':
-                return constraints.video.mandatory.minHeight;
-            default:
-                return constraints.video.mandatory[failedConstraintName] || '';
-            }
+           switch (failedConstraintName) {
+    case 'width':
+        return constraints.video.mandatory.minWidth ?? '';
+    case 'height':
+        return constraints.video.mandatory.minHeight ?? '';
+    default:
+        return constraints.video.mandatory[failedConstraintName] ?? '';
+}
         }
 
         return '';


### PR DESCRIPTION
… nullish coalescing

test: improve JitsiTranscriptionStatus test with type safety and snapshot

## Description

<!--- Describe your changes in detail -->
This PR improves the JitsiTranscriptionStatus Jest test with the following small but meaningful updates:

1. Added TypeScript type annotation for destructured exports to improve type safety.
2. Fixed minor formatting in the .withContext() message for cleaner console output.
3. Added a snapshot test for JitsiTranscriptionStatus to detect accidental changes in the exported object in the future.

These changes maintain backward compatibility while enhancing test reliability and developer confidence.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.