### PR TITLE
Add moderator chat shadow-mute support 

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -3755,6 +3755,50 @@ export default class JitsiConference extends Listenable {
         this.room.muteParticipant(participant.getJid(), true, mediaType);
     }
 
+    /**
+     * Shadow-mutes a participant's chat messages so they are not delivered
+     * to the rest of the conference. The participant is not notified.
+     *
+     * @param {string} id - The id of the participant to mute.
+     * @returns {void}
+     */
+    public muteChatParticipant(id: string): void {
+        if (!this.isModerator()) {
+            logger.error(`Cannot mute chat participant ${id}, not a moderator`);
+
+            return;
+        }
+
+        const participant = this.getParticipantById(id);
+
+        if (!participant) {
+            return;
+        }
+
+        this.room.muteChatParticipant(participant.getJid());
+    }
+
+    /**
+     * Restores a shadow-muted participant's chat.
+     *
+     * @param {string} id - The id of the participant to unmute.
+     * @returns {void}
+     */
+    public unmuteChatParticipant(id: string): void {
+        if (!this.isModerator()) {
+            logger.error(`Cannot unmute chat participant ${id}, not a moderator`);
+
+            return;
+        }
+
+        const participant = this.getParticipantById(id);
+
+        if (!participant) {
+            return;
+        }
+
+        this.room.unmuteChatParticipant(participant.getJid());
+    }
 
     /* eslint-disable max-params */
 

--- a/JitsiConferenceEventManager.ts
+++ b/JitsiConferenceEventManager.ts
@@ -421,6 +421,26 @@ export default class JitsiConferenceEventManager {
                     participantId, txt, ts, messageId, displayName, isVisitor, replyToId);
             });
 
