### PR TITLE
chore(deps): bump @jitsi/js-utils to 6.3.2

### DIFF
--- a/modules/browser/BrowserCapabilities.ts
+++ b/modules/browser/BrowserCapabilities.ts
@@ -1,4 +1,4 @@
-import BrowserDetection from '@jitsi/js-utils/browser-detection/BrowserDetection';
+import { BrowserDetection } from '@jitsi/js-utils/browser-detection';
 
 /* Minimum required Chrome / Chromium version. This applies also to derivatives. */
 const MIN_REQUIRED_CHROME_VERSION = 72;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jitsi/js-utils": "^2.6.7",
+        "@jitsi/js-utils": "6.3.2",
         "@jitsi/logger": "2.1.1",
         "@jitsi/precall-test": "1.0.6",
         "@jitsi/rtcstats": "9.7.1",
@@ -1837,12 +1837,12 @@
       }
     },
     "node_modules/@jitsi/js-utils": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-2.6.7.tgz",
-      "integrity": "sha512-r16J3CjYt325CFIpfHznND4O3b9BE7CZ7cu+Xx0uk1C+ZY6/bDPZFM/0d4t0VH+1/rmfG4I7i18qxXct3xmPrw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-6.3.2.tgz",
+      "integrity": "sha512-nGF24WVADFQF2OfdlJWbel2MvwTRbxxZdNDzIqUBKGtRYd10CukgrcydB2WRPRLtn4Q97KrpdqrcAuH0Idi3yg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hapi/bourne": "^3.0.0",
+        "@hapi/bourne": "3.0.0",
         "js-md5": "0.7.3",
         "ua-parser-js": "1.0.35"
       }
@@ -1887,10 +1887,40 @@
         "uuid": "^8.3.2"
       }
     },
+    "node_modules/@jitsi/rtcstats/node_modules/@jitsi/js-utils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-2.8.2.tgz",
+      "integrity": "sha512-tMFuci2lPmbQIFF/f3b5QdkL1vzY6sii9nj0e+K0EEJcFUJiX/QVkv5GbI6pMZ74BYAQXGFZqeASo8hKItniUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@hapi/bourne": "3.0.0",
+        "js-md5": "0.7.3",
+        "ua-parser-js": "1.0.35"
+      }
+    },
     "node_modules/@jitsi/rtcstats/node_modules/@jitsi/logger": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@jitsi/logger/-/logger-2.0.2.tgz",
       "integrity": "sha512-qwbpRwuwkBFgh0F5jivq/5fAm46yVoXURc5LCklEs8lAShYVangFEXKW7RLpZuZ5nQnrHrlvU8MswQNREmvahg=="
+    },
+    "node_modules/@jitsi/rtcstats/node_modules/ua-parser-js": {
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
+      "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/@jitsi/rtcstats/node_modules/uuid": {
       "version": "8.3.2",
@@ -10477,11 +10507,11 @@
       }
     },
     "@jitsi/js-utils": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-2.6.7.tgz",
-      "integrity": "sha512-r16J3CjYt325CFIpfHznND4O3b9BE7CZ7cu+Xx0uk1C+ZY6/bDPZFM/0d4t0VH+1/rmfG4I7i18qxXct3xmPrw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-6.3.2.tgz",
+      "integrity": "sha512-nGF24WVADFQF2OfdlJWbel2MvwTRbxxZdNDzIqUBKGtRYd10CukgrcydB2WRPRLtn4Q97KrpdqrcAuH0Idi3yg==",
       "requires": {
-        "@hapi/bourne": "^3.0.0",
+        "@hapi/bourne": "3.0.0",
         "js-md5": "0.7.3",
         "ua-parser-js": "1.0.35"
       },
@@ -10514,10 +10544,25 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
+        "@jitsi/js-utils": {
+          "version": "2.8.2",
+          "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-2.8.2.tgz",
+          "integrity": "sha512-tMFuci2lPmbQIFF/f3b5QdkL1vzY6sii9nj0e+K0EEJcFUJiX/QVkv5GbI6pMZ74BYAQXGFZqeASo8hKItniUA==",
+          "requires": {
+            "@hapi/bourne": "3.0.0",
+            "js-md5": "0.7.3",
+            "ua-parser-js": "1.0.35"
+          }
+        },
         "@jitsi/logger": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/@jitsi/logger/-/logger-2.0.2.tgz",
           "integrity": "sha512-qwbpRwuwkBFgh0F5jivq/5fAm46yVoXURc5LCklEs8lAShYVangFEXKW7RLpZuZ5nQnrHrlvU8MswQNREmvahg=="
+        },
+        "ua-parser-js": {
+          "version": "1.0.35",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
+          "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA=="
         },
         "uuid": {
           "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "readmeFilename": "README.md",
   "dependencies": {
-    "@jitsi/js-utils": "^2.6.7",
+    "@jitsi/js-utils": "6.3.2",
     "@jitsi/logger": "2.1.1",
     "@jitsi/precall-test": "1.0.6",
     "@jitsi/rtcstats": "9.7.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "lib": [
       "DOM",


### PR DESCRIPTION
## Summary
- Bumps `@jitsi/js-utils` from `^2.6.7` to `6.3.2`.
- Switches `tsconfig.json` `moduleResolution` from `node` (legacy) to `bundler` so TypeScript honors the `exports` field introduced in `@jitsi/js-utils` 6.x. The legacy `node` resolution does not traverse `exports`, which made the package's subpaths (`/json`, `/polyfills`, `/browser-detection`) unresolvable. `bundler` matches lib-jitsi-meet's actual build/consumption model (webpack) and avoids the multi-PR cost of migrating to `node16` (which would require explicit `.js` extensions on every relative import).
- Updates the `BrowserDetection` import in `modules/browser/BrowserCapabilities.ts` to use the barrel re-export `@jitsi/js-utils/browser-detection`. The previous deep path `@jitsi/js-utils/browser-detection/BrowserDetection` is no longer reachable through the new `exports` map; the class itself is API-compatible.

## Test plan
- [x] `npm run lint` — eslint + `tsc --noEmit` clean.
- [x] `npm run build` — UMD bundle + ESM build succeed.
- [x] `npm test` — both native and polyfill Karma suites green (482 / 482 specs each).
- [ ] Sanity smoke on a deployment (e.g. hristo.jitsi.net) to confirm runtime behavior in a real conference.