### PR TITLE
feat(RTC): recover wedged remote audio sources under SSRC rewriting

### DIFF
--- a/modules/RTC/MockClasses.ts
+++ b/modules/RTC/MockClasses.ts
@@ -293,6 +293,13 @@ export class MockPeerConnection {
     getLocalVideoTracks(): any[] {
         return [];
     }
+
+    /**
+     * {@link TraceablePeerConnection.getTrackBySSRC}.
+     */
+    getTrackBySSRC(): any {
+        return null;
+    }
 }
 
 /**

--- a/modules/RTC/RemoteAudioWedgeDetector.spec.ts
+++ b/modules/RTC/RemoteAudioWedgeDetector.spec.ts
@@ -1,0 +1,344 @@
+import { MediaType } from '../../service/RTC/MediaType';
+
+import RemoteAudioWedgeDetector from './RemoteAudioWedgeDetector';
+
+/**
+ * Builds a minimal mock of a remote audio track.
+ *
+ * @param {number} ssrc - The track SSRC.
+ * @param {string} source - The source name.
+ * @param {boolean} muted - Whether the track is muted.
+ * @returns {object}
+ */
+function mockTrack(ssrc: number, source: string, muted = false): any {
+    return {
+        getParticipantId: () => 'endpoint-1',
+        getSourceName: () => source,
+        getSsrc: () => ssrc,
+        isMuted: () => muted
+    };
+}
+
+/**
+ * Builds a mock getStats() report (a Map keyed by report id) for the given inbound-rtp audio packet counts.
+ *
+ * @param {Array<{packetsReceived: number; ssrc: number;}>} entries - The per-SSRC inbound-rtp entries.
+ * @returns {Map<string, object>}
+ */
+function mockStats(entries: Array<{ packetsReceived: number; ssrc: number; }>): Map<string, any> {
+    const report = new Map();
+
+    entries.forEach((entry, idx) => {
+        report.set(`inbound-rtp-${idx}`, {
+            kind: 'audio',
+            packetsReceived: entry.packetsReceived,
+            ssrc: entry.ssrc,
+            type: 'inbound-rtp'
+        });
+    });
+
+    return report;
+}
+
+describe('RemoteAudioWedgeDetector', () => {
+    let tracks: any[];
+    let statsEntries: Array<{ packetsReceived: number; ssrc: number; }>;
+    let pc: any;
+    let onWedgeDetected: jasmine.Spy;
+    let detector: RemoteAudioWedgeDetector;
+
+    const POLL_INTERVAL_MS = 1000;
+    const WEDGE_TIMEOUT_MS = 3000;
+
+    /**
+     * Runs a single detection poll.
+     *
+     * @returns {Promise<void>}
+     */
+    function poll(): Promise<void> {
+        return (detector as any)._check();
+    }
+
+    /**
+     * Advances the mocked clock by one poll interval.
+     *
+     * @returns {void}
+     */
+    function tick(): void {
+        jasmine.clock().tick(POLL_INTERVAL_MS);
+    }
+
+    beforeEach(() => {
+        jasmine.clock().install();
+        jasmine.clock().mockDate(new Date(0));
+
+        tracks = [];
+        statsEntries = [];
+        pc = {
+            getRemoteTracks: (_endpointId: any, mediaType: MediaType) => {
+                expect(mediaType).toBe(MediaType.AUDIO);
+
+                return tracks;
+            },
+            getStats: jasmine.createSpy('getStats').and.callFake(() => Promise.resolve(mockStats(statsEntries)))
+        };
+        onWedgeDetected = jasmine.createSpy('onWedgeDetected');
+
+        detector = new RemoteAudioWedgeDetector(pc, {
+            onWedgeDetected,
+            pollIntervalMs: POLL_INTERVAL_MS,
+            wedgeTimeoutMs: WEDGE_TIMEOUT_MS
+        });
+    });
+
+    afterEach(() => {
+        detector.stop();
+        jasmine.clock().uninstall();
+    });
+
+    it('does not call getStats() when there are no remote audio sources', async () => {
+        tracks = [];
+
+        await poll();
+        expect(pc.getStats).not.toHaveBeenCalled();
+    });
+
+    it('does not call getStats() when every remote audio source is muted', async () => {
+        tracks = [ mockTrack(111, 'source-A', true /* muted */), mockTrack(222, 'source-B', true /* muted */) ];
+        statsEntries = [ { packetsReceived: 0, ssrc: 111 }, { packetsReceived: 0, ssrc: 222 } ];
+
+        await poll();
+        expect(pc.getStats).not.toHaveBeenCalled();
+    });
+
+    it('calls getStats() when at least one remote audio source is unmuted', async () => {
+        tracks = [ mockTrack(111, 'source-A', true /* muted */), mockTrack(222, 'source-B') ];
+        statsEntries = [ { packetsReceived: 0, ssrc: 111 }, { packetsReceived: 0, ssrc: 222 } ];
+
+        await poll();
+        expect(pc.getStats).toHaveBeenCalled();
+    });
+
+    it('stops calling getStats() once every source has received a packet', async () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        statsEntries = [ { packetsReceived: 7, ssrc: 111 } ];
+
+        await poll(); // confirms the source healthy
+        expect(pc.getStats).toHaveBeenCalledTimes(1);
+
+        tick();
+        await poll(); // source is confirmed healthy -> no candidates -> getStats skipped
+        tick();
+        await poll();
+        expect(pc.getStats).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps polling while one source is silent even though another is healthy', async () => {
+        tracks = [ mockTrack(111, 'source-A'), mockTrack(222, 'source-B') ];
+        statsEntries = [ { packetsReceived: 7, ssrc: 111 }, { packetsReceived: 0, ssrc: 222 } ];
+
+        await poll();
+        tick();
+        await poll();
+        expect(pc.getStats).toHaveBeenCalledTimes(2);
+    });
+
+    it('resumes polling when a new source appears after all were healthy', async () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        statsEntries = [ { packetsReceived: 7, ssrc: 111 } ];
+
+        await poll(); // source-A confirmed healthy
+        tick();
+        await poll(); // skipped
+        expect(pc.getStats).toHaveBeenCalledTimes(1);
+
+        // A new participant joins; its source has not been confirmed yet.
+        tracks = [ mockTrack(111, 'source-A'), mockTrack(222, 'source-B') ];
+        statsEntries = [ { packetsReceived: 7, ssrc: 111 }, { packetsReceived: 0, ssrc: 222 } ];
+        tick();
+        await poll();
+        expect(pc.getStats).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not fire for a source that received packets and later reports zero (cumulative is monotonic)', async () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        statsEntries = [ { packetsReceived: 7, ssrc: 111 } ];
+
+        await poll(); // healthy
+
+        // A subsequent (hypothetical) zero reading must never re-arm a confirmed-healthy source.
+        for (let i = 0; i < 5; i++) {
+            tick();
+            statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
+            await poll(); // eslint-disable-line no-await-in-loop
+        }
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+    });
+
+    it('does not fire on the first eligible zero poll', async () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
+
+        await poll();
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+    });
+
+    it('fires once the zero-RTP duration elapses while unmuted', async () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
+
+        // Polls while the timeout has not yet elapsed.
+        await poll(); // t=0, streak starts
+        tick();
+        await poll(); // t=1000
+        tick();
+        await poll(); // t=2000
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+
+        tick();
+        await poll(); // t=3000, elapsed >= WEDGE_TIMEOUT_MS
+        expect(onWedgeDetected).toHaveBeenCalledTimes(1);
+        expect(onWedgeDetected.calls.mostRecent().args[0]).toBe(tracks[0]);
+    });
+
+    it('does not fire before the timeout elapses, even across many polls', async () => {
+        const detector2 = new RemoteAudioWedgeDetector(pc, {
+            onWedgeDetected,
+            pollIntervalMs: POLL_INTERVAL_MS,
+            wedgeTimeoutMs: 60000
+        });
+
+        tracks = [ mockTrack(111, 'source-A') ];
+        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
+
+        for (let i = 0; i < 10; i++) {
+            await (detector2 as any)._check(); // eslint-disable-line no-await-in-loop
+            tick();
+        }
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+        detector2.stop();
+    });
+
+    it('requires at least two samples even when the timeout is tiny', async () => {
+        const detector2 = new RemoteAudioWedgeDetector(pc, {
+            onWedgeDetected,
+            pollIntervalMs: POLL_INTERVAL_MS,
+            wedgeTimeoutMs: 0
+        });
+
+        tracks = [ mockTrack(111, 'source-A') ];
+        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
+
+        // A single poll cannot fire (only one sample) even though the elapsed time already satisfies the timeout.
+        await (detector2 as any)._check();
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+
+        tick();
+        await (detector2 as any)._check();
+        expect(onWedgeDetected).toHaveBeenCalledTimes(1);
+        detector2.stop();
+    });
+
+    it('does not fire when the source is receiving packets', async () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        statsEntries = [ { packetsReceived: 42, ssrc: 111 } ];
+
+        for (let i = 0; i < 5; i++) {
+            await poll(); // eslint-disable-line no-await-in-loop
+            tick();
+        }
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+    });
+
+    it('does not fire when the source is muted', async () => {
+        tracks = [ mockTrack(111, 'source-A', true /* muted */) ];
+        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
+
+        for (let i = 0; i < 5; i++) {
+            await poll(); // eslint-disable-line no-await-in-loop
+            tick();
+        }
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+    });
+
+    it('resets the streak clock once the source starts receiving, even after earlier zero polls', async () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
+
+        // Two zero polls accumulate, but the timeout has not elapsed.
+        await poll(); // t=0
+        tick();
+        await poll(); // t=1000
+
+        // Packets begin to flow; the source is demuxing correctly. Detection keys off the cumulative count, so once
+        // any packet is seen the source stays healthy even if the count later plateaus (e.g. DTX/silence) - the earlier
+        // zero polls must not carry over and trip the watchdog.
+        tick();
+        statsEntries = [ { packetsReceived: 5, ssrc: 111 } ];
+        await poll(); // t=2000, streak reset
+        tick();
+        statsEntries = [ { packetsReceived: 5, ssrc: 111 } ];
+        await poll(); // t=3000
+        tick();
+        await poll(); // t=4000
+        tick();
+        await poll(); // t=5000
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+    });
+
+    it('does not re-fire for the same source during the cooldown window', async () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
+
+        await poll(); // t=0
+        tick();
+        await poll(); // t=1000
+        tick();
+        await poll(); // t=2000
+        tick();
+        await poll(); // t=3000, fires
+        expect(onWedgeDetected).toHaveBeenCalledTimes(1);
+
+        // The (still-wedged) source keeps reporting zero packets, but the watchdog stays quiet for the cooldown
+        // window while the recycle renegotiation is assumed to be in flight.
+        tick();
+        await poll(); // t=4000
+        tick();
+        await poll(); // t=5000
+        tick();
+        await poll(); // t=6000 (== fire time + cooldown), cooldown just elapsed; streak restarts here
+        expect(onWedgeDetected).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears bookkeeping for SSRCs that are no longer mapped', async () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
+
+        await poll(); // t=0, streak starts
+        tick();
+        await poll(); // t=1000
+
+        // The source is remapped/removed before the timeout; its streak must not survive to wedge a later source that
+        // reuses the SSRC.
+        tick();
+        tracks = [];
+        statsEntries = [];
+        await poll(); // t=2000
+
+        tracks = [ mockTrack(111, 'source-A') ];
+        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
+        tick();
+        await poll(); // t=3000, fresh streak starts here
+        tick();
+        await poll(); // t=4000
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+
+        tick();
+        await poll(); // t=5000, elapsed since fresh streak (t=3000) is 2000 < timeout
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+
+        tick();
+        await poll(); // t=6000, elapsed since fresh streak is 3000 >= timeout
+        expect(onWedgeDetected).toHaveBeenCalledTimes(1);
+    });
+});

