### PR TITLE
Forward trace data from jingle offer

### DIFF
--- a/modules/util/OTel.ts
+++ b/modules/util/OTel.ts
@@ -24,7 +24,13 @@ export class TraceParentExtension {
         }
 
         const traceId = getAttribute(traceParentExtension, TRACE_ID_ATTR_NAME);
+        if (traceId == null) {
+            return null;
+        }
         const parentId = getAttribute(traceParentExtension, PARENT_ID_ATTR_NAME);
+        if (parentId == null) {
+            return null;
+        }
 
         return new TraceParentExtension(traceId, parentId);
     }

--- a/modules/util/OTel.ts
+++ b/modules/util/OTel.ts
@@ -17,7 +17,7 @@ export class TraceParentExtension {
     }
 
     static fromElement(element: Element) {
-        const traceParentExtension = findFirst(element, `:scope ${ELEMENT}[*|xmlns="${NAMESPACE}"]`);
+        const traceParentExtension = findFirst(element, `:scope>${ELEMENT}[*|xmlns="${NAMESPACE}"]`);
 
         if (traceParentExtension == null) {
             return null;

--- a/modules/util/OTel.ts
+++ b/modules/util/OTel.ts
@@ -1,19 +1,22 @@
 import { findFirst, getAttribute } from './XMLUtils';
 
 const ELEMENT = 'traceparent';
-const NAMESPACE = 'opentelemetry';
+const NAMESPACE = 'jitsi:opentelemetry';
 const TRACE_ID_ATTR_NAME = 'trace_id';
 const PARENT_ID_ATTR_NAME = 'parent_id';
+const TRACE_FLAGS_ATTR_NAME = 'trace_flags';
 
 export class TraceParentExtension {
     traceId: string;
     parentId: string;
+    traceFlags: string;
 
     readonly ELEMENT = ELEMENT;
 
-    constructor(traceId: string, parentId: string) {
+    constructor(traceId: string, parentId: string, traceFlags: string) {
         this.traceId = traceId;
         this.parentId = parentId;
+        this.traceFlags = traceFlags;
     }
 
     static fromElement(element: Element) {
@@ -31,8 +34,12 @@ export class TraceParentExtension {
         if (parentId == null) {
             return null;
         }
+        const traceFlags = getAttribute(traceParentExtension, TRACE_FLAGS_ATTR_NAME);
+        if (traceFlags == null) {
+            return null;
+        }
 
-        return new TraceParentExtension(traceId, parentId);
+        return new TraceParentExtension(traceId, parentId, traceFlags);
     }
 
     asAttributes() {
@@ -42,6 +49,7 @@ export class TraceParentExtension {
 
         attrs[TRACE_ID_ATTR_NAME] = this.traceId;
         attrs[PARENT_ID_ATTR_NAME] = this.parentId;
+        attrs[TRACE_FLAGS_ATTR_NAME] = this.traceFlags;
 
         return attrs;
     }

--- a/modules/util/OTel.ts
+++ b/modules/util/OTel.ts
@@ -1,0 +1,42 @@
+import { findFirst, getAttribute } from './XMLUtils';
+
+const ELEMENT = 'traceparent';
+const NAMESPACE = 'opentelemetry';
+const TRACE_ID_ATTR_NAME = 'trace_id';
+const PARENT_ID_ATTR_NAME = 'parent_id';
+
+export class TraceParentExtension {
+    traceId: string;
+    parentId: string;
+
+    readonly ELEMENT = ELEMENT;
+
+    constructor(traceId: string, parentId: string) {
+        this.traceId = traceId;
+        this.parentId = parentId;
+    }
+
+    static fromElement(element: Element) {
+        const traceParentExtension = findFirst(element, `:scope ${ELEMENT}[*|xmlns="${NAMESPACE}"]`);
+
+        if (traceParentExtension == null) {
+            return null;
+        }
+
+        const traceId = getAttribute(traceParentExtension, TRACE_ID_ATTR_NAME);
+        const parentId = getAttribute(traceParentExtension, PARENT_ID_ATTR_NAME);
+
+        return new TraceParentExtension(traceId, parentId);
+    }
+
+    asAttributes() {
+        const attrs = {
+            xmlns: NAMESPACE,
+        };
+
+        attrs[TRACE_ID_ATTR_NAME] = this.traceId;
+        attrs[PARENT_ID_ATTR_NAME] = this.parentId;
+
+        return attrs;
+    }
+}

--- a/modules/util/OTel.ts
+++ b/modules/util/OTel.ts
@@ -27,14 +27,19 @@ export class TraceParentExtension {
         }
 
         const traceId = getAttribute(traceParentExtension, TRACE_ID_ATTR_NAME);
+
         if (traceId == null) {
             return null;
         }
+
         const parentId = getAttribute(traceParentExtension, PARENT_ID_ATTR_NAME);
+
         if (parentId == null) {
             return null;
         }
+
         const traceFlags = getAttribute(traceParentExtension, TRACE_FLAGS_ATTR_NAME);
+
         if (traceFlags == null) {
             return null;
         }

--- a/modules/xmpp/JingleSessionPC.ts
+++ b/modules/xmpp/JingleSessionPC.ts
@@ -24,6 +24,7 @@ import { SDPDiffer } from '../sdp/SDPDiffer';
 import SDPUtil from '../sdp/SDPUtil';
 import Statistics from '../statistics/statistics';
 import AsyncQueue, { ClearedQueueError } from '../util/AsyncQueue';
+import { TraceParentExtension } from '../util/OTel';
 import { exists, findAll, findFirst, getAttribute } from '../util/XMLUtils';
 
 import JingleSession from './JingleSession';
@@ -1041,7 +1042,7 @@ export default class JingleSessionPC extends JingleSession {
      * @param {function(error)} failure called when we receive an error response or when the request has timed out.
      * @returns {void}
      */
-    private _sendSessionAccept(success: () => void, failure: (error: IJingleError) => void) {
+    private _sendSessionAccept(success: () => void, failure: (error: IJingleError) => void, trace: TraceParentExtension) {
         // NOTE: since we're just reading from it, we don't need to be within
         //  the modification queue to access the local description
         const localSDP = new SDP(this.peerconnection.localDescription.sdp, this.isP2P);
@@ -1067,6 +1068,9 @@ export default class JingleSessionPC extends JingleSession {
         if (typeof this.options.channelLastN === 'number' && this.options.channelLastN >= 0) {
             // @ts-ignore will be fixed after merge of sdp
             localSDP.initialLastN = this.options.channelLastN;
+        }
+        if (trace != null) {
+            accept.c(trace.ELEMENT, trace.asAttributes()).up();
         }
         localSDP.toJingle(
             accept,
@@ -1460,6 +1464,8 @@ export default class JingleSessionPC extends JingleSession {
             success: () => void,
             failure: (error: any) => void,
             localTracks: JitsiLocalTrack[] = []): void {
+        const trace = TraceParentExtension.fromElement(jingleOffer);
+
         this.setOfferAnswerCycle(
             jingleOffer,
             () => {
@@ -1487,7 +1493,7 @@ export default class JingleSessionPC extends JingleSession {
                 error => {
                     failure(error);
                     this.room.eventEmitter.emit(XMPPEvents.SESSION_ACCEPT_ERROR, this, error);
-                });
+                }, trace);
             },
             failure,
             localTracks);

--- a/modules/xmpp/JingleSessionPC.ts
+++ b/modules/xmpp/JingleSessionPC.ts
@@ -1042,7 +1042,7 @@ export default class JingleSessionPC extends JingleSession {
      * @param {function(error)} failure called when we receive an error response or when the request has timed out.
      * @returns {void}
      */
-    private _sendSessionAccept(success: () => void, failure: (error: IJingleError) => void, trace: TraceParentExtension) {
+    private _sendSessionAccept(success: () => void, failure: (error: IJingleError) => void, trace?: TraceParentExtension) {
         // NOTE: since we're just reading from it, we don't need to be within
         //  the modification queue to access the local description
         const localSDP = new SDP(this.peerconnection.localDescription.sdp, this.isP2P);


### PR DESCRIPTION
The PR https://github.com/JulianGCalderon/jitsi-jicofo/pull/1 propagates trace context through a custom extension in the Jingle session-initiate message. This PR takes the trace context, and propagates through the jingle-accept message.

Related to the tracing backend GSoC project: https://summerofcode.withgoogle.com/programs/2026/projects/GseggmSv