### PR TITLE
GSoc : fix(conference) make receiverId optional in sendReaction

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -2774,7 +2774,7 @@ export default class JitsiConference extends Listenable {
    * @param {string} messageId - The ID of the message to attach the reaction to.
    * @param {string} receiverId - The intended recipient, if the message is private.
    */
-    public sendReaction(reaction: string, messageId: string, receiverId: string): void {
+    public sendReaction(reaction: string, messageId: string, receiverId?: string): void {
         if (this.room) {
             this.room.sendReaction(reaction, messageId, receiverId);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a type mismatch in `sendReaction` where `receiverId` is required in lib-jitsi-meet but is optional in jitsi-meet usage.
Updated the `sendReaction` method in `JitsiConference.ts` to accept an optional `receiverId` to align with how it is used in the application layer.


## Related Issue

Issue : #3009 

## Motivation and Context

In jitsi-meet, reactions can be sent without a specific receiver (e.g., group chat messages), making `receiverId` optional.
However, in lib-jitsi-meet, `sendReaction` required `receiverId` as a string. This created a mismatch between the API and its actual usage, potentially leading to incorrect assumptions and type inconsistencies.
This change ensures that the API correctly reflects valid use cases such as group reactions.

## How Has This Been Tested?

- Verified that the code compiles without type errors
- Ran linter (`npm run lint`) successfully

## Screenshots or GIF (In case of UI changes): NA

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.