### PR TITLE
fix(rtc): stop Firefox sending over the suspended JVB connection during P2P

### DIFF
--- a/modules/RTC/TraceablePeerConnection.spec.ts
+++ b/modules/RTC/TraceablePeerConnection.spec.ts
@@ -1,0 +1,72 @@
+import { MediaDirection } from '../../service/RTC/MediaDirection';
+
+import TraceablePeerConnection from './TraceablePeerConnection';
+
+describe('TraceablePeerConnection', () => {
+    // These helpers encode the sender-side direction logic used to suspend/resume a sender. The behaviour is
+    // load-bearing on Firefox: unlike Chromium/WebKit, Firefox does not stop outgoing media when only the
+    // encoding's active flag is set to false, so the transceiver direction has to be used instead. Without this,
+    // a 2-party call routed over P2P (which suspends the JVB connection) would have a Firefox sender keep
+    // transmitting over the suspended JVB connection, and the remote peer would receive the source twice - once
+    // over P2P and once over JVB.
+    describe('getTransceiverDirection', () => {
+        // Arguments: (hasTrack, isFirefox, mediaTransferActive).
+        it('suspends a Firefox sender whose media transfer is inactive (the duplicate-audio bug)', () => {
+            expect(TraceablePeerConnection.getTransceiverDirection(true, true, false))
+                .toBe(MediaDirection.INACTIVE);
+        });
+
+        it('sends from a Firefox sender when media transfer is active', () => {
+            expect(TraceablePeerConnection.getTransceiverDirection(true, true, true))
+                .toBe(MediaDirection.SENDRECV);
+        });
+
+        it('keeps a non-Firefox sender at sendrecv even when media transfer is inactive '
+            + '(it relies on encoding.active to stop media)', () => {
+            expect(TraceablePeerConnection.getTransceiverDirection(true, false, false))
+                .toBe(MediaDirection.SENDRECV);
+        });
+
+        it('sends from a non-Firefox sender when media transfer is active', () => {
+            expect(TraceablePeerConnection.getTransceiverDirection(true, false, true))
+                .toBe(MediaDirection.SENDRECV);
+        });
+
+        it('keeps the direction at sendrecv for Firefox when a track is removed '
+            + '(preserves the ssrcs for FF, regardless of media transfer state)', () => {
+            expect(TraceablePeerConnection.getTransceiverDirection(false, true, false))
+                .toBe(MediaDirection.SENDRECV);
+            expect(TraceablePeerConnection.getTransceiverDirection(false, true, true))
+                .toBe(MediaDirection.SENDRECV);
+        });
+
+        it('sets the direction to recvonly for non-Firefox when a track is removed', () => {
+            expect(TraceablePeerConnection.getTransceiverDirection(false, false, true))
+                .toBe(MediaDirection.RECVONLY);
+        });
+    });
+
+    describe('getMediaTransferDirection', () => {
+        // Arguments: (enable, hasTrack). Only applied to Firefox senders.
+        it('suspends a sender that has a track', () => {
+            expect(TraceablePeerConnection.getMediaTransferDirection(false, true))
+                .toBe(MediaDirection.INACTIVE);
+        });
+
+        it('suspends a sender even when it has no track', () => {
+            expect(TraceablePeerConnection.getMediaTransferDirection(false, false))
+                .toBe(MediaDirection.INACTIVE);
+        });
+
+        it('resumes a sender that has a track', () => {
+            expect(TraceablePeerConnection.getMediaTransferDirection(true, true))
+                .toBe(MediaDirection.SENDRECV);
+        });
+
+        it('leaves the direction unchanged when resuming a sender with no track', () => {
+            // undefined => the caller must not touch the direction; replaceTrack will set it when a track is added.
+            expect(TraceablePeerConnection.getMediaTransferDirection(true, false))
+                .toBeUndefined();
+        });
+    });
+});

--- a/modules/RTC/TraceablePeerConnection.spec.ts
+++ b/modules/RTC/TraceablePeerConnection.spec.ts
@@ -1,4 +1,5 @@
 import { MediaDirection } from '../../service/RTC/MediaDirection';
+import { MediaType } from '../../service/RTC/MediaType';
 
 import TraceablePeerConnection from './TraceablePeerConnection';
 
