### PR TITLE
fix(xmpp): strip XML-invalid characters from chat messages

### DIFF
--- a/modules/util/XMLUtils.spec.ts
+++ b/modules/util/XMLUtils.spec.ts
@@ -1,0 +1,37 @@
+import { stripXMLInvalidChars } from './XMLUtils';
+
+describe('stripXMLInvalidChars', () => {
+    it('strips the XML-invalid C0 control characters', () => {
+        // U+0000 - U+0008, U+000B, U+000C, U+000E - U+001F
+        expect(stripXMLInvalidChars('\u0000\u0001\u0002\u0007\u0008\u000B\u000C\u000E\u001F')).toBe('');
+        expect(stripXMLInvalidChars('a\u0000b\u000Bc\u000Cd\u001Fe')).toBe('abcde');
+    });
+
+    it('preserves the XML-valid whitespace characters', () => {
+        expect(stripXMLInvalidChars('\u0009\u000A\u000D')).toBe('\u0009\u000A\u000D');
+        expect(stripXMLInvalidChars('line1\tline2\nline3\rline4')).toBe('line1\tline2\nline3\rline4');
+    });
+
+    it('strips the non-characters U+FFFE and U+FFFF', () => {
+        expect(stripXMLInvalidChars('a\uFFFEb\uFFFFc')).toBe('abc');
+    });
+
+    it('strips lone surrogates', () => {
+        expect(stripXMLInvalidChars('a\uD800b\uDFFFc')).toBe('abc');
+    });
+
+    it('preserves astral characters encoded as surrogate pairs', () => {
+        expect(stripXMLInvalidChars('emoji 😀 is fine')).toBe('emoji 😀 is fine');
+        expect(stripXMLInvalidChars('\u{1F600}')).toBe('\u{1F600}');
+    });
+
+    it('preserves characters in the valid XML ranges', () => {
+        expect(stripXMLInvalidChars('Hello, world! 123')).toBe('Hello, world! 123');
+        // Boundary checks for the allowed ranges: U+20, U+D7FF, U+E000, U+FFFD
+        expect(stripXMLInvalidChars('\u0020\uD7FF\uE000\uFFFD')).toBe('\u0020\uD7FF\uE000\uFFFD');
+    });
+
+    it('handles the empty string', () => {
+        expect(stripXMLInvalidChars('')).toBe('');
+    });
+});

--- a/modules/util/XMLUtils.ts
+++ b/modules/util/XMLUtils.ts
@@ -154,3 +154,33 @@ export function findFirst(element: Element | Document, selector: string): Elemen
         return null;
     }
 }
+
+/**
+ * Matches the characters that are not allowed in an XML 1.0 document. Sending
+ * such characters (e.g. the START OF TEXT control character U+0002) in a
+ * message produces a malformed stanza which makes the server terminate the
+ * stream, dropping everyone from the meeting.
+ *
+ * The pattern is the inverse of the characters allowed by the XML 1.0
+ * specification:
+ *
+ *     #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+ *
+ * Encoding the allowed ranges (rather than denying a list of forbidden ones)
+ * keeps every permitted code point intact - including astral characters such
+ * as emoji, which are represented as surrogate pairs - while stripping lone
+ * surrogates (U+D800-U+DFFF), which are invalid in XML 1.0. The unicode flag
+ * makes the pattern operate on whole code points instead of surrogate halves.
+ */
+// eslint-disable-next-line no-control-regex
+const INVALID_XML_CHARS_REGEXP = /[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/gu;
+
+/**
+ * Removes the characters that are not allowed in an XML 1.0 document from the
+ * given string.
+ * @param text - The text to sanitize.
+ * @returns The text without the XML-invalid characters.
+ */
+export function stripXMLInvalidChars(text: string): string {
+    return text.replace(INVALID_XML_CHARS_REGEXP, '');
+}

--- a/modules/xmpp/ChatRoom.spec.ts
+++ b/modules/xmpp/ChatRoom.spec.ts
@@ -523,13 +523,6 @@ describe('ChatRoom', () => {
                 '<body>string message</body>' +
                 '</message>');
         });
