### PR TITLE
feat(RTC): Add camera pan/tilt/zoom control API

### DIFF
--- a/JitsiMediaDevices.spec.ts
+++ b/JitsiMediaDevices.spec.ts
@@ -1,0 +1,37 @@
+import JitsiMediaDevices from './JitsiMediaDevices';
+
+describe('JitsiMediaDevices', () => {
+    describe('getCameraPTZPermission', () => {
+        let mediaDevices: JitsiMediaDevices;
+
+        beforeEach(() => {
+            mediaDevices = new JitsiMediaDevices();
+
+            if (!navigator.permissions) {
+                (navigator as any).permissions = { query: () => Promise.resolve({ state: 'prompt' }) };
+            }
+        });
+
+        it('queries the camera permission with the panTiltZoom descriptor', async () => {
+            const query = spyOn(navigator.permissions, 'query')
+                .and.returnValue(Promise.resolve({ state: 'granted' } as any));
+
+            await mediaDevices.getCameraPTZPermission();
+
+            expect(query).toHaveBeenCalledWith(jasmine.objectContaining({ name: 'camera',
+                panTiltZoom: true }));
+        });
+
+        it('resolves the queried permission state', async () => {
+            spyOn(navigator.permissions, 'query').and.returnValue(Promise.resolve({ state: 'denied' } as any));
+
+            await expectAsync(mediaDevices.getCameraPTZPermission()).toBeResolvedTo('denied');
+        });
+
+        it('resolves to prompt when the query rejects (permission not exposed by the browser)', async () => {
+            spyOn(navigator.permissions, 'query').and.returnValue(Promise.reject(new Error('unsupported')));
+
+            await expectAsync(mediaDevices.getCameraPTZPermission()).toBeResolvedTo('prompt');
+        });
+    });
+});

--- a/JitsiMediaDevices.ts
+++ b/JitsiMediaDevices.ts
@@ -160,6 +160,18 @@ export default class JitsiMediaDevices extends Listenable {
     }
 
     /**
+     * Returns the pan/tilt/zoom support detected for the given camera device during the last device enumeration.
+     * Detection is best-effort and reflects what the browser exposes at enumeration time; pan/tilt may only be
+     * reported once the panTiltZoom permission has been granted for the camera.
+     *
+     * @param {string} deviceId - The id of the 'videoinput' device.
+     * @returns {{ pan: boolean, tilt: boolean, zoom: boolean }}
+     */
+    getCameraPTZCapabilities(deviceId: string): { pan: boolean; tilt: boolean; zoom: boolean; } {
+        return RTC.getCameraPTZCapabilities(deviceId);
+    }
+
+    /**
      * Returns true if changing the input (camera / microphone) or output
      * (audio) device is supported and false if not.
      * @param {string} [deviceType] - type of device to change. Default is

--- a/JitsiMediaDevices.ts
+++ b/JitsiMediaDevices.ts
@@ -2,6 +2,7 @@ import { JitsiMediaDevicesEvents } from './JitsiMediaDevicesEvents';
 import RTC from './modules/RTC/RTC';
 import browser from './modules/browser';
 import Listenable from './modules/util/Listenable';
+import { CameraControlType } from './service/RTC/CameraControlType';
 import { MediaType } from './service/RTC/MediaType';
 import { RTCEvents } from './service/RTC/RTCEvents';
 
@@ -165,9 +166,9 @@ export default class JitsiMediaDevices extends Listenable {
      * reported once the panTiltZoom permission has been granted for the camera.
      *
      * @param {string} deviceId - The id of the 'videoinput' device.
-     * @returns {{ pan: boolean, tilt: boolean, zoom: boolean }}
+     * @returns {Record<CameraControlType, boolean>}
      */
