### PR TITLE
fix(RTCStats): buffer stats entries emitted before the trace connects

### DIFF
--- a/modules/RTCStats/RTCStats.ts
+++ b/modules/RTCStats/RTCStats.ts
@@ -15,6 +15,19 @@ import { ITraceOptions } from './interfaces';
 const logger = getLogger('analytics:RTCStats');
 
 /**
+ * Cap on stats entries buffered while the trace module is not connected. Bounds memory when a client
+ * never connects the trace (e.g. rtcstats disabled); pre-connect entries are rare so this is ample.
+ */
+const MAX_PENDING_STATS_ENTRIES = 100;
+
+/** A stats entry buffered while the trace was disconnected, replayed once it connects. */
+interface IPendingStatsEntry {
+    data?: Optional<any>;
+    pcId?: Optional<string>;
+    statsType: RTCStatsEvents;
+}
+
+/**
  * RTCStats Singleton that is initialized only once for the lifetime of the app, subsequent calls to init will be
  * ignored. Config and conference changes are handled by the start method.
  * RTCStats "proxies" WebRTC functions such as GUM and RTCPeerConnection by rewriting the global objects.
@@ -24,6 +37,7 @@ const logger = getLogger('analytics:RTCStats');
 class RTCStats {
     private _defaultLogCollector: any = null;
     private _initialized: boolean = false;
+    private _pendingStatsEntries: IPendingStatsEntry[] = [];
     private _startedWithNewConnection: boolean = true;
     private _trace: any = null;
     public events: EventEmitter = new EventEmitter();
@@ -225,6 +239,28 @@ class RTCStats {
         this.reset();
         this._trace = traceInit(traceOptionsComplete);
         this._trace.connect(isBreakoutRoom);
+
+        // Replay entries buffered while the trace was down so pre-join events aren't dropped.
+        this._flushPendingStatsEntries();
+    }
+
+    /**
+     * Replays the stats entries that sendStatsEntry buffered while the trace was not connected, in the
+     * order they occurred. Called right after the trace connects.
+     *
+     * @returns {void}
+     */
+    _flushPendingStatsEntries(): void {
+        if (!this._trace || this._pendingStatsEntries.length === 0) {
+            return;
+        }
+
+        const pending = this._pendingStatsEntries;
+
+        this._pendingStatsEntries = [];
+        for (const entry of pending) {
+            this._trace.statsEntry(entry.statsType, entry.pcId, entry.data);
+        }
     }
 
     /**
@@ -261,7 +297,18 @@ class RTCStats {
      * @returns {void}
      */
     sendStatsEntry(statsType: RTCStatsEvents, pcId?: Optional<string>, data?: Optional<any>): void {
-        this._trace?.statsEntry(statsType, pcId, data);
+        if (this._trace) {
+            this._trace.statsEntry(statsType, pcId, data);
+
+            return;
+        }
+
+        // Not connected yet (e.g. a pre-join getUserMedia failure): buffer and replay on connect rather
+        // than drop, mirroring how logs are retained via the log collector. Cap so a client that never
+        // connects can't grow this unbounded, keeping the earliest entries which carry the root cause.
+        if (this._pendingStatsEntries.length < MAX_PENDING_STATS_ENTRIES) {
+            this._pendingStatsEntries.push({ data, pcId, statsType });
+        }
     }
 
     /**

--- a/modules/RTCStats/RTCStats.ts
+++ b/modules/RTCStats/RTCStats.ts
@@ -22,9 +22,9 @@ const MAX_PENDING_STATS_ENTRIES = 100;
 
 /** A stats entry buffered while the trace was disconnected, replayed once it connects. */
 interface IPendingStatsEntry {
-    data?: Optional<any>;
-    pcId?: Optional<string>;
     statsType: RTCStatsEvents;
+    pcId: Optional<string>;
+    data: Optional<any>;
 }
 
 /**

--- a/modules/RTCStats/RTCStats.ts
+++ b/modules/RTCStats/RTCStats.ts
@@ -22,9 +22,9 @@ const MAX_PENDING_STATS_ENTRIES = 100;
 
 /** A stats entry buffered while the trace was disconnected, replayed once it connects. */
 interface IPendingStatsEntry {
-    statsType: RTCStatsEvents;
-    pcId: Optional<string>;
     data: Optional<any>;
+    pcId: Optional<string>;
+    statsType: RTCStatsEvents;
 }
 
 /**


### PR DESCRIPTION
### Problem
`RTCStats.sendStatsEntry` sends via `this._trace?.statsEntry(...)`. When an entry is emitted before the trace module is connected — most notably a `getUserMediaError` from a getUserMedia failure at pre-join — `_trace` is `null` and the optional chain drops it with no buffer. Console logs survive the same window because the log collector is buffered and flushed on connect, so the failure is visible in logs but the structured event is lost.

### Fix
Buffer stats entries emitted while `_trace` is `null` and replay them, in order, right after the trace connects (`_connectTrace`). The buffer is bounded (`MAX_PENDING_STATS_ENTRIES = 100`, keeping the earliest entries) so a client that never connects can't grow it unbounded. Entries emitted while connected are unaffected.

### Testing
`npm run lint` and `npm run type-check` pass clean.