--- a/modules/RTC/RemoteAudioWedgeDetector.ts
+++ b/modules/RTC/RemoteAudioWedgeDetector.ts
@@ -1,0 +1,308 @@
+import { getLogger } from '@jitsi/logger';
+
+import { MediaType } from '../../service/RTC/MediaType';
+
+import JitsiRemoteTrack from './JitsiRemoteTrack';
+import TraceablePeerConnection from './TraceablePeerConnection';
+
+const logger = getLogger('rtc:RemoteAudioWedgeDetector');
+
+/**
+ * The default interval (in milliseconds) at which the inbound-rtp stats are polled.
+ */
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+
+/**
+ * The default duration (in milliseconds) for which a mapped, unmuted remote audio source must receive zero inbound RTP
+ * before it is considered wedged.
+ */
+const DEFAULT_WEDGE_TIMEOUT_MS = 15000;
+
+/**
+ * The minimum number of consecutive eligible (mapped + unmuted) zero-RTP samples required before a source can be
+ * declared wedged, regardless of how short the configured timeout is. This debounces transient stats artifacts - most
+ * notably the inbound-rtp report being momentarily absent (treated as zero) during renegotiation/track churn - so a
+ * single bad sample cannot trigger a recovery.
+ */
+const MIN_SAMPLES = 2;
+
+interface IEligibleZeroState {
+
+    /**
+     * The number of consecutive eligible zero-RTP polls observed in the current streak.
+     */
+    samples: number;
+
+    /**
+     * The timestamp (Date.now()) of the first eligible zero-RTP poll in the current streak.
+     */
+    since: number;
+}
+
+export interface IRemoteAudioWedgeDetectorOptions {
+
+    /**
+     * Callback invoked with the wedged remote audio track when the watchdog fires. The consumer is expected to recover
+     * the source (e.g. by recycling it via source-remove/source-add).
+     */
+    onWedgeDetected: (track: JitsiRemoteTrack) => void;
+
+    /**
+     * The interval (in milliseconds) at which the inbound-rtp stats are polled. Defaults to
+     * {@link DEFAULT_POLL_INTERVAL_MS}.
+     */
+    pollIntervalMs?: number;
+
+    /**
+     * The duration (in milliseconds) for which a source must receive zero inbound RTP before it is considered wedged.
+     * Defaults to {@link DEFAULT_WEDGE_TIMEOUT_MS}.
+     */
+    wedgeTimeoutMs?: number;
+}
+
+/**
+ * Watchdog that detects the Chrome/WebRTC audio-demux wedge against a JVB peerconnection that uses SSRC rewriting.
+ *
+ * When the bridge starts forwarding a rewritten remote audio SSRC before the client's Jingle renegotiation signals it,
+ * Chrome can latch an unsignaled receive stream on the wrong audio m-section and then silently fail to bind the
+ * signaled sink, leaving the app with a receiver that never receives a packet. The user-visible symptom is a remote
+ * participant that is permanently silent while {@code getStats()} reports zero inbound RTP for the SSRC even though RTP
+ * is arriving on the wire.
+ *
+ * This detector is purely a recovery mechanism: it does not depend on any Chrome internals. It periodically polls the
+ * peerconnection's inbound-rtp stats and flags any remote audio source that is mapped (a {@link JitsiRemoteTrack}
+ * exists) and unmuted (per signaling) yet has received no RTP packets at all for the detection window. The wedge is
+ * recoverable from JS because recycling the source (source-remove then source-add) deletes the zombie receive stream
+ * and a subsequent re-add binds cleanly.
+ *
+ * Detection keys off the cumulative {@code packetsReceived} being zero (i.e. "literally nothing inbound", which is the
+ * confirmed signature of the wedge) rather than off a per-poll delta. A delta-based "no growth" check would produce
+ * false positives for a genuinely unmuted-but-silent participant, since audio can stop emitting packets during silence
+ * (DTX/comfort noise). A source that has ever received a packet is therefore considered healthy and is excluded from
+ * further polling, so once every mapped source has delivered its first packet the watchdog stops calling getStats()
+ * entirely until a new (not-yet-confirmed) source appears.
+ *
+ * A source must stay continuously eligible (mapped + unmuted) and at zero RTP for {@code wedgeTimeoutMs} of wall-clock
+ * time before it fires. Eligibility - unlike the cumulative packet count - is not monotonic (a participant can mute and
+ * unmute), so the streak is reset whenever the source becomes muted, unmapped, or receives any packet; this is what the
+ * repeated polling verifies. A {@link MIN_SAMPLES} floor debounces transient stats artifacts.
+ */
+export default class RemoteAudioWedgeDetector {
+    private _pc: TraceablePeerConnection;
+    private _onWedgeDetected: (track: JitsiRemoteTrack) => void;
+    private _pollIntervalMs: number;
+    private _wedgeTimeoutMs: number;
+    private _intervalId: Nullable<ReturnType<typeof setInterval>>;
+    private _checkInProgress: boolean;
+
+    /**
+     * Maps an SSRC to the state of its current streak of eligible (mapped + unmuted) zero-RTP polls.
+     */
+    private _eligibleZeroBySsrc: Map<number, IEligibleZeroState>;
+
+    /**
+     * The set of SSRCs that have been observed receiving at least one RTP packet. Such a source is demuxing correctly
+     * and cannot be wedged (the wedge is "never received anything", and the cumulative packet count is monotonic), so
+     * it is excluded from polling for the rest of its lifetime. This lets the watchdog stop calling getStats() entirely
+     * once every mapped source has delivered its first packet.
+     */
+    private _healthyBySsrc: Set<number>;
+
+    /**
+     * Maps a source name to the timestamp (Date.now()) until which detection is suppressed for that source. Used as a
+     * cooldown after a recovery is triggered so the watchdog does not re-fire while the recycle renegotiation is in
+     * flight and the re-added source (same SSRC, fresh m-line/track) starts receiving.
+     */
+    private _cooldownUntilBySource: Map<string, number>;
+
+    /**
+     * Creates a new {@code RemoteAudioWedgeDetector}. The detector is inert until {@link start} is called.
+     *
+     * @param {TraceablePeerConnection} pc - The peerconnection to monitor.
+     * @param {IRemoteAudioWedgeDetectorOptions} options - The detector options.
+     */
+    constructor(pc: TraceablePeerConnection, options: IRemoteAudioWedgeDetectorOptions) {
+        this._pc = pc;
+        this._onWedgeDetected = options.onWedgeDetected;
+        this._pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+        this._wedgeTimeoutMs = options.wedgeTimeoutMs ?? DEFAULT_WEDGE_TIMEOUT_MS;
+        this._intervalId = null;
+        this._checkInProgress = false;
+        this._eligibleZeroBySsrc = new Map();
+        this._healthyBySsrc = new Set();
+        this._cooldownUntilBySource = new Map();
+    }
+
+    /**
+     * Polls the inbound-rtp stats once and evaluates every mapped, unmuted remote audio source for the wedge signature.
+     *
+     * @returns {Promise<void>}
+     */
+    private async _check(): Promise<void> {
+        // Guard against overlapping checks if a getStats() call takes longer than the poll interval.
+        if (this._checkInProgress) {
+            return;
+        }
+        this._checkInProgress = true;
+
+        const now = Date.now();
+
+        try {
+            // A source can only be wedged if it is mapped, unmuted, not in a post-recovery cooldown, and has not yet
+            // been confirmed healthy (received a packet). Collect just those candidates first so we can skip the
+            // (relatively expensive) getStats() call entirely when there is nothing that could be wedged this poll -
+            // notably the steady state where every source has already delivered its first packet.
+            const mappedSsrcs = new Set<number>();
+            const candidates: Array<{ ssrc: number; track: JitsiRemoteTrack; }> = [];
+
+            for (const track of this._pc.getRemoteTracks(undefined, MediaType.AUDIO)) {
+                const ssrc = track.getSsrc();
+
+                if (typeof ssrc !== 'number') {
+                    continue; // eslint-disable-line no-continue
+                }
+                mappedSsrcs.add(ssrc);
+
+                if (this._healthyBySsrc.has(ssrc) || track.isMuted()) {
+                    continue; // eslint-disable-line no-continue
+                }
+
+                const cooldownUntil = this._cooldownUntilBySource.get(track.getSourceName());
+
+                if (cooldownUntil !== undefined) {
+                    if (now < cooldownUntil) {
+                        continue; // eslint-disable-line no-continue
+                    }
+                    this._cooldownUntilBySource.delete(track.getSourceName());
+                }
+
+                candidates.push({
+                    ssrc,
+                    track
+                });
+            }
+
+            // Drop the confirmed-healthy mark for any SSRC that is no longer mapped (the source was removed/remapped),
+            // so a future source reusing the SSRC is re-evaluated from scratch.
+            for (const ssrc of this._healthyBySsrc) {
+                if (!mappedSsrcs.has(ssrc)) {
+                    this._healthyBySsrc.delete(ssrc);
+                }
+            }
+
+            // Drop streak bookkeeping for any SSRC that is no longer a candidate (unmapped, muted, cooling down, or now
+            // healthy). This is what resets the streak for a source that became ineligible mid-window.
+            const candidateSsrcs = new Set(candidates.map(candidate => candidate.ssrc));
+
+            for (const ssrc of this._eligibleZeroBySsrc.keys()) {
+                if (!candidateSsrcs.has(ssrc)) {
+                    this._eligibleZeroBySsrc.delete(ssrc);
+                }
+            }
+
+            if (!candidates.length) {
+                return;
+            }
+
+            const report = await this._pc.getStats();
+            const packetsBySsrc = new Map<number, number>();
+
+            report.forEach((stat: any) => {
+                if (stat.type === 'inbound-rtp' && (stat.kind === 'audio' || stat.mediaType === 'audio')) {
+                    packetsBySsrc.set(stat.ssrc, this._getNonNegativeValue(stat.packetsReceived));
+                }
+            });
+
+            for (const { ssrc, track } of candidates) {
+                // A source that has received any RTP is demuxing correctly. Mark it healthy so it is never polled
+                // again (the cumulative count is monotonic, so it cannot regress to zero) and reset any streak.
+                if ((packetsBySsrc.get(ssrc) ?? 0) > 0) {
+                    this._healthyBySsrc.add(ssrc);
+                    this._eligibleZeroBySsrc.delete(ssrc);
+
+                    continue; // eslint-disable-line no-continue
+                }
+
+                const state = this._eligibleZeroBySsrc.get(ssrc);
+
+                if (!state) {
+                    // Start of a streak: record when the source first went silent so the elapsed duration can be
+                    // measured against wall-clock time on subsequent polls.
+                    this._eligibleZeroBySsrc.set(ssrc, {
+                        samples: 1,
+                        since: now
+                    });
+
+                    continue; // eslint-disable-line no-continue
+                }
+
+                state.samples++;
+
+                if (state.samples >= MIN_SAMPLES && now - state.since >= this._wedgeTimeoutMs) {
+                    logger.warn(`Detected wedged remote audio source ${track.getSourceName()} (ssrc=${ssrc}, owner=`
+                        + `${track.getParticipantId()}): zero inbound RTP for ${now - state.since}ms `
+                        + 'while continuously mapped and unmuted. Triggering recovery.');
+                    this._eligibleZeroBySsrc.delete(ssrc);
+
+                    // Suppress further detection for this source while the recycle renegotiation completes. Until then
+                    // the source is still wedged (so it would immediately re-fire), and once recovery re-adds it (same
+                    // SSRC, fresh m-line/track) the new receiver reads zero for a moment before media flows. Keying the
+                    // cooldown off the stable source name covers the remove/re-add transition.
+                    this._cooldownUntilBySource.set(track.getSourceName(), now + this._wedgeTimeoutMs);
+                    this._onWedgeDetected(track);
+                }
+            }
+        } catch (error) {
+            logger.warn('Error while polling for wedged remote audio sources', error);
+        } finally {
+            this._checkInProgress = false;
+        }
+    }
+
+    /**
+     * Coerces a stats value to a non-negative number, treating undefined/invalid values as zero.
+     *
+     * @param {unknown} value - The value to coerce.
+     * @returns {number}
+     */
+    private _getNonNegativeValue(value: unknown): number {
+        const numeric = Number(value);
+
+        if (!Number.isFinite(numeric) || numeric < 0) {
+            return 0;
+        }
+
+        return numeric;
+    }
+
+    /**
+     * Starts the watchdog. Subsequent calls are no-ops while it is already running.
+     *
+     * @returns {void}
+     */
+    start(): void {
+        if (this._intervalId) {
+            return;
+        }
+        logger.debug(`Starting remote audio wedge detector (pollInterval=${this._pollIntervalMs}ms, `
+            + `wedgeTimeout=${this._wedgeTimeoutMs}ms)`);
+        this._intervalId = setInterval(() => {
+            this._check();
+        }, this._pollIntervalMs);
+    }
+
+    /**
+     * Stops the watchdog and clears its bookkeeping. Safe to call when not started.
+     *
+     * @returns {void}
+     */
+    stop(): void {
+        if (this._intervalId) {
+            clearInterval(this._intervalId);
+            this._intervalId = null;
+        }
+        this._eligibleZeroBySsrc.clear();
+        this._healthyBySsrc.clear();
+        this._cooldownUntilBySource.clear();
+    }
+}