-    getCameraPTZCapabilities(deviceId: string): { pan: boolean; tilt: boolean; zoom: boolean; } {
+    getCameraPTZCapabilities(deviceId: string): Record<CameraControlType, boolean> {
         return RTC.getCameraPTZCapabilities(deviceId);
     }
 

--- a/JitsiMediaDevices.ts
+++ b/JitsiMediaDevices.ts
@@ -7,6 +7,9 @@ import { MediaType } from './service/RTC/MediaType';
 import { RTCEvents } from './service/RTC/RTCEvents';
 
 const AUDIO_PERMISSION_NAME = 'microphone' as PermissionName;
+// The key under which the camera pan/tilt/zoom (panTiltZoom) permission is tracked in the permissions cache
+// and reported in the PERMISSIONS_CHANGED event. It is queried as { name: 'camera', panTiltZoom: true }.
+const CAMERA_PTZ_PERMISSION_KEY = 'panTiltZoom';
 const PERMISSION_GRANTED_STATUS = 'granted';
 const VIDEO_PERMISSION_NAME = 'camera' as PermissionName;
 
@@ -56,8 +59,7 @@ export default class JitsiMediaDevices extends Listenable {
      */
     private _handlePermissionsChange(permissions: { [key: string]: boolean; }): void {
         const hasPermissionsChanged
-            = [ MediaType.AUDIO, MediaType.VIDEO ]
-                .some(type => type in permissions && permissions[type] !== this._permissions[type]);
+            = Object.keys(permissions).some(type => permissions[type] !== this._permissions[type]);
 
         if (hasPermissionsChanged) {
             this._permissions = {
@@ -147,6 +149,29 @@ export default class JitsiMediaDevices extends Listenable {
                 })
                 .catch(() => false));
 
+            // Track the panTiltZoom permission best-effort. It is intentionally not part of the support
+            // calculation above, because a browser that does not implement it (Firefox/Safari) would otherwise
+            // mark the whole permissions API as unsupported.
+            navigator.permissions.query({ name: VIDEO_PERMISSION_NAME,
+                panTiltZoom: true } as PermissionDescriptor)
+                .then(status => {
+                    this._handlePermissionsChange({
+                        [CAMERA_PTZ_PERMISSION_KEY]: this._parsePermissionState(status)
+                    });
+                    status.onchange = () => {
+                        try {
+                            this._handlePermissionsChange({
+                                [CAMERA_PTZ_PERMISSION_KEY]: this._parsePermissionState(status)
+                            });
+                        } catch (error) {
+                            // Nothing to do.
+                        }
+                    };
+                })
+                .catch(() => {
+                    // The panTiltZoom permission is not queryable on this browser.
+                });
+
             Promise.all(promises).then(results => resolve(results.every(supported => supported)));
 
         });
@@ -170,6 +195,26 @@ export default class JitsiMediaDevices extends Listenable {
      */
     getCameraPTZCapabilities(deviceId: string): Record<CameraControlType, boolean> {
         return RTC.getCameraPTZCapabilities(deviceId);
+    }
+
+    /**
+     * Returns the current state of the camera pan/tilt/zoom (panTiltZoom) permission. Used by the application to tell
+     * a denied permission apart from a camera that simply has no PTZ hardware (both surface as empty track
+     * capabilities): 'denied' means the user rejected it and the feature should stay disabled, 'prompt' means it can
+     * be requested, 'granted' means it is available.
+     *
+     * @returns {Promise<PermissionState>} - Resolves to 'granted', 'denied' or 'prompt'. Resolves to 'prompt' when the
+     * browser does not expose the panTiltZoom permission, so the caller falls back to capability probing.
+     */
+    getCameraPTZPermission(): Promise<PermissionState> {
+        if (!navigator.permissions) {
+            return Promise.resolve('prompt');
+        }
+
+        return navigator.permissions.query({ name: VIDEO_PERMISSION_NAME,
+            panTiltZoom: true } as PermissionDescriptor)
+            .then(status => status.state)
+            .catch(() => 'prompt' as PermissionState);
     }
 
     /**

--- a/JitsiMeetJS.ts
+++ b/JitsiMeetJS.ts
@@ -79,6 +79,7 @@ function getAnalyticsAttributesFromOptions(options) {
 
 interface ICreateLocalTrackOptions {
     cameraDeviceId?: string;
+    cameraPtz?: boolean;
     devices?: any[];
     fireSlowPromiseEvent?: boolean;
     micDeviceId?: string;
@@ -183,6 +184,7 @@ const JitsiMeetJS = {
      * @param {Array} options.devices the devices that will be requested
      * @param {string} options.resolution resolution constraints
      * @param {string} options.cameraDeviceId
+     * @param {boolean} options.cameraPtz whether to ask for the pan/tilt/zoom capabilities of the camera
      * @param {string} options.micDeviceId
      *
      * @returns {Promise.<{Array.<JitsiTrack>}, JitsiTrackError>} A promise that returns an array of created

--- a/modules/RTC/JitsiLocalTrack.spec.ts
+++ b/modules/RTC/JitsiLocalTrack.spec.ts
@@ -1,0 +1,111 @@
+import { VideoType } from '../../service/RTC/VideoType';
+
+import JitsiLocalTrack from './JitsiLocalTrack';
+
+/* eslint-disable require-jsdoc */
+
+describe('JitsiLocalTrack camera control', () => {
+    const getCapabilities = (JitsiLocalTrack.prototype as any).getCameraControlCapabilities;
+    const getSettings = (JitsiLocalTrack.prototype as any).getCameraControlSettings;
+    const setControl = (JitsiLocalTrack.prototype as any).setCameraControl;
+
+    // Builds the minimal `this` context the camera-control methods touch.
+    function context({
+        isVideo = true,
+        videoType = VideoType.CAMERA,
+        capabilities = {},
+        settings = {},
+        applyConstraints = () => Promise.resolve()
+    }: any = {}): any {
+        return {
+            isVideoTrack: () => isVideo,
+            track: {
+                applyConstraints: jasmine.createSpy('applyConstraints').and.callFake(applyConstraints),
+                getCapabilities: () => capabilities,
+                getSettings: () => settings
+            },
+            videoType
+        };
+    }
+
+    describe('getCameraControlCapabilities', () => {
+        it('returns the pan/tilt/zoom ranges reported by the track', () => {
+            const ctx = context({
+                capabilities: {
+                    pan: { max: 100, min: -100, step: 1 },
+                    tilt: { max: 50, min: -50, step: 2 },
+                    zoom: { max: 4, min: 1, step: 0.1 }
+                }
+            });
+
+            expect(getCapabilities.call(ctx)).toEqual({
+                pan: { max: 100, min: -100, step: 1 },
+                tilt: { max: 50, min: -50, step: 2 },
+                zoom: { max: 4, min: 1, step: 0.1 }
+            });
+        });
+
+        it('omits controls the camera does not expose and defaults a missing step to 1', () => {
+            const ctx = context({ capabilities: { zoom: { max: 4, min: 1 } } });
+
+            expect(getCapabilities.call(ctx)).toEqual({ zoom: { max: 4, min: 1, step: 1 } });
+        });
+
+        it('returns an empty object for a non-camera video track', () => {
+            const ctx = context({ videoType: VideoType.DESKTOP, capabilities: { zoom: { max: 4, min: 1 } } });
+
+            expect(getCapabilities.call(ctx)).toEqual({});
+        });
+
+        it('returns an empty object for an audio track', () => {
+            const ctx = context({ isVideo: false });
+
+            expect(getCapabilities.call(ctx)).toEqual({});
+        });
+    });
+
+    describe('getCameraControlSettings', () => {
+        it('returns the current pan/tilt/zoom values', () => {
+            const ctx = context({ settings: { pan: 10, tilt: -5, zoom: 2 } });
+
+            expect(getSettings.call(ctx)).toEqual({ pan: 10, tilt: -5, zoom: 2 });
+        });
+
+        it('omits keys the track does not report', () => {
+            const ctx = context({ settings: { zoom: 2 } });
+
+            expect(getSettings.call(ctx)).toEqual({ zoom: 2 });
+        });
+    });
+
+    describe('setCameraControl', () => {
+        it('applies only the provided controls via advanced constraints without re-acquiring the stream', async () => {
+            const ctx = context();
+
+            await setControl.call(ctx, { pan: 10, zoom: 2 });
+
+            expect(ctx.track.applyConstraints).toHaveBeenCalledWith({ advanced: [ { pan: 10, zoom: 2 } ] });
+        });
+
+        it('is a no-op when no numeric controls are provided', async () => {
+            const ctx = context();
+
+            await setControl.call(ctx, { pan: undefined } as any);
+
+            expect(ctx.track.applyConstraints).not.toHaveBeenCalled();
+        });
+
+        it('rejects for a non-camera track', async () => {
+            const ctx = context({ videoType: VideoType.DESKTOP });
+
+            await expectAsync(setControl.call(ctx, { zoom: 2 })).toBeRejected();
+            expect(ctx.track.applyConstraints).not.toHaveBeenCalled();
+        });
+
+        it('propagates a rejection from the underlying applyConstraints', async () => {
+            const ctx = context({ applyConstraints: () => Promise.reject(new Error('out of range')) });
+
+            await expectAsync(setControl.call(ctx, { zoom: 999 })).toBeRejectedWithError('out of range');
+        });
+    });
+});

--- a/modules/RTC/JitsiLocalTrack.spec.ts
+++ b/modules/RTC/JitsiLocalTrack.spec.ts
@@ -8,22 +8,39 @@ describe('JitsiLocalTrack camera control', () => {
     const getCapabilities = (JitsiLocalTrack.prototype as any).getCameraControlCapabilities;
     const getSettings = (JitsiLocalTrack.prototype as any).getCameraControlSettings;
     const setControl = (JitsiLocalTrack.prototype as any).setCameraControl;
+    const getSourceTrack = (JitsiLocalTrack.prototype as any)._getCameraSourceTrack;
 
-    // Builds the minimal `this` context the camera-control methods touch.
-    function context({
-        isVideo = true,
-        videoType = VideoType.CAMERA,
-        capabilities = {},
-        settings = {},
-        applyConstraints = () => Promise.resolve()
-    }: any = {}): any {
+    // Builds a mock MediaStreamTrack with the given PTZ capabilities/settings.
+    function mockTrack({ capabilities = {}, settings = {}, applyConstraints = () => Promise.resolve() }: any = {}) {
         return {
+            applyConstraints: jasmine.createSpy('applyConstraints').and.callFake(applyConstraints),
+            getCapabilities: () => capabilities,
+            getSettings: () => settings
+        };
+    }
+
+    // Builds the minimal `this` context the camera-control methods touch. When `effect` is true, `this.track` is the
+    // effect output (no PTZ, like a virtual-background canvas capture) and the real camera lives in `_originalStream`.
+    function context({ isVideo = true, videoType = VideoType.CAMERA, effect = false, ...trackOptions }: any = {}): any {
+        const cameraTrack = mockTrack(trackOptions);
+
+        if (effect) {
+            return {
+                _effectEnabled: true,
+                _getCameraSourceTrack: getSourceTrack,
+                _originalStream: { getVideoTracks: () => [ cameraTrack ] },
+                isVideoTrack: () => isVideo,
+                track: mockTrack({ /* canvas output: no PTZ caps/settings */ }),
+                videoType
+            };
+        }
+
+        return {
+            _effectEnabled: false,
+            _getCameraSourceTrack: getSourceTrack,
             isVideoTrack: () => isVideo,
-            track: {
-                applyConstraints: jasmine.createSpy('applyConstraints').and.callFake(applyConstraints),
-                getCapabilities: () => capabilities,
-                getSettings: () => settings
-            },
+            stream: { getVideoTracks: () => [ cameraTrack ] },
+            track: cameraTrack,
             videoType
         };
     }
@@ -61,6 +78,13 @@ describe('JitsiLocalTrack camera control', () => {
             const ctx = context({ isVideo: false });
 
             expect(getCapabilities.call(ctx)).toEqual({});
+        });
+
+        it('reads capabilities from the camera source, not the effect output, when an effect is active', () => {
+            const ctx = context({ effect: true, capabilities: { zoom: { max: 4, min: 1, step: 1 } } });
+
+            // this.track (canvas output) has no caps; the camera source in _originalStream does.
+            expect(getCapabilities.call(ctx)).toEqual({ zoom: { max: 4, min: 1, step: 1 } });
         });
     });
 
@@ -106,6 +130,16 @@ describe('JitsiLocalTrack camera control', () => {
             const ctx = context({ applyConstraints: () => Promise.reject(new Error('out of range')) });
 
             await expectAsync(setControl.call(ctx, { zoom: 999 })).toBeRejectedWithError('out of range');
+        });
+
+        it('applies to the camera source, not the effect output, when an effect is active', async () => {
+            const ctx = context({ effect: true });
+            const cameraTrack = ctx._originalStream.getVideoTracks()[0];
+
+            await setControl.call(ctx, { zoom: 2 });
+
+            expect(cameraTrack.applyConstraints).toHaveBeenCalledWith({ advanced: [ { zoom: 2 } ] });
+            expect(ctx.track.applyConstraints).not.toHaveBeenCalled();
         });
     });
 });

