### PR TITLE
fix(sdp): Validate signaled ssrc/semantics and drop RegExp source removal

### DIFF
--- a/modules/sdp/SDP.spec.ts
+++ b/modules/sdp/SDP.spec.ts
@@ -1647,4 +1647,84 @@ a=rtcp-mux
             expect(sdp.raw).toContain('a=group:BUNDLE 0 1 2\r\n');
         });
     });
+
+    describe('updateRemoteSources source removal', () => {
+        const videoMLine = [
+            'm=video 9 UDP/TLS/RTP/SAVPF 100\r\n',
+            'c=IN IP4 0.0.0.0\r\n',
+            'a=rtpmap:100 VP8/90000\r\n',
+            'a=mid:0\r\n',
+            'a=sendonly\r\n',
+            'a=ssrc:12345 msid:stream track\r\n',
+            'a=ssrc:12345 cname:abcd\r\n',
+            'a=ssrc:123456 msid:other track2\r\n',
+            'a=ssrc-group:FID 12345 67890\r\n'
+        ].join('');
+        const baseSdp = [
+            'v=0\r\n',
+            'o=- 123 2 IN IP4 127.0.0.1\r\n',
+            's=-\r\n',
+            't=0 0\r\n',
+            'a=group:BUNDLE 0\r\n',
+            videoMLine
+        ].join('');
+
+        it('removes only the a=ssrc lines for the exact ssrc, not a prefix-matching one', () => {
+            const sdp = new SDP(baseSdp, true /* isP2P */);
+
+            sdp.updateRemoteSources(new Map([ [ 'src', {
+                groups: [],
+                mediaType: MediaType.VIDEO,
+                ssrcList: [ '12345' ]
+            } ] ]), false /* isAdd */);
+
+            expect(sdp.media[0]).not.toContain('a=ssrc:12345 ');
+
+            // ssrc 123456 shares the "12345" prefix but must survive.
+            expect(sdp.media[0]).toContain('a=ssrc:123456 msid:other track2\r\n');
+        });
+
+        it('removes the a=ssrc-group line for the given semantics', () => {
+            const sdp = new SDP(baseSdp, true /* isP2P */);
+
+            sdp.updateRemoteSources(new Map([ [ 'src', {
+                groups: [ { semantics: 'FID', ssrcs: [ '12345', '67890' ] } ],
+                mediaType: MediaType.VIDEO,
+                ssrcList: [ '12345' ]
+            } ] ]), false /* isAdd */);
+
+            expect(sdp.media[0]).not.toContain('a=ssrc-group:FID');
+        });
+
+        it('matches the ssrc token literally, not as a regex pattern', () => {
+            const metaMLine = [
+                'm=video 9 UDP/TLS/RTP/SAVPF 100\r\n',
+                'c=IN IP4 0.0.0.0\r\n',
+                'a=rtpmap:100 VP8/90000\r\n',
+                'a=mid:0\r\n',
+                'a=sendonly\r\n',
+                'a=ssrc:1.* cname:evil\r\n',
+                'a=ssrc:1234 cname:legit\r\n'
+            ].join('');
+            const sdp = new SDP([
+                'v=0\r\n',
+                'o=- 123 2 IN IP4 127.0.0.1\r\n',
+                's=-\r\n',
+                't=0 0\r\n',
+                'a=group:BUNDLE 0\r\n',
+                metaMLine
+            ].join(''), true /* isP2P */);
+
+            sdp.updateRemoteSources(new Map([ [ 'src', {
+                groups: [],
+                mediaType: MediaType.VIDEO,
+                ssrcList: [ '1.*' ]
+            } ] ]), false /* isAdd */);
+
+            expect(sdp.media[0]).not.toContain('a=ssrc:1.* cname:evil');
+
+            // The 1234 line, which the regex `a=ssrc:1.*` would have matched, must survive - proving literal matching.
+            expect(sdp.media[0]).toContain('a=ssrc:1234 cname:legit\r\n');
+        });
+    });
 });

