### PR TITLE
feat(browser): Enable VP9 on Firefox 151+

### DIFF
--- a/modules/browser/BrowserCapabilities.ts
+++ b/modules/browser/BrowserCapabilities.ts
@@ -280,17 +280,14 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
-     * Returns true if VP9 is supported by the client on the browser. VP9 is currently disabled on Safari
-     * and older versions of Firefox because of issues. Please check https://bugs.webkit.org/show_bug.cgi?id=231074 for
-     * details.
+     * Returns true if VP9 is supported by the client on the browser.
+     *
+     * Firefox is supported on version 151+ where https://bugzilla.mozilla.org/show_bug.cgi?id=1633876 is fixed.
      *
      * @returns {boolean}
      */
     supportsVP9(): boolean {
-        // Keep this disabled for FF because simulcast is disabled by default.
-        // For versions 136+ if the media.webrtc.simulcast.vp9.enabled config is set to true it will work.
-        // TODO: enable for FF with version 136+ once media.webrtc.simulcast.vp9.enabled is set to true by default.
-        return !(this.isWebKitBased() || this.isFirefox());
+        return !this.isWebKitBased() && !(this.isFirefox() && this.isVersionLessThan(151));
     }
 
     /**

--- a/modules/browser/BrowserCapabilities.ts
+++ b/modules/browser/BrowserCapabilities.ts
@@ -282,8 +282,8 @@ export default class BrowserCapabilities extends BrowserDetection {
     /**
      * Returns true if VP9 is supported by the client on the browser.
      *
-     * Firefox is supported on version 151+ where https://bugzilla.mozilla.org/show_bug.cgi?id=1633876 is fixed.
-     *
+     * Disabled on WebKit-based browsers (Safari/iOS). Firefox is supported on version 151+ (see:
+     * https://bugzilla.mozilla.org/show_bug.cgi?id=1633876).
      * @returns {boolean}
      */
     supportsVP9(): boolean {


### PR DESCRIPTION
## Description

Enables VP9 encode for Firefox 151 and newer in `BrowserCapabilities.supportsVP9()`. Previously the method returned `false` for every Firefox version; now it returns `false` only for `< 151`. Safari behaviour is unchanged.

## Motivation and Context

The blocker for VP9 on Firefox was https://bugzilla.mozilla.org/show_bug.cgi?id=1633876, which has been fixed and ships in Firefox 151. With that fix in place, Firefox 151+ clients can negotiate and encode VP9 without the simulcast/regression issues that previously kept the codec disabled.

## How Has This Been Tested?

- `npm run lint` and `npm run type-check`.
- Manual reasoning verification:
  - Firefox < 151 -> `false` (unchanged).
  - Firefox 151+ -> `true` (newly enabled).
  - Safari / other WebKit-based browsers -> `false` (unchanged).
  - All other Chromium / Chrome-based browsers -> `true` (unchanged).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
