### PR TITLE
Adds getCaptureTrack() to return the real camera track when an effect is enabled

### DIFF
--- a/modules/RTC/JitsiLocalTrack.ts
+++ b/modules/RTC/JitsiLocalTrack.ts
@@ -754,6 +754,20 @@ export default class JitsiLocalTrack extends JitsiTrack {
     }
 
     /**
+     * Returns the underlying capture MediaStreamTrack.
+     */
+    public getCaptureTrack(): MediaStreamTrack | null {
+        if (this._originalStream) {
+            const kind = this.track?.kind;
+            const tracks = this._originalStream.getTracks().filter(t => t.kind === kind);
+
+            return tracks.length ? tracks[0] : this._originalStream.getTracks()[0] ?? null;
+        }
+
+        return this.track ?? null;
+    }
+
+    /**
      * Returns device id associated with track.
      *
      * @returns {string}
@@ -1053,16 +1067,21 @@ export default class JitsiLocalTrack extends JitsiTrack {
     }
 
     /**
-     * Applies media constraints to the current MediaStreamTrack.
+     * Applies constraints to the capture track (physical device).
      *
-     * @param {IAudioConstraints} constraints - Media constraints to apply.
-     * @returns {Promise<void>}
+     * @param {MediaTrackConstraints | IAudioConstraints} constraints - Media constraints to apply.
      */
-    async applyConstraints(constraints: IAudioConstraints): Promise<void> {
+    async applyConstraints(constraints: MediaTrackConstraints | IAudioConstraints): Promise<void> {
         const mediaType = this.getType();
 
         if (!this.isAudioTrack()) {
-            throw new Error(`Media ${mediaType} is not supported, track must be audio`);
+            const captureTrack = this.getCaptureTrack();
+
+            if (!captureTrack) {
+                return Promise.reject(new Error('No capture track available'));
+            }
+
+            return (captureTrack as any).applyConstraints(constraints) as Promise<void>;
         }
 
         const hasAudioMixEffect = typeof this._streamEffect?.setMuted === 'function';

--- a/modules/RTC/JitsiTrack.ts
+++ b/modules/RTC/JitsiTrack.ts
@@ -377,6 +377,13 @@ export default class JitsiTrack extends Listenable {
     }
 
     /**
+     * Returns the underlying capture MediaStreamTrack.
+     */
+    public getCaptureTrack(): MediaStreamTrack | null {
+        return this.track;
+    }
+
+    /**
      * Return the underlying WebRTC MediaStreamTrack label
      * @returns {string}
      */


### PR DESCRIPTION
**The Problem:**
When a virtual background or video effect is enabled, `_startStreamEffect()` swaps out `this.track` with a Canvas-based output track, while keeping the actual camera stream hidden away in the private `this._originalStream` field.

This causes issues if an application needs to apply physical hardware constraints to the camera (like Pan/Tilt/Zoom, hardware focus, etc). If you try to call `applyConstraints()` on the current `this.track` while an effect is running, Chrome gets confused applying physical constraints to a Canvas track and throws an `UnknownError`. The UI might look fine, but the camera ignores the command.

**The Fix:**
- Added `getCaptureTrack()` to `JitsiTrack` and `JitsiLocalTrack`. It safely checks if `_originalStream` exists (meaning an effect is running) and returns the real camera track. If there's no effect, it just returns `this.track`.
- Updated `applyConstraints()` in `JitsiLocalTrack` to intercept `MediaTrackConstraints` and proxy them straight to the physical capture track provided by `getCaptureTrack()`. (Audio constraints are handled exactly as before).

**Testing:**
I added a quick test suite for `JitsiLocalTrack` to verify that the accessor handles effect mocks cleanly and that `applyConstraints()` doesn't accidentally touch the Canvas track. Ran it locally through Karma and all tests pass. I have not commited that test suite, but if asked I will commit it.