--- a/modules/sdp/SDP.ts
+++ b/modules/sdp/SDP.ts
@@ -100,6 +100,23 @@ export default class SDP {
     }
 
     /**
+     * Removes every line of the given media section whose token (the text up to the first space) equals the provided
+     * prefix. Used to drop the {@code a=ssrc:} / {@code a=ssrc-group:} lines for a source that is being removed. The
+     * prefix is matched with a plain string comparison rather than a constructed RegExp so that a value carried in the
+     * signaling can never be interpreted as a pattern.
+     *
+     * @param {string} mediaSection - The media section (m-line block) to filter.
+     * @param {string} prefix - The full line token to remove, e.g. {@code a=ssrc:12345} or {@code a=ssrc-group:FID}.
+     * @returns {string} The media section with the matching lines removed.
+     */
+    private _removeLinesWithPrefix(mediaSection: string, prefix: string): string {
+        return mediaSection
+            .split('\r\n')
+            .filter(line => line !== prefix && !line.startsWith(`${prefix} `))
+            .join('\r\n');
+    }
+
+    /**
      * Adds or removes the sources from the SDP.
      *
      * @param {Map<SourceName, ITPCSourceInfo>} sourceMap - The map of the sources that are being added/removed.
@@ -142,11 +159,10 @@ export default class SDP {
                 });
             } else {
                 ssrcList.forEach(ssrc => {
-                    this.media[idx] = this.media[idx].replace(new RegExp(`a=ssrc:${ssrc}.*\r\n`, 'g'), '');
+                    this.media[idx] = this._removeLinesWithPrefix(this.media[idx], `a=ssrc:${ssrc}`);
                 });
                 groups?.forEach(group => {
-                    this.media[idx] = this.media[idx]
-                        .replace(new RegExp(`a=ssrc-group:${group.semantics}.*\r\n`, 'g'), '');
+                    this.media[idx] = this._removeLinesWithPrefix(this.media[idx], `a=ssrc-group:${group.semantics}`);
                 });
 
                 if (!this.isP2P) {

--- a/modules/xmpp/JingleSessionPC.spec.ts
+++ b/modules/xmpp/JingleSessionPC.spec.ts
@@ -361,6 +361,63 @@ describe('JingleSessionPC', () => {
             expect(removeSsrcOwnersSpy).toHaveBeenCalledWith([ 1234, 5678, 4321, 8765 ]);
             expect(updateRemoteSourcesSpy).toHaveBeenCalledWith(sourceInfo, false);
         });
+
+        it('ignores a source whose ssrc is not a valid 32-bit decimal integer', () => {
+            const jingle = parseXML(
+                    `<jingle xmlns='urn:xmpp:jingle:1'>
+                        <content name='video'>
+                            <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='video'>
+                                <source xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' ssrc='(.+)+$' name='evil' owner='peer'>
+                                    <parameter name='msid' value='stream1'/>
+                                </source>
+                                <source xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' ssrc='99999999999999999999' name='big' owner='peer'>
+                                    <parameter name='msid' value='stream2'/>
+                                </source>
+                                <source xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' ssrc='1234' name='ok' owner='peer'>
+                                    <parameter name='msid' value='stream3'/>
+                                </source>
+                            </description>
+                        </content>
+                    </jingle>`
+            );
+
+            const sourceAddElem = findAll(jingle.documentElement, ':scope>content');
+
+            sourceInfo = jingleSession._processSourceMapFromJingle(sourceAddElem, true);
+
+            expect(sourceInfo.has('evil')).toBe(false);
+            expect(sourceInfo.has('big')).toBe(false);
+            expect(sourceInfo.get('ok').ssrcList).toEqual([ '1234' ]);
+            expect(setSsrcOwnerSpy).toHaveBeenCalledWith(1234, null, 'ok');
+            expect(setSsrcOwnerSpy).not.toHaveBeenCalledWith(NaN, jasmine.anything(), 'evil');
+        });
+
+        it('ignores an ssrc-group whose semantics is not a known value', () => {
+            const jingle = parseXML(
+                    `<jingle xmlns='urn:xmpp:jingle:1'>
+                        <content name='video'>
+                            <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='video'>
+                                <source xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' ssrc='1234' name='source1' owner='peer'>
+                                    <parameter name='msid' value='stream1'/>
+                                </source>
+                                <source xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' ssrc='5678' name='source1' owner='peer'>
+                                    <parameter name='msid' value='stream1'/>
+                                </source>
+                                <ssrc-group xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' semantics='(.+)+$'>
+                                    <source xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' ssrc='1234'/>
+                                    <source xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' ssrc='5678'/>
+                                </ssrc-group>
+                            </description>
+                        </content>
+                    </jingle>`
+            );
+
+            const sourceAddElem = findAll(jingle.documentElement, ':scope>content');
+
+            sourceInfo = jingleSession._processSourceMapFromJingle(sourceAddElem, true);
+
+            expect(sourceInfo.get('source1').groups).toEqual([]);
+        });
     });
 
     describe('_recoverWedgedAudioSource', () => {

--- a/modules/xmpp/JingleSessionPC.ts
+++ b/modules/xmpp/JingleSessionPC.ts
@@ -55,6 +55,30 @@ const DEFAULT_MAX_STATS: number = 300;
 const ICE_CAND_GATHERING_TIMEOUT: number = 150;
 
 /**
+ * Matches a plain decimal string (no sign, no separators). Used as the first check on a signaled ssrc attribute.
+ * @type {RegExp}
+ */
+const SSRC_PATTERN = /^\d+$/;
+
+/**
+ * The largest valid RTP SSRC, i.e. the unsigned 32-bit maximum (RFC 5576).
+ * @type {number}
+ */
+const MAX_SSRC = 0xFFFFFFFF;
+
+/**
+ * Checks that a signaled ssrc attribute is a plain decimal string within the unsigned 32-bit SSRC range (RFC 5576).
+ * Signaled ssrcs are validated before use since they end up in SDP text, string lookups, and {@code Number()}
+ * coercion (a digit string above the 32-bit range would lose integer precision when coerced).
+ *
+ * @param {string} ssrc - The raw ssrc attribute value.
+ * @returns {boolean} Whether the value is a valid SSRC.
+ */
+function isValidSsrc(ssrc: string): boolean {
+    return SSRC_PATTERN.test(ssrc) && Number(ssrc) <= MAX_SSRC;
+}
+
+/**
  * Reads the endpoint ID given a string which represents either the endpoint's full JID, or the endpoint ID itself.
  * @param {String} jidOrEndpointId A string which is either the full JID of a participant, or the ID of an
  * endpoint/participant.
@@ -674,6 +698,14 @@ export default class JingleSessionPC extends JingleSession {
 
                 for (const source of sources) {
                     const ssrc = getAttribute(source, 'ssrc');
+
+                    if (!isValidSsrc(ssrc)) {
+                        logger.warn(`${this} Ignoring source with invalid ssrc=${ssrc}`);
+
+                        // eslint-disable-next-line no-continue
+                        continue;
+                    }
+
                     const sourceName = getAttribute(source, 'name');
                     const msid = getAttribute(findFirst(source, ':scope>parameter[name="msid"]'), 'value');
                     const mid = getAttribute(findFirst(source, ':scope>parameter[name="mid"]'), 'value');
@@ -719,12 +751,22 @@ export default class JingleSessionPC extends JingleSession {
 
                 findAll(description, ':scope>ssrc-group').forEach(group => {
                     const semantics = getAttribute(group, 'semantics');
+
+                    if (!Object.values(SSRC_GROUP_SEMANTICS).includes(semantics as SSRC_GROUP_SEMANTICS)) {
+                        logger.warn(`${this} Ignoring ssrc-group with unknown semantics=${semantics}`);
+
+                        return;
+                    }
+
                     const groupSsrcs = [];
 
                     findAll(group, ':scope>source').forEach(source => {
                         groupSsrcs.push(getAttribute(source, 'ssrc'));
                     });
 
+                    // A group's member ssrcs are only used if the group's ssrc set matches a source's (already
+                    // validated) ssrcList below, so a group referencing an invalid ssrc can never be attached and
+                    // does not need a separate numeric check here.
                     for (const [ sourceName, { ssrcList } ] of sourceDescription) {
                         if (isEqual(ssrcList.slice().sort(), groupSsrcs.slice().sort())) {
                             sourceDescription.get(sourceName).groups.push({


### PR DESCRIPTION
Hardens the handling of signaled `ssrc` and `ssrc-group` `semantics` attributes when processing remote source add/remove.