### PR TITLE
GSoC: guard against undefined values for participantPropertyListener to avoid crashes in ChatRoom.ts

### DIFF
--- a/modules/xmpp/ChatRoom.ts
+++ b/modules/xmpp/ChatRoom.ts
@@ -189,7 +189,8 @@ const MEMBERS_AFFILIATIONS = [ 'owner', 'admin', 'member' ];
  */
 function extractIdentityInformation(node: IPresenceNode, hiddenFromRecorderFeatureEnabled: boolean): IIdentity {
     const identity: IIdentity = {};
-    const userInfo = node.children.find(c => c.tagName === 'user');
+    const children = node.children ?? [];
+    const userInfo = children.find(c => c.tagName === 'user');
 
     if (userInfo) {
         identity.user = {};
@@ -200,15 +201,14 @@ function extractIdentityInformation(node: IPresenceNode, hiddenFromRecorderFeatu
         }
 
         for (const tag of tags) {
-            const child
-                = userInfo.children.find(c => c.tagName === tag);
+            const child = (userInfo.children ?? []).find(c => c.tagName === tag);
 
             if (child) {
                 identity.user[tag] = child.value;
             }
         }
     }
-    const groupInfo = node.children.find(c => c.tagName === 'group');
+    const groupInfo = children.find(c => c.tagName === 'group');
 
     if (groupInfo) {
         identity.group = groupInfo.value;
@@ -1091,8 +1091,10 @@ export default class ChatRoom extends Listenable {
         // All participant properties are in `participantProperties`, call the event handlers now.
         const participantId = Strophe.getResourceFromJid(from);
 
-        for (const [ key, value ] of participantProperties) {
-            this.participantPropertyListener(participantId, key, value);
+        if (this.participantPropertyListener) {
+            for (const [ key, value ] of participantProperties) {
+                this.participantPropertyListener(participantId, key, value);
+            }
         }
 
         // Trigger status message update if necessary


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds null-safety guards for participantPropertyListener in ChatRoom to prevent potential runtime errors when optional values are undefined.

## Related Issue

N/A – This PR addresses a potential runtime issue identified during code review.

## Motivation and Context

`participantPropertyListener` is optional and may be undefined in certain scenarios.
This PR ensures safer handling of this case and improves overall robustness.

## How Has This Been Tested?

N/A

## Screenshots or GIF (In case of UI changes): N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.