### PR TITLE
fix: correct 'Unkown' to 'Unknown' typo in ELECTRON_DESKTOP_PICKER_ERROR message

### DIFF
--- a/JitsiTrackError.ts
+++ b/JitsiTrackError.ts
@@ -29,7 +29,7 @@ const TRACK_ERROR_TO_MESSAGE_MAP: { [key: string]: string; } = {
     [JitsiTrackErrors.SCREENSHARING_USER_CANCELED]: 'User canceled screen sharing prompt',
     [JitsiTrackErrors.SCREENSHARING_GENERIC_ERROR]: 'Unknown error from screensharing',
     [JitsiTrackErrors.SCREENSHARING_NOT_SUPPORTED_ERROR]: 'Not supported',
-    [JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_ERROR]: 'Unkown error from desktop picker',
+    [JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_ERROR]: 'Unknown error from desktop picker',
     [JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_NOT_FOUND]: 'Failed to detect desktop picker',
     [JitsiTrackErrors.GENERAL]: 'Generic getUserMedia error',
     [JitsiTrackErrors.PERMISSION_DENIED]: 'User denied permission to use device(s): ',


### PR DESCRIPTION
## Summary
Corrects a typo in the user-facing error message shown when the desktop picker encounters an error.

## Change
`JitsiTrackError.ts` line 32:
- Before: `'Unkown error from desktop picker'`
- After: `'Unknown error from desktop picker'`

## Testing
This is a minimal string correction with no logic change. The error message is displayed via the existing error handling flow.

## Checklist
- [x] Code compiles without errors
- [x] One-line change, surgical fix