### PR TITLE
feat(audio-translation): bridge + component signals for translation indicators

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -320,6 +320,9 @@ export default class JitsiConference extends Listenable {
      */
     private _translationErrorHandler?: ReturnType<Strophe.Connection['addHandler']>;
 
+    // Stored so the (connection-scoped) translation-listeners handler can be removed on leave().
+    private _translationListenersHandler?: ReturnType<Strophe.Connection['addHandler']>;
+
     /**
      * Monotonic counter used to mint translation-request stanza ids for error correlation.
      */
@@ -2311,6 +2314,57 @@ export default class JitsiConference extends Listenable {
     }
 
     /**
+     * Registers (once) the handler for translation-listeners pushes from the audio-translation component.
+     * Registered on join and independent of whether the local participant ever requests a translation, since
+     * the notification is about other participants translating this participant's audio.
+     *
+     * @returns {void}
+     */
+    private _registerTranslationListenersHandler(): void {
+        const componentAddress = this.xmpp.audioTranslationComponentAddress;
+
+        if (this._translationListenersHandler || !componentAddress) {
+            return;
+        }
+        this._translationListenersHandler = this.xmpp.connection.addHandler(
+            this._onTranslationListenersChanged.bind(this), null, 'message', null, null, componentAddress);
+    }
+
+    /**
+     * Handles a translation-listeners push from the audio-translation component and emits
+     * {@link JitsiConferenceEvents.AUDIO_TRANSLATION_LISTENERS_CHANGED} with the endpoint ids currently
+     * listening to a translation of the local participant. Returns true to keep the handler registered.
+     *
+     * @param {Element} stanza - The message stanza from the component.
+     * @returns {boolean}
+     */
+    private _onTranslationListenersChanged(stanza: Element): boolean {
+        const child = findFirst(stanza, 'translation-listeners');
+
+        if (!child) {
+            return true; // Another message from the component (e.g. an error reply handled elsewhere).
+        }
+
+        let listeners: string[] = [];
+
+        try {
+            const parsed = JSON.parse(child.textContent ?? '[]');
+
+            if (Array.isArray(parsed)) {
+                listeners = parsed.filter((id): id is string => typeof id === 'string');
+            }
+        } catch (e) {
+            logger.warn('Ignoring malformed translation-listeners payload', e);
+
+            return true;
+        }
+
+        this.eventEmitter.emit(JitsiConferenceEvents.AUDIO_TRANSLATION_LISTENERS_CHANGED, listeners);
+
+        return true;
+    }
+
+    /**
      * Subscribes to the cumulative set of translated sources by including them on top of the `all` baseline,
      * named by convention {endpointId}-a0.{language} so they can be requested before the source is signaled.
      * Keeping the baseline means the original audio still flows (and can be ducked); an empty include list
@@ -2528,6 +2582,7 @@ export default class JitsiConference extends Listenable {
      */
     _onMucJoined(): void {
         this._numberOfParticipantsOnJoin = this.getParticipantCount();
+        this._registerTranslationListenersHandler();
         this._maybeStartOrStopP2P();
     }
 
@@ -2822,6 +2877,11 @@ export default class JitsiConference extends Listenable {
         if (this._translationErrorHandler) {
             this.xmpp.connection?.deleteHandler(this._translationErrorHandler);
             this._translationErrorHandler = undefined;
+        }
+
+        if (this._translationListenersHandler) {
+            this.xmpp.connection?.deleteHandler(this._translationListenersHandler);
+            this._translationListenersHandler = undefined;
         }
 
         this.eventManager.removeXMPPListeners();

--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -2347,16 +2347,22 @@ export default class JitsiConference extends Listenable {
 
         let listeners: string[] = [];
 
-        try {
-            const parsed = JSON.parse(child.textContent ?? '[]');
+        // A blank body means "no listeners" (an empty list), so only non-empty text is parsed; genuinely
+        // malformed JSON still falls into the catch below and is logged.
+        const text = (child.textContent ?? '').trim();
 
-            if (Array.isArray(parsed)) {
-                listeners = parsed.filter((id): id is string => typeof id === 'string');
+        if (text) {
+            try {
+                const parsed = JSON.parse(text);
+
+                if (Array.isArray(parsed)) {
+                    listeners = parsed.filter((id): id is string => typeof id === 'string');
+                }
+            } catch (e) {
+                logger.warn('Ignoring malformed translation-listeners payload', e);
+
+                return true;
             }
-        } catch (e) {
-            logger.warn('Ignoring malformed translation-listeners payload', e);
-
-            return true;
         }
 
         this.eventEmitter.emit(JitsiConferenceEvents.AUDIO_TRANSLATION_LISTENERS_CHANGED, listeners);

--- a/JitsiConferenceEventManager.ts
+++ b/JitsiConferenceEventManager.ts
@@ -563,6 +563,10 @@ export default class JitsiConferenceEventManager {
             conference.eventEmitter.emit(JitsiConferenceEvents.BRIDGE_BWE_STATS_RECEIVED, bwe);
         });
 
+        rtc.addListener(RTCEvents.TRANSLATED_SOURCE_SENDING_CHANGED, (change: any) => {
+            conference.eventEmitter.emit(JitsiConferenceEvents.TRANSLATED_SOURCE_SENDING_CHANGED, change);
+        });
+
         rtc.addListener(RTCEvents.ENDPOINT_MESSAGE_RECEIVED,
             (from: string, payload: any) => {
                 if (from === 'transcriber') {

--- a/JitsiConferenceEvents.spec.ts
+++ b/JitsiConferenceEvents.spec.ts
@@ -70,6 +70,8 @@ describe( "/JitsiConferenceEvents members", () => {
         expect( JitsiConferenceEvents.TRACK_REMOVED ).toBe( 'conference.trackRemoved' );
         expect( JitsiConferenceEvents.TRACK_UNMUTE_REJECTED ).toBe( 'conference.trackUnmuteRejected' );
         expect( JitsiConferenceEvents.TRANSCRIPTION_STATUS_CHANGED ).toBe( 'conference.transcriptionStatusChanged' );
+        expect( JitsiConferenceEvents.TRANSLATED_SOURCE_SENDING_CHANGED )
+            .toBe( 'conference.translatedSourceSendingChanged' );
         expect( JitsiConferenceEvents.USER_JOINED ).toBe( 'conference.userJoined' );
         expect( JitsiConferenceEvents.USER_LEFT ).toBe( 'conference.userLeft' );
         expect( JitsiConferenceEvents.USER_ROLE_CHANGED ).toBe( 'conference.roleChanged' );

--- a/JitsiConferenceEvents.spec.ts
+++ b/JitsiConferenceEvents.spec.ts
@@ -13,6 +13,8 @@ describe( "/JitsiConferenceEvents members", () => {
 
         expect( JitsiConferenceEvents.AUDIO_INPUT_STATE_CHANGE ).toBe( 'conference.audio_input_state_changed' );
         expect( JitsiConferenceEvents.AUDIO_TRANSLATION_FAILED ).toBe( 'conference.audio_translation_failed' );
+        expect( JitsiConferenceEvents.AUDIO_TRANSLATION_LISTENERS_CHANGED )
+            .toBe( 'conference.audio_translation_listeners_changed' );
         expect( JitsiConferenceEvents.AUDIO_UNMUTE_PERMISSIONS_CHANGED ).toBe( 'conference.audio_unmute_permissions_changed' );
         expect( JitsiConferenceEvents.AUTH_STATUS_CHANGED ).toBe( 'conference.auth_status_changed' );
         expect( JitsiConferenceEvents.BEFORE_STATISTICS_DISPOSED ).toBe( 'conference.beforeStatisticsDisposed' );

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -14,6 +14,13 @@ export enum JitsiConferenceEvents {
     AUDIO_TRANSLATION_FAILED = 'conference.audio_translation_failed',
 
     /**
+     * Event fired when the set of remote participants translating the local participant's audio changes. The
+     * audio-translation component pushes this per-sender (only to the participant being translated), so the
+     * payload is the array of endpoint ids currently listening to a translation of the local participant.
+     */
+    AUDIO_TRANSLATION_LISTENERS_CHANGED = 'conference.audio_translation_listeners_changed',
+
+    /**
      * Event indicates that the permission for unmuting audio has changed based on the number of audio senders in the
      * call and the audio sender limit configured in Jicofo.
      */

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -459,6 +459,13 @@ export enum JitsiConferenceEvents {
     TRANSCRIPTION_STATUS_CHANGED = 'conference.transcriptionStatusChanged',
 
     /**
+     * Indicates that a translated audio source started or stopped being forwarded to the local endpoint. The
+     * listener receives { sourceName, sending, timestamp }; timestamp is an RTP timestamp (48 kHz, wraps at
+     * 2^32) — not epoch ms.
+     */
+    TRANSLATED_SOURCE_SENDING_CHANGED = 'conference.translatedSourceSendingChanged',
+
+    /**
      * A new user joined the conference.
      */
     USER_JOINED = 'conference.userJoined',

--- a/modules/RTC/BridgeChannel.ts
+++ b/modules/RTC/BridgeChannel.ts
@@ -409,7 +409,8 @@ export default class BridgeChannel {
                 // `timestamp` is an RTP timestamp (48 kHz, wraps at 2^32), not epoch ms. Validated here
                 // like SenderSourceConstraints; malformed messages are logged and dropped.
                 if (typeof obj.sourceName === 'string' && typeof obj.sending === 'boolean'
-                        && typeof obj.timestamp === 'number') {
+                        && Number.isInteger(obj.timestamp)
+                        && obj.timestamp >= 0 && obj.timestamp <= 0xFFFFFFFF) {
                     logger.info(`SyntheticSourceSendingChangeEvent: ${obj.sourceName} `
                         + `sending=${obj.sending} ts=${obj.timestamp}`);
                     emitter.emit(RTCEvents.TRANSLATED_SOURCE_SENDING_CHANGED, {

--- a/modules/RTC/BridgeChannel.ts
+++ b/modules/RTC/BridgeChannel.ts
@@ -405,6 +405,23 @@ export default class BridgeChannel {
                 logger.info(`Received ServerHello, version=${obj.version}.`);
                 break;
             }
+            case 'SyntheticSourceSendingChangeEvent': {
+                // `timestamp` is an RTP timestamp (48 kHz, wraps at 2^32), not epoch ms. Validated here
+                // like SenderSourceConstraints; malformed messages are logged and dropped.
+                if (typeof obj.sourceName === 'string' && typeof obj.sending === 'boolean'
+                        && typeof obj.timestamp === 'number') {
+                    logger.info(`SyntheticSourceSendingChangeEvent: ${obj.sourceName} `
+                        + `sending=${obj.sending} ts=${obj.timestamp}`);
+                    emitter.emit(RTCEvents.TRANSLATED_SOURCE_SENDING_CHANGED, {
+                        sending: obj.sending,
+                        sourceName: obj.sourceName,
+                        timestamp: obj.timestamp
+                    });
+                } else {
+                    logger.error(`Invalid SyntheticSourceSendingChangeEvent: ${JSON.stringify(obj)}`);
+                }
+                break;
+            }
             case 'VideoSourcesMap': {
                 logger.info(`Received VideoSourcesMap: ${JSON.stringify(obj.mappedSources)}`);
                 emitter.emit(RTCEvents.VIDEO_SSRCS_REMAPPED, obj);

--- a/service/RTC/RTCEvents.spec.ts
+++ b/service/RTC/RTCEvents.spec.ts
@@ -16,6 +16,7 @@ describe( "/service/RTC/RTCEvents members", () => {
         expect( RTCEvents.DOMINANT_SPEAKER_CHANGED ).toBe( 'rtc.dominant_speaker_changed' );
         expect( RTCEvents.PERMISSIONS_CHANGED ).toBe( 'rtc.permissions_changed' );
         expect( RTCEvents.SENDER_VIDEO_CONSTRAINTS_CHANGED ).toBe( 'rtc.sender_video_constraints_changed' );
+        expect( RTCEvents.TRANSLATED_SOURCE_SENDING_CHANGED ).toBe( 'rtc.translated_source_sending_changed' );
         expect( RTCEvents.INBOUND_AUDIO_STATS ).toBe( 'rtc.inbound_audio_stats' );
         expect( RTCEvents.LASTN_VALUE_CHANGED ).toBe( 'rtc.lastn_value_changed' );
         expect( RTCEvents.LOCAL_TRACK_MAX_ENABLED_RESOLUTION_CHANGED ).toBe( 'rtc.local_track_max_enabled_resolution_changed' );

--- a/service/RTC/RTCEvents.ts
+++ b/service/RTC/RTCEvents.ts
@@ -133,6 +133,13 @@ export enum RTCEvents {
     SENDER_VIDEO_CONSTRAINTS_CHANGED = 'rtc.sender_video_constraints_changed',
 
     /**
+     * Indicates that a translated audio source started or stopped being sent (forwarded) to this endpoint by
+     * the bridge. The payload is { sourceName, sending, timestamp }; timestamp is an RTP timestamp (48 kHz,
+     * arbitrary origin, wraps at 2^32) — not epoch milliseconds.
+     */
+    TRANSLATED_SOURCE_SENDING_CHANGED = 'rtc.translated_source_sending_changed',
+
+    /**
      * Designates an event indicating that some video SSRCs that have already been signaled will now map to new remote
      * sources.
      */


### PR DESCRIPTION
## Summary

Adds the two signals the jitsi-meet "audio translation active" indicators consume. Paired with the same-named branch `feat/audio-translation-indicators` in **jitsi-meet** — the torture tests build them together.

- **Receiving** — a new bridge-channel message `SyntheticSourceSendingChangeEvent { sourceName, sending, timestamp }` is validated in `BridgeChannel` and re-emitted as `RTCEvents.TRANSLATED_SOURCE_SENDING_CHANGED` → `JitsiConferenceEvents.TRANSLATED_SOURCE_SENDING_CHANGED`. It tells a receiver which translated sources are actively being forwarded to it. `sourceName` follows the translated-source convention (`<regularSourceName>.<language>`); `timestamp` is an RTP timestamp (48 kHz, wraps at 2^32), not epoch ms.
- **Enabled** — the audio-translation component pushes each translated sender a directed `<translation-listeners>` message; a per-conference handler (registered on join, removed on leave) emits `JitsiConferenceEvents.AUDIO_TRANSLATION_LISTENERS_CHANGED` with the endpoint ids currently translating the local participant.

## Testing
- `tsc --noEmit` and eslint clean.
- 534 unit tests pass (event specs updated for both new conference events).
