### PR TITLE
feat: Expose IceRestartReason on JitsiMeetJS.constants

### DIFF
--- a/JitsiMeetJS.ts
+++ b/JitsiMeetJS.ts
@@ -35,6 +35,7 @@ import Deferred from './modules/util/Deferred';
 import ScriptUtil from './modules/util/ScriptUtil';
 import * as VideoSIPGWConstants from './modules/videosipgw/VideoSIPGWConstants';
 import AudioMixer from './modules/webaudio/AudioMixer';
+import { IceRestartReason } from './service/RTC/IceRestartReason';
 import { MediaType } from './service/RTC/MediaType';
 import { VideoType } from './service/RTC/VideoType';
 import { ConnectionQualityEvents } from './service/connectivity/ConnectionQualityEvents';
@@ -158,6 +159,7 @@ const JitsiMeetJS = {
      * Constants used throughout the library.
      */
     constants: {
+        iceRestartReason: IceRestartReason,
         recording: recordingConstants,
         sipVideoGW: VideoSIPGWConstants,
         trackStreamingStatus: TrackStreamingStatus,


### PR DESCRIPTION
## Summary

- Exposes `IceRestartReason` (added in #3089) on `JitsiMeetJS.constants`, following the same pattern as `trackStreamingStatus`, `recording`, etc.
- This package has no `"types"` field, so consumers like jitsi-meet import `JitsiMeetJS` untyped and reach every other enum through `JitsiMeetJS.constants`/`.errors`/`.events` rather than a direct module import. Without this, jitsi-meet's mobile network-change trigger (jitsi-meet#17720) has no way to reference the enum's actual values and has to fall back to a bare string.