--- a/modules/xmpp/JingleSessionPC.spec.ts
+++ b/modules/xmpp/JingleSessionPC.spec.ts
@@ -1,5 +1,6 @@
 import { MockRTC } from '../RTC/MockClasses';
 import SDP from '../sdp/SDP';
+import Statistics from '../statistics/statistics';
 import { parseXML, findAll, findFirst } from '../util/XMLUtils';
 import { XMPPEvents } from '../../service/xmpp/XMPPEvents';
 
@@ -307,6 +308,79 @@ describe('JingleSessionPC', () => {
 
             expect(removeSsrcOwnersSpy).toHaveBeenCalledWith([ 1234, 5678, 4321, 8765 ]);
             expect(updateRemoteSourcesSpy).toHaveBeenCalledWith(sourceInfo, false);
+        });
+    });
+
+    describe('_recoverWedgedAudioSource', () => {
+        let addOrRemoveSpy, peerconnection, pushSpy;
+
+        /**
+         * Builds a minimal mock of a remote audio track.
+         *
+         * @param {number} ssrc - The track SSRC.
+         * @param {string} source - The source name.
+         * @param {string} owner - The owner endpoint id.
+         * @returns {object}
+         */
+        function mockTrack(ssrc: number, source: string, owner = 'owner-A'): any {
+            return {
+                getParticipantId: () => owner,
+                getSourceName: () => source,
+                getSsrc: () => ssrc
+            };
+        }
+
+        /**
+         * Runs the recovery task that was queued on the modification queue.
+         *
+         * @returns {void}
+         */
+        function runQueuedTask(): void {
+            const workFunction = pushSpy.calls.mostRecent().args[0];
+
+            workFunction(() => { }); // eslint-disable-line no-empty-function
+        }
+
+        beforeEach(() => {
+            peerconnection = jingleSession.peerconnection;
+            addOrRemoveSpy = spyOn(jingleSession as any, '_addOrRemoveRemoteStream');
+            spyOn(Statistics, 'sendAnalytics');
+
+            // Capture (do not run) the queued recovery task so it can be invoked deterministically.
+            pushSpy = spyOn(jingleSession.modificationQueue, 'push');
+        });
+
+        it('recycles the source via source-remove then source-add when the slot is unchanged', () => {
+            spyOn(peerconnection, 'getTrackBySSRC').and.returnValue(mockTrack(111, 'source-A'));
+
+            (jingleSession as any)._recoverWedgedAudioSource(mockTrack(111, 'source-A'));
+            runQueuedTask();
+
+            expect(addOrRemoveSpy).toHaveBeenCalledTimes(2);
+            expect(addOrRemoveSpy.calls.argsFor(0)[0]).toBe(false); // source-remove first
+            expect(addOrRemoveSpy.calls.argsFor(1)[0]).toBe(true); // source-add second
+            expect(Statistics.sendAnalytics).toHaveBeenCalled();
+        });
+
+        it('skips recovery when the slot was remapped to a different source', () => {
+            // The SSRC now belongs to a different source (a remap landed between detection and execution).
+            spyOn(peerconnection, 'getTrackBySSRC').and.returnValue(mockTrack(111, 'source-B'));
+
+            (jingleSession as any)._recoverWedgedAudioSource(mockTrack(111, 'source-A'));
+            runQueuedTask();
+
+            expect(addOrRemoveSpy).not.toHaveBeenCalled();
+            expect(Statistics.sendAnalytics).not.toHaveBeenCalled();
+        });
+
+        it('skips recovery when the slot was removed', () => {
+            spyOn(peerconnection, 'getTrackBySSRC').and.returnValue(null);
+
+            (jingleSession as any)._recoverWedgedAudioSource(mockTrack(111, 'source-A'));
+            runQueuedTask();
+
+            expect(addOrRemoveSpy).not.toHaveBeenCalled();
+            expect(Statistics.sendAnalytics).not.toHaveBeenCalled();
         });
     });
 });