--- a/modules/RTC/JitsiLocalTrack.ts
+++ b/modules/RTC/JitsiLocalTrack.ts
@@ -8,6 +8,7 @@ import {
     TRACK_NO_STREAM_FOUND
 } from '../../JitsiTrackErrors';
 import { JitsiTrackEvents } from '../../JitsiTrackEvents';
+import { CameraControlType } from '../../service/RTC/CameraControlType';
 import { CameraFacingMode } from '../../service/RTC/CameraFacingMode';
 import { MediaType } from '../../service/RTC/MediaType';
 import { RTCEvents } from '../../service/RTC/RTCEvents';
@@ -75,23 +76,15 @@ export interface IAudioConstraints {
     noiseSuppression?: boolean;
 }
 
-export interface ICameraControls {
-    pan?: number;
-    tilt?: number;
-    zoom?: number;
-}
-
 export interface ICameraControlRange {
     max: number;
     min: number;
     step: number;
 }
 
-export interface ICameraControlCapabilities {
-    pan?: ICameraControlRange;
-    tilt?: ICameraControlRange;
-    zoom?: ICameraControlRange;
-}
+export type ICameraControls = Partial<Record<CameraControlType, number>>;
+
+export type ICameraControlCapabilities = Partial<Record<CameraControlType, ICameraControlRange>>;
 
 /**
  * Represents a single media track(either audio or video).
@@ -1213,7 +1206,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
         const capabilities = this._getCameraSourceTrack()?.getCapabilities?.() ?? {};
         const result: ICameraControlCapabilities = {};
 
-        for (const key of [ 'pan', 'tilt', 'zoom' ] as const) {
+        for (const key of Object.values(CameraControlType)) {
             const range = (capabilities as any)[key];
 
             if (range && typeof range.min === 'number' && typeof range.max === 'number') {
@@ -1242,7 +1235,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
         const settings = this._getCameraSourceTrack()?.getSettings?.() ?? {};
         const result: ICameraControls = {};
 
-        for (const key of [ 'pan', 'tilt', 'zoom' ] as const) {
+        for (const key of Object.values(CameraControlType)) {
             const value = (settings as any)[key];
 
             if (typeof value === 'number') {
@@ -1279,7 +1272,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
 
         const control: ICameraControls = {};
 
-        for (const key of [ 'pan', 'tilt', 'zoom' ] as const) {
+        for (const key of Object.values(CameraControlType)) {
             if (typeof controls[key] === 'number') {
                 control[key] = controls[key];
             }

--- a/modules/RTC/JitsiLocalTrack.ts
+++ b/modules/RTC/JitsiLocalTrack.ts
@@ -354,6 +354,21 @@ export default class JitsiLocalTrack extends JitsiTrack {
     }
 
     /**
+     * Returns the camera MediaStreamTrack that pan/tilt/zoom must be read from and applied to. When a stream effect
+     * (e.g. virtual background) is active, {@link this.track} is the effect's output track (a canvas/insertable-streams
+     * capture) which has no pan/tilt/zoom; the actual camera is the source that feeds the effect and lives in
+     * {@link this._originalStream}. Panning/zooming that source flows through to the composited output.
+     *
+     * @private
+     * @returns {Optional<MediaStreamTrack>} - The camera source track, or undefined if unavailable.
+     */
+    private _getCameraSourceTrack(): Optional<MediaStreamTrack> {
+        const stream = this._effectEnabled ? this._originalStream : this.stream;
+
+        return stream?.getVideoTracks()[0] ?? this.track;
+    }
+
+    /**
      * Sets handlers to the MediaStreamTrack object that will detect camera issues.
      *
      * @private
@@ -1172,21 +1187,6 @@ export default class JitsiLocalTrack extends JitsiTrack {
                 audioAnalyser._trackAdded(this);
             }
         }
-    }
-
-    /**
-     * Returns the camera MediaStreamTrack that pan/tilt/zoom must be read from and applied to. When a stream effect
-     * (e.g. virtual background) is active, {@link this.track} is the effect's output track (a canvas/insertable-streams
-     * capture) which has no pan/tilt/zoom; the actual camera is the source that feeds the effect and lives in
-     * {@link this._originalStream}. Panning/zooming that source flows through to the composited output.
-     *
-     * @private
-     * @returns {Optional<MediaStreamTrack>} - The camera source track, or undefined if unavailable.
-     */
-    private _getCameraSourceTrack(): Optional<MediaStreamTrack> {
-        const stream = this._effectEnabled ? this._originalStream : this.stream;
-
-        return stream?.getVideoTracks()[0] ?? this.track;
     }
 
     /**

--- a/modules/RTC/JitsiLocalTrack.ts
+++ b/modules/RTC/JitsiLocalTrack.ts
@@ -1182,9 +1182,25 @@ export default class JitsiLocalTrack extends JitsiTrack {
     }
 
     /**
-     * Returns the pan/tilt/zoom ranges supported by the underlying camera, read from the live
+     * Returns the camera MediaStreamTrack that pan/tilt/zoom must be read from and applied to. When a stream effect
+     * (e.g. virtual background) is active, {@link this.track} is the effect's output track (a canvas/insertable-streams
+     * capture) which has no pan/tilt/zoom; the actual camera is the source that feeds the effect and lives in
+     * {@link this._originalStream}. Panning/zooming that source flows through to the composited output.
+     *
+     * @private
+     * @returns {Optional<MediaStreamTrack>} - The camera source track, or undefined if unavailable.
+     */
+    private _getCameraSourceTrack(): Optional<MediaStreamTrack> {
+        const stream = this._effectEnabled ? this._originalStream : this.stream;
+
+        return stream?.getVideoTracks()[0] ?? this.track;
+    }
+
+    /**
+     * Returns the pan/tilt/zoom ranges supported by the underlying camera, read from the live camera
      * MediaStreamTrack.getCapabilities(). A key is present only when the camera exposes that control (which also
-     * requires the panTiltZoom permission to have been granted at getUserMedia time for pan/tilt).
+     * requires the panTiltZoom permission to have been granted at getUserMedia time for pan/tilt). When a stream
+     * effect is active the ranges are read from the camera source feeding the effect, not the effect output.
      *
      * @returns {ICameraControlCapabilities} - The supported ranges. Empty when the track is not a camera track or the
      * camera exposes no pan/tilt/zoom controls.
@@ -1194,7 +1210,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
             return {};
         }
 
-        const capabilities = this.track.getCapabilities?.() ?? {};
+        const capabilities = this._getCameraSourceTrack()?.getCapabilities?.() ?? {};
         const result: ICameraControlCapabilities = {};
 
         for (const key of [ 'pan', 'tilt', 'zoom' ] as const) {
@@ -1213,8 +1229,8 @@ export default class JitsiLocalTrack extends JitsiTrack {
     }
 
     /**
-     * Returns the current pan/tilt/zoom values of the underlying camera, read from the live
-     * MediaStreamTrack.getSettings().
+     * Returns the current pan/tilt/zoom values of the underlying camera, read from the live camera
+     * MediaStreamTrack.getSettings() (the camera source feeding the effect when one is active).
      *
      * @returns {ICameraControls} - The current values. A key is present only when the camera reports it.
      */
