### PR TITLE
fix(RTC): repair wedged-audio recovery track re-add and fold detection into StatsCollector

### DIFF
--- a/modules/RTC/RemoteAudioWedgeDetector.spec.ts
+++ b/modules/RTC/RemoteAudioWedgeDetector.spec.ts
@@ -1,4 +1,6 @@
 import { MediaType } from '../../service/RTC/MediaType';
+import { RTCEvents } from '../../service/RTC/RTCEvents';
+import EventEmitter from '../util/EventEmitter';
 
 import RemoteAudioWedgeDetector from './RemoteAudioWedgeDetector';
 
@@ -20,52 +22,45 @@ function mockTrack(ssrc: number, source: string, muted = false): any {
 }
 
 /**
- * Builds a mock getStats() report (a Map keyed by report id) for the given inbound-rtp audio packet counts.
+ * Builds the per-SSRC inbound audio packet-count map the detector consumes.
  *
- * @param {Array<{packetsReceived: number; ssrc: number;}>} entries - The per-SSRC inbound-rtp entries.
- * @returns {Map<string, object>}
+ * @param {Array<{packetsReceived: number; ssrc: number;}>} entries - The per-SSRC packet counts.
+ * @returns {Map<number, number>}
  */
-function mockStats(entries: Array<{ packetsReceived: number; ssrc: number; }>): Map<string, any> {
-    const report = new Map();
+function toMap(entries: Array<{ packetsReceived: number; ssrc: number; }>): Map<number, number> {
+    const map = new Map<number, number>();
 
-    entries.forEach((entry, idx) => {
-        report.set(`inbound-rtp-${idx}`, {
-            kind: 'audio',
-            packetsReceived: entry.packetsReceived,
-            ssrc: entry.ssrc,
-            type: 'inbound-rtp'
-        });
-    });
+    entries.forEach(entry => map.set(entry.ssrc, entry.packetsReceived));
 
-    return report;
+    return map;
 }
 
 describe('RemoteAudioWedgeDetector', () => {
     let tracks: any[];
-    let statsEntries: Array<{ packetsReceived: number; ssrc: number; }>;
     let pc: any;
     let onWedgeDetected: jasmine.Spy;
     let detector: RemoteAudioWedgeDetector;
 
-    const POLL_INTERVAL_MS = 1000;
+    const TICK_MS = 1000;
     const WEDGE_TIMEOUT_MS = 3000;
 
     /**
-     * Runs a single detection poll.
+     * Feeds one batch of inbound audio packet counts through the detector's evaluation, as the stats poll would.
      *
-     * @returns {Promise<void>}
+     * @param {Array<{packetsReceived: number; ssrc: number;}>} entries - The per-SSRC packet counts.
+     * @returns {void}
      */
-    function poll(): Promise<void> {
-        return (detector as any)._check();
+    function poll(entries: Array<{ packetsReceived: number; ssrc: number; }>): void {
+        (detector as any)._evaluate(toMap(entries));
     }
 
     /**
-     * Advances the mocked clock by one poll interval.
+     * Advances the mocked clock by one tick.
      *
      * @returns {void}
      */
     function tick(): void {
-        jasmine.clock().tick(POLL_INTERVAL_MS);
+        jasmine.clock().tick(TICK_MS);
     }
 
     beforeEach(() => {
@@ -73,20 +68,18 @@ describe('RemoteAudioWedgeDetector', () => {
         jasmine.clock().mockDate(new Date(0));
 
         tracks = [];
-        statsEntries = [];
         pc = {
+            eventEmitter: new EventEmitter(),
             getRemoteTracks: (_endpointId: any, mediaType: MediaType) => {
                 expect(mediaType).toBe(MediaType.AUDIO);
 
                 return tracks;
-            },
-            getStats: jasmine.createSpy('getStats').and.callFake(() => Promise.resolve(mockStats(statsEntries)))
+            }
         };
         onWedgeDetected = jasmine.createSpy('onWedgeDetected');
 
         detector = new RemoteAudioWedgeDetector(pc, {
             onWedgeDetected,
-            pollIntervalMs: POLL_INTERVAL_MS,
             wedgeTimeoutMs: WEDGE_TIMEOUT_MS
         });
     });
@@ -96,249 +89,230 @@ describe('RemoteAudioWedgeDetector', () => {
         jasmine.clock().uninstall();
     });
 
-    it('does not call getStats() when there are no remote audio sources', async () => {
-        tracks = [];
-
-        await poll();
-        expect(pc.getStats).not.toHaveBeenCalled();
-    });
-
-    it('does not call getStats() when every remote audio source is muted', async () => {
-        tracks = [ mockTrack(111, 'source-A', true /* muted */), mockTrack(222, 'source-B', true /* muted */) ];
-        statsEntries = [ { packetsReceived: 0, ssrc: 111 }, { packetsReceived: 0, ssrc: 222 } ];
-
-        await poll();
-        expect(pc.getStats).not.toHaveBeenCalled();
-    });
-
-    it('calls getStats() when at least one remote audio source is unmuted', async () => {
-        tracks = [ mockTrack(111, 'source-A', true /* muted */), mockTrack(222, 'source-B') ];
-        statsEntries = [ { packetsReceived: 0, ssrc: 111 }, { packetsReceived: 0, ssrc: 222 } ];
-
-        await poll();
-        expect(pc.getStats).toHaveBeenCalled();
-    });
-
-    it('stops calling getStats() once every source has received a packet', async () => {
+    it('does not fire on the first eligible zero sample', () => {
         tracks = [ mockTrack(111, 'source-A') ];
-        statsEntries = [ { packetsReceived: 7, ssrc: 111 } ];
 
-        await poll(); // confirms the source healthy
-        expect(pc.getStats).toHaveBeenCalledTimes(1);
-
-        tick();
-        await poll(); // source is confirmed healthy -> no candidates -> getStats skipped
-        tick();
-        await poll();
-        expect(pc.getStats).toHaveBeenCalledTimes(1);
-    });
-
-    it('keeps polling while one source is silent even though another is healthy', async () => {
-        tracks = [ mockTrack(111, 'source-A'), mockTrack(222, 'source-B') ];
-        statsEntries = [ { packetsReceived: 7, ssrc: 111 }, { packetsReceived: 0, ssrc: 222 } ];
-
-        await poll();
-        tick();
-        await poll();
-        expect(pc.getStats).toHaveBeenCalledTimes(2);
-    });
-
-    it('resumes polling when a new source appears after all were healthy', async () => {
-        tracks = [ mockTrack(111, 'source-A') ];
-        statsEntries = [ { packetsReceived: 7, ssrc: 111 } ];
-
-        await poll(); // source-A confirmed healthy
-        tick();
-        await poll(); // skipped
-        expect(pc.getStats).toHaveBeenCalledTimes(1);
-
-        // A new participant joins; its source has not been confirmed yet.
-        tracks = [ mockTrack(111, 'source-A'), mockTrack(222, 'source-B') ];
-        statsEntries = [ { packetsReceived: 7, ssrc: 111 }, { packetsReceived: 0, ssrc: 222 } ];
-        tick();
-        await poll();
-        expect(pc.getStats).toHaveBeenCalledTimes(2);
-    });
-
-    it('does not fire for a source that received packets and later reports zero (cumulative is monotonic)', async () => {
-        tracks = [ mockTrack(111, 'source-A') ];
-        statsEntries = [ { packetsReceived: 7, ssrc: 111 } ];
-
-        await poll(); // healthy
-
-        // A subsequent (hypothetical) zero reading must never re-arm a confirmed-healthy source.
-        for (let i = 0; i < 5; i++) {
-            tick();
-            statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
-            await poll(); // eslint-disable-line no-await-in-loop
-        }
+        poll([ { packetsReceived: 0, ssrc: 111 } ]);
         expect(onWedgeDetected).not.toHaveBeenCalled();
     });
 
-    it('does not fire on the first eligible zero poll', async () => {
+    it('fires once the zero-RTP duration elapses while unmuted', () => {
         tracks = [ mockTrack(111, 'source-A') ];
-        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
+        const entries = [ { packetsReceived: 0, ssrc: 111 } ];
 
-        await poll();
-        expect(onWedgeDetected).not.toHaveBeenCalled();
-    });
-
-    it('fires once the zero-RTP duration elapses while unmuted', async () => {
-        tracks = [ mockTrack(111, 'source-A') ];
-        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
-
-        // Polls while the timeout has not yet elapsed.
-        await poll(); // t=0, streak starts
+        poll(entries); // t=0, streak starts
         tick();
-        await poll(); // t=1000
+        poll(entries); // t=1000
         tick();
-        await poll(); // t=2000
+        poll(entries); // t=2000
         expect(onWedgeDetected).not.toHaveBeenCalled();
 
         tick();
-        await poll(); // t=3000, elapsed >= WEDGE_TIMEOUT_MS
+        poll(entries); // t=3000, elapsed >= WEDGE_TIMEOUT_MS
         expect(onWedgeDetected).toHaveBeenCalledTimes(1);
         expect(onWedgeDetected.calls.mostRecent().args[0]).toBe(tracks[0]);
     });
 
-    it('does not fire before the timeout elapses, even across many polls', async () => {
+    it('does not fire before the timeout elapses, even across many samples', () => {
         const detector2 = new RemoteAudioWedgeDetector(pc, {
             onWedgeDetected,
-            pollIntervalMs: POLL_INTERVAL_MS,
             wedgeTimeoutMs: 60000
         });
 
         tracks = [ mockTrack(111, 'source-A') ];
-        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
 
         for (let i = 0; i < 10; i++) {
-            await (detector2 as any)._check(); // eslint-disable-line no-await-in-loop
+            (detector2 as any)._evaluate(toMap([ { packetsReceived: 0, ssrc: 111 } ]));
             tick();
         }
         expect(onWedgeDetected).not.toHaveBeenCalled();
         detector2.stop();
     });
 
-    it('requires at least two samples even when the timeout is tiny', async () => {
+    it('requires at least two samples even when the timeout is tiny', () => {
         const detector2 = new RemoteAudioWedgeDetector(pc, {
             onWedgeDetected,
-            pollIntervalMs: POLL_INTERVAL_MS,
             wedgeTimeoutMs: 0
         });
 
         tracks = [ mockTrack(111, 'source-A') ];
-        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
 
-        // A single poll cannot fire (only one sample) even though the elapsed time already satisfies the timeout.
-        await (detector2 as any)._check();
+        // A single sample cannot fire (only one sample) even though the elapsed time already satisfies the timeout.
+        (detector2 as any)._evaluate(toMap([ { packetsReceived: 0, ssrc: 111 } ]));
         expect(onWedgeDetected).not.toHaveBeenCalled();
 
         tick();
-        await (detector2 as any)._check();
+        (detector2 as any)._evaluate(toMap([ { packetsReceived: 0, ssrc: 111 } ]));
         expect(onWedgeDetected).toHaveBeenCalledTimes(1);
         detector2.stop();
     });
 
-    it('does not fire when the source is receiving packets', async () => {
+    it('does not fire when the source is receiving packets', () => {
         tracks = [ mockTrack(111, 'source-A') ];
-        statsEntries = [ { packetsReceived: 42, ssrc: 111 } ];
 
         for (let i = 0; i < 5; i++) {
-            await poll(); // eslint-disable-line no-await-in-loop
+            poll([ { packetsReceived: 42, ssrc: 111 } ]);
             tick();
         }
         expect(onWedgeDetected).not.toHaveBeenCalled();
     });
 
-    it('does not fire when the source is muted', async () => {
+    it('does not fire when the source is muted', () => {
         tracks = [ mockTrack(111, 'source-A', true /* muted */) ];
-        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
 
         for (let i = 0; i < 5; i++) {
-            await poll(); // eslint-disable-line no-await-in-loop
+            poll([ { packetsReceived: 0, ssrc: 111 } ]);
             tick();
         }
         expect(onWedgeDetected).not.toHaveBeenCalled();
     });
 
-    it('resets the streak clock once the source starts receiving, even after earlier zero polls', async () => {
+    it('does not fire for a source that received packets and later reports zero (cumulative is monotonic)', () => {
         tracks = [ mockTrack(111, 'source-A') ];
-        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
 
-        // Two zero polls accumulate, but the timeout has not elapsed.
-        await poll(); // t=0
-        tick();
-        await poll(); // t=1000
+        poll([ { packetsReceived: 7, ssrc: 111 } ]); // healthy
 
-        // Packets begin to flow; the source is demuxing correctly. Detection keys off the cumulative count, so once
-        // any packet is seen the source stays healthy even if the count later plateaus (e.g. DTX/silence) - the earlier
-        // zero polls must not carry over and trip the watchdog.
-        tick();
-        statsEntries = [ { packetsReceived: 5, ssrc: 111 } ];
-        await poll(); // t=2000, streak reset
-        tick();
-        statsEntries = [ { packetsReceived: 5, ssrc: 111 } ];
-        await poll(); // t=3000
-        tick();
-        await poll(); // t=4000
-        tick();
-        await poll(); // t=5000
+        // A subsequent (hypothetical) zero reading must never re-arm a confirmed-healthy source.
+        for (let i = 0; i < 5; i++) {
+            tick();
+            poll([ { packetsReceived: 0, ssrc: 111 } ]);
+        }
         expect(onWedgeDetected).not.toHaveBeenCalled();
     });
 
-    it('does not re-fire for the same source during the cooldown window', async () => {
-        tracks = [ mockTrack(111, 'source-A') ];
-        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
+    it('fires for a silent source even when another source is healthy', () => {
+        tracks = [ mockTrack(111, 'source-A'), mockTrack(222, 'source-B') ];
+        const entries = [ { packetsReceived: 7, ssrc: 111 }, { packetsReceived: 0, ssrc: 222 } ];
 
-        await poll(); // t=0
+        poll(entries); // t=0
         tick();
-        await poll(); // t=1000
+        poll(entries); // t=1000
         tick();
-        await poll(); // t=2000
+        poll(entries); // t=2000
         tick();
-        await poll(); // t=3000, fires
+        poll(entries); // t=3000, source-B fires
+        expect(onWedgeDetected).toHaveBeenCalledTimes(1);
+        expect(onWedgeDetected.calls.mostRecent().args[0]).toBe(tracks[1]);
+    });
+
+    it('resets the streak clock once the source starts receiving, even after earlier zero samples', () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+
+        // Two zero samples accumulate, but the timeout has not elapsed.
+        poll([ { packetsReceived: 0, ssrc: 111 } ]); // t=0
+        tick();
+        poll([ { packetsReceived: 0, ssrc: 111 } ]); // t=1000
+
+        // Packets begin to flow; the source is demuxing correctly. Detection keys off the cumulative count, so once any
+        // packet is seen the source stays healthy even if the count later plateaus (e.g. DTX/silence) - the earlier zero
+        // samples must not carry over and trip the watchdog.
+        tick();
+        poll([ { packetsReceived: 5, ssrc: 111 } ]); // t=2000, streak reset
+        tick();
+        poll([ { packetsReceived: 5, ssrc: 111 } ]); // t=3000
+        tick();
+        poll([ { packetsReceived: 5, ssrc: 111 } ]); // t=4000
+        tick();
+        poll([ { packetsReceived: 5, ssrc: 111 } ]); // t=5000
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+    });
+
+    it('does not re-fire for the same source during the cooldown window', () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        const entries = [ { packetsReceived: 0, ssrc: 111 } ];
+
+        poll(entries); // t=0
+        tick();
+        poll(entries); // t=1000
+        tick();
+        poll(entries); // t=2000
+        tick();
+        poll(entries); // t=3000, fires
         expect(onWedgeDetected).toHaveBeenCalledTimes(1);
 
-        // The (still-wedged) source keeps reporting zero packets, but the watchdog stays quiet for the cooldown
-        // window while the recycle renegotiation is assumed to be in flight.
+        // The (still-wedged) source keeps reporting zero packets, but the watchdog stays quiet for the cooldown window
+        // while the recycle renegotiation is assumed to be in flight.
         tick();
-        await poll(); // t=4000
+        poll(entries); // t=4000
         tick();
-        await poll(); // t=5000
+        poll(entries); // t=5000
         tick();
-        await poll(); // t=6000 (== fire time + cooldown), cooldown just elapsed; streak restarts here
+        poll(entries); // t=6000 (== fire time + cooldown), cooldown just elapsed; streak restarts here
         expect(onWedgeDetected).toHaveBeenCalledTimes(1);
     });
 
-    it('clears bookkeeping for SSRCs that are no longer mapped', async () => {
+    it('clears bookkeeping for SSRCs that are no longer mapped', () => {
         tracks = [ mockTrack(111, 'source-A') ];
-        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
 
-        await poll(); // t=0, streak starts
+        poll([ { packetsReceived: 0, ssrc: 111 } ]); // t=0, streak starts
         tick();
-        await poll(); // t=1000
+        poll([ { packetsReceived: 0, ssrc: 111 } ]); // t=1000
 
         // The source is remapped/removed before the timeout; its streak must not survive to wedge a later source that
         // reuses the SSRC.
         tick();
         tracks = [];
-        statsEntries = [];
-        await poll(); // t=2000
+        poll([]); // t=2000
 
         tracks = [ mockTrack(111, 'source-A') ];
-        statsEntries = [ { packetsReceived: 0, ssrc: 111 } ];
         tick();
-        await poll(); // t=3000, fresh streak starts here
+        poll([ { packetsReceived: 0, ssrc: 111 } ]); // t=3000, fresh streak starts here
         tick();
-        await poll(); // t=4000
+        poll([ { packetsReceived: 0, ssrc: 111 } ]); // t=4000
         expect(onWedgeDetected).not.toHaveBeenCalled();
 
         tick();
-        await poll(); // t=5000, elapsed since fresh streak (t=3000) is 2000 < timeout
+        poll([ { packetsReceived: 0, ssrc: 111 } ]); // t=5000, elapsed since fresh streak (t=3000) is 2000 < timeout
         expect(onWedgeDetected).not.toHaveBeenCalled();
 
         tick();
-        await poll(); // t=6000, elapsed since fresh streak is 3000 >= timeout
+        poll([ { packetsReceived: 0, ssrc: 111 } ]); // t=6000, elapsed since fresh streak is 3000 >= timeout
         expect(onWedgeDetected).toHaveBeenCalledTimes(1);
+    });
+
+    describe('stats event wiring', () => {
+        it('evaluates on INBOUND_AUDIO_STATS for its own peerconnection', () => {
+            tracks = [ mockTrack(111, 'source-A') ];
+            detector.start();
+
+            const entries = toMap([ { packetsReceived: 0, ssrc: 111 } ]);
+
+            pc.eventEmitter.emit(RTCEvents.INBOUND_AUDIO_STATS, pc, entries); // t=0
+            tick();
+            pc.eventEmitter.emit(RTCEvents.INBOUND_AUDIO_STATS, pc, entries); // t=1000
+            tick();
+            pc.eventEmitter.emit(RTCEvents.INBOUND_AUDIO_STATS, pc, entries); // t=2000
+            tick();
+            pc.eventEmitter.emit(RTCEvents.INBOUND_AUDIO_STATS, pc, entries); // t=3000, fires
+            expect(onWedgeDetected).toHaveBeenCalledTimes(1);
+        });
+
+        it('ignores INBOUND_AUDIO_STATS emitted for a different peerconnection', () => {
+            tracks = [ mockTrack(111, 'source-A') ];
+            detector.start();
+
+            const otherPc = {};
+            const entries = toMap([ { packetsReceived: 0, ssrc: 111 } ]);
+
+            for (let i = 0; i < 5; i++) {
+                pc.eventEmitter.emit(RTCEvents.INBOUND_AUDIO_STATS, otherPc, entries);
+                tick();
+            }
+            expect(onWedgeDetected).not.toHaveBeenCalled();
+        });
+
+        it('stops evaluating after stop()', () => {
+            tracks = [ mockTrack(111, 'source-A') ];
+            detector.start();
+            detector.stop();
+
+            const entries = toMap([ { packetsReceived: 0, ssrc: 111 } ]);
+
+            for (let i = 0; i < 5; i++) {
+                pc.eventEmitter.emit(RTCEvents.INBOUND_AUDIO_STATS, pc, entries);
+                tick();
+            }
+            expect(onWedgeDetected).not.toHaveBeenCalled();
+        });
     });
 });

--- a/modules/RTC/RemoteAudioWedgeDetector.ts
+++ b/modules/RTC/RemoteAudioWedgeDetector.ts
@@ -1,16 +1,12 @@
 import { getLogger } from '@jitsi/logger';
 
 import { MediaType } from '../../service/RTC/MediaType';
+import { RTCEvents } from '../../service/RTC/RTCEvents';
 
 import JitsiRemoteTrack from './JitsiRemoteTrack';
 import TraceablePeerConnection from './TraceablePeerConnection';
 
 const logger = getLogger('rtc:RemoteAudioWedgeDetector');
-
-/**
- * The default interval (in milliseconds) at which the inbound-rtp stats are polled.
- */
-const DEFAULT_POLL_INTERVAL_MS = 5000;
 
 /**
  * The default duration (in milliseconds) for which a mapped, unmuted remote audio source must receive zero inbound RTP
@@ -29,12 +25,12 @@ const MIN_SAMPLES = 2;
 interface IEligibleZeroState {
 
     /**
-     * The number of consecutive eligible zero-RTP polls observed in the current streak.
+     * The number of consecutive eligible zero-RTP samples observed in the current streak.
      */
     samples: number;
 
     /**
-     * The timestamp (Date.now()) of the first eligible zero-RTP poll in the current streak.
+     * The timestamp (Date.now()) of the first eligible zero-RTP sample in the current streak.
      */
     since: number;
 }
@@ -46,12 +42,6 @@ export interface IRemoteAudioWedgeDetectorOptions {
      * the source (e.g. by recycling it via source-remove/source-add).
      */
     onWedgeDetected: (track: JitsiRemoteTrack) => void;
-
-    /**
-     * The interval (in milliseconds) at which the inbound-rtp stats are polled. Defaults to
-     * {@link DEFAULT_POLL_INTERVAL_MS}.
-     */
-    pollIntervalMs?: number;
 
     /**
      * The duration (in milliseconds) for which a source must receive zero inbound RTP before it is considered wedged.
@@ -69,42 +59,39 @@ export interface IRemoteAudioWedgeDetectorOptions {
  * participant that is permanently silent while {@code getStats()} reports zero inbound RTP for the SSRC even though RTP
  * is arriving on the wire.
  *
- * This detector is purely a recovery mechanism: it does not depend on any Chrome internals. It periodically polls the
- * peerconnection's inbound-rtp stats and flags any remote audio source that is mapped (a {@link JitsiRemoteTrack}
- * exists) and unmuted (per signaling) yet has received no RTP packets at all for the detection window. The wedge is
- * recoverable from JS because recycling the source (source-remove then source-add) deletes the zombie receive stream
- * and a subsequent re-add binds cleanly.
+ * This detector is purely a recovery mechanism: it does not depend on any Chrome internals. Rather than running its own
+ * stats poll, it piggybacks on the {@link StatsCollector} that already polls the peerconnection every stats cycle: it
+ * consumes the per-SSRC inbound audio packet counts emitted as {@link RTCEvents.INBOUND_AUDIO_STATS} and flags any
+ * remote audio source that is mapped (a {@link JitsiRemoteTrack} exists) and unmuted (per signaling) yet has received
+ * no RTP packets at all for the detection window. The wedge is recoverable from JS because recycling the source
+ * (source-remove then source-add) deletes the zombie receive stream and a subsequent re-add binds cleanly.
  *
  * Detection keys off the cumulative {@code packetsReceived} being zero (i.e. "literally nothing inbound", which is the
  * confirmed signature of the wedge) rather than off a per-poll delta. A delta-based "no growth" check would produce
  * false positives for a genuinely unmuted-but-silent participant, since audio can stop emitting packets during silence
  * (DTX/comfort noise). A source that has ever received a packet is therefore considered healthy and is excluded from
- * further polling, so once every mapped source has delivered its first packet the watchdog stops calling getStats()
- * entirely until a new (not-yet-confirmed) source appears.
+ * further evaluation.
  *
  * A source must stay continuously eligible (mapped + unmuted) and at zero RTP for {@code wedgeTimeoutMs} of wall-clock
  * time before it fires. Eligibility - unlike the cumulative packet count - is not monotonic (a participant can mute and
  * unmute), so the streak is reset whenever the source becomes muted, unmapped, or receives any packet; this is what the
- * repeated polling verifies. A {@link MIN_SAMPLES} floor debounces transient stats artifacts.
+ * repeated samples verify. A {@link MIN_SAMPLES} floor debounces transient stats artifacts.
  */
 export default class RemoteAudioWedgeDetector {
     private _pc: TraceablePeerConnection;
     private _onWedgeDetected: (track: JitsiRemoteTrack) => void;
-    private _pollIntervalMs: number;
     private _wedgeTimeoutMs: number;
-    private _intervalId: Nullable<ReturnType<typeof setInterval>>;
-    private _checkInProgress: boolean;
+    private _started: boolean;
 
     /**
-     * Maps an SSRC to the state of its current streak of eligible (mapped + unmuted) zero-RTP polls.
+     * Maps an SSRC to the state of its current streak of eligible (mapped + unmuted) zero-RTP samples.
      */
     private _eligibleZeroBySsrc: Map<number, IEligibleZeroState>;
 
     /**
      * The set of SSRCs that have been observed receiving at least one RTP packet. Such a source is demuxing correctly
      * and cannot be wedged (the wedge is "never received anything", and the cumulative packet count is monotonic), so
-     * it is excluded from polling for the rest of its lifetime. This lets the watchdog stop calling getStats() entirely
-     * once every mapped source has delivered its first packet.
+     * it is excluded from evaluation for the rest of its lifetime.
      */
     private _healthyBySsrc: Set<number>;
 
@@ -124,171 +111,148 @@ export default class RemoteAudioWedgeDetector {
     constructor(pc: TraceablePeerConnection, options: IRemoteAudioWedgeDetectorOptions) {
         this._pc = pc;
         this._onWedgeDetected = options.onWedgeDetected;
-        this._pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
         this._wedgeTimeoutMs = options.wedgeTimeoutMs ?? DEFAULT_WEDGE_TIMEOUT_MS;
-        this._intervalId = null;
-        this._checkInProgress = false;
+        this._started = false;
         this._eligibleZeroBySsrc = new Map();
         this._healthyBySsrc = new Set();
         this._cooldownUntilBySource = new Map();
     }
 
     /**
-     * Polls the inbound-rtp stats once and evaluates every mapped, unmuted remote audio source for the wedge signature.
+     * Handles a batch of inbound audio packet counts from the {@link StatsCollector}'s stats poll. Ignores reports for
+     * other peerconnections (the stats event is emitted on the shared RTC event bus).
      *
-     * @returns {Promise<void>}
+     * @param {TraceablePeerConnection} pc - The peerconnection the stats belong to.
+     * @param {Map<number, number>} packetsBySsrc - Cumulative packetsReceived per inbound audio SSRC.
+     * @returns {void}
      */
-    private async _check(): Promise<void> {
-        // Guard against overlapping checks if a getStats() call takes longer than the poll interval.
-        if (this._checkInProgress) {
+    private _onInboundAudioStats = (pc: TraceablePeerConnection, packetsBySsrc: Map<number, number>): void => {
+        if (pc !== this._pc) {
             return;
         }
-        this._checkInProgress = true;
-
-        const now = Date.now();
 
         try {
-            // A source can only be wedged if it is mapped, unmuted, not in a post-recovery cooldown, and has not yet
-            // been confirmed healthy (received a packet). Collect just those candidates first so we can skip the
-            // (relatively expensive) getStats() call entirely when there is nothing that could be wedged this poll -
-            // notably the steady state where every source has already delivered its first packet.
-            const mappedSsrcs = new Set<number>();
-            const candidates: Array<{ ssrc: number; track: JitsiRemoteTrack; }> = [];
-
-            for (const track of this._pc.getRemoteTracks(undefined, MediaType.AUDIO)) {
-                const ssrc = track.getSsrc();
-
-                if (typeof ssrc !== 'number') {
-                    continue; // eslint-disable-line no-continue
-                }
-                mappedSsrcs.add(ssrc);
-
-                if (this._healthyBySsrc.has(ssrc) || track.isMuted()) {
-                    continue; // eslint-disable-line no-continue
-                }
-
-                const cooldownUntil = this._cooldownUntilBySource.get(track.getSourceName());
-
-                if (cooldownUntil !== undefined) {
-                    if (now < cooldownUntil) {
-                        continue; // eslint-disable-line no-continue
-                    }
-                    this._cooldownUntilBySource.delete(track.getSourceName());
-                }
-
-                candidates.push({
-                    ssrc,
-                    track
-                });
-            }
-
-            // Drop the confirmed-healthy mark for any SSRC that is no longer mapped (the source was removed/remapped),
-            // so a future source reusing the SSRC is re-evaluated from scratch.
-            for (const ssrc of this._healthyBySsrc) {
-                if (!mappedSsrcs.has(ssrc)) {
-                    this._healthyBySsrc.delete(ssrc);
-                }
-            }
-
-            // Drop streak bookkeeping for any SSRC that is no longer a candidate (unmapped, muted, cooling down, or now
-            // healthy). This is what resets the streak for a source that became ineligible mid-window.
-            const candidateSsrcs = new Set(candidates.map(candidate => candidate.ssrc));
-
-            for (const ssrc of this._eligibleZeroBySsrc.keys()) {
-                if (!candidateSsrcs.has(ssrc)) {
-                    this._eligibleZeroBySsrc.delete(ssrc);
-                }
-            }
-
-            if (!candidates.length) {
-                return;
-            }
-
-            const report = await this._pc.getStats();
-            const packetsBySsrc = new Map<number, number>();
-
-            report.forEach((stat: any) => {
-                if (stat.type === 'inbound-rtp' && (stat.kind === 'audio' || stat.mediaType === 'audio')) {
-                    packetsBySsrc.set(stat.ssrc, this._getNonNegativeValue(stat.packetsReceived));
-                }
-            });
-
-            for (const { ssrc, track } of candidates) {
-                // A source that has received any RTP is demuxing correctly. Mark it healthy so it is never polled
-                // again (the cumulative count is monotonic, so it cannot regress to zero) and reset any streak.
-                if ((packetsBySsrc.get(ssrc) ?? 0) > 0) {
-                    this._healthyBySsrc.add(ssrc);
-                    this._eligibleZeroBySsrc.delete(ssrc);
-
-                    continue; // eslint-disable-line no-continue
-                }
-
-                const state = this._eligibleZeroBySsrc.get(ssrc);
-
-                if (!state) {
-                    // Start of a streak: record when the source first went silent so the elapsed duration can be
-                    // measured against wall-clock time on subsequent polls.
-                    this._eligibleZeroBySsrc.set(ssrc, {
-                        samples: 1,
-                        since: now
-                    });
-
-                    continue; // eslint-disable-line no-continue
-                }
-
-                state.samples++;
-
-                if (state.samples >= MIN_SAMPLES && now - state.since >= this._wedgeTimeoutMs) {
-                    logger.warn(`Detected wedged remote audio source ${track.getSourceName()} (ssrc=${ssrc}, owner=`
-                        + `${track.getParticipantId()}): zero inbound RTP for ${now - state.since}ms `
-                        + 'while continuously mapped and unmuted. Triggering recovery.');
-                    this._eligibleZeroBySsrc.delete(ssrc);
-
-                    // Suppress further detection for this source while the recycle renegotiation completes. Until then
-                    // the source is still wedged (so it would immediately re-fire), and once recovery re-adds it (same
-                    // SSRC, fresh m-line/track) the new receiver reads zero for a moment before media flows. Keying the
-                    // cooldown off the stable source name covers the remove/re-add transition.
-                    this._cooldownUntilBySource.set(track.getSourceName(), now + this._wedgeTimeoutMs);
-                    this._onWedgeDetected(track);
-                }
-            }
+            this._evaluate(packetsBySsrc);
         } catch (error) {
-            logger.warn('Error while polling for wedged remote audio sources', error);
-        } finally {
-            this._checkInProgress = false;
+            logger.warn('Error while evaluating remote audio sources for the wedge', error);
         }
-    }
+    };
 
     /**
-     * Coerces a stats value to a non-negative number, treating undefined/invalid values as zero.
+     * Evaluates every mapped, unmuted remote audio source against the given inbound packet counts for the wedge
+     * signature.
      *
-     * @param {unknown} value - The value to coerce.
-     * @returns {number}
+     * @param {Map<number, number>} packetsBySsrc - Cumulative packetsReceived per inbound audio SSRC.
+     * @returns {void}
      */
-    private _getNonNegativeValue(value: unknown): number {
-        const numeric = Number(value);
+    private _evaluate(packetsBySsrc: Map<number, number>): void {
+        const now = Date.now();
 
-        if (!Number.isFinite(numeric) || numeric < 0) {
-            return 0;
+        // A source can only be wedged if it is mapped, unmuted, not in a post-recovery cooldown, and has not yet been
+        // confirmed healthy (received a packet).
+        const mappedSsrcs = new Set<number>();
+        const candidates: Array<{ ssrc: number; track: JitsiRemoteTrack; }> = [];
+
+        for (const track of this._pc.getRemoteTracks(undefined, MediaType.AUDIO)) {
+            const ssrc = track.getSsrc();
+
+            if (typeof ssrc !== 'number') {
+                continue; // eslint-disable-line no-continue
+            }
+            mappedSsrcs.add(ssrc);
+
+            if (this._healthyBySsrc.has(ssrc) || track.isMuted()) {
+                continue; // eslint-disable-line no-continue
+            }
+
+            const cooldownUntil = this._cooldownUntilBySource.get(track.getSourceName());
+
+            if (cooldownUntil !== undefined) {
+                if (now < cooldownUntil) {
+                    continue; // eslint-disable-line no-continue
+                }
+                this._cooldownUntilBySource.delete(track.getSourceName());
+            }
+
+            candidates.push({
+                ssrc,
+                track
+            });
         }
 
-        return numeric;
+        // Drop the confirmed-healthy mark for any SSRC that is no longer mapped (the source was removed/remapped), so a
+        // future source reusing the SSRC is re-evaluated from scratch.
+        for (const ssrc of this._healthyBySsrc) {
+            if (!mappedSsrcs.has(ssrc)) {
+                this._healthyBySsrc.delete(ssrc);
+            }
+        }
+
+        // Drop streak bookkeeping for any SSRC that is no longer a candidate (unmapped, muted, cooling down, or now
+        // healthy). This is what resets the streak for a source that became ineligible mid-window.
+        const candidateSsrcs = new Set(candidates.map(candidate => candidate.ssrc));
+
+        for (const ssrc of this._eligibleZeroBySsrc.keys()) {
+            if (!candidateSsrcs.has(ssrc)) {
+                this._eligibleZeroBySsrc.delete(ssrc);
+            }
+        }
+
+        for (const { ssrc, track } of candidates) {
+            // A source that has received any RTP is demuxing correctly. Mark it healthy so it is never evaluated again
+            // (the cumulative count is monotonic, so it cannot regress to zero) and reset any streak.
+            if ((packetsBySsrc.get(ssrc) ?? 0) > 0) {
+                this._healthyBySsrc.add(ssrc);
+                this._eligibleZeroBySsrc.delete(ssrc);
+
+                continue; // eslint-disable-line no-continue
+            }
+
+            const state = this._eligibleZeroBySsrc.get(ssrc);
+
+            if (!state) {
+                // Start of a streak: record when the source first went silent so the elapsed duration can be measured
+                // against wall-clock time on subsequent samples.
+                this._eligibleZeroBySsrc.set(ssrc, {
+                    samples: 1,
+                    since: now
+                });
+
+                continue; // eslint-disable-line no-continue
+            }
+
+            state.samples++;
+
+            if (state.samples >= MIN_SAMPLES && now - state.since >= this._wedgeTimeoutMs) {
+                logger.warn(`Detected wedged remote audio source ${track.getSourceName()} (ssrc=${ssrc}, owner=`
+                    + `${track.getParticipantId()}): zero inbound RTP for ${now - state.since}ms `
+                    + 'while continuously mapped and unmuted. Triggering recovery.');
+                this._eligibleZeroBySsrc.delete(ssrc);
+
+                // Suppress further detection for this source while the recycle renegotiation completes. Until then the
+                // source is still wedged (so it would immediately re-fire), and once recovery re-adds it (same SSRC,
+                // fresh m-line/track) the new receiver reads zero for a moment before media flows. Keying the cooldown
+                // off the stable source name covers the remove/re-add transition.
+                this._cooldownUntilBySource.set(track.getSourceName(), now + this._wedgeTimeoutMs);
+                this._onWedgeDetected(track);
+            }
+        }
     }
 
     /**
-     * Starts the watchdog. Subsequent calls are no-ops while it is already running.
+     * Starts the watchdog by subscribing to the {@link StatsCollector}'s inbound audio stats. Subsequent calls are
+     * no-ops while it is already running.
      *
      * @returns {void}
      */
     start(): void {
-        if (this._intervalId) {
+        if (this._started) {
             return;
         }
-        logger.debug(`Starting remote audio wedge detector (pollInterval=${this._pollIntervalMs}ms, `
-            + `wedgeTimeout=${this._wedgeTimeoutMs}ms)`);
-        this._intervalId = setInterval(() => {
-            this._check();
-        }, this._pollIntervalMs);
+        this._started = true;
+        logger.debug(`Starting remote audio wedge detector (wedgeTimeout=${this._wedgeTimeoutMs}ms), driven by the `
+            + 'stats collector inbound audio stats');
+        this._pc.eventEmitter.addListener(RTCEvents.INBOUND_AUDIO_STATS, this._onInboundAudioStats);
     }
 
     /**
@@ -297,9 +261,9 @@ export default class RemoteAudioWedgeDetector {
      * @returns {void}
      */
     stop(): void {
-        if (this._intervalId) {
-            clearInterval(this._intervalId);
-            this._intervalId = null;
+        if (this._started) {
+            this._pc.eventEmitter.removeListener(RTCEvents.INBOUND_AUDIO_STATS, this._onInboundAudioStats);
+            this._started = false;
         }
         this._eligibleZeroBySsrc.clear();
         this._healthyBySsrc.clear();

--- a/modules/RTC/TraceablePeerConnection.spec.ts
+++ b/modules/RTC/TraceablePeerConnection.spec.ts
@@ -1,5 +1,7 @@
 import { MediaDirection } from '../../service/RTC/MediaDirection';
 import { MediaType } from '../../service/RTC/MediaType';
+import { RTCEvents } from '../../service/RTC/RTCEvents';
+import FeatureFlags from '../flags/FeatureFlags';
 
 import TraceablePeerConnection from './TraceablePeerConnection';
 
@@ -77,6 +79,85 @@ describe('TraceablePeerConnection', () => {
             // undefined => the caller must not touch the direction; replaceTrack will set it when a track is added.
             expect(TraceablePeerConnection.getMediaTransferDirection(true, false))
                 .toBeUndefined();
+        });
+    });
+
+    describe('_removeRemoteTrack under SSRC rewriting', () => {
+        // The remote audio wedge recovery recycles a source via source-remove then source-add reusing the SAME
+        // rewritten SSRC. Remote tracks are keyed by SSRC in remoteTracksBySsrc and _createRemoteTrack drops a create
+        // whose SSRC is already present. So _removeRemoteTrack must clear that SSRC entry, otherwise the re-add is
+        // discarded as a duplicate and the participant is left with no audio track.
+        const SSRC = 12345;
+
+        /**
+         * Builds a minimal remote track stub.
+         *
+         * @param {string} participantId - The owner endpoint id.
+         * @returns {object}
+         */
+        function mockRemoteTrack(participantId = 'endpoint-1'): any {
+            return {
+                dispose: jasmine.createSpy('dispose'),
+                getParticipantId: () => participantId,
+                getSsrc: () => SSRC,
+                getStreamId: () => 'stream-1',
+                getTrackId: () => 'track-1',
+                getType: () => MediaType.AUDIO
+            };
+        }
+
+        /**
+         * Builds the minimal `this` context {@link TraceablePeerConnection._removeRemoteTrack} touches.
+         *
+         * @param {Map} remoteTracksBySsrc - The SSRC->track map.
+         * @returns {object}
+         */
+        function context(remoteTracksBySsrc: Map<number, any>): any {
+            return {
+                eventEmitter: { emit: jasmine.createSpy('emit') },
+                isP2P: false,
+                remoteTracks: new Map(),
+                remoteTracksBySsrc
+            };
+        }
+
+        const removeRemoteTrack = (TraceablePeerConnection.prototype as any)._removeRemoteTrack;
+
+        beforeEach(() => {
+            spyOn(FeatureFlags, 'isSsrcRewritingSupported').and.returnValue(true);
+        });
+
+        it('clears the SSRC entry so a re-add for the same SSRC is not deduped, and emits REMOTE_TRACK_REMOVED', () => {
+            const track = mockRemoteTrack();
+            const ctx = context(new Map([ [ SSRC, track ] ]));
+
+            removeRemoteTrack.call(ctx, track);
+
+            expect(ctx.remoteTracksBySsrc.has(SSRC)).toBe(false);
+            expect(track.dispose).toHaveBeenCalled();
+            expect(ctx.eventEmitter.emit).toHaveBeenCalledWith(RTCEvents.REMOTE_TRACK_REMOVED, track);
+        });
+
+        it('does not clear the SSRC entry when it now maps to a different (remapped) current track', () => {
+            const oldTrack = mockRemoteTrack();
+            const currentTrack = mockRemoteTrack();
+            const ctx = context(new Map([ [ SSRC, currentTrack ] ]));
+
+            removeRemoteTrack.call(ctx, oldTrack);
+
+            // The slot was remapped to currentTrack; removing the stale oldTrack must not evict currentTrack's entry.
+            expect(ctx.remoteTracksBySsrc.get(SSRC)).toBe(currentTrack);
+            expect(ctx.eventEmitter.emit).toHaveBeenCalledWith(RTCEvents.REMOTE_TRACK_REMOVED, oldTrack);
+        });
+
+        it('is a no-op for a track with no owner (does not emit or clear)', () => {
+            const track = mockRemoteTrack('' /* no participantId */);
+            const ctx = context(new Map([ [ SSRC, track ] ]));
+
+            removeRemoteTrack.call(ctx, track);
+
+            expect(ctx.remoteTracksBySsrc.has(SSRC)).toBe(true);
+            expect(ctx.eventEmitter.emit).not.toHaveBeenCalled();
         });
     });
 });

--- a/modules/RTC/TraceablePeerConnection.ts
+++ b/modules/RTC/TraceablePeerConnection.ts
@@ -1875,12 +1875,23 @@ export default class TraceablePeerConnection {
         logger.info(`${this} Removing remote track stream[id=${toBeRemoved.getStreamId()},`
             + `trackId=${toBeRemoved.getTrackId()}]`);
 
-        toBeRemoved.dispose();
         const participantId = toBeRemoved.getParticipantId();
+        const ssrc = toBeRemoved.getSsrc();
 
-        if (FeatureFlags.isSsrcRewritingSupported() && !participantId) {
-            return;
-        } else if (!FeatureFlags.isSsrcRewritingSupported()) {
+        toBeRemoved.dispose();
+
+        if (FeatureFlags.isSsrcRewritingSupported()) {
+            if (!participantId) {
+                return;
+            }
+
+            // Drop the SSRC->track entry so that a later source-add reusing the same rewritten SSRC (e.g. the wedge
+            // recovery recycling a source via source-remove then source-add) is not discarded as a duplicate by
+            // _createRemoteTrack. Guarded so a slot already remapped to a different current track is left alone.
+            if (this.remoteTracksBySsrc.get(ssrc) === toBeRemoved) {
+                this.remoteTracksBySsrc.delete(ssrc);
+            }
+        } else {
             const userTracksByMediaType = this.remoteTracks.get(participantId);
 
             if (!userTracksByMediaType) {

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -1,6 +1,7 @@
 import { getLogger } from '@jitsi/logger';
 
 import { MediaType } from '../../service/RTC/MediaType';
+import { RTCEvents } from '../../service/RTC/RTCEvents';
 import { StatisticsEvents } from '../../service/statistics/Events';
 import browser from '../browser';
 import FeatureFlags from '../flags/FeatureFlags';
@@ -546,6 +547,10 @@ export default class StatsCollector {
         const byteSentStats = {};
         const encodedTimeStatsPerSsrc = new Map();
 
+        // Cumulative packetsReceived per inbound audio SSRC, collected during the pass below and emitted once so the
+        // RemoteAudioWedgeDetector can run off this poll instead of a separate getStats() loop.
+        const inboundAudioPacketsBySsrc = new Map();
+
         this.currentStatsReport.forEach(now => {
             const before = this.previousStatsReport ? this.previousStatsReport.get(now.id) : null;
 
@@ -630,6 +635,10 @@ export default class StatsCollector {
 
                 if (!packetsNow || packetsNow < 0) {
                     packetsNow = 0;
+                }
+
+                if (now.type === 'inbound-rtp' && (now.kind === MediaType.AUDIO || now.mediaType === MediaType.AUDIO)) {
+                    inboundAudioPacketsBySsrc.set(ssrc, packetsNow);
                 }
 
                 if (before) {
@@ -777,6 +786,11 @@ export default class StatsCollector {
         if (encodedTimeStatsPerSsrc.size) {
             this.eventEmitter.emit(StatisticsEvents.ENCODE_TIME_STATS, this.peerconnection, encodedTimeStatsPerSsrc);
         }
+
+        // Emitted on the RTC event bus (not the statistics one) so RemoteAudioWedgeDetector, which is scoped to a
+        // peerconnection, can consume it directly without threading through the conference-level stats plumbing.
+        this.peerconnection.eventEmitter.emit(
+            RTCEvents.INBOUND_AUDIO_STATS, this.peerconnection, inboundAudioPacketsBySsrc);
 
         this._processAndEmitReport();
     }

--- a/service/RTC/RTCEvents.spec.ts
+++ b/service/RTC/RTCEvents.spec.ts
@@ -16,6 +16,7 @@ describe( "/service/RTC/RTCEvents members", () => {
         expect( RTCEvents.DOMINANT_SPEAKER_CHANGED ).toBe( 'rtc.dominant_speaker_changed' );
         expect( RTCEvents.PERMISSIONS_CHANGED ).toBe( 'rtc.permissions_changed' );
         expect( RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED ).toBe( 'rtc.sender_video_constraints_changed' );
+        expect( RTCEvents.INBOUND_AUDIO_STATS ).toBe( 'rtc.inbound_audio_stats' );
         expect( RTCEvents.LASTN_VALUE_CHANGED ).toBe( 'rtc.lastn_value_changed' );
         expect( RTCEvents.LOCAL_TRACK_MAX_ENABLED_RESOLUTION_CHANGED ).toBe( 'rtc.local_track_max_enabled_resolution_changed' );
         expect( RTCEvents.REMOTE_TRACK_ADDED ).toBe( 'rtc.remote_track_added' );

--- a/service/RTC/RTCEvents.ts
+++ b/service/RTC/RTCEvents.ts
@@ -66,6 +66,14 @@ export enum RTCEvents {
     FORWARDED_SOURCES_CHANGED = 'rtc.forwarded_sources_changed',
 
     /**
+     * Per-poll inbound audio stats emitted by the {@code StatsCollector} on each stats cycle. The payload is the
+     * source {@code TraceablePeerConnection} and a {@code Map<ssrc, packetsReceived>} of the cumulative received
+     * packet count for every inbound audio SSRC. Consumed by {@link RemoteAudioWedgeDetector} so it can piggyback on
+     * the existing stats poll instead of running its own {@code getStats()} loop.
+     */
+    INBOUND_AUDIO_STATS = 'rtc.inbound_audio_stats',
+
+    /**
      * Event emitted when {@link RTC.setLastN} method is called to update with the new value set.
      * The first argument is the value passed to {@link RTC.setLastN}.
      */


### PR DESCRIPTION
Two follow-ups to the merged remote-audio wedge watchdog (#3051), combined in one PR.

## 1. fix(RTC): clear the SSRC→track entry on remote track removal under SSRC rewriting

The recovery added in #3051 recycles a wedged source via source-remove then source-add, reusing the **same** rewritten SSRC. Under SSRC rewriting, remote tracks are keyed by SSRC in `remoteTracksBySsrc`, and `_createRemoteTrack` discards a create whose SSRC is already mapped (*"ignored duplicated track event for SSRC"*). That map was only ever `set` or cleared wholesale — never deleted per-track — so a source-remove left the SSRC still mapped to the disposed track, and the recovery's re-add was dropped as a duplicate: **no `REMOTE_TRACK_ADDED`, leaving the participant with zero audio tracks after a recovery — worse than the wedge it is meant to fix.**

`_removeRemoteTrack` now deletes the `remoteTracksBySsrc` entry, guarded (`=== toBeRemoved`) so a slot already remapped to a different *current* track is left alone. Normal slot remaps are unaffected — they mutate the track in place and never remove+add, which is why this never surfaced before; the recovery is the first path to do a genuine same-SSRC remove+add.

Verified live against a JVB with SSRC rewriting: invoking the recovery on a remote audio track now emits `TRACK_REMOVED` (old) then `TRACK_ADDED` (new track, same SSRC), the participant retains exactly one audio track, and it unmutes as media resumes. Adds 3 unit tests.

## 2. refactor(RTC): drive wedge detection off the stats poll

`RemoteAudioWedgeDetector` ran its own `setInterval` + `getStats()` loop, duplicating the poll `StatsCollector` already performs every stats cycle. `StatsCollector` now emits per-SSRC cumulative `packetsReceived` for inbound audio as `RTCEvents.INBOUND_AUDIO_STATS`; the detector consumes that (filtered to its own peerconnection) and runs the same eligibility/streak/timeout/cooldown state machine with no `getStats()` call or interval of its own. The detector's public surface and all of the recovery wiring/gating in `JingleSessionPC` are unchanged.

Detection latency moves from ~15s (a dedicated 5s poll) to ~20s (the 10s stats interval, with the 2-sample debounce), which is acceptable for a permanent wedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
