### PR TITLE
feat(RTCStats): Report getUserMedia errors via RTCStats

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -429,14 +429,16 @@ class RTCUtils extends Listenable {
                     logger.warn(`Failed to get access to local media. ${error} ${JSON.stringify(constraints)}`);
                     const jitsiError = new JitsiTrackError(error, constraints, umDevices);
 
-                    RTCStats.sendStatsEntry(RTCStatsEvents.GET_USER_MEDIA_ERROR_EVENT, null, {
-                        constraint: error.constraint,
-                        devices: umDevices,
-                        message: error.message,
-                        name: error.name
-                    });
-
                     if (!timeoutExpired) {
+                        // Skip emitting when the timeout already fired and reported the failure,
+                        // to avoid double-reporting a single gUM call.
+                        RTCStats.sendStatsEntry(RTCStatsEvents.GET_USER_MEDIA_ERROR_EVENT, null, {
+                            constraint: error.constraint,
+                            devices: umDevices,
+                            message: error.message,
+                            name: error.name
+                        });
+
                         if (typeof gumTimeout !== 'undefined') {
                             clearTimeout(gumTimeout);
                         }

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -9,6 +9,8 @@ import { RTCEvents } from '../../service/RTC/RTCEvents';
 import Resolutions from '../../service/RTC/Resolutions';
 import { VideoType } from '../../service/RTC/VideoType';
 import { AnalyticsEvents } from '../../service/statistics/AnalyticsEvents';
+import RTCStats from '../RTCStats/RTCStats';
+import { RTCStatsEvents } from '../RTCStats/RTCStatsEvents';
 import browser from '../browser';
 import Statistics from '../statistics/statistics';
 import Listenable from '../util/Listenable';
@@ -399,7 +401,16 @@ class RTCUtils extends Listenable {
                 gumTimeout = setTimeout(() => {
                     timeoutExpired = true;
                     gumTimeout = undefined;
-                    reject(new JitsiTrackError(JitsiTrackErrors.TIMEOUT));
+
+                    const timeoutError = new JitsiTrackError(JitsiTrackErrors.TIMEOUT);
+
+                    RTCStats.sendStatsEntry(RTCStatsEvents.GET_USER_MEDIA_ERROR_EVENT, null, {
+                        devices: umDevices,
+                        message: timeoutError.message,
+                        name: timeoutError.name
+                    });
+
+                    reject(timeoutError);
                 }, timeout);
             }
 
@@ -417,6 +428,13 @@ class RTCUtils extends Listenable {
                 .catch(error => {
                     logger.warn(`Failed to get access to local media. ${error} ${JSON.stringify(constraints)}`);
                     const jitsiError = new JitsiTrackError(error, constraints, umDevices);
+
+                    RTCStats.sendStatsEntry(RTCStatsEvents.GET_USER_MEDIA_ERROR_EVENT, null, {
+                        constraint: error.constraint,
+                        devices: umDevices,
+                        message: error.message,
+                        name: error.name
+                    });
 
                     if (!timeoutExpired) {
                         if (typeof gumTimeout !== 'undefined') {

--- a/modules/RTC/RTCUtils.spec.ts
+++ b/modules/RTC/RTCUtils.spec.ts
@@ -85,6 +85,33 @@ describe('RTCUtils', () => {
             jasmine.clock().uninstall();
         });
 
+        it('emits the error event only once when timeout fires before gUM rejects', async () => {
+            jasmine.clock().install();
+
+            let rejectGum: ((reason: unknown) => void) | undefined;
+
+            getUserMediaSpy.and.returnValue(new Promise((_resolve, reject) => {
+                rejectGum = reject;
+            }));
+
+            const gumPromise = (RTCUtils as any)._getUserMedia([ 'audio' ], {}, 100);
+
+            // Trigger the timeout — emits once.
+            jasmine.clock().tick(150);
+            await expectAsync(gumPromise).toBeRejected();
+
+            expect(rtcStatsSpy).toHaveBeenCalledTimes(1);
+
+            // Now have the underlying gUM reject after the fact — must not emit a second event.
+            rejectGum?.(Object.assign(new Error('Late rejection'), { name: 'NotAllowedError' }));
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(rtcStatsSpy).toHaveBeenCalledTimes(1);
+
+            jasmine.clock().uninstall();
+        });
+
         it('does not emit GET_USER_MEDIA_ERROR_EVENT when getUserMedia succeeds', async () => {
             const fakeStream = {
                 getAudioTracks: () => [],

--- a/modules/RTC/RTCUtils.spec.ts
+++ b/modules/RTC/RTCUtils.spec.ts
@@ -1,0 +1,104 @@
+import * as JitsiTrackErrors from '../../JitsiTrackErrors';
+import RTCStats from '../RTCStats/RTCStats';
+import { RTCStatsEvents } from '../RTCStats/RTCStatsEvents';
+
+import RTCUtils from './RTCUtils';
+
+describe('RTCUtils', () => {
+    describe('_getUserMedia', () => {
+        let rtcStatsSpy: jasmine.Spy;
+        let getUserMediaSpy: jasmine.Spy;
+
+        beforeEach(() => {
+            rtcStatsSpy = spyOn(RTCStats, 'sendStatsEntry');
+
+            if (!navigator.mediaDevices) {
+                (navigator as any).mediaDevices = {};
+            }
+            if (!navigator.mediaDevices.getUserMedia) {
+                (navigator.mediaDevices as any).getUserMedia = () => Promise.resolve();
+            }
+            getUserMediaSpy = spyOn(navigator.mediaDevices, 'getUserMedia');
+        });
+
+        it('emits GET_USER_MEDIA_ERROR_EVENT when getUserMedia rejects', async () => {
+            const error = Object.assign(new Error('Permission denied by user'), {
+                name: 'NotAllowedError'
+            });
+
+            getUserMediaSpy.and.returnValue(Promise.reject(error));
+
+            await expectAsync((RTCUtils as any)._getUserMedia([ 'audio', 'video' ], {})).toBeRejected();
+
+            expect(rtcStatsSpy).toHaveBeenCalledWith(
+                RTCStatsEvents.GET_USER_MEDIA_ERROR_EVENT,
+                null,
+                {
+                    constraint: undefined,
+                    devices: [ 'audio', 'video' ],
+                    message: 'Permission denied by user',
+                    name: 'NotAllowedError'
+                });
+        });
+
+        it('includes the failed constraint name when getUserMedia rejects with OverconstrainedError', async () => {
+            const error = Object.assign(new Error('Cannot satisfy constraints'), {
+                constraint: 'width',
+                name: 'OverconstrainedError'
+            });
+
+            getUserMediaSpy.and.returnValue(Promise.reject(error));
+
+            await expectAsync((RTCUtils as any)._getUserMedia([ 'video' ], {})).toBeRejected();
+
+            expect(rtcStatsSpy).toHaveBeenCalledWith(
+                RTCStatsEvents.GET_USER_MEDIA_ERROR_EVENT,
+                null,
+                {
+                    constraint: 'width',
+                    devices: [ 'video' ],
+                    message: 'Cannot satisfy constraints',
+                    name: 'OverconstrainedError'
+                });
+        });
+
+        it('emits GET_USER_MEDIA_ERROR_EVENT when the gUM call times out', async () => {
+            jasmine.clock().install();
+
+            // The native getUserMedia never resolves so the timeout fires.
+            getUserMediaSpy.and.returnValue(new Promise(() => { /* never resolves */ }));
+
+            const gumPromise = (RTCUtils as any)._getUserMedia([ 'audio' ], {}, 100);
+
+            jasmine.clock().tick(150);
+
+            await expectAsync(gumPromise).toBeRejected();
+
+            expect(rtcStatsSpy).toHaveBeenCalledWith(
+                RTCStatsEvents.GET_USER_MEDIA_ERROR_EVENT,
+                null,
+                jasmine.objectContaining({
+                    devices: [ 'audio' ],
+                    name: JitsiTrackErrors.TIMEOUT
+                }));
+
+            jasmine.clock().uninstall();
+        });
+
+        it('does not emit GET_USER_MEDIA_ERROR_EVENT when getUserMedia succeeds', async () => {
+            const fakeStream = {
+                getAudioTracks: () => [],
+                getVideoTracks: () => []
+            };
+
+            getUserMediaSpy.and.returnValue(Promise.resolve(fakeStream));
+
+            await (RTCUtils as any)._getUserMedia([ 'audio' ], {});
+
+            expect(rtcStatsSpy).not.toHaveBeenCalledWith(
+                RTCStatsEvents.GET_USER_MEDIA_ERROR_EVENT,
+                jasmine.anything(),
+                jasmine.anything());
+        });
+    });
+});

--- a/modules/RTCStats/RTCStatsEvents.ts
+++ b/modules/RTCStats/RTCStatsEvents.ts
@@ -36,6 +36,17 @@ export enum RTCStatsEvents {
     ENCODER_CPU_RESTRICTED_EVENT = 'cpuRestricted',
 
     /**
+     * Event that indicates that a getUserMedia call has failed.
+     *
+     * @param {object} data - The data.
+     * @param {string} data.name - The error name (e.g. 'NotAllowedError', 'NotFoundError', 'OverconstrainedError').
+     * @param {string} data.message - The error message.
+     * @param {string} [data.constraint] - The failed constraint name, when applicable (OverconstrainedError).
+     * @param {Array<string>} data.devices - The media types that were requested (e.g. ['audio', 'video', 'desktop']).
+     */
+    GET_USER_MEDIA_ERROR_EVENT = 'getUserMediaError',
+
+    /**
      * Event that indicates that the JVB media session is restarted because of ICE failure.
      */
     JVB_ICE_RESTARTED_EVENT = 'jvbIceRestarted',


### PR DESCRIPTION
## Description

Adds a new `GET_USER_MEDIA_ERROR_EVENT` to `RTCStatsEvents` and emits it from
`RTCUtils._getUserMedia` whenever a `getUserMedia` call fails — both when the
native browser call rejects (e.g. `NotAllowedError`, `NotFoundError`,
`OverconstrainedError`) and when the gUM call hits the lib-jitsi-meet timeout
path.

The reported payload is:

```js
{
    name: string,            // error name, e.g. 'NotAllowedError', 'gum.timeout'
    message: string,         // error message
    constraint?: string,     // failed constraint name (OverconstrainedError only)
    devices: string[]        // requested media kinds, e.g. ['audio', 'video']
}
```

## Motivation and Context

`getUserMedia` failures are a major source of "I cannot join with mic/camera"
support cases, but today they only surface in client-side logs. Forwarding them
through RTCStats lets us track failure rates, surface the most common error
names per browser/device, and correlate them with the rest of the call's stats
without relying on users to send logs.

## How Has This Been Tested?

- Added unit tests in `modules/RTC/RTCUtils.spec.ts` covering:
  - gUM rejects with `NotAllowedError` -> event emitted with name/message/devices
  - gUM rejects with `OverconstrainedError` -> event includes the failed
    constraint name
  - gUM call exceeds the timeout -> event emitted with `name: 'gum.timeout'`
  - gUM resolves successfully -> no error event emitted
- `npm test` passes for the new tests; the only remaining failure
  (`JitsiMeetJS.spec.ts` -- `Cannot find module './version'`) is a pre-existing
  build-time generated module issue unrelated to this change.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