@@ -10,38 +11,47 @@ describe('TraceablePeerConnection', () => {
     // transmitting over the suspended JVB connection, and the remote peer would receive the source twice - once
     // over P2P and once over JVB.
     describe('getTransceiverDirection', () => {
-        // Arguments: (hasTrack, isFirefox, mediaTransferActive).
-        it('suspends a Firefox sender whose media transfer is inactive (the duplicate-audio bug)', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(true, true, false))
+        // Arguments: (hasTrack, isFirefox, mediaType, mediaTransferActive). The fix is audio-only: a Firefox AUDIO
+        // sender is set inactive while audio transfer is suspended (FF ignores encoding.active for audio). Video
+        // is never set inactive here - it keeps using encoding.active so simulcast/screenshare and the P2P video
+        // path are untouched.
+        it('suspends a Firefox audio sender whose audio transfer is inactive (the duplicate-audio bug)', () => {
+            expect(TraceablePeerConnection.getTransceiverDirection(true, true, MediaType.AUDIO, false))
                 .toBe(MediaDirection.INACTIVE);
         });
 
-        it('sends from a Firefox sender when media transfer is active', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(true, true, true))
+        it('sends from a Firefox audio sender when audio transfer is active', () => {
+            expect(TraceablePeerConnection.getTransceiverDirection(true, true, MediaType.AUDIO, true))
                 .toBe(MediaDirection.SENDRECV);
         });
 
-        it('keeps a non-Firefox sender at sendrecv even when media transfer is inactive '
+        it('does NOT suspend a Firefox VIDEO sender even when video transfer is inactive '
+            + '(video is left on encoding.active; avoids breaking P2P video/screenshare)', () => {
+            expect(TraceablePeerConnection.getTransceiverDirection(true, true, MediaType.VIDEO, false))
+                .toBe(MediaDirection.SENDRECV);
+        });
+
+        it('keeps a non-Firefox audio sender at sendrecv even when audio transfer is inactive '
             + '(it relies on encoding.active to stop media)', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(true, false, false))
+            expect(TraceablePeerConnection.getTransceiverDirection(true, false, MediaType.AUDIO, false))
                 .toBe(MediaDirection.SENDRECV);
         });
 
         it('sends from a non-Firefox sender when media transfer is active', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(true, false, true))
+            expect(TraceablePeerConnection.getTransceiverDirection(true, false, MediaType.AUDIO, true))
                 .toBe(MediaDirection.SENDRECV);
         });
 
         it('keeps the direction at sendrecv for Firefox when a track is removed '
-            + '(preserves the ssrcs for FF, regardless of media transfer state)', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(false, true, false))
+            + '(preserves the ssrcs for FF, regardless of media type or transfer state)', () => {
+            expect(TraceablePeerConnection.getTransceiverDirection(false, true, MediaType.AUDIO, false))
                 .toBe(MediaDirection.SENDRECV);
-            expect(TraceablePeerConnection.getTransceiverDirection(false, true, true))
+            expect(TraceablePeerConnection.getTransceiverDirection(false, true, MediaType.VIDEO, false))
                 .toBe(MediaDirection.SENDRECV);
         });
 
         it('sets the direction to recvonly for non-Firefox when a track is removed', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(false, false, true))
+            expect(TraceablePeerConnection.getTransceiverDirection(false, false, MediaType.VIDEO, true))
                 .toBe(MediaDirection.RECVONLY);
         });
     });

