### PR TITLE
fix: Drop scheduling ws keep-alive on shard set.

### DIFF
--- a/modules/xmpp/XmppConnection.ts
+++ b/modules/xmpp/XmppConnection.ts
@@ -323,11 +323,6 @@ export default class XmppConnection extends Listenable {
      */
     set shard(value: string) {
         this._options.shard = value;
-
-        // shard setting changed so let's schedule a new keep-alive check if connected
-        if (this._oneSuccessfulConnect) {
-            this._maybeStartWSKeepAlive();
-        }
     }
 
     /**


### PR DESCRIPTION
If set shard is executed after connect we will clear the check that is scheduled in 5 seconds after connecting.
