### PR TITLE
fix(RTC): Silence setSinkId console spam on Firefox / Safari / iPadOS

### DIFF
--- a/modules/RTC/JitsiTrack.ts
+++ b/modules/RTC/JitsiTrack.ts
@@ -543,22 +543,26 @@ export default class JitsiTrack extends Listenable {
                 new Error('Audio output device change is not supported'));
         }
 
-        return (
-            Promise.all(
-                this.containers.map(
-                    element =>
-                        (element as HTMLAudioElement | HTMLVideoElement).setSinkId(audioOutputDeviceId)
-                            .catch(error => {
-                                logger.warn(
-                                    'Failed to change audio output device on element. Default or previously set'
-                                        + ' audio output device will be used.',
-                                    element,
-                                    error);
-                            }))
-            )
-                .then(() => {
+        // Use Promise.allSettled so a rejection on one container does not short-circuit the others and does not
+        // surface as an unhandled rejection (both callers — RTC._updateAudioOutputForAudioTracks and the
+        // AUDIO_OUTPUT_DEVICE_CHANGED listener on local tracks — invoke this fire-and-forget). The event is
+        // suppressed when every container failed so UI consumers do not show a sink change that did not happen.
+        return Promise.allSettled(
+            this.containers.map(element =>
+                (element as HTMLAudioElement | HTMLVideoElement).setSinkId(audioOutputDeviceId)
+                    .catch(error => {
+                        logger.warn(
+                            'Failed to change audio output device on element. Default or previously set audio'
+                                + ' output device will be used.',
+                            element,
+                            error);
+                        throw error;
+                    })))
+            .then(results => {
+                if (results.some(result => result.status === 'fulfilled')) {
                     this.emit(JitsiTrackEvents.TRACK_AUDIO_OUTPUT_CHANGED, audioOutputDeviceId);
-                }));
+                }
+            });
     }
 
     /**

--- a/modules/RTC/JitsiTrack.ts
+++ b/modules/RTC/JitsiTrack.ts
@@ -534,15 +534,13 @@ export default class JitsiTrack extends Listenable {
      * @returns {Promise}
      */
     public setAudioOutput(audioOutputDeviceId: string): Promise<void> {
+        if (this.isVideoTrack()) {
+            return Promise.resolve();
+        }
+
         if (!RTCUtils.isDeviceChangeAvailable('output')) {
             return Promise.reject(
                 new Error('Audio output device change is not supported'));
-        }
-
-        // All audio communication is done through audio tracks, so ignore
-        // changing audio output for video tracks at all.
-        if (this.isVideoTrack()) {
-            return Promise.resolve();
         }
 
         return (
@@ -552,18 +550,14 @@ export default class JitsiTrack extends Listenable {
                         (element as HTMLAudioElement | HTMLVideoElement).setSinkId(audioOutputDeviceId)
                             .catch(error => {
                                 logger.warn(
-                                    'Failed to change audio output device on'
-                                        + ' element. Default or previously set'
+                                    'Failed to change audio output device on element. Default or previously set'
                                         + ' audio output device will be used.',
                                     element,
                                     error);
-                                throw error;
                             }))
             )
                 .then(() => {
-                    this.emit(
-                        JitsiTrackEvents.TRACK_AUDIO_OUTPUT_CHANGED,
-                        audioOutputDeviceId);
+                    this.emit(JitsiTrackEvents.TRACK_AUDIO_OUTPUT_CHANGED, audioOutputDeviceId);
                 }));
     }
 

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -68,8 +68,19 @@ let disableAGC = false;
 let stereo = null;
 
 const featureDetectionAudioEl = document.createElement('audio');