+        chatRoom.addListener(
+            XMPPEvents.CHAT_PARTICIPANT_MUTED,
+            (jid: string) => {
+                const participantId = Strophe.getResourceFromJid(jid);
+
+                conference.eventEmitter.emit(
+                    JitsiConferenceEvents.CHAT_PARTICIPANT_MUTED,
+                    participantId);
+            });
+
+        chatRoom.addListener(
+            XMPPEvents.CHAT_PARTICIPANT_UNMUTED,
+            (jid: string) => {
+                const participantId = Strophe.getResourceFromJid(jid);
+
+                conference.eventEmitter.emit(
+                    JitsiConferenceEvents.CHAT_PARTICIPANT_UNMUTED,
+                    participantId);
+            });
+
         chatRoom.addListener(XMPPEvents.PRESENCE_STATUS,
             (jid: string, status: string) => {
                 const id = Strophe.getResourceFromJid(jid);

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -104,6 +104,16 @@ export enum JitsiConferenceEvents {
     BRIDGE_BWE_STATS_RECEIVED = 'conference.bridgeBweStatsReceived',
 
     /**
+     * Event fired when a moderator shadow-mutes a participant's chat.
+     */
+    CHAT_PARTICIPANT_MUTED = 'conference.chatParticipantMuted',
+
+    /**
+     * Event fired when a moderator restores a participant's chat.
+     */
+    CHAT_PARTICIPANT_UNMUTED = 'conference.chatParticipantUnmuted',
+
+    /**
      * UTC conference timestamp when first participant joined.
      */
     CONFERENCE_CREATED_TIMESTAMP = 'conference.createdTimestamp',

--- a/modules/xmpp/ChatRoom.ts
+++ b/modules/xmpp/ChatRoom.ts
@@ -236,6 +236,7 @@ export default class ChatRoom extends Listenable {
     private eventsForwarder: EventEmitterForwarder;
     private lobby?: Lobby;
     private avModeration: AVModeration;
+    private shadowBannedJids: Set<string> = new Set();
     private breakoutRooms: BreakoutRooms;
     private fileSharing: FileSharing;
     private polls: Polls;
@@ -439,6 +440,26 @@ export default class ChatRoom extends Listenable {
             findFirst(msg, ':scope>reply[*|xmlns="urn:xmpp:reply:0"]'),
             'to'
         );
+    }
+
+    /**
+     *
+     * @param jid
+     * @param action
+     */
+    private _sendChatModerationMessage(jid: string, action: 'mute' | 'unmute'): void {
+        const msg = $msg({
+            to: this.roomjid,
+            type: 'groupchat'
+        });
+
+        msg.c('chat-moderation', {
+            action,
+            jid: Strophe.getResourceFromJid(jid),
+            xmlns: 'http://jitsi.org/jitmeet',
+        }).up();
+
+        this.connection.send(msg);
     }
 
     /**
@@ -1492,6 +1513,55 @@ export default class ChatRoom extends Listenable {
             }
         }
 
+        const chatModerationNode = findFirst(msg, ':scope>chat-moderation[*|xmlns="http://jitsi.org/jitmeet"]');
+
+        if (chatModerationNode) {
+            // A plain groupchat message isn't server-gated to moderators the way
+            // kick()/setAffiliation() IQs are — this check is what stops a
+            // non-moderator from forging a mute directive. Note: getMemberRole()
+            // only tracks *other* members — the local user's own role is tracked
+            // separately via this.role, so we special-case the reflected copy of
+            // our own stanza (from === this.myroomjid).
+            const getRoleForOccupant = (occupantJid: string): Nullable<string> => {
+                if (occupantJid === this.myroomjid) {
+                    return this.role;
+                }
+
+                const occupantResource = Strophe.getResourceFromJid(occupantJid);
+
+                return Object.entries(this.members)
+                    .find(([ memberJid ]) => Strophe.getResourceFromJid(memberJid) === occupantResource)
+                    ?.[1].role ?? null;
+            };
+
+            const senderRole = getRoleForOccupant(from);
+
+            if (senderRole !== 'moderator') {
+                logger.warn(`Ignoring chat-moderation stanza from non-moderator ${from}`);
+
+                return true;
+            }
+
+            const targetResource = getAttribute(chatModerationNode, 'jid');
+            const action = getAttribute(chatModerationNode, 'action');
+
+            if (!targetResource || !action) {
+                logger.warn('Ignoring malformed chat-moderation stanza: missing jid or action');
+
+                return true;
+            }
+
+            if (action === 'mute') {
+                this.shadowBannedJids.add(targetResource);
+                this.eventEmitter.emit(XMPPEvents.CHAT_PARTICIPANT_MUTED, `${this.roomjid}/${targetResource}`);
+            } else if (action === 'unmute') {
+                this.shadowBannedJids.delete(targetResource);
+                this.eventEmitter.emit(XMPPEvents.CHAT_PARTICIPANT_UNMUTED, `${this.roomjid}/${targetResource}`);
+            }
+
+            return true;
+        }
+
         if (txt) {
             const messageId = getAttribute(msg, 'id') || uuidv4();
             const replyToId = this._parseReplyMessage(msg);
@@ -1520,6 +1590,12 @@ export default class ChatRoom extends Listenable {
                 this.eventEmitter.emit(XMPPEvents.PRIVATE_MESSAGE_RECEIVED,
                         from, txt, this.myroomjid, stamp, messageId, displayName, isVisitorMessage, originalFrom, replyToId);
             } else if (type === 'groupchat') {
+                const fromResource = Strophe.getResourceFromJid(from);
+
+                if (from !== this.myroomjid && this.shadowBannedJids.has(fromResource)) {
+                    return true;
+                }
+
                 const displayName = displayNameEl ? getText(displayNameEl) : undefined;
                 let sourceAttrValue = getAttribute(displayNameEl, 'source');
 
@@ -1728,6 +1804,34 @@ export default class ChatRoom extends Listenable {
                     userJid: this.connection.jid
                 });
             }, undefined);
+    }
+
+    /**
+     *
+     * @param jid
+     */
+    public muteChatParticipant(jid: string): void {
+        if (!this.isModerator()) {
+            logger.error('Cannot mute chat, not a moderator');
+
+            return;
+        }
+
+        this._sendChatModerationMessage(jid, 'mute');
+    }
+
+    /**
+     *
+     * @param jid
+     */
+    public unmuteChatParticipant(jid: string): void {
+        if (!this.isModerator()) {
+            logger.error('Cannot unmute chat, not a moderator');
+
+            return;
+        }
+
+        this._sendChatModerationMessage(jid, 'unmute');
     }
 
     /* eslint-disable max-params */

--- a/service/xmpp/XMPPEvents.ts
+++ b/service/xmpp/XMPPEvents.ts
@@ -75,6 +75,19 @@ export enum XMPPEvents {
 
     CHAT_ERROR_RECEIVED = 'xmpp.chat_error_received',
 
+    /**
+     * Event fired when a moderator's chat-mute directive for a participant is
+     * received and applied. The muted participant's messages will stop being
+     * delivered to the rest of the room.
+     */
+    CHAT_PARTICIPANT_MUTED = 'xmpp.chat_participant_muted',
+
+    /**
+     * Event fired when a moderator's chat-unmute directive for a participant is
+     * received and applied, restoring delivery of their messages to the room.
+     */
+    CHAT_PARTICIPANT_UNMUTED = 'xmpp.chat_participant_unmuted',
+
     // The conference properties (as advertised by jicofo) have changed
     CONFERENCE_PROPERTIES_CHANGED = 'xmpp.conference_properties_changed',
 


### PR DESCRIPTION
## Description

Adds support for moderators to shadow-mute a participant's chat.
When muted, the participant's chat messages are silently dropped for
every other participant in the room — the muted participant is not
notified, and their own client continues to show their messages
locally (only their outgoing delivery to others is suppressed).

Adds:
- `ChatRoom.muteChatParticipant(jid)` / `unmuteChatParticipant(jid)` —
  moderator-only, broadcasts a `chat-moderation` directive as a plain
  groupchat message (not a server-gated admin IQ, since there's no
  dedicated backend component for this).
- Moderator-role verification on receipt, via `getMemberRole()`, since
  a plain groupchat message isn't restricted to moderators by the MUC
  server the way `kick()`/`setAffiliation()` are.
- Message-drop logic in `ChatRoom.onMessage()`: once a JID is
  shadow-banned, subsequent messages from that JID are dropped before
  `MESSAGE_RECEIVED` is emitted, for every client except the sender's own.
- `XMPPEvents.CHAT_PARTICIPANT_MUTED` / `_UNMUTED` and their public
  `JitsiConferenceEvents` equivalents, wired through
  `JitsiConferenceEventManager`.
- `JitsiConference.muteChatParticipant(id)` / `unmuteChatParticipant(id)`
  public API, moderator-guarded.

## Related Issue

N.A.

## Motivation and Context

Moderators can currently mute a participant's audio/video, but have no
way to restrict chat messages short of kicking them from the meeting
entirely. This adds a lighter-weight, reversible option: a silent
shadow-mute rather than a visible restriction, so disruptive chat can
be handled without a public confrontation or an outright removal.

An earlier design reused XEP-0045's `visitor` role for this, but that
was dropped — `visitor` is already used by the visitors/large-meeting
feature, and role changes affect screen-share/promotion eligibility
well beyond chat. This approach avoids overloading role semantics by
introducing a dedicated mechanism instead.

## How Has This Been Tested?

Tested locally with three participants in a conference (one moderator,
two regular participants), using a jitsi-meet build wired to this
branch via a local link:

- Moderator calls `muteChatParticipant()` on a target participant;
  target's subsequent messages are dropped for the moderator and a
  third participant, but still visible in the target's own chat.
- `unmuteChatParticipant()` restores delivery correctly.
- A non-moderator's client is verified to reject a manually
  constructed `chat-moderation` stanza (forged via console), confirming
  the `getMemberRole()` check.
- Verified the mute action correctly applies when triggered by the
  moderator's own client, including the case where the moderator's own
  reflected stanza needed a role check against `this.role` rather than
  `getMemberRole()`, since the local user's own role isn't tracked in
  `this.members`.

## Screenshots or GIF (In case of UI changes):

N/A — this is a lib-jitsi-meet-only change; UI lives in the
corresponding jitsi-meet PR (#<PR_NUMBER>).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.