### PR TITLE
fix(RTC): Drop malformed EndpointMessage frames at the bridge channel boundary

### DIFF
--- a/modules/RTC/BridgeChannel.ts
+++ b/modules/RTC/BridgeChannel.ts
@@ -365,6 +365,10 @@ export default class BridgeChannel {
                 break;
             }
             case 'EndpointMessage': {
+                if (!obj.msgPayload || typeof obj.msgPayload !== 'object') {
+                    logger.warn(`Dropping malformed EndpointMessage from ${obj.from}: missing msgPayload`);
+                    break;
+                }
                 emitter.emit(RTCEvents.ENDPOINT_MESSAGE_RECEIVED, obj.from, obj.msgPayload);
 
                 break;


### PR DESCRIPTION
A payload-less EndpointMessage colibri frame relayed by the videobridge ({ colibriClass: 'EndpointMessage', from: <id> } with no msgPayload key) crashed every downstream listener — ConnectionQuality.ts:213 dereferenced payload.type on undefined and turned the malformed frame into a page-killing UnhandledError that aborted the rest of the event emit chain. Three sibling listeners (e2eping, OlmAdapter, SpeakerStatsCollector) share the same unguarded assumption.

Guard at the boundary in BridgeChannel so one bad frame does not bring down four consumers. Frames without an object msgPayload are logged and dropped before being emitted.