-const isAudioOutputDeviceChangeAvailable
-    = typeof featureDetectionAudioEl.setSinkId !== 'undefined';
+let isAudioOutputDeviceChangeAvailable = typeof featureDetectionAudioEl.setSinkId !== 'undefined';
+
+// The presence of the setSinkId symbol does not imply a working implementation. Probe the API once against the system
+// default sink ('') and downgrade the availability flag if the probe rejects, so the rest of the code stops trying
+// to call setSinkId for the duration of the session.
+if (isAudioOutputDeviceChangeAvailable) {
+    featureDetectionAudioEl.setSinkId('')
+        .catch(error => {
+            isAudioOutputDeviceChangeAvailable = false;
+            logger.info(
+                `setSinkId probe rejected (${error?.name}); audio output device change disabled for this session`);
+        });
+}
 
 let availableDevices = [];
 let availableDevicesPollTimer;
@@ -350,17 +361,11 @@ class RTCUtils extends Listenable {
                 // we skip setting audio output if there was no explicit change
                 && audioOutputChanged) {
             return element.setSinkId(this.getAudioOutputDevice()).catch(ex => {
-                const err
-                    = new JitsiTrackError(ex, null, [ 'audiooutput' ]);
-
                 logger.warn(
-                    'Failed to set audio output device for the element.'
-                        + ' Default audio output device will be used'
+                    'Failed to set audio output device for the element. Default audio output device will be used'
                         + ' instead',
                     element?.id,
-                    err);
-
-                throw err;
+                    new JitsiTrackError(ex, null, [ 'audiooutput' ]));
             });
         }
 


### PR DESCRIPTION
## Description

Two small fixes that together stop the `setSinkId` console spam we see on Firefox, Safari, and iPadOS during conferences.

1. **Probe `setSinkId` instead of feature-detecting via `typeof`.** Today `isAudioOutputDeviceChangeAvailable` is just `typeof featureDetectionAudioEl.setSinkId !== 'undefined'`. The symbol exists on iPadOS (because it impersonates macOS Safari), on Firefox builds where the user hasn't granted output-device permission, and on Safari elements that haven't been attached to the DOM — but actually calling `setSinkId` rejects. We now issue a real `setSinkId('')` probe against the system-default sink. If the probe rejects, the flag is flipped to `false` for the rest of the session and every downstream guard short-circuits.

2. **Stop the warn-and-rethrow double logging.** `RTCUtils.attachMediaStream` and `JitsiTrack.setAudioOutput` both used to `logger.warn(...)` and then `throw` from the `setSinkId` `.catch`. Both call sites are fire-and-forget (the AUDIO_OUTPUT_DEVICE_CHANGED listener cascade, the per-attach path), so the rethrow only produced an unhandled promise rejection per failure — doubling the noise. Now we log once and resolve.

## Motivation and Context

Customers and developers complain about heavy `setSinkId` warning floods in the JS console on Firefox / Safari / iPad. The root cause is that the feature detector reports the API as available even when every call will reject, and each rejection is logged twice (once as `logger.warn`, once as an unhandled promise rejection). With these two changes:

- Browsers where `setSinkId` doesn't actually work get one `logger.info` line at module load and then go quiet for the rest of the session.
- Browsers where `setSinkId` works for the default sink but rejects for a specific deviceId get one `logger.warn` per failure instead of one warn + one unhandled rejection.

## How Has This Been Tested?

- `npm run lint` and `npm run type-check` (no new errors introduced in the touched files).
- Manual reasoning verification of the call graph:
  - Chrome / Chromium: probe resolves -> flag stays `true` -> behavior unchanged.
  - Firefox 116+ desktop with permission: probe resolves -> behavior unchanged.
  - Firefox without permission / older Firefox: probe rejects -> flag flipped to `false` -> guards in `attachMediaStream`, `setAudioOutput`, `setAudioOutputDevice` skip the `setSinkId` call.
  - Safari 17+ macOS: probe of `''` (system default) should resolve without a user gesture -> behavior unchanged.
  - iPadOS impersonating macOS Safari: probe rejects with `NotSupportedError` -> flag flipped to `false` -> silent thereafter.
  - iOS Safari: symbol undefined as before, no change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
