### PR TITLE
fix(RTC): Gate the Firefox audio-active workaround on a browser capability

### DIFF
--- a/modules/RTC/TraceablePeerConnection.spec.ts
+++ b/modules/RTC/TraceablePeerConnection.spec.ts
@@ -1,6 +1,7 @@
 import { MediaDirection } from '../../service/RTC/MediaDirection';
 import { MediaType } from '../../service/RTC/MediaType';
 import { RTCEvents } from '../../service/RTC/RTCEvents';
+import browser from '../browser';
 import FeatureFlags from '../flags/FeatureFlags';
 
 import TraceablePeerConnection from './TraceablePeerConnection';
@@ -13,47 +14,67 @@ describe('TraceablePeerConnection', () => {
     // transmitting over the suspended JVB connection, and the remote peer would receive the source twice - once
     // over P2P and once over JVB.
     describe('getTransceiverDirection', () => {
-        // Arguments: (hasTrack, isFirefox, mediaType, mediaTransferActive). The fix is audio-only: a Firefox AUDIO
-        // sender is set inactive while audio transfer is suspended (FF ignores encoding.active for audio). Video
-        // is never set inactive here - it keeps using encoding.active so simulcast/screenshare and the P2P video
-        // path are untouched.
-        it('suspends a Firefox audio sender whose audio transfer is inactive (the duplicate-audio bug)', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(true, true, MediaType.AUDIO, false))
+        // Arguments: (hasTrack, mediaType, mediaTransferActive). The two browser conditions are looked up inside
+        // the helper via the browser singleton; each test stubs the specific combination it exercises.
+        /**
+         * Stubs the two browser checks the helper reads.
+         *
+         * @param {boolean} isFirefox - value returned from browser.isFirefox().
+         * @param {boolean} audioActiveSupported - value returned from supportsRTCRtpEncodingParametersActiveForAudio.
+         * @returns {void}
+         */
+        function stubBrowser(isFirefox: boolean, audioActiveSupported: boolean): void {
+            spyOn(browser, 'isFirefox').and.returnValue(isFirefox);
+            spyOn(browser, 'supportsRTCRtpEncodingParametersActiveForAudio').and.returnValue(audioActiveSupported);
+        }
+
+        it('suspends an audio sender that needs the audio-active workaround while audio transfer is inactive', () => {
+            stubBrowser(true /* isFirefox */, false /* audioActiveSupported */);
+            expect(TraceablePeerConnection.getTransceiverDirection(true, MediaType.AUDIO, false))
                 .toBe(MediaDirection.INACTIVE);
         });
 
-        it('sends from a Firefox audio sender when audio transfer is active', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(true, true, MediaType.AUDIO, true))
+        it('sends from an audio sender when audio transfer is active', () => {
+            stubBrowser(true, false);
+            expect(TraceablePeerConnection.getTransceiverDirection(true, MediaType.AUDIO, true))
                 .toBe(MediaDirection.SENDRECV);
         });
 
-        it('does NOT suspend a Firefox VIDEO sender even when video transfer is inactive '
-            + '(video is left on encoding.active; avoids breaking P2P video/screenshare)', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(true, true, MediaType.VIDEO, false))
+        it('does not suspend a video sender even when video transfer is inactive', () => {
+            stubBrowser(true, false);
+            expect(TraceablePeerConnection.getTransceiverDirection(true, MediaType.VIDEO, false))
                 .toBe(MediaDirection.SENDRECV);
         });
 
-        it('keeps a non-Firefox audio sender at sendrecv even when audio transfer is inactive '
-            + '(it relies on encoding.active to stop media)', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(true, false, MediaType.AUDIO, false))
+        it('keeps an audio sender at sendrecv when the audio-active workaround is not needed', () => {
+            stubBrowser(false /* isFirefox */, true /* audioActiveSupported */);
+            expect(TraceablePeerConnection.getTransceiverDirection(true, MediaType.AUDIO, false))
+                .toBe(MediaDirection.SENDRECV);
+        });
+
+        it('keeps a Firefox audio sender at sendrecv when the audio-active workaround is not needed', () => {
+            stubBrowser(true /* isFirefox */, true /* audioActiveSupported (Firefox 154+) */);
+            expect(TraceablePeerConnection.getTransceiverDirection(true, MediaType.AUDIO, false))
                 .toBe(MediaDirection.SENDRECV);
         });
 
         it('sends from a non-Firefox sender when media transfer is active', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(true, false, MediaType.AUDIO, true))
+            stubBrowser(false, true);
+            expect(TraceablePeerConnection.getTransceiverDirection(true, MediaType.AUDIO, true))
                 .toBe(MediaDirection.SENDRECV);
         });
 
-        it('keeps the direction at sendrecv for Firefox when a track is removed '
-            + '(preserves the ssrcs for FF, regardless of media type or transfer state)', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(false, true, MediaType.AUDIO, false))
+        it('keeps the direction at sendrecv for Firefox when a track is removed', () => {
+            stubBrowser(true /* isFirefox */, true /* audioActiveSupported */);
+            expect(TraceablePeerConnection.getTransceiverDirection(false, MediaType.AUDIO, false))
                 .toBe(MediaDirection.SENDRECV);
-            expect(TraceablePeerConnection.getTransceiverDirection(false, true, MediaType.VIDEO, false))
+            expect(TraceablePeerConnection.getTransceiverDirection(false, MediaType.VIDEO, false))
                 .toBe(MediaDirection.SENDRECV);
         });
 
         it('sets the direction to recvonly for non-Firefox when a track is removed', () => {
-            expect(TraceablePeerConnection.getTransceiverDirection(false, false, MediaType.VIDEO, true))
+            stubBrowser(false /* isFirefox */, true /* audioActiveSupported */);
+            expect(TraceablePeerConnection.getTransceiverDirection(false, MediaType.VIDEO, true))
                 .toBe(MediaDirection.RECVONLY);
         });
     });