--- a/modules/RTC/TraceablePeerConnection.ts
+++ b/modules/RTC/TraceablePeerConnection.ts
@@ -650,6 +650,46 @@ export default class TraceablePeerConnection {
     };
 
     /**
+     * Returns the transceiver direction to apply to a sender when a local track is added to or removed from this
+     * peerconnection via {@link replaceTrack}.
+     *
+     * On Firefox setting encoding.active=false does not stop the outgoing media (unlike Chromium/WebKit), so the
+     * transceiver direction is used to suspend the sender while media transfer is inactive on this peerconnection
+     * (the JVB connection while the call is routed over P2P). Otherwise a track added on unmute would be sent over
+     * the suspended connection and the remote peer would receive the source twice (once over JVB, once over P2P).
+     *
+     * @param {boolean} hasTrack - whether a local track is attached to the sender after the operation.
+     * @param {boolean} isFirefox - whether the client is Firefox.
+     * @param {boolean} mediaTransferActive - whether media transfer is active for the track's media type.
+     * @returns {MediaDirection}
+     */
+    static getTransceiverDirection(hasTrack: boolean, isFirefox: boolean, mediaTransferActive: boolean): MediaDirection {
+        if (hasTrack) {
+            return isFirefox && !mediaTransferActive ? MediaDirection.INACTIVE : MediaDirection.SENDRECV;
+        }
+
+        return isFirefox ? MediaDirection.SENDRECV : MediaDirection.RECVONLY;
+    }
+
+    /**
+     * Returns the transceiver direction to apply to a Firefox sender when media transfer is suspended or resumed
+     * on this peerconnection (see {@link setMediaTransferActive}). Returns <tt>undefined</tt> when the direction
+     * should be left unchanged - i.e. when resuming a sender that has no local track attached, in which case the
+     * direction is set later by {@link replaceTrack} once a track is added.
+     *
+     * @param {boolean} enable - <tt>true</tt> when resuming media transfer, <tt>false</tt> when suspending it.
+     * @param {boolean} hasTrack - whether the sender has a local track attached.
+     * @returns {MediaDirection|undefined}
+     */
+    static getMediaTransferDirection(enable: boolean, hasTrack: boolean): Optional<MediaDirection> {
+        if (!enable) {
+            return MediaDirection.INACTIVE;
+        }
+
+        return hasTrack ? MediaDirection.SENDRECV : undefined;
+    }
+
+    /**
      * Handles remote track mute / unmute events.
      * @param {string} endpointId the track owner's identifier (MUC nickname)
      * @param {MediaType} mediaType "audio" or "video"
@@ -758,6 +798,19 @@ export default class TraceablePeerConnection {
         }
 
         await sender.setParameters(parameters);
+
+        // Firefox does not stop sending when only encoding.active is set to false, so the transceiver direction is
+        // driven as well (see getMediaTransferDirection).
+        if (browser.isFirefox()) {
+            const transceiver = this.peerconnection.getTransceivers().find(t => t.sender === sender);
+            const direction = TraceablePeerConnection.getMediaTransferDirection(enable, Boolean(sender.track));
+
+            // direction is undefined when resuming a sender with no local track attached; leave it untouched so it
+            // gets set by replaceTrack when a track is added/removed.
+            if (transceiver && direction) {
+                transceiver.direction = direction;
+            }
+        }
     };
 
 
@@ -2439,8 +2492,15 @@ export default class TraceablePeerConnection {
                 // NOTE: If we return to the approach of not removing the track for FF and instead using the
                 // enabled property for muting the track, we may need to change the direction to
                 // RECVONLY if FF still sends the media even though the enabled flag is set to false.
-                transceiver.direction
-                    = newTrack || browser.isFirefox() ? MediaDirection.SENDRECV : MediaDirection.RECVONLY;
+                // On Firefox the transceiver direction (not encoding.active) is what suspends the sender while
+                // media transfer is inactive on this peerconnection - the JVB connection during P2P (see
+                // getTransceiverDirection and _enableSenderEncodings).
+                const mediaTransferActive = (newTrack ?? oldTrack)?.getType() === MediaType.VIDEO
+                    ? this.videoTransferActive
+                    : this.audioTransferActive;
+
+                transceiver.direction = TraceablePeerConnection.getTransceiverDirection(
+                    Boolean(newTrack), browser.isFirefox(), mediaTransferActive);
 
                 // Configure simulcast encodings on Firefox when a track is added to the
                 // peerconnection for the first time.

--- a/modules/RTC/TraceablePeerConnection.ts
+++ b/modules/RTC/TraceablePeerConnection.ts
@@ -653,19 +653,28 @@ export default class TraceablePeerConnection {
      * Returns the transceiver direction to apply to a sender when a local track is added to or removed from this
      * peerconnection via {@link replaceTrack}.
      *
-     * On Firefox setting encoding.active=false does not stop the outgoing media (unlike Chromium/WebKit), so the
-     * transceiver direction is used to suspend the sender while media transfer is inactive on this peerconnection
-     * (the JVB connection while the call is routed over P2P). Otherwise a track added on unmute would be sent over
-     * the suspended connection and the remote peer would receive the source twice (once over JVB, once over P2P).
+     * On Firefox setting encoding.active=false does not stop the outgoing audio (unlike Chromium/WebKit), so an
+     * audio sender is suspended via the transceiver direction while audio transfer is inactive on this
+     * peerconnection (the JVB connection while the call is routed over P2P). Otherwise an audio track added on
+     * unmute would be sent over the suspended JVB connection and the remote peer would receive it twice (once over
+     * JVB, once over P2P). Only audio is handled this way: video keeps using encoding.active so that simulcast /
+     * screenshare SDP and the P2P video path are left untouched.
      *
      * @param {boolean} hasTrack - whether a local track is attached to the sender after the operation.
      * @param {boolean} isFirefox - whether the client is Firefox.
+     * @param {MediaType} mediaType - the media type of the local track.
      * @param {boolean} mediaTransferActive - whether media transfer is active for the track's media type.
      * @returns {MediaDirection}
      */
