### PR TITLE
feat(xmpp): XEP-0359 stable message ID extraction in ChatRoom

### DIFF
--- a/modules/xmpp/ChatRoom.spec.ts
+++ b/modules/xmpp/ChatRoom.spec.ts
@@ -1009,4 +1009,184 @@ describe('ChatRoom', () => {
                 null);       // replyToId ← null when no 'to' attribute
         });
     });
+
+    describe('onMessage - XEP-0359 stable message ID extraction', () => {
+        let room: ChatRoom;
+        let emitterSpy: jasmine.Spy;
+
+        beforeEach(() => {
+            const xmpp = {
+                moderator: new Moderator({
+                    options: {}
+                }),
+                options: {},
+                addListener: () => {} // eslint-disable-line no-empty-function
+            };
+
+            // roomjid is derived from bare JID, so 'room@conference.example.com'
+            room = new ChatRoom(
+                {}/* connection */,
+                'room@conference.example.com/nick',
+                'password',
+                xmpp,
+                {});
+            emitterSpy = spyOn(room.eventEmitter, 'emit');
+        });
+
+        it('prefers stanza-id whose by matches the MUC bare JID', () => {
+            const msgStr = '' +
+                '<message to="jid" from="fromjid" type="groupchat" id="fallback-id" xmlns="jabber:client">' +
+                    '<body>Hello</body>' +
+                    '<stanza-id xmlns="urn:xmpp:sid:0" id="server-assigned-id" by="room@conference.example.com"/>' +
+                    '<origin-id xmlns="urn:xmpp:sid:0" id="client-origin-id"/>' +
+                '</message>';
+            const msg = new DOMParser().parseFromString(msgStr, 'text/xml').documentElement;
+
+            room.onMessage(msg, 'fromjid');
+            expect(emitterSpy).toHaveBeenCalledWith(
+                XMPPEvents.MESSAGE_RECEIVED,
+                'fromjid',
+                'Hello',
+                room.myroomjid,
+                null,
+                undefined,
+                false,
+                'server-assigned-id', // stanza-id preferred
+                undefined,
+                null);
+        });
+
+        it('ignores stanza-id with non-matching by attribute and falls back to origin-id', () => {
+            const msgStr = '' +
+                '<message to="jid" from="fromjid" type="groupchat" id="fallback-id" xmlns="jabber:client">' +
+                    '<body>Hello</body>' +
+                    '<stanza-id xmlns="urn:xmpp:sid:0" id="other-server-id" by="other@conference.example.com"/>' +
+                    '<origin-id xmlns="urn:xmpp:sid:0" id="client-origin-id"/>' +
+                '</message>';
+            const msg = new DOMParser().parseFromString(msgStr, 'text/xml').documentElement;
+
+            room.onMessage(msg, 'fromjid');
+            expect(emitterSpy).toHaveBeenCalledWith(
+                XMPPEvents.MESSAGE_RECEIVED,
+                'fromjid',
+                'Hello',
+                room.myroomjid,
+                null,
+                undefined,
+                false,
+                'client-origin-id', // origin-id used when stanza-id by doesn't match
+                undefined,
+                null);
+        });
+
+        it('falls back to origin-id when no stanza-id is present', () => {
+            const msgStr = '' +
+                '<message to="jid" from="fromjid" type="groupchat" id="fallback-id" xmlns="jabber:client">' +
+                    '<body>Hello</body>' +
+                    '<origin-id xmlns="urn:xmpp:sid:0" id="client-origin-id"/>' +
+                '</message>';
+            const msg = new DOMParser().parseFromString(msgStr, 'text/xml').documentElement;
+
+            room.onMessage(msg, 'fromjid');
+            expect(emitterSpy).toHaveBeenCalledWith(
+                XMPPEvents.MESSAGE_RECEIVED,
+                'fromjid',
+                'Hello',
+                room.myroomjid,
+                null,
+                undefined,
+                false,
+                'client-origin-id', // origin-id fallback
+                undefined,
+                null);
+        });
+
+        it('falls back to stanza id attribute when no XEP-0359 elements are present', () => {
+            const msgStr = '' +
+                '<message to="jid" from="fromjid" type="groupchat" id="plain-stanza-id" xmlns="jabber:client">' +
+                    '<body>Hello</body>' +
+                '</message>';
+            const msg = new DOMParser().parseFromString(msgStr, 'text/xml').documentElement;
+
+            room.onMessage(msg, 'fromjid');
+            expect(emitterSpy).toHaveBeenCalledWith(
+                XMPPEvents.MESSAGE_RECEIVED,
+                'fromjid',
+                'Hello',
+                room.myroomjid,
+                null,
+                undefined,
+                false,
+                'plain-stanza-id', // stanza id attribute fallback
+                undefined,
+                null);
+        });
+
+        it('ignores stanza-id with wrong namespace', () => {
+            const msgStr = '' +
+                '<message to="jid" from="fromjid" type="groupchat" id="fallback-id" xmlns="jabber:client">' +
+                    '<body>Hello</body>' +
+                    '<stanza-id xmlns="urn:xmpp:wrong:0" id="wrong-ns-id" by="room@conference.example.com"/>' +
+                '</message>';
+            const msg = new DOMParser().parseFromString(msgStr, 'text/xml').documentElement;
+
+            room.onMessage(msg, 'fromjid');
+            expect(emitterSpy).toHaveBeenCalledWith(
+                XMPPEvents.MESSAGE_RECEIVED,
+                'fromjid',
+                'Hello',
+                room.myroomjid,
+                null,
+                undefined,
+                false,
+                'fallback-id', // falls back to stanza id attr
+                undefined,
+                null);
+        });
+
+        it('selects the correct stanza-id among multiple stanza-id elements', () => {
+            const msgStr = '' +
+                '<message to="jid" from="fromjid" type="groupchat" id="fallback-id" xmlns="jabber:client">' +
+                    '<body>Hello</body>' +
+                    '<stanza-id xmlns="urn:xmpp:sid:0" id="other-server-id" by="other@server.example.com"/>' +
+                    '<stanza-id xmlns="urn:xmpp:sid:0" id="correct-muc-id" by="room@conference.example.com"/>' +
+                '</message>';
+            const msg = new DOMParser().parseFromString(msgStr, 'text/xml').documentElement;
+
+            room.onMessage(msg, 'fromjid');
+            expect(emitterSpy).toHaveBeenCalledWith(
+                XMPPEvents.MESSAGE_RECEIVED,
+                'fromjid',
+                'Hello',
+                room.myroomjid,
+                null,
+                undefined,
+                false,
+                'correct-muc-id', // correct stanza-id by matching MUC JID
+                undefined,
+                null);
+        });
+
+        it('also works for private (chat) messages with stanza-id', () => {
+            const msgStr = '' +
+                '<message to="jid" from="fromjid" type="chat" id="fallback-id" xmlns="jabber:client">' +
+                    '<body>Private hello</body>' +
+                    '<stanza-id xmlns="urn:xmpp:sid:0" id="server-assigned-id" by="room@conference.example.com"/>' +
+                '</message>';
+            const msg = new DOMParser().parseFromString(msgStr, 'text/xml').documentElement;
+
+            room.onMessage(msg, 'fromjid');
+            expect(emitterSpy).toHaveBeenCalledWith(
+                XMPPEvents.PRIVATE_MESSAGE_RECEIVED,
+                'fromjid',
+                'Private hello',
+                room.myroomjid,
+                null,
+                'server-assigned-id', // stanza-id preferred for private messages too
+                undefined,
+                false,
+                undefined,
+                null);
+        });
+    });
 });