--- a/modules/RTC/TraceablePeerConnection.ts
+++ b/modules/RTC/TraceablePeerConnection.ts
@@ -654,31 +654,37 @@ export default class TraceablePeerConnection {
      * Returns the transceiver direction to apply to a sender when a local track is added to or removed from this
      * peerconnection via {@link replaceTrack}.
      *
-     * On Firefox setting encoding.active=false does not stop the outgoing audio (unlike Chromium/WebKit), so an
-     * audio sender is suspended via the transceiver direction while audio transfer is inactive on this
-     * peerconnection (the JVB connection while the call is routed over P2P). Otherwise an audio track added on
-     * unmute would be sent over the suspended JVB connection and the remote peer would receive it twice (once over
-     * JVB, once over P2P). Only audio is handled this way: video keeps using encoding.active so that simulcast /
-     * screenshare SDP and the P2P video path are left untouched.
+     * Two orthogonal Firefox workarounds share this helper:
+     *
+     * - On track addition: Firefox <= 153 does not honor <tt>encoding.active = false</tt> for audio senders
+     *   (https://bugzilla.mozilla.org/show_bug.cgi?id=1813848), so an audio sender is suspended via the transceiver
+     *   direction while audio transfer is inactive on this peerconnection (the JVB connection while the call is
+     *   routed over P2P). Otherwise an audio track added on unmute would be sent over the suspended JVB connection
+     *   and the remote peer would receive it twice (once over JVB, once over P2P). Only audio is handled this way:
+     *   video keeps using <tt>encoding.active</tt> so that simulcast / screenshare SDP and the P2P video path are
+     *   left untouched.
+     * - On track removal: Firefox does not rebuild the m-line if the direction goes to <tt>recvonly</tt>, so the
+     *   ssrcs from the removed track need to be preserved by keeping direction at <tt>sendrecv</tt>
+     *   (https://bugzilla.mozilla.org/show_bug.cgi?id=1768729). This still applies to all Firefox versions.
      *
      * @param {boolean} hasTrack - whether a local track is attached to the sender after the operation.
-     * @param {boolean} isFirefox - whether the client is Firefox.
      * @param {MediaType} mediaType - the media type of the local track.
      * @param {boolean} mediaTransferActive - whether media transfer is active for the track's media type.
      * @returns {MediaDirection}
      */
     static getTransceiverDirection(
             hasTrack: boolean,
-            isFirefox: boolean,
             mediaType: Optional<MediaType>,
             mediaTransferActive: boolean): MediaDirection {
         if (hasTrack) {
-            return isFirefox && mediaType === MediaType.AUDIO && !mediaTransferActive
+            return !browser.supportsRTCRtpEncodingParametersActiveForAudio()
+                    && mediaType === MediaType.AUDIO
+                    && !mediaTransferActive
                 ? MediaDirection.INACTIVE
                 : MediaDirection.SENDRECV;
         }
 
-        return isFirefox ? MediaDirection.SENDRECV : MediaDirection.RECVONLY;
+        return browser.isFirefox() ? MediaDirection.SENDRECV : MediaDirection.RECVONLY;
     }
 
     /**
@@ -809,10 +815,12 @@ export default class TraceablePeerConnection {
 
         await sender.setParameters(parameters);
 
-        // Firefox does not stop sending audio when only encoding.active is set to false, so an audio sender is
-        // suspended/resumed via the transceiver direction as well (see getMediaTransferDirection). Audio only -
-        // video keeps using encoding.active to avoid perturbing simulcast/screenshare SDP and the P2P video path.
-        if (browser.isFirefox() && sender.track?.kind === MediaType.AUDIO) {
+        // Firefox <= 153 does not stop sending audio when only encoding.active is set to false
+        // (https://bugzilla.mozilla.org/show_bug.cgi?id=1813848), so an audio sender is suspended/resumed via the
+        // transceiver direction as well (see getMediaTransferDirection). Gated on the browser capability so the
+        // workaround drops out once Firefox 154+ ships the fix. Audio only - video keeps using encoding.active to
+        // avoid perturbing simulcast/screenshare SDP and the P2P video path.
+        if (!browser.supportsRTCRtpEncodingParametersActiveForAudio() && sender.track?.kind === MediaType.AUDIO) {
             const transceiver = this.peerconnection.getTransceivers().find(t => t.sender === sender);
             const direction = TraceablePeerConnection.getMediaTransferDirection(enable, Boolean(sender.track));
 
@@ -2532,7 +2540,7 @@ export default class TraceablePeerConnection {
                     : this.audioTransferActive;
 
                 transceiver.direction = TraceablePeerConnection.getTransceiverDirection(
-                    Boolean(newTrack), browser.isFirefox(), mediaType, mediaTransferActive);
+                    Boolean(newTrack), mediaType, mediaTransferActive);
 
                 // Configure simulcast encodings on Firefox when a track is added to the
                 // peerconnection for the first time.

--- a/modules/browser/BrowserCapabilities.ts
+++ b/modules/browser/BrowserCapabilities.ts
@@ -47,6 +47,20 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
+     * Checks whether the browser honors <tt>RTCRtpEncodingParameters.active = false</tt> for audio senders. Firefox
+     * versions <= 153 ignore this flag and keep transmitting audio even when the encoding is deactivated, which is
+     * why the transceiver-direction workaround exists in {@link TraceablePeerConnection.getTransceiverDirection} and
+     * {@link TraceablePeerConnection.getMediaTransferDirection}. The fix is tracked in
+     * https://bugzilla.mozilla.org/show_bug.cgi?id=1813848 and ships in Firefox 154.
+     *
+     * @returns {boolean} <tt>true</tt> when the browser honors the flag (all non-Firefox browsers, and Firefox
+     * 154+), <tt>false</tt> when the workaround is required.
+     */
+    supportsRTCRtpEncodingParametersActiveForAudio(): boolean {
+        return !(this.isFirefox() && this.isVersionLessThan(154));
+    }
+
+    /**
      * Tells whether or not the <tt>MediaStream/tt> is removed from the <tt>PeerConnection</tt> and disposed on video
      * mute (in order to turn off the camera device). This is needed on Firefox because of the following bug
      * https://bugzilla.mozilla.org/show_bug.cgi?id=1735951


### PR DESCRIPTION
## Description

Gates the Firefox audio-active workaround added in #3060 on a browser-capability check so it retires automatically once Firefox 154 ships the fix for the underlying bug.

The bug — https://bugzilla.mozilla.org/show_bug.cgi?id=1813848 — is Firefox <= 153 not honoring `RTCRtpEncodingParameters.active = false` for audio senders. Fixed in Firefox 154.

Changes:

- **New `BrowserCapabilities.browserSupportsRTCRtpParametersActiveForAudio()`** returning `true` for every browser that honors the flag (all non-Firefox, plus Firefox 154+), `false` for Firefox <= 153.
- **`TraceablePeerConnection._enableSenderEncodings`**: replaces `browser.isFirefox()` with `!browser.browserSupportsRTCRtpParametersActiveForAudio()` when deciding whether to also toggle the transceiver direction.
- **`TraceablePeerConnection.getTransceiverDirection`**: gains a `needsAudioActiveWorkaround` parameter (positioned after `isFirefox`) to gate the addition-side suspend-via-direction behaviour independently of the ssrc-preservation-on-removal workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1768729 (which still applies to all Firefox versions and remains gated on `isFirefox`). An explicit `isFirefox && needsAudioActiveWorkaround` guard in the addition branch enforces the invariant that the audio-active workaround only ever runs on Firefox.
- **`replaceTrack` call site**: now passes both `browser.isFirefox()` (for the ssrc-preservation gate) and `!browser.browserSupportsRTCRtpParametersActiveForAudio()` (for the audio-active gate).

Once Firefox 154 is broadly deployed on the client side, the workaround drops out automatically without any further code changes.

## Testing

- `npm test` passes (535/535).
- `TraceablePeerConnection.spec.ts` updated to the new 5-arg signature. Only valid parameter combinations are exercised (i.e., never `isFirefox=false` with `needsAudioActiveWorkaround=true`, which is impossible in production).
- Added a spec asserting that a Firefox client with the fix (`isFirefox=true, needsAudioActiveWorkaround=false`) does not suspend the audio sender via the transceiver direction.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
