### PR TITLE
fix: Fixes type error when build in jitsi-meet.

### DIFF
--- a/modules/detection/VADNoiseDetection.ts
+++ b/modules/detection/VADNoiseDetection.ts
@@ -62,7 +62,7 @@ export default class VADNoiseDetection extends EventEmitter {
     /**
      * Timeout reference for processing VAD scores.
      */
-    private _processTimeout?: NodeJS.Timeout;
+    private _processTimeout?: ReturnType<typeof setTimeout>;
 
     /**
      * Creates <tt>VADNoiseDetection</tt>

--- a/modules/xmpp/ResumeTask.ts
+++ b/modules/xmpp/ResumeTask.ts
@@ -24,7 +24,7 @@ export default class ResumeTask {
     private _stropheConn: Strophe.Connection;
     private _resumeRetryN: number;
     private _retryDelay: Optional<number>;
-    private _resumeTimeout: Optional<NodeJS.Timeout>;
+    private _resumeTimeout: Optional<ReturnType<typeof setTimeout>>;
     private _networkOnlineListener: Nullable<() => void>;
 
     /**


### PR DESCRIPTION
When TypeScript runs inside node_modules/lib-jitsi-meet, it doesn't just look in its own node_modules/@types/ — Node.js module resolution walks up
   the directory tree. So it also finds jitsi-meet/node_modules/@types/node (version 20.17.6).

  The lib-jitsi-meet code explicitly types timeout variables as NodeJS.Timeout:

  // VADNoiseDetection.ts:65
  private _processTimeout?: NodeJS.Timeout;

  // ResumeTask.ts:27
  private _resumeTimeout: Optional<NodeJS.Timeout>;

  But lib-jitsi-meet's own tsconfig.json only specifies "lib": ["DOM", "ES2021", "ES2024.Promise"] with no Node.js lib. So when DOM lib is active,
  setTimeout() is the DOM version which returns number. The outer jitsi-meet's @types/node v20.17.6 defines NodeJS.Timeout as a class (with .ref(),
  .unref(), etc.), which is not compatible with number. Hence the mismatch:

  Type 'number' is not assignable to type 'Timeout'