--- a/modules/xmpp/JingleSessionPC.ts
+++ b/modules/xmpp/JingleSessionPC.ts
@@ -9,10 +9,12 @@ import { MediaDirection } from '../../service/RTC/MediaDirection';
 import { MediaType } from '../../service/RTC/MediaType';
 import { SSRC_GROUP_SEMANTICS } from '../../service/RTC/StandardVideoQualitySettings';
 import { VideoType } from '../../service/RTC/VideoType';
-import { AnalyticsEvents } from '../../service/statistics/AnalyticsEvents';
+import { AnalyticsEvents, createAudioWedgeRecoveryEvent } from '../../service/statistics/AnalyticsEvents';
 import { XMPPEvents } from '../../service/xmpp/XMPPEvents';
 import { XEP } from '../../service/xmpp/XMPPExtensioProtocols';
 import JitsiLocalTrack from '../RTC/JitsiLocalTrack';
+import JitsiRemoteTrack from '../RTC/JitsiRemoteTrack';
+import RemoteAudioWedgeDetector from '../RTC/RemoteAudioWedgeDetector';
 import { SS_DEFAULT_FRAME_RATE } from '../RTC/ScreenObtainer';
 import TraceablePeerConnection, { IAudioQuality, IVideoQuality } from '../RTC/TraceablePeerConnection';
 import browser from '../browser';
