### PR TITLE
fix(xmpp): remove window unload listeners on disconnect

### DIFF
--- a/modules/xmpp/xmpp.ts
+++ b/modules/xmpp/xmpp.ts
@@ -261,6 +261,8 @@ export default class XMPP extends Listenable {
     private _preComponentsMsgs: Element[];
     private _sysMessageHandler: unknown;
     private _startConnecting: Optional<boolean>;
+    private _unloadEventTypes: string[];
+    private _unloadHandler: Optional<(ev: Event) => void>;
     private _wasDisconnected: boolean;
     public connection: Nullable<XmppConnection>;
     public connectionTimes: Record<string, number>;
@@ -401,7 +403,8 @@ export default class XMPP extends Listenable {
         // of their own. However, it should be fairly easy for them to do that
         // by registering their unload handler before us.
         const events = `${this.options.disableBeforeUnloadHandlers ? '' : 'beforeunload '}unload`;
-        const handleDisconnect = ev => {
+
+        this._unloadHandler = (ev: Event) => {
             // type-checking added as disconnect returns Promise<void> | boolean
             const result = this.disconnect(ev);
 
@@ -411,10 +414,29 @@ export default class XMPP extends Listenable {
                 });
             }
         };
+        this._unloadEventTypes = events.split(' ');
 
-        for (const event of events.split(' ')) {
-            window.addEventListener(event, handleDisconnect);
+        for (const event of this._unloadEventTypes) {
+            window.addEventListener(event, this._unloadHandler);
         }
+    }
+
+    /**
+     * Removes the beforeunload/unload listeners registered in the constructor. Without this each created connection
+     * would leak its listeners on the window object.
+     *
+     * @returns {void}
+     */
+    private _removeUnloadHandlers(): void {
+        if (!this._unloadHandler) {
+            return;
+        }
+
+        for (const event of this._unloadEventTypes) {
+            window.removeEventListener(event, this._unloadHandler);
+        }
+
+        this._unloadHandler = undefined;
     }
 
     /**
@@ -1237,6 +1259,11 @@ export default class XMPP extends Listenable {
      */
     public disconnect(ev: Optional<Event> = undefined): Promise<void> | boolean {
         logger.info(`XMPP disconnect triggered by the event=${ev?.type}`);
+
+        // Remove the window unload listeners registered in the constructor so we don't leak them when multiple
+        // connections are created over the lifetime of the page.
+        this._removeUnloadHandlers();
+
         if (this._disconnectInProgress) {
             return this._disconnectInProgress;
         } else if (!this.connection || !this._startConnecting) {


### PR DESCRIPTION
The beforeunload/unload listeners added in the XMPP constructor were never removed, so each connection created over the lifetime of the page leaked its listeners on the window object. Keep a reference to the handler and remove it in disconnect().
