### PR TITLE
fix(RTC): Spec-compliant simulcast on Firefox

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -979,18 +979,32 @@ export default class JitsiConference extends Listenable {
    * @param {JingleSessionPC} jingleSession - The media session.
    * @param {Error} error - The error message.
    * @param {MediaType} mediaType - The media type of the track associated with the source that was rejected.
+   * @param {Object} _ctx - Unused context object passed by JingleSessionPC.
+   * @param {Array<string>} sourceNames - Source names of the rejected sources, when available.
    * @returns {void}
    */
-    private _removeLocalSourceOnReject(jingleSession: JingleSessionPC, error: Error, mediaType: MediaType): void {
+    private _removeLocalSourceOnReject(
+            jingleSession: JingleSessionPC,
+            error: Error,
+            mediaType: MediaType,
+            _ctx?: object,
+            sourceNames: string[] = []): void {
         if (!jingleSession) {
             return;
         }
         const errorReason = (error as { reason?: string; })?.reason;
 
-        logger.warn(`Source-add rejected on ${jingleSession}, reason="${errorReason}", message="${error?.message}"`);
-        const track = this.getLocalTracks(mediaType)[0];
+        logger.warn(`Source-add rejected on ${jingleSession}, reason="${errorReason}", message="${error?.message}"`
+            + `, sourceNames=${sourceNames.join(',')}`);
 
-        this.eventEmitter.emit(JitsiConferenceEvents.TRACK_UNMUTE_REJECTED, track);
+        const localTracks = this.getLocalTracks(mediaType);
+        const rejectedTracks = sourceNames.length
+            ? localTracks.filter(t => sourceNames.includes(t.getSourceName()))
+            : localTracks.slice(0, 1);
+
+        for (const track of rejectedTracks) {
+            this.eventEmitter.emit(JitsiConferenceEvents.TRACK_UNMUTE_REJECTED, track);
+        }
     }
 
     /**

--- a/modules/RTC/MockClasses.ts
+++ b/modules/RTC/MockClasses.ts
@@ -129,6 +129,10 @@ export class MockPeerConnection {
      */
     id: string;
     /**
+     * @internal
+     */
+    _midsWithSentTrack: Set<string>;
+    /**
      * Constructor.
      *
      * @param {string} id RTC id
@@ -140,6 +144,7 @@ export class MockPeerConnection {
         this._usesUnifiedPlan = usesUnifiedPlan;
         this.peerconnection = new MockRTCPeerConnection();
         this._simulcast = simulcast;
+        this._midsWithSentTrack = new Set<string>();
     }
 
     /**

--- a/modules/RTC/TPCUtils.ts
+++ b/modules/RTC/TPCUtils.ts
@@ -661,29 +661,30 @@ export class TPCUtils {
      */
     injectSsrcGroupForSimulcast(desc: RTCSessionDescription): RTCSessionDescription {
         const sdp = transform.parse(desc.sdp);
-        const video = sdp.media.find(mline => mline.type === 'video');
+        const videoMlines = sdp.media.filter(mline => mline.type === 'video');
+        let modified = false;
 
-        // Check if the browser supports RTX, add only the primary ssrcs to the SIM group if that is the case.
-        video.ssrcGroups = video.ssrcGroups || [];
-        const fidGroups = video.ssrcGroups.filter(group => group.semantics === SSRC_GROUP_SEMANTICS.FID);
-
-        if (video.simulcast || video.simulcast_03) {
+        for (const video of videoMlines) {
+            if (!(video.simulcast || video.simulcast_03)) {
+                continue;
+            }
+            video.ssrcGroups = video.ssrcGroups || [];
+            if (video.ssrcGroups.find(group => group.semantics === SSRC_GROUP_SEMANTICS.SIM)) {
+                continue;
+            }
+            const fidGroups = video.ssrcGroups.filter(group => group.semantics === SSRC_GROUP_SEMANTICS.FID);
             const ssrcs = [];
 
             if (fidGroups?.length) {
                 fidGroups.forEach(group => {
                     ssrcs.push(group.ssrcs.split(' ')[0]);
                 });
-            } else {
+            } else if (video.ssrcs) {
                 video.ssrcs.forEach(ssrc => {
                     if (ssrc.attribute === 'msid') {
                         ssrcs.push(ssrc.id);
                     }
                 });
-            }
-            if (video.ssrcGroups.find(group => group.semantics === SSRC_GROUP_SEMANTICS.SIM)) {
-                // Group already exists, no need to do anything
-                return desc;
             }
 
             // Add a SIM group for every 3 FID groups.
@@ -694,7 +695,12 @@ export class TPCUtils {
                     semantics: SSRC_GROUP_SEMANTICS.SIM,
                     ssrcs: simSsrcs.join(' ')
                 });
+                modified = true;
             }
+        }
+
+        if (!modified) {
+            return desc;
         }
 
         return new RTCSessionDescription({
@@ -740,8 +746,13 @@ export class TPCUtils {
         const senderMids = Array.from(this.pc.localTrackTransceiverMids.values());
 
         mLines.forEach((mLine, idx) => {
-            // Make sure the simulcast recv line is only set on video descriptions that are associated with senders.
-            if (senderMids.find(sender => mLine.mid.toString() === sender.toString()) || idx === 0) {
+            // FF 110+: recvonly slots reserved for local senders that haven't been registered yet
+            // (e.g., secondary sources before replaceTrack runs) also need simulcast info.
+            const isSenderMline = Boolean(senderMids.find(sender => mLine.mid.toString() === sender.toString()))
+                || idx === 0
+                || (browser.supportsEncodingsConfig() && mLine.direction === MediaDirection.RECVONLY);
+
+            if (isSenderMline) {
                 if (!mLine.simulcast_03 || !mLine.simulcast) {
                     mLine.rids = rids;
 

--- a/modules/RTC/TraceablePeerConnection.ts
+++ b/modules/RTC/TraceablePeerConnection.ts
@@ -170,13 +170,11 @@ export default class TraceablePeerConnection {
      */
     _capScreenshareBitrate: boolean;
     /**
+     * Mids of transceivers that have ever carried a local sender track. Never cleared on mute/remove
+     * so LocalSdpMunger can preserve the SSRCs of previously-active sender slots.
      * @internal
      */
-    _hasHadAudioTrack: boolean;
-    /**
-     * @internal
-     */
-    _hasHadVideoTrack: boolean;
+    _midsWithSentTrack: Set<string>;
 
     // public property declarations
     audioTransferActive: boolean;
@@ -488,15 +486,7 @@ export default class TraceablePeerConnection {
          */
         this._usesCodecSelectionAPI = this.options.usesCodecSelectionAPI;
 
-        /**
-         * Indicates whether an audio track has ever been added to the peer connection.
-         */
-        this._hasHadAudioTrack = false;
-
-        /**
-         * Indicates whether a video track has ever been added to the peer connection.
-         */
-        this._hasHadVideoTrack = false;
+        this._midsWithSentTrack = new Set<string>();
 
         /**
          * @type {number} The max number of stats to keep in this.stats. Limit to
@@ -718,7 +708,36 @@ export default class TraceablePeerConnection {
             return;
         }
 
-        parameters.encodings = this.tpcUtils.getStreamEncodings(localTrack) as RTCRtpEncodingParameters[];
+        const desiredEncodings = this.tpcUtils.getStreamEncodings(localTrack);
+
+        if (browser.supportsEncodingsConfig()) {
+            // FF 110+ rejects encodings length/rid changes; skip on mismatch to keep the call alive.
+            if (parameters.encodings.length !== desiredEncodings.length) {
+                return;
+            }
+            parameters.encodings.forEach((encoding: IRTCRtpEncodingParameters, idx: number) => {
+                const desired = desiredEncodings[idx];
+
+                if (!desired) {
+                    return;
+                }
+                if (desired.active !== undefined) {
+                    encoding.active = desired.active;
+                }
+                if (desired.maxBitrate !== undefined) {
+                    encoding.maxBitrate = desired.maxBitrate;
+                }
+                if (desired.scaleResolutionDownBy !== undefined) {
+                    encoding.scaleResolutionDownBy = desired.scaleResolutionDownBy;
+                }
+                if (desired.scalabilityMode !== undefined) {
+                    encoding.scalabilityMode = desired.scalabilityMode;
+                }
+            });
+        } else {
+            parameters.encodings = desiredEncodings as RTCRtpEncodingParameters[];
+        }
+
         await transceiver.sender.setParameters(parameters);
     };
 
@@ -2030,7 +2049,7 @@ export default class TraceablePeerConnection {
                 streams
             };
 
-            if (!browser.isFirefox()) {
+            if (!browser.isFirefox() || browser.supportsEncodingsConfig()) {
                 transceiverInit.sendEncodings = this.tpcUtils.getStreamEncodings(track);
             }
 
@@ -2046,20 +2065,19 @@ export default class TraceablePeerConnection {
         }
 
         if (transceiver?.mid) {
-            this.localTrackTransceiverMids.set(track.rtcId, transceiver.mid.toString());
+            const mid = transceiver.mid.toString();
+
+            this.localTrackTransceiverMids.set(track.rtcId, mid);
+            this._midsWithSentTrack.add(mid);
         }
 
         if (track) {
             this.localTracks.set(rtcId, track);
-            if (track.isAudioTrack()) {
-                this._hasHadAudioTrack = true;
-            } else {
-                this._hasHadVideoTrack = true;
-            }
         }
 
-        // On Firefox, the encodings have to be configured on the sender only after the transceiver is created.
-        if (browser.isFirefox() && webrtcStream && this.doesTrueSimulcast(track)) {
+        // FF < 110 doesn't honor sendEncodings on addTransceiver; configure the encodings via setParameters.
+        if (browser.isFirefox() && !browser.supportsEncodingsConfig()
+                && webrtcStream && this.doesTrueSimulcast(track)) {
             await this._setEncodings(track);
         }
     };
@@ -2092,7 +2110,6 @@ export default class TraceablePeerConnection {
 
             if (track) {
                 if (track.isAudioTrack()) {
-                    this._hasHadAudioTrack = true;
                     // Sync audioQualityLocal from microphone track settings (stereo/mono)
                     const isMicrophoneTrack = !track.sourceType && !track.sourceId && track.deviceId;
 
@@ -2120,8 +2137,6 @@ export default class TraceablePeerConnection {
                             }
                         }
                     }
-                } else {
-                    this._hasHadVideoTrack = true;
                 }
             }
 
@@ -2380,13 +2395,13 @@ export default class TraceablePeerConnection {
                 }
 
                 if (newTrack) {
-                    if (newTrack.isAudioTrack()) {
-                        this._hasHadAudioTrack = true;
-                    } else {
-                        this._hasHadVideoTrack = true;
-                    }
-                    this.localTrackTransceiverMids.set(newTrack.rtcId, transceiver?.mid?.toString());
+                    const newMid = transceiver?.mid?.toString();
+
+                    this.localTrackTransceiverMids.set(newTrack.rtcId, newMid);
                     this.localTracks.set(newTrack.rtcId, newTrack);
+                    if (newMid) {
+                        this._midsWithSentTrack.add(newMid);
+                    }
 
                     // Send RTCStats event when the track is added for the first time.
                     this._sendRtcStatsEvent(newTrack, false);

--- a/modules/browser/BrowserCapabilities.ts
+++ b/modules/browser/BrowserCapabilities.ts
@@ -250,6 +250,15 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
+     * Returns true on Firefox 110+, where RTCRtpTransceiverInit.sendEncodings is honored.
+     *
+     * @returns {boolean}
+     */
+    supportsEncodingsConfig(): boolean {
+        return this.isFirefox() && this.isVersionGreaterThan(109);
+    }
+
+    /**
      * Returns true if the browser supports the new Scalability Mode API for VP9/AV1 simulcast and full SVC. H.264
      * simulcast will also be supported by the jvb for this version because the bridge is able to read the Dependency
      * Descriptor RTP header extension to extract layers information for H.264 as well.

--- a/modules/sdp/LocalSdpMunger.ts
+++ b/modules/sdp/LocalSdpMunger.ts
@@ -110,22 +110,16 @@ export default class LocalSdpMunger {
             mediaSection.ssrcs = mediaSection.ssrcs.filter(ssrc => ssrc.attribute !== 'cname');
         }
 
-        // On FF when the user has started muted create answer will generate a recv only SSRC. We don't want to signal
-        // this SSRC in order to reduce the load of the xmpp server for large calls. Therefore the SSRC needs to be
-        // removed from the SDP.
-        //
-        // For all other use cases (when the user has had media but then the user has stopped it) we want to keep the
-        // receive only SSRCs in the SDP. Otherwise source-remove will be triggered and the next time the user add a
-        // track we will reuse the SSRCs and send source-add with the same SSRCs. This is problematic because of issues
-        // on Chrome and FF (https://bugzilla.mozilla.org/show_bug.cgi?id=1768729) when removing and then adding the
-        // same SSRC in the remote sdp the remote track is not rendered.
+        // FF generates phantom SSRCs for recvonly/inactive m-lines that should not be signaled. Only strip
+        // them on m-lines that have never carried a local sender track — preserving SSRCs on previously
+        // active sender slots avoids a source-remove on mute and the SSRC-reuse rendering issue
+        // (https://bugzilla.mozilla.org/show_bug.cgi?id=1768729).
+        const mid = mediaSection._mLine.mid?.toString();
+        const midHasSentTrack = mid && this._tpc._midsWithSentTrack.has(mid);
+
         if (browser.isFirefox()
             && (mediaDirection === MediaDirection.RECVONLY || mediaDirection === MediaDirection.INACTIVE)
-            && (
-                (mediaType === MediaType.VIDEO && !this._tpc._hasHadVideoTrack)
-                || (mediaType === MediaType.AUDIO && !this._tpc._hasHadAudioTrack)
-            )
-        ) {
+            && !midHasSentTrack) {
             mediaSection.ssrcs = undefined;
             mediaSection.ssrcGroups = undefined;
         }

--- a/modules/xmpp/JingleSessionPC.ts
+++ b/modules/xmpp/JingleSessionPC.ts
@@ -1129,6 +1129,7 @@ export default class JingleSessionPC extends JingleSession {
             const newMedia = sdpDiffer.getNewMedia();
             let ssrcs = [];
             let mediaType = null;
+            const sourceNames = new Set<string>();
 
             // It is assumed that sources are signaled one at a time.
             Object.keys(newMedia).forEach(mediaIndex => {
@@ -1137,11 +1138,19 @@ export default class JingleSessionPC extends JingleSession {
                 mediaType = newMedia[mediaIndex].mediaType;
                 if (signaledSsrcs?.length) {
                     ssrcs = ssrcs.concat(signaledSsrcs);
+                    signaledSsrcs.forEach(ssrcNum => {
+                        const sourceName = SDPUtil.parseSourceNameLine(newMedia[mediaIndex].ssrcs[ssrcNum].lines);
+
+                        if (sourceName) {
+                            sourceNames.add(sourceName);
+                        }
+                    });
                 }
             });
 
             return {
                 mediaType,
+                sourceNames: Array.from(sourceNames),
                 ssrcs
             };
         };
@@ -1216,7 +1225,13 @@ export default class JingleSessionPC extends JingleSession {
                     this.room.eventEmitter.emit(XMPPEvents.SOURCE_ADD, this, ctx);
                 },
                 this.newJingleErrorHandler(error => {
-                    this.room.eventEmitter.emit(XMPPEvents.SOURCE_ADD_ERROR, this, error, addedSsrcInfo.mediaType, ctx);
+                    this.room.eventEmitter.emit(
+                        XMPPEvents.SOURCE_ADD_ERROR,
+                        this,
+                        error,
+                        addedSsrcInfo.mediaType,
+                        ctx,
+                        addedSsrcInfo.sourceNames);
                 }),
                 IQ_TIMEOUT);
         }


### PR DESCRIPTION
Firefox 138+ enforces the WebRTC spec strictly on RTCRtpSender.setParameters: the encodings array length and rid values cannot change after the transceiver is created, otherwise the call is rejected with InvalidModificationError.