@@ -1223,7 +1239,7 @@ export default class JitsiLocalTrack extends JitsiTrack {
             return {};
         }
 
-        const settings = this.track.getSettings?.() ?? {};
+        const settings = this._getCameraSourceTrack()?.getSettings?.() ?? {};
         const result: ICameraControls = {};
 
         for (const key of [ 'pan', 'tilt', 'zoom' ] as const) {
@@ -1239,10 +1255,12 @@ export default class JitsiLocalTrack extends JitsiTrack {
 
     /**
      * Applies pan/tilt/zoom values to the underlying camera. Unlike {@link applyConstraints}, this is a lightweight
-     * operation: it calls MediaStreamTrack.applyConstraints() directly on the existing track and does not re-acquire
-     * the stream or renegotiate, since pan/tilt/zoom do not change the encoded stream. Only the provided controls are
-     * applied; the rest are left unchanged. The caller is responsible for clamping the values to the ranges reported
-     * by {@link getCameraControlCapabilities}.
+     * operation: it calls MediaStreamTrack.applyConstraints() directly on the existing camera track and does not
+     * re-acquire the stream or renegotiate, since pan/tilt/zoom do not change the encoded stream. When a stream effect
+     * (e.g. virtual background) is active the values are applied to the camera source feeding the effect - applying
+     * them to the effect's canvas output would silently no-op, since advanced constraints it cannot satisfy are
+     * ignored rather than rejected. Only the provided controls are applied; the rest are left unchanged. The caller is
+     * responsible for clamping the values to the ranges reported by {@link getCameraControlCapabilities}.
      *
      * @param {ICameraControls} controls - The pan/tilt/zoom values to apply.
      * @returns {Promise<void>} - Resolves when the constraints have been applied, rejects if the browser rejects them
@@ -1251,6 +1269,12 @@ export default class JitsiLocalTrack extends JitsiTrack {
     setCameraControl(controls: ICameraControls): Promise<void> {
         if (!this.isVideoTrack() || this.videoType !== VideoType.CAMERA) {
             return Promise.reject(new Error('Camera control is only supported on camera video tracks'));
+        }
+
+        const cameraTrack = this._getCameraSourceTrack();
+
+        if (!cameraTrack) {
+            return Promise.reject(new Error('No camera track to apply the control to'));
         }
 
         const control: ICameraControls = {};
@@ -1267,6 +1291,6 @@ export default class JitsiLocalTrack extends JitsiTrack {
 
         logger.debug(`setCameraControl for track ${this}: ${JSON.stringify(control)}`);
 
-        return this.track.applyConstraints({ advanced: [ control ] } as MediaTrackConstraints);
+        return cameraTrack.applyConstraints({ advanced: [ control ] } as MediaTrackConstraints);
     }
 }

--- a/modules/RTC/JitsiLocalTrack.ts
+++ b/modules/RTC/JitsiLocalTrack.ts
@@ -75,6 +75,24 @@ export interface IAudioConstraints {
     noiseSuppression?: boolean;
 }
 
+export interface ICameraControls {
+    pan?: number;
+    tilt?: number;
+    zoom?: number;
+}
+
+export interface ICameraControlRange {
+    max: number;
+    min: number;
+    step: number;
+}
+
+export interface ICameraControlCapabilities {
+    pan?: ICameraControlRange;
+    tilt?: ICameraControlRange;
+    zoom?: ICameraControlRange;
+}
+
 /**
  * Represents a single media track(either audio or video).
  * One <tt>JitsiLocalTrack</tt> corresponds to one WebRTC MediaStreamTrack.
@@ -1161,5 +1179,94 @@ export default class JitsiLocalTrack extends JitsiTrack {
                 audioAnalyser._trackAdded(this);
             }
         }
+    }
+
+    /**
+     * Returns the pan/tilt/zoom ranges supported by the underlying camera, read from the live
+     * MediaStreamTrack.getCapabilities(). A key is present only when the camera exposes that control (which also
+     * requires the panTiltZoom permission to have been granted at getUserMedia time for pan/tilt).
+     *
+     * @returns {ICameraControlCapabilities} - The supported ranges. Empty when the track is not a camera track or the
+     * camera exposes no pan/tilt/zoom controls.
+     */
+    getCameraControlCapabilities(): ICameraControlCapabilities {
+        if (!this.isVideoTrack() || this.videoType !== VideoType.CAMERA) {
+            return {};
+        }
+
+        const capabilities = this.track.getCapabilities?.() ?? {};
+        const result: ICameraControlCapabilities = {};
+
+        for (const key of [ 'pan', 'tilt', 'zoom' ] as const) {
+            const range = (capabilities as any)[key];
+
+            if (range && typeof range.min === 'number' && typeof range.max === 'number') {
+                result[key] = {
+                    max: range.max,
+                    min: range.min,
+                    step: typeof range.step === 'number' ? range.step : 1
+                };
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Returns the current pan/tilt/zoom values of the underlying camera, read from the live
+     * MediaStreamTrack.getSettings().
+     *
+     * @returns {ICameraControls} - The current values. A key is present only when the camera reports it.
+     */
+    getCameraControlSettings(): ICameraControls {
+        if (!this.isVideoTrack() || this.videoType !== VideoType.CAMERA) {
+            return {};
+        }
+
+        const settings = this.track.getSettings?.() ?? {};
+        const result: ICameraControls = {};
+
+        for (const key of [ 'pan', 'tilt', 'zoom' ] as const) {
+            const value = (settings as any)[key];
+
+            if (typeof value === 'number') {
+                result[key] = value;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Applies pan/tilt/zoom values to the underlying camera. Unlike {@link applyConstraints}, this is a lightweight
+     * operation: it calls MediaStreamTrack.applyConstraints() directly on the existing track and does not re-acquire
+     * the stream or renegotiate, since pan/tilt/zoom do not change the encoded stream. Only the provided controls are
+     * applied; the rest are left unchanged. The caller is responsible for clamping the values to the ranges reported
+     * by {@link getCameraControlCapabilities}.
+     *
+     * @param {ICameraControls} controls - The pan/tilt/zoom values to apply.
+     * @returns {Promise<void>} - Resolves when the constraints have been applied, rejects if the browser rejects them
+     * (e.g. the value is out of range or the page is not visible).
+     */
+    setCameraControl(controls: ICameraControls): Promise<void> {
+        if (!this.isVideoTrack() || this.videoType !== VideoType.CAMERA) {
+            return Promise.reject(new Error('Camera control is only supported on camera video tracks'));
+        }
+
+        const control: ICameraControls = {};
+
+        for (const key of [ 'pan', 'tilt', 'zoom' ] as const) {
+            if (typeof controls[key] === 'number') {
+                control[key] = controls[key];
+            }
+        }
+
+        if (!Object.keys(control).length) {
+            return Promise.resolve();
+        }
+
+        logger.debug(`setCameraControl for track ${this}: ${JSON.stringify(control)}`);
+
+        return this.track.applyConstraints({ advanced: [ control ] } as MediaTrackConstraints);
     }
 }

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -630,6 +630,16 @@ export default class RTC extends Listenable {
     }
 
     /**
+     * Returns the pan/tilt/zoom support detected for the given camera device during the last device enumeration.
+     *
+     * @param {string} deviceId - The id of the 'videoinput' device.
+     * @returns {{ pan: boolean, tilt: boolean, zoom: boolean }}
+     */
+    static getCameraPTZCapabilities(deviceId) {
+        return RTCUtils.getCameraPTZCapabilities(deviceId);
+    }
+
+    /**
      * Returns event data for device to be reported to stats.
      * @returns {MediaDeviceInfo} device.
      */

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -4,6 +4,7 @@ import 'webrtc-adapter';
 
 import JitsiTrackError from '../../JitsiTrackError';
 import * as JitsiTrackErrors from '../../JitsiTrackErrors';
+import { CameraControlType } from '../../service/RTC/CameraControlType';
 import { CameraFacingMode } from '../../service/RTC/CameraFacingMode';
 import { RTCEvents } from '../../service/RTC/RTCEvents';
 import Resolutions from '../../service/RTC/Resolutions';
@@ -117,9 +118,9 @@ function probeCameraPTZSupport(devices) {
         }
 
         support.set(device.deviceId, {
-            pan: Boolean(capabilities.pan),
-            tilt: Boolean(capabilities.tilt),
-            zoom: Boolean(capabilities.zoom)
+            [CameraControlType.PAN]: Boolean(capabilities[CameraControlType.PAN]),
+            [CameraControlType.TILT]: Boolean(capabilities[CameraControlType.TILT]),
+            [CameraControlType.ZOOM]: Boolean(capabilities[CameraControlType.ZOOM])
         });
     }
 
@@ -448,9 +449,9 @@ class RTCUtils extends Listenable {
      */
     getCameraPTZCapabilities(deviceId) {
         return cameraPTZSupport.get(deviceId) ?? {
-            pan: false,
-            tilt: false,
-            zoom: false
+            [CameraControlType.PAN]: false,
+            [CameraControlType.TILT]: false,
+            [CameraControlType.ZOOM]: false
         };
     }
 

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -140,6 +140,7 @@ function emptyFuncton() {
  * @param {Array} um - An array of user media types to get. The accepted types are "video", "audio", and "desktop."
  * @param {Object} options - Various values to be added to the constraints.
  * @param {string} options.cameraDeviceId - The device id for the video capture device to get video from.
+ * @param {boolean} options.cameraPtz - Whether to ask for the pan/tilt/zoom capabilities of the camera.
  * @param {Object} options.constraints - Default constraints object to use as a base for the returned constraints.
  * @param {Object} options.desktopStream - The desktop source id from which to capture a desktop sharing video.
  * @param {string} options.facingMode - Which direction the camera is pointing to (applicable on mobile)
@@ -194,6 +195,15 @@ function getConstraints(um = [], options = {}) {
             constraints.video.deviceId = { exact: options.cameraDeviceId };
         } else if (browser.isMobileDevice()) {
             constraints.video.facingMode = options.facingMode || CameraFacingMode.USER;
+        }
+
+        // The pan/tilt/zoom capabilities of a camera are only exposed on a track that asked for them, and asking
+        // prompts the user for a permission separate from the camera one. Denying it still resolves with a working
+        // camera, just without the capabilities.
+        if (options.cameraPtz && browser.supportsCameraPtz()) {
+            constraints.video[CameraControlType.PAN] = true;
+            constraints.video[CameraControlType.TILT] = true;
+            constraints.video[CameraControlType.ZOOM] = true;
         }
     } else {
         constraints.video = false;

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -85,6 +85,47 @@ if (isAudioOutputDeviceChangeAvailable) {
 let availableDevices = [];
 let availableDevicesPollTimer;
 
+// Per-camera pan/tilt/zoom support, keyed by deviceId. Populated best-effort during device enumeration by probing
+// InputDeviceInfo.getCapabilities(). Used by the application to decide whether to offer camera control for a device
+// without having to first acquire a stream from it. The values reflect what the browser reports at enumeration time;
+// pan/tilt in particular may only appear once the panTiltZoom permission has been granted, so the authoritative
+// capabilities for a live track come from JitsiLocalTrack.getCameraControlCapabilities().
+let cameraPTZSupport = new Map();
+
+/**
+ * Probes the pan/tilt/zoom support of every video input device in the given list via InputDeviceInfo.getCapabilities()
+ * and stores the result in {@link cameraPTZSupport}. Best-effort: browsers without InputDeviceInfo.getCapabilities()
+ * (or that throw) simply record no PTZ support for the device.
+ *
+ * @param {MediaDeviceInfo[]} devices - The enumerated devices.
+ * @returns {void}
+ */
+function probeCameraPTZSupport(devices) {
+    const support = new Map();
+
+    for (const device of devices) {
+        if (device.kind !== 'videoinput') {
+            continue; // eslint-disable-line no-continue
+        }
+
+        let capabilities = {};
+
+        try {
+            capabilities = typeof device.getCapabilities === 'function' ? device.getCapabilities() : {};
+        } catch (error) {
+            logger.warn(`Failed to read capabilities for camera ${device.deviceId}: ${error}`);
+        }
+
+        support.set(device.deviceId, {
+            pan: Boolean(capabilities.pan),
+            tilt: Boolean(capabilities.tilt),
+            zoom: Boolean(capabilities.zoom)
+        });
+    }
+
+    cameraPTZSupport = support;
+}
+
 /**
  * An empty function.
  */
@@ -385,14 +426,32 @@ class RTCUtils extends Listenable {
     enumerateDevices(callback) {
         navigator.mediaDevices.enumerateDevices()
             .then(devices => {
+                probeCameraPTZSupport(devices);
                 this._updateKnownDevices(devices);
                 callback(devices);
             })
             .catch(error => {
                 logger.warn(`Failed to  enumerate devices. ${error}`);
+                probeCameraPTZSupport([]);
                 this._updateKnownDevices([]);
                 callback([]);
             });
+    }
+
+    /**
+     * Returns the pan/tilt/zoom support that was detected for the camera with the given device id during the last
+     * device enumeration.
+     *
+     * @param {string} deviceId - The id of the 'videoinput' device.
+     * @returns {{ pan: boolean, tilt: boolean, zoom: boolean }} - The detected support. All false when the device is
+     * unknown or the browser does not expose camera capabilities.
+     */
+    getCameraPTZCapabilities(deviceId) {
+        return cameraPTZSupport.get(deviceId) ?? {
+            pan: false,
+            tilt: false,
+            zoom: false
+        };
     }
 
     /**

--- a/modules/RTC/RTCUtils.spec.ts
+++ b/modules/RTC/RTCUtils.spec.ts
@@ -128,4 +128,89 @@ describe('RTCUtils', () => {
                 jasmine.anything());
         });
     });
+
+    describe('camera PTZ capability probing', () => {
+        /* eslint-disable require-jsdoc */
+        const enumerate = (devices: any[]): Promise<void> => {
+            if (!navigator.mediaDevices) {
+                (navigator as any).mediaDevices = {};
+            }
+            spyOn(navigator.mediaDevices, 'enumerateDevices').and.returnValue(Promise.resolve(devices));
+
+            return new Promise(resolve => (RTCUtils as any).enumerateDevices(() => resolve()));
+        };
+        /* eslint-enable require-jsdoc */
+
+        it('records pan/tilt/zoom support read from InputDeviceInfo.getCapabilities()', async () => {
+            await enumerate([
+                {
+                    deviceId: 'ptz-cam',
+                    kind: 'videoinput',
+                    getCapabilities: () => ({
+                        pan: { max: 1, min: 0, step: 1 },
+                        tilt: { max: 1, min: 0, step: 1 },
+                        zoom: { max: 4, min: 1, step: 1 }
+                    })
+                }
+            ]);
+
+            expect(RTCUtils.getCameraPTZCapabilities('ptz-cam')).toEqual({ pan: true,
+                tilt: true,
+                zoom: true });
+        });
+
+        it('reports a zoom-only camera and a plain camera correctly', async () => {
+            await enumerate([
+                { deviceId: 'zoom-cam', kind: 'videoinput', getCapabilities: () => ({ zoom: { max: 4, min: 1 } }) },
+                { deviceId: 'plain-cam', kind: 'videoinput', getCapabilities: () => ({}) }
+            ]);
+
+            expect(RTCUtils.getCameraPTZCapabilities('zoom-cam')).toEqual({ pan: false,
+                tilt: false,
+                zoom: true });
+            expect(RTCUtils.getCameraPTZCapabilities('plain-cam')).toEqual({ pan: false,
+                tilt: false,
+                zoom: false });
+        });
+
+        it('treats a camera without getCapabilities() as having no PTZ support', async () => {
+            await enumerate([ { deviceId: 'legacy-cam', kind: 'videoinput' } ]);
+
+            expect(RTCUtils.getCameraPTZCapabilities('legacy-cam')).toEqual({ pan: false,
+                tilt: false,
+                zoom: false });
+        });
+
+        it('does not throw when getCapabilities() throws and records no support', async () => {
+            await enumerate([
+                {
+                    deviceId: 'bad-cam',
+                    kind: 'videoinput',
+                    getCapabilities: () => {
+                        throw new Error('boom');
+                    }
+                }
+            ]);
+
+            expect(RTCUtils.getCameraPTZCapabilities('bad-cam')).toEqual({ pan: false,
+                tilt: false,
+                zoom: false });
+        });
+
+        it('ignores non-videoinput devices', async () => {
+            await enumerate([
+                { deviceId: 'mic', kind: 'audioinput', getCapabilities: () => ({ zoom: { max: 4, min: 1 } }) }
+            ]);
+
+            expect(RTCUtils.getCameraPTZCapabilities('mic')).toEqual({ pan: false,
+                tilt: false,
+                zoom: false });
+        });
+
+        it('returns all-false for an unknown device id', () => {
+            expect(RTCUtils.getCameraPTZCapabilities('does-not-exist')).toEqual({ pan: false,
+                tilt: false,
+                zoom: false });
+        });
+    });
 });

--- a/modules/browser/BrowserCapabilities.spec.ts
+++ b/modules/browser/BrowserCapabilities.spec.ts
@@ -1,0 +1,37 @@
+import BrowserCapabilities from './BrowserCapabilities';
+
+describe('BrowserCapabilities', () => {
+    describe('supportsCameraPtz', () => {
+        let browser: BrowserCapabilities;
+
+        beforeEach(() => {
+            browser = new BrowserCapabilities();
+
+            if (!navigator.mediaDevices) {
+                (navigator as any).mediaDevices = {};
+            }
+            if (!navigator.mediaDevices.getSupportedConstraints) {
+                (navigator.mediaDevices as any).getSupportedConstraints = () => ({});
+            }
+        });
+
+        it('returns true when getSupportedConstraints reports pan, tilt and zoom', () => {
+            spyOn(navigator.mediaDevices, 'getSupportedConstraints')
+                .and.returnValue({ pan: true, tilt: true, zoom: true } as any);
+
+            expect(browser.supportsCameraPtz()).toBe(true);
+        });
+
+        it('returns false when only some PTZ constraints are reported (e.g. zoom-only)', () => {
+            spyOn(navigator.mediaDevices, 'getSupportedConstraints').and.returnValue({ zoom: true } as any);
+
+            expect(browser.supportsCameraPtz()).toBe(false);
+        });
+
+        it('returns false when no PTZ constraints are reported', () => {
+            spyOn(navigator.mediaDevices, 'getSupportedConstraints').and.returnValue({} as any);
+
+            expect(browser.supportsCameraPtz()).toBe(false);
+        });
+    });
+});

--- a/modules/browser/BrowserCapabilities.ts
+++ b/modules/browser/BrowserCapabilities.ts
@@ -189,6 +189,20 @@ export default class BrowserCapabilities extends BrowserDetection {
     }
 
     /**
+     * Checks whether the browser implements the MediaCapture camera pan/tilt/zoom (PTZ) constraints, via
+     * navigator.mediaDevices.getSupportedConstraints(). This reflects API support only, not whether a connected
+     * camera has PTZ hardware or whether the panTiltZoom permission has been granted - the caller combines this with
+     * the per-camera capabilities and the panTiltZoom permission for those.
+     *
+     * @returns {boolean}
+     */
+    supportsCameraPtz(): boolean {
+        const supported = navigator.mediaDevices?.getSupportedConstraints?.() ?? {};
+
+        return Boolean((supported as any).pan && (supported as any).tilt && (supported as any).zoom);
+    }
+
+    /**
      * Checks if the current browser supports setting codec preferences on the transceiver.
      *
      * @returns {boolean}

--- a/service/RTC/CameraControlType.spec.ts
+++ b/service/RTC/CameraControlType.spec.ts
@@ -1,0 +1,23 @@
+import * as exported from "./CameraControlType";
+
+// this test is brittle on purpose because it's designed to ensure that the TypeScript conversion maintains backward compatibility
+
+describe( "/service/RTC/CameraControlType members", () => {
+    const {
+        CameraControlType,
+        ...others
+    } = exported;
+
+    it( "known members", () => {
+        expect( CameraControlType ).toBeDefined();
+
+        expect( CameraControlType.PAN ).toBe( 'pan' );
+        expect( CameraControlType.TILT ).toBe( 'tilt' );
+        expect( CameraControlType.ZOOM ).toBe( 'zoom' );
+    } );
+
+    it( "unknown members", () => {
+        const keys = Object.keys( others );
+        expect( keys ).withContext( `Extra members: ${ keys.join( ", " ) }` ).toEqual( [] );
+    } );
+} );

--- a/service/RTC/CameraControlType.ts
+++ b/service/RTC/CameraControlType.ts
@@ -1,0 +1,10 @@
+/**
+ * Enumeration of the camera pan/tilt/zoom controls. The values match the corresponding
+ * MediaTrackConstraints/MediaTrackCapabilities/MediaTrackSettings member names defined by the
+ * MediaCapture PTZ spec, so they can be used directly as constraint keys.
+ */
+export enum CameraControlType {
+    PAN = 'pan',
+    TILT = 'tilt',
+    ZOOM = 'zoom'
+}


### PR DESCRIPTION
## Description

Adds the lib-jitsi-meet foundation for camera pan/tilt/zoom (PTZ) support. This is the shared base that jitsi-meet builds both **local PTZ control** and **far-end camera control (FECC)** on top of — FECC signaling itself lives entirely in jitsi-meet (like `remote-control`), using generic endpoint messages plus the receive-side track API added here.

### Track control (JitsiLocalTrack)

- `getCameraControlCapabilities()` — pan/tilt/zoom `{ min, max, step }` ranges from the live camera `MediaStreamTrack.getCapabilities()`. A control is present only when the camera exposes it.
- `getCameraControlSettings()` — current pan/tilt/zoom values from `getSettings()`.
- `setCameraControl({ pan, tilt, zoom })` — applies the given values via `MediaStreamTrack.applyConstraints({ advanced: [...] })` **directly on the existing track**. No stream re-acquisition, no renegotiation — PTZ does not change the encoded stream or SSRCs. Only the provided controls are applied; the rest are untouched. The caller clamps to the reported ranges. Camera-tracks only (rejects otherwise).

### Capability probing at enumeration (RTCUtils)

- During `enumerateDevices`, each `videoinput` is probed best-effort via `InputDeviceInfo.getCapabilities()` for `pan`/`tilt`/`zoom` presence.
- Exposed through `RTC.getCameraPTZCapabilities(deviceId)` and `JitsiMediaDevices.getCameraPTZCapabilities(deviceId)` so the app can decide whether to offer camera control for a device **without first acquiring a stream from it**.
- Detection is a hint: `pan`/`tilt` may only appear once the `panTiltZoom` permission is granted, so the authoritative per-track capabilities come from `getCameraControlCapabilities()`.

### Permission

Requesting the (separate) `panTiltZoom` permission is left to the application: `createLocalTracks({ devices: ['video'], constraints: { video: { pan: true, tilt: true, zoom: true } } })`. `getConstraints` already passes those through unchanged, so no change is needed here. jitsi-meet drives the mid-call re-acquire + replaceTrack.

## Testing

- `modules/RTC/JitsiLocalTrack.spec.ts` (new): capabilities/settings reads, `setCameraControl` applies only provided controls via advanced constraints, no-op on empty, rejects for non-camera tracks, propagates underlying rejection.
- `modules/RTC/RTCUtils.spec.ts`: enumeration probe for full-PTZ, zoom-only, plain, no-`getCapabilities`, throwing, and non-video devices, plus unknown-device fallback.
- `npm test` 573/573; `npm run type-check` clean.

## Follow-up (jitsi-meet)

Consumes this API to add: local PTZ UI + mid-call permission re-acquire, and the FECC feature (absolute-value endpoint messages both directions, remote video-menu control, receive-side `setCameraControl`), gated to non-mobile Chromium and a config flag. Not part of this PR.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