-        it('sends a object msg with elementName body correctly', () => {
-            room.sendMessage({ object: 'message' } as any, 'body');
-            expect(connectionSpy.calls.argsFor(0).toString()).toBe(
-                '<message to="jid" type="groupchat" xmlns="jabber:client">' +
-                '<body object="message"/>' +
-                '</message>');
-        });
         it('sends a string msg with elementName json-message correctly', () => {
             room.sendMessage('string message', 'json-message');
             expect(connectionSpy.calls.argsFor(0).toString()).toBe(
@@ -537,12 +530,133 @@ describe('ChatRoom', () => {
                 '<json-message xmlns="http://jitsi.org/jitmeet">string message</json-message>' +
                 '</message>');
         });
-        it('sends a object msg with elementName json-message correctly', () => {
-            room.sendMessage({ object: 'message' } as any, 'json-message');
+        it('strips XML-invalid control characters from the message', () => {
+            room.sendMessage('hello\u0002world', 'body');
             expect(connectionSpy.calls.argsFor(0).toString()).toBe(
                 '<message to="jid" type="groupchat" xmlns="jabber:client">' +
-                '<json-message object="message" xmlns="http://jitsi.org/jitmeet"/>' +
+                '<body>helloworld</body>' +
                 '</message>');
+        });
+        it('preserves XML-valid whitespace characters in the message', () => {
+            room.sendMessage('line1\tline2\nline3', 'body');
+            expect(connectionSpy.calls.argsFor(0).toString()).toBe(
+                '<message to="jid" type="groupchat" xmlns="jabber:client">' +
+                '<body>line1\tline2\nline3</body>' +
+                '</message>');
+        });
+        it('strips XML-invalid control characters from json-message stanzas', () => {
+            room.sendMessage('{"text":"hello\u0002world"}', 'json-message');
+            expect(connectionSpy.calls.argsFor(0).toString()).toBe(
+                '<message to="jid" type="groupchat" xmlns="jabber:client">' +
+                '<json-message xmlns="http://jitsi.org/jitmeet">{&quot;text&quot;:&quot;helloworld&quot;}</json-message>' +
+                '</message>');
+        });
+        it('strips lone surrogates from the message', () => {
+            room.sendMessage('hello\uD800world', 'body');
+            expect(connectionSpy.calls.argsFor(0).toString()).toBe(
+                '<message to="jid" type="groupchat" xmlns="jabber:client">' +
+                '<body>helloworld</body>' +
+                '</message>');
+        });
+        it('preserves astral characters (surrogate pairs) in the message', () => {
+            room.sendMessage('hello😀world', 'body');
+            expect(connectionSpy.calls.argsFor(0).toString()).toBe(
+                '<message to="jid" type="groupchat" xmlns="jabber:client">' +
+                '<body>hello😀world</body>' +
+                '</message>');
+        });
+    });
+
+    describe('sendPrivateMessage', () => {
+        let room: ChatRoom;
+        let connectionSpy: jasmine.Spy;
+
+        beforeEach(() => {
+            const xmpp: IMockXMPP = {
+                moderator: new Moderator({
+                    options: {}
+                } as any),
+                options: {},
+                addListener: () => {} // eslint-disable-line no-empty-function
+            };
+
+            room = new ChatRoom(
+                // eslint-disable-next-line no-empty-function
+                { send: () => {} } as any as XmppConnection /* connection */,
+                'jid',
+                'password',
+                xmpp as any as XMPP,
+                {} /* options */);
+            connectionSpy = spyOn(room.connection, 'send');
+        });
+        it('sends a string msg with elementName body correctly', () => {
+            room.sendPrivateMessage('pid', 'string message', 'body');
+            expect(connectionSpy.calls.argsFor(0).toString()).toBe(
+                '<message to="jid/pid" type="chat" xmlns="jabber:client">' +
+                '<body>string message</body>' +
+                '</message>');
+        });
+        it('strips XML-invalid control characters from the message', () => {
+            room.sendPrivateMessage('pid', 'hello\u0002world', 'body');
+            expect(connectionSpy.calls.argsFor(0).toString()).toBe(
+                '<message to="jid/pid" type="chat" xmlns="jabber:client">' +
+                '<body>helloworld</body>' +
+                '</message>');
+        });
+    });
+
+    describe('setSubject', () => {
+        let room: ChatRoom;
+        let connectionSpy: jasmine.Spy;
+
+        beforeEach(() => {
+            const xmpp: IMockXMPP = {
+                moderator: new Moderator({
+                    options: {}
+                } as any),
+                options: {},
+                addListener: () => {} // eslint-disable-line no-empty-function
+            };
+
+            room = new ChatRoom(
+                // eslint-disable-next-line no-empty-function
+                { send: () => {} } as any as XmppConnection /* connection */,
+                'jid',
+                'password',
+                xmpp as any as XMPP,
+                {} /* options */);
+            connectionSpy = spyOn(room.connection, 'send');
+        });
+        it('sends the trimmed subject correctly', () => {
+            room.setSubject('  Hello room  ');
+            expect(connectionSpy.calls.argsFor(0).toString()).toBe(
+                '<message to="jid" type="groupchat" xmlns="jabber:client">' +
+                '<subject>Hello room</subject>' +
+                '</message>');
+        });
+        it('strips XML-invalid control characters from the subject', () => {
+            room.setSubject('hello\u0002world');
+            expect(connectionSpy.calls.argsFor(0).toString()).toBe(
+                '<message to="jid" type="groupchat" xmlns="jabber:client">' +
+                '<subject>helloworld</subject>' +
+                '</message>');
+        });
+        it('preserves XML-valid whitespace in the subject', () => {
+            room.setSubject('line1\tline2\nline3');
+            expect(connectionSpy.calls.argsFor(0).toString()).toBe(
+                '<message to="jid" type="groupchat" xmlns="jabber:client">' +
+                '<subject>line1\tline2\nline3</subject>' +
+                '</message>');
+        });
+        it('does not resend an identical subject', () => {
+            room.setSubject('Hello');
+            room.setSubject('Hello');
+            expect(connectionSpy.calls.count()).toBe(1);
+        });
+        it('does not resend a subject that only differs by invalid characters', () => {
+            room.setSubject('hello\u0002world');
+            room.setSubject('helloworld');
+            expect(connectionSpy.calls.count()).toBe(1);
         });
     });
 

--- a/modules/xmpp/ChatRoom.ts
+++ b/modules/xmpp/ChatRoom.ts
@@ -14,7 +14,7 @@ import Settings from '../settings/Settings';
 import EventEmitterForwarder from '../util/EventEmitterForwarder';
 import Listenable from '../util/Listenable';
 import { getJitterDelay } from '../util/Retry';
-import { exists, findAll, findFirst, getAttribute, getText } from '../util/XMLUtils';
+import { exists, findAll, findFirst, getAttribute, getText, stripXMLInvalidChars } from '../util/XMLUtils';
 
 import AVModeration from './AVModeration';
 import BreakoutRooms from './BreakoutRooms';
@@ -1140,13 +1140,15 @@ export default class ChatRoom extends Listenable {
             type: 'groupchat'
         });
 
+        const cleanMessage = stripXMLInvalidChars(message);
+
         // We are adding the message in a packet extension. If this element
         // is different from 'body', we add a custom namespace.
         // e.g. for 'json-message' extension of message stanza.
         if (elementName === 'body') {
-            msg.c(elementName, {}, message);
+            msg.c(elementName, {}, cleanMessage);
         } else {
-            msg.c(elementName, { xmlns: 'http://jitsi.org/jitmeet' }, message);
+            msg.c(elementName, { xmlns: 'http://jitsi.org/jitmeet' }, cleanMessage);
         }
 
         if (replyToId) {
@@ -1154,7 +1156,7 @@ export default class ChatRoom extends Listenable {
         }
 
         this.connection.send(msg);
-        this.eventEmitter.emit(XMPPEvents.SENDING_CHAT_MESSAGE, message);
+        this.eventEmitter.emit(XMPPEvents.SENDING_CHAT_MESSAGE, cleanMessage);
     }
 
     /**
@@ -1204,13 +1206,15 @@ export default class ChatRoom extends Listenable {
 
         const msg = $msg(attrs);
 
+        const cleanMessage = stripXMLInvalidChars(message);
+
         // We are adding the message in packet. If this element is different
         // from 'body', we add our custom namespace for the same.
         // e.g. for 'json-message' message extension.
         if (elementName === 'body') {
-            msg.c(elementName, message).up();
+            msg.c(elementName, cleanMessage).up();
         } else {
-            msg.c(elementName, { xmlns: 'http://jitsi.org/jitmeet' }, message)
+            msg.c(elementName, { xmlns: 'http://jitsi.org/jitmeet' }, cleanMessage)
                 .up();
         }
 
@@ -1219,7 +1223,7 @@ export default class ChatRoom extends Listenable {
         }
         this.connection.send(msg);
         this.eventEmitter.emit(
-            XMPPEvents.SENDING_PRIVATE_CHAT_MESSAGE, message);
+            XMPPEvents.SENDING_PRIVATE_CHAT_MESSAGE, cleanMessage);
     }
     /* eslint-enable max-params */
 
@@ -1228,7 +1232,7 @@ export default class ChatRoom extends Listenable {
      * @param subject
      */
     public setSubject(subject: string): void {
-        const valueToProcess = subject ? subject.trim() : subject;
+        const valueToProcess = subject ? stripXMLInvalidChars(subject.trim()) : subject;
 
         if (valueToProcess === this.subject) {
             // subject already set to the new value
@@ -1239,6 +1243,7 @@ export default class ChatRoom extends Listenable {
             type: 'groupchat' });
 
         msg.c('subject', valueToProcess);
+        this.subject = valueToProcess;
         this.connection.send(msg);
     }
 


### PR DESCRIPTION
Fixes the protocol-side part of https://github.com/jitsi/jitsi-meet/issues/17267, as suggested by @damencho in https://github.com/jitsi/jitsi-meet/pull/17677#issuecomment-5175894528.

### What

Sending a message containing a character that is not allowed in an XML 1.0 document (e.g. the START OF TEXT control character U+0002) produces a malformed stanza. The XMPP server (e.g. Prosody) then terminates the stream, dropping every participant from the meeting.

This sanitizes the message in the XMPP layer, right before building the stanza:

- `sendMessage()` and `sendPrivateMessage()` in `ChatRoom` now run the message through `stripXMLInvalidChars()`.
- The sanitized text is emitted in `SENDING_CHAT_MESSAGE` / `SENDING_PRIVATE_CHAT_MESSAGE` so the UI history never shows the raw control character.
- `SENDING_PRIVATE_CHAT_MESSAGE` also gains a test (it previously had none).

Since the sanitization now happens in lib-jitsi-meet, the client-side strip in https://github.com/jitsi/jitsi-meet/pull/17677 is kept only as defense-in-depth.

### Test

- `npx eslint --max-warnings 0` on the touched source files: pass
- `npx tsc --noEmit`: pass
- Karma: `ChatRoom` spec 42/42 pass (3 new `sendMessage` tests + 2 new `sendPrivateMessage` tests)

cc @damencho