### PR TITLE
fix(RTC): stop the remote audio wedge watchdog firing when nothing is being sent

### DIFF
--- a/modules/RTC/RemoteAudioWedgeDetector.spec.ts
+++ b/modules/RTC/RemoteAudioWedgeDetector.spec.ts
@@ -242,6 +242,57 @@ describe('RemoteAudioWedgeDetector', () => {
         expect(onWedgeDetected).toHaveBeenCalledTimes(1);
     });
 
+    it('stops recovering a source that recycling does not fix', () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        const entries = [ { packetsReceived: 0, ssrc: 111 } ];
+
+        // The source never receives anything however often it is recycled - it is not wedged, nothing is being sent to
+        // it - so recoveries must stop rather than churning a renegotiation every detection window for the whole call.
+        for (let i = 0; i < 100; i++) {
+            poll(entries);
+            tick();
+        }
+        expect(onWedgeDetected).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives a source a fresh recovery budget when it moves to a new receive slot', () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+
+        for (let i = 0; i < 100; i++) {
+            poll([ { packetsReceived: 0, ssrc: 111 } ]);
+            tick();
+        }
+        expect(onWedgeDetected).toHaveBeenCalledTimes(2);
+
+        // A new SSRC for the same source name means a source-add created a new receive m-line for it, which is a fresh
+        // wedge opportunity rather than a continuation of the slot that was already recycled to no effect.
+        tracks = [ mockTrack(222, 'source-A') ];
+        for (let i = 0; i < 100; i++) {
+            poll([ { packetsReceived: 0, ssrc: 222 } ]);
+            tick();
+        }
+        expect(onWedgeDetected).toHaveBeenCalledTimes(4);
+    });
+
+    it('keeps an exhausted recovery budget with the slot when it is remapped to another source', () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+
+        for (let i = 0; i < 100; i++) {
+            poll([ { packetsReceived: 0, ssrc: 111 } ]);
+            tick();
+        }
+        expect(onWedgeDetected).toHaveBeenCalledTimes(2);
+
+        // The bridge remapped the slot to a different source. The m-line is the same one that recycling already failed
+        // to revive, so the new occupant must not earn a fresh budget on it.
+        tracks = [ mockTrack(111, 'source-B') ];
+        for (let i = 0; i < 100; i++) {
+            poll([ { packetsReceived: 0, ssrc: 111 } ]);
+            tick();
+        }
+        expect(onWedgeDetected).toHaveBeenCalledTimes(2);
+    });
+
     it('keeps a source that has received packets exempt after it is unmapped and remapped', () => {
         tracks = [ mockTrack(111, 'source-A') ];
 

--- a/modules/RTC/RemoteAudioWedgeDetector.spec.ts
+++ b/modules/RTC/RemoteAudioWedgeDetector.spec.ts
@@ -242,6 +242,26 @@ describe('RemoteAudioWedgeDetector', () => {
         expect(onWedgeDetected).toHaveBeenCalledTimes(1);
     });
 
+    it('keeps a source that has received packets exempt after it is unmapped and remapped', () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+
+        poll([ { packetsReceived: 7, ssrc: 111 } ]); // healthy: the m-line demuxes this SSRC correctly
+
+        // Under SSRC rewriting a rewritten SSRC keeps its receive m-line for the lifetime of the peerconnection, so a
+        // later source remapped onto the same SSRC inherits an m-line that is known to demux it and cannot be wedged -
+        // even while it reports zero packets (the new owner may simply be silent).
+        tick();
+        tracks = [];
+        poll([]);
+
+        tracks = [ mockTrack(111, 'source-B') ];
+        for (let i = 0; i < 10; i++) {
+            tick();
+            poll([ { packetsReceived: 0, ssrc: 111 } ]);
+        }
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+    });
+
     it('does not fire while media transfer is suspended on the peerconnection', () => {
         tracks = [ mockTrack(111, 'source-A') ];
         pc.audioTransferActive = false;

--- a/modules/RTC/RemoteAudioWedgeDetector.spec.ts
+++ b/modules/RTC/RemoteAudioWedgeDetector.spec.ts
@@ -69,6 +69,7 @@ describe('RemoteAudioWedgeDetector', () => {
 
         tracks = [];
         pc = {
+            audioTransferActive: true,
             eventEmitter: new EventEmitter(),
             getRemoteTracks: (_endpointId: any, mediaType: MediaType) => {
                 expect(mediaType).toBe(MediaType.AUDIO);
@@ -238,6 +239,44 @@ describe('RemoteAudioWedgeDetector', () => {
         poll(entries); // t=5000
         tick();
         poll(entries); // t=6000 (== fire time + cooldown), cooldown just elapsed; streak restarts here
+        expect(onWedgeDetected).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire while media transfer is suspended on the peerconnection', () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        pc.audioTransferActive = false;
+
+        // A JVB session is suspended for the duration of an active P2P session and receives no RTP at all while it is,
+        // so its remote audio sources report zero packets indefinitely without being wedged.
+        for (let i = 0; i < 20; i++) {
+            poll([ { packetsReceived: 0, ssrc: 111 } ]);
+            tick();
+        }
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+    });
+
+    it('restarts the detection window when media transfer resumes', () => {
+        tracks = [ mockTrack(111, 'source-A') ];
+        const entries = [ { packetsReceived: 0, ssrc: 111 } ];
+
+        pc.audioTransferActive = false;
+        for (let i = 0; i < 5; i++) {
+            poll(entries); // t=0..4000, suspended
+            tick();
+        }
+
+        // The suspended period must not count towards the timeout: the first samples after resuming start a fresh
+        // streak rather than firing immediately on an elapsed-looking window.
+        pc.audioTransferActive = true;
+        poll(entries); // t=5000, fresh streak starts here
+        tick();
+        poll(entries); // t=6000
+        tick();
+        poll(entries); // t=7000
+        expect(onWedgeDetected).not.toHaveBeenCalled();
+
+        tick();
+        poll(entries); // t=8000, elapsed since the fresh streak is 3000 >= timeout
         expect(onWedgeDetected).toHaveBeenCalledTimes(1);
     });
 

--- a/modules/RTC/RemoteAudioWedgeDetector.ts
+++ b/modules/RTC/RemoteAudioWedgeDetector.ts
@@ -22,6 +22,13 @@ const DEFAULT_WEDGE_TIMEOUT_MS = 15000;
  */
 const MIN_SAMPLES = 2;
 
+/**
+ * The maximum number of recoveries to trigger for a receive slot (a rewritten SSRC). Recycling the source is only a fix
+ * for the wedge; if the slot still receives nothing after this many attempts it is not wedged (the sender is silent, or
+ * the bridge is not forwarding it), and further recycles are pure renegotiation churn.
+ */
+const MAX_RECOVERY_ATTEMPTS = 2;
+
 interface IEligibleZeroState {
 
     /**
@@ -33,6 +40,20 @@ interface IEligibleZeroState {
      * The timestamp (Date.now()) of the first eligible zero-RTP sample in the current streak.
      */
     since: number;
+}
+
+interface IRecoveryState {
+
+    /**
+     * The number of recoveries triggered for the slot so far.
+     */
+    attempts: number;
+
+    /**
+     * The timestamp (Date.now()) until which detection is suppressed for the slot, so the watchdog does not re-fire
+     * while a recycle renegotiation is in flight.
+     */
+    cooldownUntil: number;
 }
 
 export interface IRemoteAudioWedgeDetectorOptions {
@@ -80,6 +101,13 @@ export interface IRemoteAudioWedgeDetectorOptions {
  * Evaluation is skipped entirely while media transfer is suspended on the peerconnection. A JVB session is kept alive
  * but suspended for the duration of an active P2P session, and a suspended session receives no RTP at all by design, so
  * every remote audio source on it would otherwise look permanently wedged.
+ *
+ * Recoveries are capped at {@link MAX_RECOVERY_ATTEMPTS} per receive slot, i.e. per rewritten SSRC - the identity a
+ * recovery preserves, since recycling the source hands it a new m-line and msid. Zero inbound RTP is not exclusive to
+ * the wedge - a bridge that discards silence forwards nothing at all for a sender that is digitally silent from the
+ * start of its stream - and recycling cannot fix a slot that is receiving nothing because nothing is being sent to it.
+ * The cap bounds that case to a couple of renegotiations instead of one every detection window for the rest of the
+ * call.
  */
 export default class RemoteAudioWedgeDetector {
     private _pc: TraceablePeerConnection;
@@ -107,11 +135,16 @@ export default class RemoteAudioWedgeDetector {
     private _healthyBySsrc: Set<number>;
 
     /**
-     * Maps a source name to the timestamp (Date.now()) until which detection is suppressed for that source. Used as a
-     * cooldown after a recovery is triggered so the watchdog does not re-fire while the recycle renegotiation is in
-     * flight and the re-added source (same SSRC, fresh m-line/track) starts receiving.
+     * Maps a receive slot (rewritten SSRC) to the state of the recoveries triggered for it: the cooldown that keeps the
+     * watchdog quiet while a recycle renegotiation is in flight and the re-added source (same SSRC, fresh m-line/track)
+     * starts receiving, and the attempt count that stops it recycling a slot that recycling cannot fix.
+     *
+     * Keyed on the SSRC rather than on the source name or the m-line. The m-line cannot carry the count because a
+     * recovery replaces it (source-remove then source-add mints a fresh msid), so a per-m-line budget would reset on
+     * every attempt and never converge. The SSRC is what a recovery preserves, and it also keeps an exhausted budget
+     * with the slot when the bridge remaps it to a different source, whose receive path is just as dead.
      */
-    private _cooldownUntilBySource: Map<string, number>;
+    private _recoveryStateBySsrc: Map<number, IRecoveryState>;
 
     /**
      * Creates a new {@code RemoteAudioWedgeDetector}. The detector is inert until {@link start} is called.
@@ -126,7 +159,7 @@ export default class RemoteAudioWedgeDetector {
         this._started = false;
         this._eligibleZeroBySsrc = new Map();
         this._healthyBySsrc = new Set();
-        this._cooldownUntilBySource = new Map();
+        this._recoveryStateBySsrc = new Map();
     }
 
     /**
@@ -183,13 +216,10 @@ export default class RemoteAudioWedgeDetector {
                 continue; // eslint-disable-line no-continue
             }
 
-            const cooldownUntil = this._cooldownUntilBySource.get(track.getSourceName());
+            const recovery = this._recoveryStateBySsrc.get(ssrc);
 
-            if (cooldownUntil !== undefined) {
-                if (now < cooldownUntil) {
-                    continue; // eslint-disable-line no-continue
-                }
-                this._cooldownUntilBySource.delete(track.getSourceName());
+            if (recovery && (recovery.attempts >= MAX_RECOVERY_ATTEMPTS || now < recovery.cooldownUntil)) {
+                continue; // eslint-disable-line no-continue
             }
 
             candidates.push({
@@ -234,16 +264,30 @@ export default class RemoteAudioWedgeDetector {
             state.samples++;
 
             if (state.samples >= MIN_SAMPLES && now - state.since >= this._wedgeTimeoutMs) {
-                logger.warn(`Detected wedged remote audio source ${track.getSourceName()} (ssrc=${ssrc}, owner=`
+                const sourceName = track.getSourceName();
+                const attempts = (this._recoveryStateBySsrc.get(ssrc)?.attempts ?? 0) + 1;
+
+                logger.warn(`Detected wedged remote audio source ${sourceName} (ssrc=${ssrc}, owner=`
                     + `${track.getParticipantId()}): zero inbound RTP for ${now - state.since}ms `
-                    + 'while continuously mapped and unmuted. Triggering recovery.');
+                    + `while continuously mapped and unmuted. Triggering recovery (attempt ${attempts} of `
+                    + `${MAX_RECOVERY_ATTEMPTS}).`);
                 this._eligibleZeroBySsrc.delete(ssrc);
 
                 // Suppress further detection for this source while the recycle renegotiation completes. Until then the
                 // source is still wedged (so it would immediately re-fire), and once recovery re-adds it (same SSRC,
-                // fresh m-line/track) the new receiver reads zero for a moment before media flows. Keying the cooldown
-                // off the stable source name covers the remove/re-add transition.
-                this._cooldownUntilBySource.set(track.getSourceName(), now + this._wedgeTimeoutMs);
+                // fresh m-line/track) the new receiver reads zero for a moment before media flows. Keying the state
+                // off the SSRC, which the re-add preserves, covers the remove/re-add transition.
+                this._recoveryStateBySsrc.set(ssrc, {
+                    attempts,
+                    cooldownUntil: now + this._wedgeTimeoutMs
+                });
+
+                if (attempts >= MAX_RECOVERY_ATTEMPTS) {
+                    logger.warn(`Remote audio source ${sourceName} (ssrc=${ssrc}) has been recycled `
+                        + `${attempts} times without receiving any RTP; it is not recoverable by recycling. No `
+                        + 'further recovery will be attempted for it on this m-line.');
+                }
+
                 this._onWedgeDetected(track);
             }
         }
@@ -277,6 +321,6 @@ export default class RemoteAudioWedgeDetector {
         }
         this._eligibleZeroBySsrc.clear();
         this._healthyBySsrc.clear();
-        this._cooldownUntilBySource.clear();
+        this._recoveryStateBySsrc.clear();
     }
 }

--- a/modules/RTC/RemoteAudioWedgeDetector.ts
+++ b/modules/RTC/RemoteAudioWedgeDetector.ts
@@ -76,6 +76,10 @@ export interface IRemoteAudioWedgeDetectorOptions {
  * time before it fires. Eligibility - unlike the cumulative packet count - is not monotonic (a participant can mute and
  * unmute), so the streak is reset whenever the source becomes muted, unmapped, or receives any packet; this is what the
  * repeated samples verify. A {@link MIN_SAMPLES} floor debounces transient stats artifacts.
+ *
+ * Evaluation is skipped entirely while media transfer is suspended on the peerconnection. A JVB session is kept alive
+ * but suspended for the duration of an active P2P session, and a suspended session receives no RTP at all by design, so
+ * every remote audio source on it would otherwise look permanently wedged.
  */
 export default class RemoteAudioWedgeDetector {
     private _pc: TraceablePeerConnection;
@@ -147,6 +151,15 @@ export default class RemoteAudioWedgeDetector {
      */
     private _evaluate(packetsBySsrc: Map<number, number>): void {
         const now = Date.now();
+
+        // Media transfer is suspended for the whole of an active P2P session, during which the session receives no RTP
+        // by design. Drop the streaks so the detection window starts over when it resumes rather than counting the
+        // suspended period against the sources.
+        if (!this._pc.audioTransferActive) {
+            this._eligibleZeroBySsrc.clear();
+
+            return;
+        }
 
         // A source can only be wedged if it is mapped, unmuted, not in a post-recovery cooldown, and has not yet been
         // confirmed healthy (received a packet).

--- a/modules/RTC/RemoteAudioWedgeDetector.ts
+++ b/modules/RTC/RemoteAudioWedgeDetector.ts
@@ -95,7 +95,14 @@ export default class RemoteAudioWedgeDetector {
     /**
      * The set of SSRCs that have been observed receiving at least one RTP packet. Such a source is demuxing correctly
      * and cannot be wedged (the wedge is "never received anything", and the cumulative packet count is monotonic), so
-     * it is excluded from evaluation for the rest of its lifetime.
+     * it is excluded from evaluation for the rest of the peerconnection's lifetime.
+     *
+     * Entries are never dropped, not even when the SSRC stops being mapped. Under SSRC rewriting a rewritten SSRC gets
+     * exactly one receive m-line for the lifetime of the peerconnection: {@link TraceablePeerConnection.addRemoteSsrc}
+     * only reports an SSRC as new once, so a source-add (which creates the m-line) happens once per SSRC and every
+     * later appearance of that SSRC in a source map is an in-place remap onto the same m-line, transceiver and track.
+     * A remap therefore inherits an m-line that is already demuxing that SSRC correctly and cannot be wedged, whichever
+     * source now occupies it.
      */
     private _healthyBySsrc: Set<number>;
 
@@ -163,7 +170,6 @@ export default class RemoteAudioWedgeDetector {
 
         // A source can only be wedged if it is mapped, unmuted, not in a post-recovery cooldown, and has not yet been
         // confirmed healthy (received a packet).
-        const mappedSsrcs = new Set<number>();
         const candidates: Array<{ ssrc: number; track: JitsiRemoteTrack; }> = [];
 
         for (const track of this._pc.getRemoteTracks(undefined, MediaType.AUDIO)) {
@@ -172,7 +178,6 @@ export default class RemoteAudioWedgeDetector {
             if (typeof ssrc !== 'number') {
                 continue; // eslint-disable-line no-continue
             }
-            mappedSsrcs.add(ssrc);
 
             if (this._healthyBySsrc.has(ssrc) || track.isMuted()) {
                 continue; // eslint-disable-line no-continue
@@ -191,14 +196,6 @@ export default class RemoteAudioWedgeDetector {
                 ssrc,
                 track
             });
-        }
-
-        // Drop the confirmed-healthy mark for any SSRC that is no longer mapped (the source was removed/remapped), so a
-        // future source reusing the SSRC is re-evaluated from scratch.
-        for (const ssrc of this._healthyBySsrc) {
-            if (!mappedSsrcs.has(ssrc)) {
-                this._healthyBySsrc.delete(ssrc);
-            }
         }
 
         // Drop streak bookkeeping for any SSRC that is no longer a candidate (unmapped, muted, cooling down, or now


### PR DESCRIPTION
The remote audio wedge watchdog added in #3051 / #3062 fires on the absence of inbound RTP, but zero inbound RTP is not exclusive to the wedge. A field report shows it recycling a healthy source 23 times over 15 minutes in an ordinary two-person call.

### What happened in the field

A 2-participant call keeps its JVB session alive as a fallback and merely *suspends* it for the duration of the P2P session, which leaves every eligibility condition the watchdog tests satisfied while no RTP can arrive:

- `_removeRemoteJVBTracks()` only detaches the tracks from the `JitsiParticipant` and emits `TRACK_REMOVED`; `TraceablePeerConnection.remoteTracks` — what the detector iterates — still holds them for the rest of the call.
- `setMediaTransferActive(false)` deactivates the sender encodings on both peers, so the bridge has nothing to forward and the session reads zero inbound RTP.
- The JVB stats collector keeps polling (`stopRemoteStats` runs only in `_stopJvbSession`), so `INBOUND_AUDIO_STATS` keeps arriving with zeros, and the detector itself only stops in `JingleSessionPC.close()`.
- Mute state is signaling-derived, so the sources stay unmuted.

From the log, bracketed exactly by the suspend/resume pair:

```
16:11:31.537  Starting remote audio wedge detector (wedgeTimeout=15000ms)
16:11:31.714  Received AudioSourcesMap: [{"source":"ebece0cc-a0","owner":"ebece0cc","ssrc":2360120133}]
16:11:31.745  Peer to peer connection established!
16:11:31.747  TPC[id=1,type=JVB] Suspending media transfer.
16:12:01.498  Detected wedged remote audio source ebece0cc-a0 ... Triggering recovery.   <- 1st of 23
16:27:11.707  Detected wedged remote audio source ebece0cc-a0 ... Triggering recovery.   <- 23rd
16:27:13.789  Resuming media transfer over the JVB connection... / Peer to peer connection closed!
```

Each firing ran a source-remove plus source-add — two offer/answer cycles — on the suspended peerconnection, with the freshly added track discarded by the conference every time (`Trying to add remote JVB track, when in P2P - IGNORED`).

### Changes

Three separate commits:

1. **Skip detection while media transfer is suspended.** Bail out of `_evaluate` when the peerconnection's `audioTransferActive` is false, clearing the streaks so the detection window restarts on resume instead of counting the suspended period against the sources. This is the fix for the report above.

2. **Keep a proven receive m-line exempt for the peerconnection's lifetime.** A source confirmed healthy by receiving RTP was re-armed as soon as its SSRC stopped being mapped, so that a future source reusing the SSRC would be re-evaluated from scratch. That is backwards: `addRemoteSsrc()` reports an SSRC as new only once, so `processSourceMap` creates the receive m-line once per SSRC and every later appearance of it in a source map is an in-place remap — same m-line, transceiver and track, metadata only, no SDP change. A remap inherits an m-line that already demuxes that SSRC correctly and cannot be wedged, whichever source now occupies it.

3. **Cap recoveries at 2 per receive slot.** A bridge that discards silence forwards nothing at all for a sender that is digitally silent from the start of its stream: `AudioLevelReader` lets the first few packets of a stream through (`forwarded-silence-packets-limit`, default 3) and discards every silence packet after that, and `AudioSsrcCache` allocates the send SSRC — and sends the `AudioSourcesMap` that makes the client create the receive m-line — on a packet that got through. If that short head-of-stream burst is spent before the m-line is negotiated, the source is mapped and unmuted yet permanently at zero RTP without being wedged, and recycling cannot change that. The attempts are counted per rewritten SSRC: the m-line cannot carry the count because a recovery replaces it (source-remove then source-add mints a fresh msid), so a per-m-line budget would reset on every attempt and never converge; the source name cannot either, since it would hand a fresh budget to whichever source the bridge next remaps onto a slot recycling has already failed to revive.

### Testing

`npm run lint` and the karma suite are green at each commit, not just at the tip (559 / 560 / 563 tests). Six new `RemoteAudioWedgeDetector` specs cover: no firing while suspended, the window restarting on resume, a healthy source staying exempt across unmap/remap, recoveries stopping at the cap, a fresh budget on a new receive slot, and an exhausted budget staying with a slot that is remapped to another source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)