### PR TITLE
fix(breakout): route a not-allowed reconnect back to the main room

### DIFF
--- a/modules/xmpp/ChatRoom.spec.ts
+++ b/modules/xmpp/ChatRoom.spec.ts
@@ -1009,4 +1009,70 @@ describe('ChatRoom', () => {
                 null);       // replyToId ← null when no 'to' attribute
         });
     });
+
+    describe('onPresenceError - breakout room', () => {
+        let room: ChatRoom;
+        let emitterSpy: jasmine.Spy;
+        const MAIN_ROOM_JID = 'mainroom@muc.example.com';
+        const BREAKOUT_OCCUPANT_JID = 'breakoutroom@breakout.example.com/me';
+
+        // A breakout MUC refusing our (re)join presence: from is our own occupant JID,
+        // error is a generic <not-allowed/>. This is what a reconnecting client gets when
+        // its session is no longer a member of the breakout.
+        const notAllowedPresence = (from: string) => {
+            const presStr = '' +
+                `<presence to="user@example.com/res" from="${from}" type="error">` +
+                    '<error type="cancel">' +
+                        '<not-allowed xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>' +
+                    '</error>' +
+                '</presence>';
+
+            return new DOMParser().parseFromString(presStr, 'text/xml').documentElement;
+        };
+
+        beforeEach(() => {
+            const xmpp: IMockXMPP = {
+                moderator: new Moderator({
+                    options: {}
+                } as any),
+                options: { hosts: {} },
+                addListener: () => {} // eslint-disable-line no-empty-function
+            };
+
+            room = new ChatRoom(
+                {} as XmppConnection /* connection */,
+                'breakoutroom@breakout.example.com',
+                'password',
+                xmpp as any,
+                {} /* options */);
+            room.myroomjid = BREAKOUT_OCCUPANT_JID;
+            emitterSpy = spyOn(room.eventEmitter, 'emit');
+        });
+
+        it('routes a breakout not-allowed back to the main room instead of failing the conference', () => {
+            room.getBreakoutRooms()._setIsBreakoutRoom(true);
+            room.getBreakoutRooms()._setMainRoomJid(MAIN_ROOM_JID);
+
+            room.onPresenceError(notAllowedPresence(BREAKOUT_OCCUPANT_JID), BREAKOUT_OCCUPANT_JID);
+
+            // The user should be moved back to the main meeting...
+            expect(emitterSpy).toHaveBeenCalledWith(
+                XMPPEvents.BREAKOUT_ROOMS_MOVE_TO_ROOM, MAIN_ROOM_JID);
+
+            // ...and NOT shown a hard "you do not have permission" failure.
+            expect(emitterSpy).not.toHaveBeenCalledWith(
+                XMPPEvents.ROOM_CONNECT_NOT_ALLOWED_ERROR, jasmine.anything(), jasmine.anything());
+        });
+
+        it('still raises not-allowed for a non-breakout room', () => {
+            room.getBreakoutRooms()._setIsBreakoutRoom(false);
+
+            room.onPresenceError(notAllowedPresence(BREAKOUT_OCCUPANT_JID), BREAKOUT_OCCUPANT_JID);
+
+            expect(emitterSpy).toHaveBeenCalledWith(
+                XMPPEvents.ROOM_CONNECT_NOT_ALLOWED_ERROR, jasmine.anything(), jasmine.anything());
+            expect(emitterSpy).not.toHaveBeenCalledWith(
+                XMPPEvents.BREAKOUT_ROOMS_MOVE_TO_ROOM, jasmine.anything());
+        });
+    });
 });

--- a/modules/xmpp/ChatRoom.ts
+++ b/modules/xmpp/ChatRoom.ts
@@ -1593,6 +1593,24 @@ export default class ChatRoom extends Listenable {
                     type = AUTH_ERROR_TYPES.NO_VISITORS_LOBBY;
                 }
 
+                // A breakout room refusing our own (re)join presence with a generic
+                // not-allowed. This happens on reconnect when our session is no longer a
+                // member of the breakout. Don't surface a hard CONFERENCE_FAILED ("you do
+                // not have permission to join the call") - route the user back to the main
+                // room via the normal move-to-room flow instead.
+                if (type === AUTH_ERROR_TYPES.GENERAL
+                        && from === this.myroomjid
+                        && this.getBreakoutRooms()?.isBreakoutRoom()) {
+                    const mainRoomJid = this.getBreakoutRooms().getMainRoomJid();
+
+                    if (mainRoomJid) {
+                        logger.warn(`Breakout join not-allowed for ${from}; moving back to main room ${mainRoomJid}`);
+                        this.eventEmitter.emit(XMPPEvents.BREAKOUT_ROOMS_MOVE_TO_ROOM, mainRoomJid);
+
+                        return;
+                    }
+                }
+
                 this.eventEmitter.emit(XMPPEvents.ROOM_CONNECT_NOT_ALLOWED_ERROR, type, txt);
             }
         } else if (exists(pres, ':scope>error>service-unavailable')) {


### PR DESCRIPTION
When a participant in a breakout room loses the XMPP connection and the client reconnects, it re-sends presence to the breakout MUC. A reconnected session is no longer a member of the (members-only) breakout, so the room replies with <error type="cancel"><not-allowed/>. ChatRoom.onPresenceError forwarded this as ROOM_CONNECT_NOT_ALLOWED_ERROR -> CONFERENCE_FAILED (notAllowed), surfacing "Sorry, you do not have permission to join the call" to a user who was simply in a breakout, before falling back to main.

Detect this case (generic not-allowed for our own occupant JID while in a breakout room) and emit BREAKOUT_ROOMS_MOVE_TO_ROOM with the main room JID instead, reusing the existing move-to-room flow so the user transitions cleanly into the main meeting. Scoped narrowly: only AUTH_ERROR_TYPES.GENERAL, only when from === myroomjid, only in a breakout, and only when the main room JID is known (otherwise the original error is raised).

Adds ChatRoom.spec.ts coverage: a breakout not-allowed routes to main and does not raise ROOM_CONNECT_NOT_ALLOWED_ERROR, while a non-breakout not-allowed still raises it.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.