### PR TITLE
chore(chatroom): apply DRY principle in onMute handlers

### DIFF
--- a/modules/xmpp/ChatRoom.ts
+++ b/modules/xmpp/ChatRoom.ts
@@ -2141,6 +2141,34 @@ export default class ChatRoom extends Listenable {
     }
 
     /**
+     * Handles remote mute request from focus for audio, video, or desktop.
+     *
+     * @param iq - The IQ element containing the mute request.
+     * @param eventType - The event type to emit.
+     * @private
+     */
+    private _handleMuteRequest(iq: Element, eventType: string): void {
+        const from = iq.getAttribute('from');
+
+        if (from !== this.focusMucJid) {
+            logger.warn('Ignored mute from non focus peer');
+
+            return;
+        }
+        const mute = findFirst(iq, 'mute');
+
+        if (getText(mute) === 'true') {
+            this.eventEmitter.emit(eventType, getAttribute(mute, 'actor'));
+        } else {
+            // XXX Why do we support anything but muting? Why do we encode the
+            // value in the text of the element? Why do we use a separate XML
+            // namespace?
+            logger.warn('Ignoring a mute request which does not explicitly '
+                + 'specify a positive mute command.');
+        }
+    }
+
+    /**
      * Returns the pin for joining the conference with phone.
      */
     public getPhonePin(): Nullable<string> {
@@ -2196,24 +2224,7 @@ export default class ChatRoom extends Listenable {
      * @internal
      */
     onMute(iq: Element): void {
-        const from = iq.getAttribute('from');
-
-        if (from !== this.focusMucJid) {
-            logger.warn('Ignored mute from non focus peer');
-
-            return;
-        }
-        const mute = findFirst(iq, 'mute');
-
-        if (getText(mute) === 'true') {
-            this.eventEmitter.emit(XMPPEvents.AUDIO_MUTED_BY_FOCUS, getAttribute(mute, 'actor'));
-        } else {
-            // XXX Why do we support anything but muting? Why do we encode the
-            // value in the text of the element? Why do we use a separate XML
-            // namespace?
-            logger.warn('Ignoring a mute request which does not explicitly '
-                + 'specify a positive mute command.');
-        }
+        this._handleMuteRequest(iq, XMPPEvents.AUDIO_MUTED_BY_FOCUS);
     }
 
     /**
@@ -2223,24 +2234,7 @@ export default class ChatRoom extends Listenable {
      * @internal
      */
     onMuteVideo(iq: Element): void {
-        const from = iq.getAttribute('from');
-
-        if (from !== this.focusMucJid) {
-            logger.warn('Ignored mute from non focus peer');
-
-            return;
-        }
-        const mute = findFirst(iq, 'mute');
-
-        if (getText(mute) === 'true') {
-            this.eventEmitter.emit(XMPPEvents.VIDEO_MUTED_BY_FOCUS, getAttribute(mute, 'actor'));
-        } else {
-            // XXX Why do we support anything but muting? Why do we encode the
-            // value in the text of the element? Why do we use a separate XML
-            // namespace?
-            logger.warn('Ignoring a mute request which does not explicitly '
-                + 'specify a positive mute command.');
-        }
+        this._handleMuteRequest(iq, XMPPEvents.VIDEO_MUTED_BY_FOCUS);
     }
 
     /**
@@ -2250,24 +2244,7 @@ export default class ChatRoom extends Listenable {
      * @internal
      */
     onMuteDesktop(iq: Element): void {
-        const from = iq.getAttribute('from');
-
-        if (from !== this.focusMucJid) {
-            logger.warn('Ignored mute from non focus peer');
-
-            return;
-        }
-        const mute = findFirst(iq, 'mute');
-
-        if (getText(mute) === 'true') {
-            this.eventEmitter.emit(XMPPEvents.DESKTOP_MUTED_BY_FOCUS, getAttribute(mute, 'actor'));
-        } else {
-            // XXX Why do we support anything but muting? Why do we encode the
-            // value in the text of the element? Why do we use a separate XML
-            // namespace?
-            logger.warn('Ignoring a mute request which does not explicitly '
-                + 'specify a positive mute command.');
-        }
+        this._handleMuteRequest(iq, XMPPEvents.DESKTOP_MUTED_BY_FOCUS);
     }
 
     /**


### PR DESCRIPTION
## Description

Applied DRY principle in the onMute, onMuteVideo and onMuteDesktop handlers by abstracting logic of the handlers

## Related Issue

fixes: #2985

## Motivation and Context

Core logic can be abstracted to a private method to apply DRY principle. Code can be reduced

## How Has This Been Tested?

N/A

## Types of changes

Improvements

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.