--- a/modules/xmpp/ChatRoom.ts
+++ b/modules/xmpp/ChatRoom.ts
@@ -442,6 +442,40 @@ export default class ChatRoom extends Listenable {
     }
 
     /**
+     * Extracts the stable message ID from a stanza per XEP-0359.
+     * Fallback priority:
+     *   1. {@code <stanza-id>} whose {@code by} matches the MUC bare JID
+     *   2. {@code <origin-id>}
+     *   3. The stanza's own {@code id} attribute
+     *   4. A freshly generated UUID
+     * 
+     * @param {Element} stanza - The message stanza.
+     * @returns {string} The resolved stable message ID.
+     * 
+     * @private
+     */
+    private _getStableMessageId(stanza: Element): string {
+        const stanzaIdElements = findAll(stanza, ':scope>stanza-id[*|xmlns="urn:xmpp:sid:0"]');
+
+        for (const el of stanzaIdElements) {
+            if (getAttribute(el, 'by') === this.roomjid) {
+                const id = getAttribute(el, 'id');
+
+                if (id) return id;
+            }
+        }
+
+        const originId = getAttribute(
+            findFirst(stanza, ':scope>origin-id[*|xmlns="urn:xmpp:sid:0"]'),
+            'id'
+        );
+
+        if (originId) return originId;
+
+        return getAttribute(stanza, 'id') || uuidv4();
+    }
+
+    /**
      * Joins the chat room.
      * @param {string} password - Password to unlock room on joining.
      * @returns {Promise} - resolved when join completes. At the time of this
@@ -1469,7 +1503,7 @@ export default class ChatRoom extends Listenable {
         }
 
         if (txt) {
-            const messageId = getAttribute(msg, 'id') || uuidv4();
+            const messageId = this._getStableMessageId(msg);
             const replyToId = this._parseReplyMessage(msg);
             const displayNameEl = findFirst(msg, ':scope>display-name[*|xmlns="http://jitsi.org/protocol/display-name"]');
             const isVisitorMessage = getAttribute(displayNameEl, 'source') === 'visitor';


### PR DESCRIPTION
## Description

Implements stable message ID extraction per XEP-0359, replacing the current getAttribute(msg, 'id') || uuidv4() with a proper fallback chain.

* ChatRoom._getStableMessageId(stanza) — new private method with fallback priority:
        <stanza-id xmlns="urn:xmpp:sid:0"> where by matches the MUC bare JID (this.roomjid)
        <origin-id xmlns="urn:xmpp:sid:0">
        Stanza id attribute
        Fresh uuidv4()
* onMessage — replaced inline ID logic with this._getStableMessageId(msg)
* new tests covering: matching/non-matching by, multiple <stanza-id> elements, <origin-id> fallback, wrong namespace, bare id attr fallback, private messages


## Related Issue
#3015 

## Motivation and Context

Jitsi is unsuitable for regulated or enterprise deployments that require audit trails, moderation controls, and correction of misinformation. The existing onMessage pipeline in ChatRoom.ts only handles plain text and JSON messages; there is no inbound parsing for control stanzas (edits, retractions, tombstones), no stable message identity layer tied to XEP-0359, and no outbound APIs for any of the above actions.

## How Has This Been Tested?

* Unit tests for each outbound API verifying the correct XMPP stanza shape is produced (tag name, namespace, child elements, attributes).

## Screenshots or GIF (In case of UI changes):

## Types of changes

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the code style of this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.