### PR TITLE
fix(RTC): Strip sdes:mid header extension from remote SDP on Firefox

### DIFF
--- a/modules/RTC/TPCUtils.ts
+++ b/modules/RTC/TPCUtils.ts
@@ -335,8 +335,8 @@ export class TPCUtils {
 
     /**
      * Removes the sdes:mid RTP header extension from the remote SDP for Firefox. Opting into sdes:mid negotiation
-     * was enabled on Chrome to fix OHTTP/SSRC demuxing issues (https://issues.webrtc.org/issues/502130956) but
-     * Firefox does not handle the sdes:mid header extension well, causing audio/video SSRC demuxing failures.
+     * was enabled on Chrome to fix SSRC demuxing issues (https://issues.webrtc.org/issues/502130956), but Firefox
+     * does not handle the sdes:mid header extension well, causing audio/video SSRC demuxing failures.
      *
      * @param {SessionDescription} parsedSdp - The parsed SDP that needs to be munged.
      * @returns {SessionDescription} The munged SDP.

--- a/modules/RTC/TPCUtils.ts
+++ b/modules/RTC/TPCUtils.ts
@@ -334,6 +334,31 @@ export class TPCUtils {
     }
 
     /**
+     * Removes the sdes:mid RTP header extension from the remote SDP for Firefox. Opting into sdes:mid negotiation
+     * was enabled on Chrome to fix OHTTP/SSRC demuxing issues (https://issues.webrtc.org/issues/502130956) but
+     * Firefox does not handle the sdes:mid header extension well, causing audio/video SSRC demuxing failures.
+     *
+     * @param {SessionDescription} parsedSdp - The parsed SDP that needs to be munged.
+     * @returns {SessionDescription} The munged SDP.
+     * @internal
+     */
+    _stripSdesMid(parsedSdp: SessionDescription): SessionDescription {
+        if (!browser.isFirefox()) {
+            return parsedSdp;
+        }
+
+        const mungedSdp = parsedSdp;
+
+        for (const mLine of mungedSdp.media) {
+            if (mLine.ext) {
+                mLine.ext = mLine.ext.filter(ext => ext.uri !== 'urn:ietf:params:rtp-hdrext:sdes:mid');
+            }
+        }
+
+        return mungedSdp;
+    }
+
+    /**
      * Returns the calculated active state of the stream encodings based on the frame height requested for the send
      * stream. All the encodings that have a resolution lower than the frame height requested will be enabled.
      *

--- a/modules/RTC/TraceablePeerConnection.ts
+++ b/modules/RTC/TraceablePeerConnection.ts
@@ -913,7 +913,7 @@ export default class TraceablePeerConnection {
      * @param {boolean} isLocal - Whether the description is local or remote.
      * @returns {RTCSessionDescription} - The munged description.
      */
-    private _mungeDescription(description: RTCSessionDescription, _isLocal: boolean = true): RTCSessionDescription {
+    private _mungeDescription(description: RTCSessionDescription, isLocal: boolean = true): RTCSessionDescription {
         this.trace('RTCSessionDescription::preTransform', TraceablePeerConnection.dumpSDP(description));
         let mungedSdp = transform.parse(description?.sdp);
         const audioQuality = this.audioQualityLocal;
@@ -921,6 +921,10 @@ export default class TraceablePeerConnection {
         mungedSdp = this.tpcUtils.mungeOpus(mungedSdp, audioQuality);
         mungedSdp = this.tpcUtils.mungeCodecOrder(mungedSdp);
         mungedSdp = this.tpcUtils.setMaxBitrates(mungedSdp, true);
+
+        if (!isLocal) {
+            mungedSdp = this.tpcUtils._stripSdesMid(mungedSdp);
+        }
         const mungedDescription = new RTCSessionDescription({
             sdp: transform.write(mungedSdp),
             type: description.type


### PR DESCRIPTION
Opting into sdes:mid negotiation was enabled on Chrome to fix SSRC demuxing issues (https://issues.webrtc.org/issues/502130956) but Firefox does not handle this extension, causing audio/video SSRC demuxing failures. Strip it from the remote offer for Firefox clients.