### PR TITLE
fix(RTC): avoid invalid maxBitrate=0 on full-SVC encodings

### DIFF
--- a/modules/RTC/TPCUtils.spec.ts
+++ b/modules/RTC/TPCUtils.spec.ts
@@ -245,8 +245,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(1000000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
@@ -266,8 +266,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(300000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
@@ -287,8 +287,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(100000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
@@ -332,8 +332,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(4000000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
@@ -353,8 +353,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(2000000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
@@ -374,8 +374,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(1000000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
@@ -395,8 +395,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(300000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
@@ -416,8 +416,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(100000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
@@ -462,8 +462,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(2500000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
@@ -549,8 +549,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(2500000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
@@ -713,8 +713,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(1200000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
@@ -734,8 +734,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(300000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
@@ -755,8 +755,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(100000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
@@ -801,8 +801,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(2500000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
@@ -847,8 +847,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(2500000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
@@ -892,8 +892,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(2500000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
@@ -913,8 +913,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(1200000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L3T3_KEY);
@@ -934,8 +934,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(300000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
@@ -955,8 +955,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(100000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);
@@ -1000,8 +1000,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(300000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
@@ -1021,8 +1021,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(300000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
@@ -1042,8 +1042,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(300000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L2T3_KEY);
@@ -1063,8 +1063,8 @@ describe('TPCUtils', () => {
 
                 maxBitrates = tpcUtils.calculateEncodingsBitrates(track, codec, height);
                 expect(maxBitrates[0]).toBe(100000);
-                expect(maxBitrates[1]).toBe(0);
-                expect(maxBitrates[2]).toBe(0);
+                expect(maxBitrates[1]).toBeUndefined();
+                expect(maxBitrates[2]).toBeUndefined();
 
                 scalabilityModes = tpcUtils.calculateEncodingsScalabilityMode(track, codec, height);
                 expect(scalabilityModes[0]).toBe(VideoEncoderScalabilityMode.L1T3);

--- a/modules/RTC/TPCUtils.ts
+++ b/modules/RTC/TPCUtils.ts
@@ -433,7 +433,7 @@ export class TPCUtils {
             if (!this.pc.isSpatialScalabilityOn() || this._isRunningInFullSvcMode(codec)) {
                 const { maxBitrate } = this._calculateActiveEncodingParams(localVideoTrack, codec, newHeight);
 
-                return idx === 0 ? maxBitrate : 0;
+                return idx === 0 ? maxBitrate : undefined;
             }
 
             // Multiple video streams.


### PR DESCRIPTION
## Summary
- `calculateEncodingsBitrates()` set `maxBitrate` to the literal `0` on the non-primary encodings whenever a video sender runs in full-SVC / single-stream mode (AV1, VP9-SVC). Per the WebRTC spec, `RTCRtpSender.setParameters()` throws a `RangeError` if any encoding's `maxBitrate` is present and `<= 0`, regardless of that encoding's `active` state.
- This caused an unhandled promise rejection out of `_updateVideoSenderEncodings` in `TraceablePeerConnection.ts`: `RangeError: Failed to execute 'setParameters' on 'RTCRtpSender': maxBitrate must be greater than 0`.
- The sibling calculations (`calculateEncodingsScaleFactor`, `calculateEncodingsScalabilityMode`) already use `undefined` for those same non-primary indices; `calculateEncodingsBitrates` was the outlier. This change brings it in line with the same pattern.

## Test plan
- [x] Updated `TPCUtils.spec.ts` expectations for the affected AV1/VP9/H.264 full-SVC test cases from `toBe(0)` to `toBeUndefined()` (23 cases / 46 assertions).
- [x] `npx karma start karma.conf.js --single-run --browsers ChromeHeadless` — 576/576 passing (one pre-existing, unrelated `afterAll` failure due to a missing generated `./version` module in this checkout).