### PR TITLE
refactor: Add a typed enum for ICE restart reasons

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -66,6 +66,7 @@ import XMPP, {
 } from './modules/xmpp/xmpp';
 import { BridgeVideoType } from './service/RTC/BridgeVideoType';
 import { CodecMimeType } from './service/RTC/CodecMimeType';
+import { IceRestartReason } from './service/RTC/IceRestartReason';
 import { MediaType } from './service/RTC/MediaType';
 import { RTCEvents } from './service/RTC/RTCEvents';
 import {
@@ -1899,7 +1900,7 @@ export default class JitsiConference extends Listenable {
             this._delayedIceFailed.start();
         };
 
-        this.restartJvbIce('ice-failed')
+        this.restartJvbIce(IceRestartReason.ICE_FAILED)
             .then(() => {
                 setTimeout(() => {
                     const iceState = this.jvbJingleSession?.getIceConnectionState();
@@ -2444,10 +2445,10 @@ export default class JitsiConference extends Listenable {
      * {@link JingleSessionPC.onBridgeIceRestartTransport}, so the promise returned here settling only means that
      * the request itself was accepted. Trigger from the console: `APP.conference._room.restartJvbIce()`.
      *
-     * @param {string} reason - Why the restart was triggered, for logs and analytics ('api', 'ice-failed', ...).
+     * @param {IceRestartReason} reason - Why the restart was triggered, for logs and analytics.
      * @returns {Promise<void>} - Resolves when Jicofo has accepted the request, rejects otherwise.
      */
-    public restartJvbIce(reason: string = 'api'): Promise<void> {
+    public restartJvbIce(reason: IceRestartReason = IceRestartReason.API): Promise<void> {
         if (!this.isIceRestartSupported()) {
             return Promise.reject(new Error('ICE restart is not supported (disabled in config)'));
         }

--- a/modules/xmpp/JingleSessionPC.spec.ts
+++ b/modules/xmpp/JingleSessionPC.spec.ts
@@ -2,6 +2,7 @@ import { MockRTC } from '../RTC/MockClasses';
 import SDP from '../sdp/SDP';
 import Statistics from '../statistics/statistics';
 import { parseXML, findAll, findFirst } from '../util/XMLUtils';
+import { IceRestartReason } from '../../service/RTC/IceRestartReason';
 import { XMPPEvents } from '../../service/xmpp/XMPPEvents';
 
 import JingleSessionPC from './JingleSessionPC';
@@ -731,7 +732,7 @@ describe('JingleSessionPC in-place ICE restart', () => {
         it('sends a session-info with a bridge-session requesting an ICE restart', async () => {
             const { connection, session } = createJvbSession();
 
-            await session.restartIce('api');
+            await session.restartIce(IceRestartReason.API);
 
             expect(connection.sentIQs.length).toBe(1);
 
@@ -752,7 +753,7 @@ describe('JingleSessionPC in-place ICE restart', () => {
 
             (session as any)._bridgeSessionId = null;
 
-            await expectAsync(session.restartIce('api')).toBeRejected();
+            await expectAsync(session.restartIce(IceRestartReason.API)).toBeRejected();
             expect(connection.sentIQs.length).toBe(0);
         });
 
@@ -761,7 +762,7 @@ describe('JingleSessionPC in-place ICE restart', () => {
 
             (session as any).isP2P = true;
 
-            await expectAsync(session.restartIce('api')).toBeRejected();
+            await expectAsync(session.restartIce(IceRestartReason.API)).toBeRejected();
         });
     });
 

--- a/modules/xmpp/JingleSessionPC.ts
+++ b/modules/xmpp/JingleSessionPC.ts
@@ -5,6 +5,7 @@ import { $build, $iq, Strophe } from 'strophe.js';
 import { JitsiConferenceEvents } from '../../JitsiConferenceEvents';
 import { JitsiTrackEvents } from '../../JitsiTrackEvents';
 import { CodecMimeType } from '../../service/RTC/CodecMimeType';
+import { IceRestartReason } from '../../service/RTC/IceRestartReason';
 import { MediaDirection } from '../../service/RTC/MediaDirection';
 import { MediaType } from '../../service/RTC/MediaType';
 import { SSRC_GROUP_SEMANTICS } from '../../service/RTC/StandardVideoQualitySettings';
@@ -1764,11 +1765,11 @@ export default class JingleSessionPC extends JingleSession {
      *
      * Grep the logs for `[ice-restart]` to follow a restart end to end.
      *
-     * @param {string} reason - why the restart was requested, for the logs.
+     * @param {IceRestartReason} reason - why the restart was requested, for the logs.
      * @returns {Promise<void>} - resolves when Jicofo has acknowledged the request, rejects if it did not accept
      * it (which is the signal to fall back to a full session restart).
      */
-    public restartIce(reason: string = 'api'): Promise<void> {
+    public restartIce(reason: IceRestartReason = IceRestartReason.API): Promise<void> {
         if (this.isP2P) {
             return Promise.reject(new Error('an in-place ICE restart is only supported for the JVB session'));
         }

--- a/service/RTC/IceRestartReason.ts
+++ b/service/RTC/IceRestartReason.ts
@@ -1,0 +1,23 @@
+/**
+ * The reason an in-place ICE restart of the JVB session was requested. Used only for local logging and
+ * telemetry (analytics, RTCStats) - it is not sent to the bridge or to jicofo, which only see a plain
+ * ice-restart request with no reason attached.
+ */
+export enum IceRestartReason {
+
+    /**
+     * Requested explicitly through the public API, for example from the browser console
+     * (`APP.conference._room.restartJvbIce()`), with no reason given.
+     */
+    API = 'api',
+
+    /**
+     * The existing ICE connection failed and the reactive recovery flow requested a restart.
+     */
+    ICE_FAILED = 'ice-failed',
+
+    /**
+     * The client proactively requested a restart after detecting a network change (mobile only).
+     */
+    NETWORK_CHANGE = 'network-change'
+}


### PR DESCRIPTION
## Summary

- `restartJvbIce()` / `restartIce()` took an arbitrary `string` as their `reason` argument, used only for local logging and telemetry. The outgoing `session-info` IQ never includes it — jicofo and the bridge just see a plain `ice-restart` request regardless of reason.
- Adds `IceRestartReason` with the three values in actual use: `API` (default, e.g. the console trigger), `ICE_FAILED` (the reactive recovery flow), and `NETWORK_CHANGE` (the mobile proactive trigger from jitsi-meet#17720).
- Follow-up from a review comment on jitsi-meet#17720.
