### PR TITLE
fix(chat): fix XEP-0461 reply stanza construction in sendMessage

### DIFF
--- a/modules/xmpp/ChatRoom.ts
+++ b/modules/xmpp/ChatRoom.ts
@@ -1144,7 +1144,7 @@ export default class ChatRoom extends Listenable {
         }
 
         if (replyToId) {
-            msg.up().c('reply', { to: replyToId });
+            msg.c('reply', { to: replyToId, xmlns: 'urn:xmpp:reply:0' });
         }
 
         this.connection.send(msg);
@@ -1202,7 +1202,7 @@ export default class ChatRoom extends Listenable {
         }
 
         if (replyToId) {
-            msg.c('reply', { to: replyToId });
+            msg.c('reply', { to: replyToId, xmlns: 'urn:xmpp:reply:0' });
         }
 
         this.connection.send(msg);


### PR DESCRIPTION
### Description

This PR fixes the reply stanza construction used for XEP-0461 threaded replies.

The reply element was being built with `msg.up().c()`, which can fail because `msg.up()` returns `null` at the top level of the builder chain. This caused a null appendChild crash during message send.

Fix:
- Use `msg.c()` directly instead of `msg.up().c()`.
- Add the required `xmlns="urn:xmpp:reply:0"` attribute so the stanza is built correctly.

This keeps reply messages valid and prevents the XMPP stanza construction crash.

### Related Issue

jitsi/jitsi-meet#17196

### Motivation and Context

This fixes the XEP-0461 reply stanza construction so reply messages are sent correctly without crashing the stanza builder.

### How Has This Been Tested?

Manually tested the chat reply flow in Jitsi Meet after integrating the lib-jitsi-meet fix. Verified that the reply stanza is created without crashing and the branch builds successfully.

### Screenshots or GIF (In case of UI changes):

Before:
<img width="1759" height="944" alt="image" src="https://github.com/user-attachments/assets/207084ea-408f-42e1-95fe-2b85e933b263" />

- No threaded reply UI in chat.

After:
<img width="1856" height="1048" alt="Screenshot from 2026-04-19 14-42-56" src="https://github.com/user-attachments/assets/8376e30b-f68a-4aba-adfe-d8fc4f50416a" />

- Reply preview shown in chat input/message flow.