@@ -173,6 +175,7 @@ export default class JingleSessionPC extends JingleSession {
     private _gatheringReported: boolean;
     private _xmppListeners: Array<() => void>;
     private _removeSenderVideoConstraintsChangeListener: Nullable<() => void>;
+    private _audioWedgeDetector: Nullable<RemoteAudioWedgeDetector>;
     private usesCodecSelectionAPI: boolean;
     private wasConnected: boolean;
     private isReconnect: boolean;
@@ -427,6 +430,8 @@ export default class JingleSessionPC extends JingleSession {
          */
         this.establishmentDuration = undefined;
 
+        this._audioWedgeDetector = null;
+
         this._xmppListeners = [];
         this._xmppListeners.push(
             connection.addCancellableListener(
@@ -571,6 +576,28 @@ export default class JingleSessionPC extends JingleSession {
     }
 
     /**
+     * Starts the remote audio wedge watchdog for this session if applicable. The watchdog only runs against a JVB
+     * connection that uses SSRC rewriting, since that is the only configuration affected by the Chrome/WebRTC
+     * audio-demux wedge. It is started once the connection is established and is a no-op on subsequent ICE
+     * (re)connections.
+     *
+     * @returns {void}
+     */
+    private _maybeStartAudioWedgeDetector(): void {
+        if (this._audioWedgeDetector
+                || this.isP2P
+                || !FeatureFlags.isSsrcRewritingSupported()
+                || this.options.startSilent) {
+            return;
+        }
+
+        this._audioWedgeDetector = new RemoteAudioWedgeDetector(this.peerconnection, {
+            onWedgeDetected: track => this._recoverWedgedAudioSource(track)
+        });
+        this._audioWedgeDetector.start();
+    }
+
+    /**
      * Takes in a jingle offer iq, returns the new sdp offer that can be set as remote description in the
      * peerconnection.
      *
@@ -700,6 +727,85 @@ export default class JingleSessionPC extends JingleSession {
         sourceDescription.size && this.peerconnection.updateRemoteSources(sourceDescription, isAdd);
 
         return sourceDescription;
+    }
+
+    /**
+     * Recovers a remote audio source that the {@link RemoteAudioWedgeDetector} has flagged as wedged (mapped and
+     * unmuted, but receiving no inbound RTP). The recovery recycles just that source by synthesizing a source-remove
+     * followed by a source-add, reusing the same machinery as {@link processSourceMap}. The source-remove rejects the
+     * source's m-line (forcing Chrome to delete the stuck receive stream) and the source-add re-signals the same SSRC
+     * on a fresh m-line, which binds cleanly. Both operations are scoped to the single affected source.
+     *
+     * The recovery is gated by a guard that runs on the modification queue: the bridge can remap the slot (the same
+     * rewritten SSRC) to a different source, or remove it entirely, between detection and execution. The guard
+     * re-resolves the track by SSRC at execution time and skips the recovery if the SSRC is no longer mapped to the
+     * source that was detected as wedged - letting the normal sources-map flow own the slot and the watchdog re-detect
+     * on a later cycle. This prevents recycling a source with stale owner/source-name metadata.
+     *
+     * @param {JitsiRemoteTrack} track - The wedged remote audio track.
+     * @returns {void}
+     */
+    private _recoverWedgedAudioSource(track: JitsiRemoteTrack): void {
+        const ssrc = track.getSsrc();
+        const detectedSource = track.getSourceName();
+
+        if (typeof ssrc !== 'number' || !detectedSource) {
+            logger.warn(`${this} Cannot recover wedged audio source, missing ssrc/source-name`);
+
+            return;
+        }
+
+        const workFunction = (finishedCallback: (error?) => void) => {
+            // The slot may have been remapped or removed between detection and now. getTrackBySSRC always resolves to a
+            // remote track for a rewritten remote SSRC.
+            const currentTrack = this.peerconnection?.getTrackBySSRC(ssrc) as Nullable<JitsiRemoteTrack>;
+
+            if (!currentTrack || currentTrack.getSourceName() !== detectedSource) {
+                logger.warn(`${this} Skipping wedge recovery for audio source ${detectedSource} (ssrc=${ssrc}): the `
+                    + `slot was remapped or removed (now=${currentTrack?.getSourceName() ?? 'gone'}). The watchdog `
+                    + 'will re-detect if it is still wedged.');
+                finishedCallback();
+
+                return;
+            }
+
+            const source = currentTrack.getSourceName();
+            const owner = currentTrack.getParticipantId();
+
+            logger.warn(`${this} Recycling wedged remote audio source ${source} (ssrc=${ssrc}, owner=${owner})`);
+
+            // Builds a single-source Jingle "content" element for the wedged source, identical in shape to the ones
+            // produced by processSourceMap for an audio source-add.
+            const buildSourceNode = () => {
+                const src = { owner, source };
+                const msid = `remote-audio-${++this.numRemoteAudioSources}`;
+                const node = $build('content', {
+                    name: MediaType.AUDIO,
+                    xmlns: 'urn:xmpp:jingle:1'
+                }).c('description', {
+                    media: MediaType.AUDIO,
+                    xmlns: XEP.RTP_MEDIA
+                });
+
+                _addSourceElement(node, src, ssrc, `${msid} ${msid}`);
+
+                return node.up().node;
+            };
+
+            this._addOrRemoveRemoteStream(false /* remove */, buildSourceNode());
+            this._addOrRemoveRemoteStream(true /* add */, buildSourceNode());
+
+            Statistics.sendAnalytics(createAudioWedgeRecoveryEvent({
+                owner,
+                'source_name': source,
+                ssrc
+            }));
+
+            finishedCallback();
+        };
+
+        logger.debug(`${this} Queued wedge recovery task for audio source ${detectedSource} (ssrc=${ssrc})`);
+        this.modificationQueue.push(workFunction);
     }
 
     /**
@@ -1545,6 +1651,9 @@ export default class JingleSessionPC extends JingleSession {
         this.state = JingleSessionState.ENDED;
         this.establishmentDuration = undefined;
 
+        this._audioWedgeDetector?.stop();
+        this._audioWedgeDetector = null;
+
         if (this.peerconnection) {
             this.peerconnection.onicecandidate = null;
             this.peerconnection.oniceconnectionstatechange = null;
@@ -1754,6 +1863,8 @@ export default class JingleSessionPC extends JingleSession {
                     isStable = true;
                     this.room.eventEmitter.emit(XMPPEvents.CONNECTION_RESTORED, this);
                 }
+
+                this._maybeStartAudioWedgeDetector();
 
                 // Add a workaround for an issue on chrome in Unified plan when the local endpoint is the offerer.
                 // The 'signalingstatechange' event for 'stable' is handled after the 'iceconnectionstatechange' event

--- a/service/statistics/AnalyticsEvents.spec.ts
+++ b/service/statistics/AnalyticsEvents.spec.ts
@@ -22,6 +22,7 @@ describe( "/service/statistics/AnalyticsEvents members", () => {
         createRttByRegionEvent,
         createTransportStatsEvent,
         createAudioOutputProblemEvent,
+        createAudioWedgeRecoveryEvent,
         createBridgeChannelClosedEvent,
         createTtfmEvent,
         AnalyticsEvents,
@@ -72,6 +73,7 @@ describe( "/service/statistics/AnalyticsEvents members", () => {
         expect( typeof ( createRttByRegionEvent ) ).toBe( 'function' );
         expect( typeof ( createTransportStatsEvent ) ).toBe( 'function' );
         expect( typeof ( createAudioOutputProblemEvent ) ).toBe( 'function' );
+        expect( typeof ( createAudioWedgeRecoveryEvent ) ).toBe( 'function' );
         expect( typeof ( createBridgeChannelClosedEvent ) ).toBe( 'function' );
         expect( typeof ( createTtfmEvent ) ).toBe( 'function' );
     } );

--- a/service/statistics/AnalyticsEvents.ts
+++ b/service/statistics/AnalyticsEvents.ts
@@ -543,6 +543,23 @@ export const createAudioOutputProblemEvent
     };
 
 /**
+ * Creates an event indicating that the remote audio wedge watchdog detected a mapped, unmuted remote audio source
+ * that received no inbound RTP for the detection window and triggered a source recycle to recover it. Used to measure
+ * the residual wedge rate in the field (see the Chrome/WebRTC audio-demux wedge).
+ *
+ * @param attributes - The attributes to add to the event. Currently used fields:
+ *      sourceName: the source name of the wedged remote audio source.
+ *      ssrc: the SSRC of the wedged remote audio source.
+ */
+export const createAudioWedgeRecoveryEvent = (attributes: object) => {
+    return {
+        action: 'audio.wedge.recovery',
+        attributes,
+        type: AnalyticsEvents.TYPE_OPERATIONAL
+    };
+};
+
+/**
  * Creates an event which contains an information related to the bridge channel close event.
  *
  * @param code - A code from {@link https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent}


### PR DESCRIPTION
## Problem

Under JVB SSRC rewriting, the bridge can start forwarding a rewritten remote audio SSRC before the client's locally-generated Jingle renegotiation signals it. When the first RTP packet wins that race, Chrome latches an **unsignaled** receive stream on the wrong audio m-section (PT demuxing) and then **silently** fails to bind the signaled sink for that SSRC at the Call level. The app is left with an `RtpReceiver` that never receives a packet — a remote participant who is **permanently silent**, while `getStats()` shows zero inbound RTP for the SSRC even though RTP is arriving on the wire.

This is the silent, Call-level sibling of the loud transport-level variant fixed by CL 464220 / webrtc:502130956; the audio equivalent of the never-landed video fix discussed in crbug webrtc:11477#13. A separate Chrome bug is being filed; this PR is the client-side recovery (defense in depth — it does not depend on any Chrome internals).

## Change

A watchdog, `RemoteAudioWedgeDetector`, owned by `JingleSessionPC`:

- **Detection** — polls inbound-rtp stats and flags a source that is mapped and unmuted yet has cumulative `packetsReceived == 0` for `wedgeTimeoutMs` (default 15s) of *continuous* wall-clock eligibility, with a minimum-samples floor to debounce transient absent-stats during renegotiation. Keying off the cumulative count (not a delta) avoids false positives from DTX/comfort-noise silence.
- **Recovery** — recycles just that source via a source-remove then source-add (same SSRC, fresh m-line) through the existing `_addOrRemoveRemoteStream` machinery. The remove forces Chrome to drop the stuck receive stream; the re-add binds cleanly. A guard re-resolves the track by SSRC on the modification queue and **skips** the recycle if the slot was remapped/removed between detection and execution, so it never acts on stale source/owner metadata.
- **Efficiency** — `getStats()` is called only when a source could actually be wedged. Muted, cooling-down, and already-confirmed-healthy sources are excluded; once every mapped source has delivered its first packet, the watchdog stops polling entirely until a new source appears.

Gated behind `FeatureFlags.isSsrcRewritingSupported()` on JVB (non-P2P) sessions, and reported via a new `audio.wedge.recovery` analytics event to measure the residual wedge rate in the field.

## Tests

New `RemoteAudioWedgeDetector.spec.ts` (detection timing, eligibility/healthy/cooldown gating, getStats short-circuit) and recovery-guard cases in `JingleSessionPC.spec.ts`. `npm run lint` (eslint + tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