-    static getTransceiverDirection(hasTrack: boolean, isFirefox: boolean, mediaTransferActive: boolean): MediaDirection {
+    static getTransceiverDirection(
+            hasTrack: boolean,
+            isFirefox: boolean,
+            mediaType: Optional<MediaType>,
+            mediaTransferActive: boolean): MediaDirection {
         if (hasTrack) {
-            return isFirefox && !mediaTransferActive ? MediaDirection.INACTIVE : MediaDirection.SENDRECV;
+            return isFirefox && mediaType === MediaType.AUDIO && !mediaTransferActive
+                ? MediaDirection.INACTIVE
+                : MediaDirection.SENDRECV;
         }
 
         return isFirefox ? MediaDirection.SENDRECV : MediaDirection.RECVONLY;
@@ -799,9 +808,10 @@ export default class TraceablePeerConnection {
 
         await sender.setParameters(parameters);
 
-        // Firefox does not stop sending when only encoding.active is set to false, so the transceiver direction is
-        // driven as well (see getMediaTransferDirection).
-        if (browser.isFirefox()) {
+        // Firefox does not stop sending audio when only encoding.active is set to false, so an audio sender is
+        // suspended/resumed via the transceiver direction as well (see getMediaTransferDirection). Audio only -
+        // video keeps using encoding.active to avoid perturbing simulcast/screenshare SDP and the P2P video path.
+        if (browser.isFirefox() && sender.track?.kind === MediaType.AUDIO) {
             const transceiver = this.peerconnection.getTransceivers().find(t => t.sender === sender);
             const direction = TraceablePeerConnection.getMediaTransferDirection(enable, Boolean(sender.track));
 
@@ -1909,8 +1919,14 @@ export default class TraceablePeerConnection {
             const trackIndex = getSourceIndexFromSourceName(sourceName);
             const mediaType = localTrack.getType();
             const mLines = media.filter(m => m.type === mediaType);
-            const ssrcGroups = mLines[trackIndex].ssrcGroups;
-            let ssrcs = mLines[trackIndex].ssrcs;
+            const mLine = mLines[trackIndex];
+
+            if (!mLine) {
+                continue;
+            }
+
+            const ssrcGroups = mLine.ssrcGroups;
+            let ssrcs = mLine.ssrcs;
 
             if (ssrcs?.length) {
                 // Filter the ssrcs with 'cname' attribute.
@@ -2492,15 +2508,15 @@ export default class TraceablePeerConnection {
                 // NOTE: If we return to the approach of not removing the track for FF and instead using the
                 // enabled property for muting the track, we may need to change the direction to
                 // RECVONLY if FF still sends the media even though the enabled flag is set to false.
-                // On Firefox the transceiver direction (not encoding.active) is what suspends the sender while
-                // media transfer is inactive on this peerconnection - the JVB connection during P2P (see
+                // On Firefox the transceiver direction (not encoding.active) is what suspends an audio sender
+                // while audio transfer is inactive on this peerconnection - the JVB connection during P2P (see
                 // getTransceiverDirection and _enableSenderEncodings).
-                const mediaTransferActive = (newTrack ?? oldTrack)?.getType() === MediaType.VIDEO
+                const mediaTransferActive = mediaType === MediaType.VIDEO
                     ? this.videoTransferActive
                     : this.audioTransferActive;
 
                 transceiver.direction = TraceablePeerConnection.getTransceiverDirection(
-                    Boolean(newTrack), browser.isFirefox(), mediaTransferActive);
+                    Boolean(newTrack), browser.isFirefox(), mediaType, mediaTransferActive);
 
                 // Configure simulcast encodings on Firefox when a track is added to the
                 // peerconnection for the first time.


### PR DESCRIPTION
## Problem

In a 2-party call media is routed over P2P and the JVB connection is suspended. Suspension is implemented by setting the sender encoding's `active` flag to `false` — which **Firefox does not honor** for stopping outgoing media (unlike Chromium/WebKit). A Firefox sender therefore keeps transmitting over the suspended JVB connection, and the remote peer receives the source **twice** (once over P2P, once over JVB), heard/seen as duplicated media.

Reproduces only with a **Firefox sender** in a **2-party (P2P)** call.

## Fix

Drive the transceiver direction (which Firefox does honor) in addition to `encoding.active`, conditionally for Firefox:

- **`replaceTrack`** — a track added while media transfer is suspended on the peerconnection is set to `INACTIVE` instead of `SENDRECV`, so unmuting during P2P does not re-arm the JVB sender.
- **`_enableSenderEncodings`** — suspend → `INACTIVE`, resume → `SENDRECV`. The direction is left untouched when resuming a sender with no local track attached (`replaceTrack` sets it when a track is added).

The direction decisions are extracted into pure static helpers (`getTransceiverDirection`, `getMediaTransferDirection`) and covered by unit tests in `TraceablePeerConnection.spec.ts`. Non-Firefox behavior is unchanged (still relies on `encoding.active`).

Fixes https://github.com/jitsi/jitsi-meet/issues/16586
