### PR TITLE
fix(sdp) keep low profile codecs that omit the profile parameter

### DIFF
--- a/modules/sdp/SDPUtil.spec.ts
+++ b/modules/sdp/SDPUtil.spec.ts
@@ -52,6 +52,51 @@ describe('SDPUtil', () => {
         });
     });
 
+    describe('strip high profile video codec', () => {
+        it('should only remove the payload types that signal a high profile', () => {
+            const sdp = SampleSdpStrings.multiProfileVideoSdp;
+            const videoMLine = sdp.media.find(m => m.type === 'video');
+
+            SDPUtil.stripCodec(videoMLine, 'VP9', true /* high profile */);
+            SDPUtil.stripCodec(videoMLine, 'H264', true /* high profile */);
+
+            const payloadTypes = videoMLine.payloads.split(' ').map(Number);
+
+            // Firefox does not signal 'profile-id' for VP9 which implies profile 0, therefore the payload type and
+            // its RTX have to be kept, otherwise Firefox ends up sending a codec that was not negotiated.
+            expect(payloadTypes).toContain(98);
+            expect(payloadTypes).toContain(99);
+
+            // Same for H264 payload types that signal the baseline profile or no profile at all.
+            expect(payloadTypes).toContain(108);
+            expect(payloadTypes).toContain(109);
+            expect(payloadTypes).toContain(102);
+            expect(payloadTypes).toContain(103);
+
+            // The high profile payload types and their RTX are removed.
+            expect(payloadTypes).not.toContain(100);
+            expect(payloadTypes).not.toContain(101);
+            expect(payloadTypes).not.toContain(114);
+            expect(payloadTypes).not.toContain(115);
+
+            // The other codecs are not touched.
+            expect(payloadTypes).toContain(45);
+            expect(payloadTypes).toContain(96);
+        });
+
+        it('should keep VP9 when profile 0 is signaled explicitly', () => {
+            const sdp = SampleSdpStrings.multiCodecVideoSdp;
+            const videoMLine = sdp.media.find(m => m.type === 'video');
+
+            SDPUtil.stripCodec(videoMLine, 'VP9', true /* high profile */);
+
+            const payloadTypes = videoMLine.payloads.split(' ').map(Number);
+
+            expect(payloadTypes).toContain(98);
+            expect(payloadTypes).toContain(99);
+        });
+    });
+
     describe('strip Audio Codec', () => {
         it('should remove an audio codec', () => {
             const sdp = SampleSdpStrings.multiCodecVideoSdp;

--- a/modules/sdp/SDPUtil.ts
+++ b/modules/sdp/SDPUtil.ts
@@ -927,9 +927,13 @@ const SDPUtil = {
                     const codec = highProfileCodecs.get(item.payload);
 
                     if (codec) {
+                        // Firefox does not signal 'profile-id' for VP9 at all and Chrome omits it for the H.264
+                        // baseline profile. Both default to the low profile when the parameter is missing, therefore
+                        // these payload types have to be preserved.
                         return codec.toLowerCase() === CodecMimeType.VP9
-                            ? !item.config.includes('profile-id=0')
-                            : !item.config.includes('profile-level-id=42');
+                            ? item.config.includes('profile-id=') && !item.config.includes('profile-id=0')
+                            : item.config.includes('profile-level-id=')
+                                && !item.config.includes('profile-level-id=42');
                     }
 
                     return false;

--- a/modules/sdp/SampleSdpStrings.ts
+++ b/modules/sdp/SampleSdpStrings.ts
@@ -506,6 +506,50 @@ const videoLineP2pFF = ''
 + 'a=ssrc:984899560 cname:peDGrDD6WsxUOki/\r\n'
 + 'a=rtcp-mux\r\n';
 
+// A video mline that advertises both low and high profile variants of VP9 and H264. VP9 payload type 98 is shaped
+// the way Firefox signals it, i.e. without a 'profile-id' parameter, and H264 payload type 102 omits
+// 'profile-level-id'. Both default to the low profile of the respective codec.
+const multiProfileVideoMLine = ''
++ 'm=video 9 RTP/SAVPF 45 46 98 99 100 101 96 97 108 109 114 115 102 103\r\n'
++ 'c=IN IP4 0.0.0.0\r\n'
++ 'a=rtpmap:45 AV1/90000\r\n'
++ 'a=rtpmap:46 rtx/90000\r\n'
++ 'a=rtpmap:98 VP9/90000\r\n'
++ 'a=rtpmap:99 rtx/90000\r\n'
++ 'a=rtpmap:100 VP9/90000\r\n'
++ 'a=rtpmap:101 rtx/90000\r\n'
++ 'a=rtpmap:96 VP8/90000\r\n'
++ 'a=rtpmap:97 rtx/90000\r\n'
++ 'a=rtpmap:108 H264/90000\r\n'
++ 'a=rtpmap:109 rtx/90000\r\n'
++ 'a=rtpmap:114 H264/90000\r\n'
++ 'a=rtpmap:115 rtx/90000\r\n'
++ 'a=rtpmap:102 H264/90000\r\n'
++ 'a=rtpmap:103 rtx/90000\r\n'
++ 'a=rtcp:9 IN IP4 0.0.0.0\r\n'
++ 'a=fmtp:45 level-idx=5;profile=0;tier=0\r\n'
++ 'a=fmtp:46 apt=45\r\n'
++ 'a=fmtp:98 max-fs=12288;max-fr=60\r\n'
++ 'a=fmtp:99 apt=98\r\n'
++ 'a=fmtp:100 profile-id=2\r\n'
++ 'a=fmtp:101 apt=100\r\n'
++ 'a=fmtp:96 max-fs=12288;max-fr=60\r\n'
++ 'a=fmtp:97 apt=96\r\n'
++ 'a=fmtp:108 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r\n'
++ 'a=fmtp:109 apt=108\r\n'
++ 'a=fmtp:114 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=64001f\r\n'
++ 'a=fmtp:115 apt=114\r\n'
++ 'a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1\r\n'
++ 'a=fmtp:103 apt=102\r\n'
++ 'a=setup:passive\r\n'
++ 'a=mid:video\r\n'
++ 'a=sendrecv\r\n'
++ 'a=ice-ufrag:adPg\r\n'
++ 'a=ice-pwd:Xsr05Mq8S7CR44DAnusZE26F\r\n'
++ 'a=fingerprint:sha-256 6A:39:DE:11:24:AD:2E:4E:63:D6:69:D3:85:05:53:C7:3C:38:A4:B7:91:74:C0:91:44:FC:94:63:7F:01:AB:A9\r\n'
++ 'a=ssrc:984899560 cname:peDGrDD6WsxUOki/\r\n'
++ 'a=rtcp-mux\r\n';
+
 // An sdp video mline with 3 simulcast streams
 const simulcastVideoMLineNoRtxSdp = ''
 + 'm=video 9 RTP/SAVPF 100\r\n'
@@ -555,6 +599,9 @@ const rtxVideoSdpStr = baseSessionSdp + baseAudioMLineSdp + rtxVideoMLineSdp + b
 // A full sdp string representing a client doing a single video stream with multiple codec options
 const multiCodecVideoSdpStr = baseSessionSdp + baseAudioMLineSdp + multiCodecVideoMLine + baseDataMLineSdp;
 
+// A full sdp string representing a client that advertises multiple profiles for VP9 and H264
+const multiProfileVideoSdpStr = baseSessionSdp + baseAudioMLineSdp + multiProfileVideoMLine + baseDataMLineSdp;
+
 // A full sdp string representing a client doing a single video stream with flexfec
 const flexFecSdpStr = baseSessionSdp + baseAudioMLineSdp + flexFecVideoMLineSdp + baseDataMLineSdp;
 
@@ -585,6 +632,10 @@ export default {
 
     get multiCodecVideoSdp(): transform.SessionDescription {
         return transform.parse(multiCodecVideoSdpStr);
+    },
+
+    get multiProfileVideoSdp(): transform.SessionDescription {
+        return transform.parse(multiProfileVideoSdpStr);
     },
 
     get plainVideoSdp(): transform.SessionDescription {


### PR DESCRIPTION
### What

`SDPUtil.stripCodec(mLine, codec, /* highProfile */ true)` is called for VP9 and H264 on every P2P description (`TPCUtils.mungeCodecOrder`) to drop the high profile payload types. The filter treated a *missing* profile parameter as high profile:

```js
codec.toLowerCase() === CodecMimeType.VP9
    ? !item.config.includes('profile-id=0')
    : !item.config.includes('profile-level-id=42');
```

Firefox never signals `profile-id` for VP9 — it emits `a=fmtp:98 max-fs=12288;max-fr=60` — and profile 0 is the default, so its only VP9 payload type was stripped from its own local description. The same applies to H264, where `profile-level-id` is optional and defaults to the baseline profile.

### Why it matters

Firefox 151+ can encode VP9 ([bugzilla 1633876](https://bugzilla.mozilla.org/show_bug.cgi?id=1633876)), so the P2P codec order now actually resolves to VP9 there. The transceiver keeps VP9 as the send codec while the munged answer no longer offers it, and Firefox ends up sending a payload type the peer never negotiated. Captured from a Firefox 154 ↔ Chrome 151 P2P call in the torture tests:

* Firefox answer (raw): `m=video ... 98 99 96 97 108 109 102 103 45 46`, `a=fmtp:98 max-fs=12288;max-fr=60`
* Firefox answer (post munge, set as local description): `m=video ... 96 108 102 45 97 109 103 46` — no VP9
* Firefox `outbound-rtp`: `codecId → video/VP9 payloadType 98`, framesEncoded 470, 505 packets sent
* Chrome `inbound-rtp` for the same ssrc: `packetsReceived 500, packetsLost 0, framesReceived 0, framesDecoded 0, keyFramesDecoded 0, pliCount 0`, no `codecId`

The receiver gets every packet, cannot map the payload type, decodes nothing and falls back to the avatar. It shows up in the torture tests as `Mute › mute before join and screen share after in p2p` timing out on `waitForRemoteVideo`, but it breaks Firefox → Chrome video in P2P in general.

### Fix

Strip a payload type only when it actually declares a profile other than the low one. A payload type with no profile parameter is now treated the same way as one with no `fmtp` line at all, which the method already preserved.

The H264 branch is included because it is the same rule and the same latent bug; browsers do send `profile-level-id` today, but endpoints are not required to.

### Tests

`modules/sdp/SDPUtil.spec.ts` gets a `strip high profile video codec` block over a new `multiProfileVideoSdp` fixture that mixes VP9 without `profile-id`, VP9 `profile-id=2`, H264 without `profile-level-id`, H264 `profile-level-id=42e01f` and H264 `profile-level-id=64001f`. Without the fix:

```
SDPUtil strip high profile video codec should only remove the payload types that signal a high profile FAILED
	Expected [ 45, 46, 96, 97, 108, 109 ] to contain 98.
	Expected [ 45, 46, 96, 97, 108, 109 ] to contain 99.
	Expected [ 45, 46, 96, 97, 108, 109 ] to contain 102.
	Expected [ 45, 46, 96, 97, 108, 109 ] to contain 103.
TOTAL: 1 FAILED, 579 SUCCESS
```

With the fix `TOTAL: 580 SUCCESS`, `eslint` and `tsc --noEmit` are clean.
