### PR TITLE
fix(ScreenObtainer): remove the legacy Electron desktop picker path

### DIFF
--- a/JitsiTrackError.ts
+++ b/JitsiTrackError.ts
@@ -29,8 +29,6 @@ const TRACK_ERROR_TO_MESSAGE_MAP: { [key: string]: string; } = {
     [JitsiTrackErrors.SCREENSHARING_USER_CANCELED]: 'User canceled screen sharing prompt',
     [JitsiTrackErrors.SCREENSHARING_GENERIC_ERROR]: 'Unknown error from screensharing',
     [JitsiTrackErrors.SCREENSHARING_NOT_SUPPORTED_ERROR]: 'Not supported',
-    [JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_ERROR]: 'Unknown error from desktop picker',
-    [JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_NOT_FOUND]: 'Failed to detect desktop picker',
     [JitsiTrackErrors.GENERAL]: 'Generic getUserMedia error',
     [JitsiTrackErrors.PERMISSION_DENIED]: 'User denied permission to use device(s): ',
     [JitsiTrackErrors.NOT_FOUND]: 'Requested device(s) was/were not found: ',

--- a/JitsiTrackErrors.spec.ts
+++ b/JitsiTrackErrors.spec.ts
@@ -5,8 +5,6 @@ import * as exported from "./JitsiTrackErrors";
 describe( "/JitsiTrackErrors members", () => {
     const {
         CONSTRAINT_FAILED,
-        ELECTRON_DESKTOP_PICKER_ERROR,
-        ELECTRON_DESKTOP_PICKER_NOT_FOUND,
         GENERAL,
         NOT_FOUND,
         PERMISSION_DENIED,
@@ -25,8 +23,6 @@ describe( "/JitsiTrackErrors members", () => {
 
     it( "known members", () => {
         expect( CONSTRAINT_FAILED ).toBe( 'gum.constraint_failed' );
-        expect( ELECTRON_DESKTOP_PICKER_ERROR ).toBe( 'gum.electron_desktop_picker_error' );
-        expect( ELECTRON_DESKTOP_PICKER_NOT_FOUND ).toBe( 'gum.electron_desktop_picker_not_found' );
         expect( GENERAL ).toBe( 'gum.general' );
         expect( NOT_FOUND ).toBe( 'gum.not_found' );
         expect( PERMISSION_DENIED ).toBe( 'gum.permission_denied' );
@@ -43,8 +39,6 @@ describe( "/JitsiTrackErrors members", () => {
         expect( JitsiTrackErrors ).toBeDefined();
 
         expect( JitsiTrackErrors.CONSTRAINT_FAILED ).toBe( 'gum.constraint_failed' );
-        expect( JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_ERROR ).toBe( 'gum.electron_desktop_picker_error' );
-        expect( JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_NOT_FOUND ).toBe( 'gum.electron_desktop_picker_not_found' );
         expect( JitsiTrackErrors.GENERAL ).toBe( 'gum.general' );
         expect( JitsiTrackErrors.NOT_FOUND ).toBe( 'gum.not_found' );
         expect( JitsiTrackErrors.PERMISSION_DENIED ).toBe( 'gum.permission_denied' );

--- a/JitsiTrackErrors.ts
+++ b/JitsiTrackErrors.ts
@@ -11,18 +11,6 @@ export enum JitsiTrackErrors {
     CONSTRAINT_FAILED = 'gum.constraint_failed',
 
     /**
-     * A generic error which indicates an error occurred while selecting
-     * a DesktopCapturerSource from the electron app.
-     */
-    ELECTRON_DESKTOP_PICKER_ERROR = 'gum.electron_desktop_picker_error',
-
-    /**
-     * An error which indicates a custom desktop picker could not be detected
-     * for the electron app.
-     */
-    ELECTRON_DESKTOP_PICKER_NOT_FOUND = 'gum.electron_desktop_picker_not_found',
-
-    /**
      * Generic getUserMedia error.
      */
     GENERAL = 'gum.general',
@@ -90,8 +78,6 @@ export enum JitsiTrackErrors {
 
 // exported for backward compatibility
 export const CONSTRAINT_FAILED = JitsiTrackErrors.CONSTRAINT_FAILED;
-export const ELECTRON_DESKTOP_PICKER_ERROR = JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_ERROR;
-export const ELECTRON_DESKTOP_PICKER_NOT_FOUND = JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_NOT_FOUND;
 export const GENERAL = JitsiTrackErrors.GENERAL;
 export const NOT_FOUND = JitsiTrackErrors.NOT_FOUND;
 export const PERMISSION_DENIED = JitsiTrackErrors.PERMISSION_DENIED;

--- a/modules/RTC/ScreenObtainer.ts
+++ b/modules/RTC/ScreenObtainer.ts
@@ -63,38 +63,6 @@ interface IObtainScreenOptions {
 }
 
 /**
- * Interface for audio constraints.
- */
-interface IAudioConstraints {
-    mandatory?: {
-        chromeMediaSource?: string;
-        chromeMediaSourceId?: string;
-    };
-    optional?: {
-        autoGainControl?: boolean;
-        channelCount?: number;
-        echoCancellation?: boolean;
-        noiseSuppression?: boolean;
-    };
-}
-
-/**
- * Interface for legacy video constraints.
- */
-interface ILegacyVideoConstraints {
-    mandatory: {
-        chromeMediaSource: string;
-        chromeMediaSourceId: string;
-        maxFrameRate: number;
-        maxHeight: number;
-        maxWidth: number;
-        minFrameRate: number;
-        minHeight?: number;
-        minWidth?: number;
-    };
-}
-
-/**
  * Interface for modern video constraints.
  */
 interface IVideoConstraints {
@@ -160,7 +128,6 @@ export const SS_DEFAULT_FRAME_RATE = 5;
  * Handles obtaining a stream from a screen capture on different browsers.
  */
 class ScreenObtainer {
-    private _electronSkipDisplayMedia: boolean;
     public obtainStream: Nullable<((
         onSuccess: (result: IScreenCaptureResult) => void,
         onFailure: (error: JitsiTrackError) => void,
@@ -175,7 +142,6 @@ class ScreenObtainer {
     constructor() {
         this.obtainStream = this._createObtainStreamMethod();
         this.options = {};
-        this._electronSkipDisplayMedia = false;
     }
 
     /**
@@ -202,9 +168,7 @@ class ScreenObtainer {
     private _createObtainStreamMethod() {
         const supportsGetDisplayMedia = browser.supportsGetDisplayMedia();
 
-        if (browser.isElectron()) {
-            return this._obtainScreenOnElectron;
-        } else if (browser.isReactNative() && supportsGetDisplayMedia) {
+        if (browser.isReactNative() && supportsGetDisplayMedia) {
             return this.obtainScreenFromGetDisplayMediaRN;
         } else if (supportsGetDisplayMedia) {
             return this._obtainScreenFromGetDisplayMedia;
@@ -257,111 +221,6 @@ class ScreenObtainer {
         }
 
         return audio;
-    }
-
-    /**
-     * Obtains a screen capture stream on Electron.
-     *
-     * @param onSuccess - Success callback.
-     * @param onFailure - Failure callback.
-     * @param {Object} options - Optional parameters.
-     */
-    private _obtainScreenOnElectron(onSuccess: (result: IScreenCaptureResult) => void, onFailure: (error: JitsiTrackError) => void, options: IObtainScreenOptions = {}) {
-        if (!this._electronSkipDisplayMedia) {
-            // Fall-back to the old API in case of not supported error. This can happen if
-            // an old Electron SDK is used with a new Jitsi Meet + lib-jitsi-meet version.
-            this._obtainScreenFromGetDisplayMedia(onSuccess, err => {
-                if (err.name === JitsiTrackErrors.SCREENSHARING_NOT_SUPPORTED_ERROR) {
-                    // Make sure we don't recurse infinitely.
-                    this._electronSkipDisplayMedia = true;
-                    this._obtainScreenOnElectron(onSuccess, onFailure);
-                } else {
-                    onFailure(err);
-                }
-            });
-
-            return;
-        }
-
-        // @ts-ignore TODO: legacy flow, remove after the Electron SDK supporting gDM has been out for a while.
-        if (typeof window.JitsiMeetScreenObtainer?.openDesktopPicker === 'function') {
-            const { desktopSharingFrameRate, desktopSharingResolution, desktopSharingSources } = this.options;
-
-            // @ts-ignore TODO: legacy flow, remove after the Electron SDK supporting gDM has been out for a while.
-            window.JitsiMeetScreenObtainer.openDesktopPicker(
-                {
-                    desktopSharingSources:
-                        options.desktopSharingSources || desktopSharingSources || [ 'screen', 'window' ]
-                },
-                (streamId: string, streamType: string, screenShareAudio = false) => {
-                    if (streamId) {
-                        let audioConstraints: boolean | IAudioConstraints = false;
-
-                        if (screenShareAudio) {
-                            audioConstraints = {};
-                            const optionalConstraints = this._getAudioConstraints();
-
-                            if (typeof optionalConstraints !== 'boolean') {
-                                audioConstraints = {
-                                    optional: optionalConstraints
-                                };
-                            }
-
-                            // Audio screen sharing for electron only works for screen type devices.
-                            // i.e. when the user shares the whole desktop.
-                            // Note. The documentation specifies that chromeMediaSourceId should not be present
-                            // which, in the case a users has multiple monitors, leads to them being shared all
-                            // at once. However we tested with chromeMediaSourceId present and it seems to be
-                            // working properly.
-                            if (streamType === 'screen') {
-                                (audioConstraints as IAudioConstraints).mandatory = {
-                                    chromeMediaSource: 'desktop'
-                                };
-                            }
-                        }
-
-                        const constraints: any = {
-                            audio: audioConstraints,
-                            video: {
-                                mandatory: {
-                                    chromeMediaSource: 'desktop',
-                                    chromeMediaSourceId: streamId,
-                                    maxFrameRate: desktopSharingFrameRate?.max ?? SS_DEFAULT_FRAME_RATE,
-                                    maxHeight: desktopSharingResolution?.height?.max ?? window.screen.height,
-                                    maxWidth: desktopSharingResolution?.width?.max ?? window.screen.width,
-                                    minFrameRate: desktopSharingFrameRate?.min ?? SS_DEFAULT_FRAME_RATE,
-                                    minHeight: desktopSharingResolution?.height?.min,
-                                    minWidth: desktopSharingResolution?.width?.min
-                                }
-                            } as ILegacyVideoConstraints
-                        };
-
-                        // We have to use the old API on Electron to get a desktop stream.
-                        navigator.mediaDevices.getUserMedia(constraints)
-                            .then(stream => {
-                                this.setContentHint(stream);
-                                onSuccess({
-                                    sourceId: streamId,
-                                    sourceType: streamType,
-                                    stream
-                                });
-                            })
-                            .catch(err => onFailure(err));
-                    } else {
-                        // As noted in Chrome Desktop Capture API:
-                        // If user didn't select any source (i.e. canceled the prompt)
-                        // then the callback is called with an empty streamId.
-                        onFailure(new JitsiTrackError(JitsiTrackErrors.SCREENSHARING_USER_CANCELED));
-                    }
-                },
-                err => onFailure(new JitsiTrackError(
-                    JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_ERROR,
-                    err
-                ))
-            );
-        } else {
-            onFailure(new JitsiTrackError(JitsiTrackErrors.ELECTRON_DESKTOP_PICKER_NOT_FOUND));
-        }
     }
 
     /**


### PR DESCRIPTION
## Description

Removes the legacy Electron desktop picker path so Electron always uses `getDisplayMedia`, like every other supported platform.

- `_createObtainStreamMethod()` no longer special-cases `browser.isElectron()`, so Electron falls through to `_obtainScreenFromGetDisplayMedia`
- Removed `_obtainScreenOnElectron()`, including the `window.JitsiMeetScreenObtainer.openDesktopPicker` flow and its `getUserMedia` constraint building
- Removed the `_electronSkipDisplayMedia` latch that selected between the two paths
- Removed `ILegacyVideoConstraints` and `IAudioConstraints`, now unused
- Removed `ELECTRON_DESKTOP_PICKER_ERROR` and `ELECTRON_DESKTOP_PICKER_NOT_FOUND` from `JitsiTrackErrors`, along with their messages in `JitsiTrackError` and their assertions in `JitsiTrackErrors.spec.ts`, since nothing can raise them any more

## Related Issue

Follow-up to #2605 / #2597, which added the gDM path and left this note in the code:

```
// @ts-ignore TODO: legacy flow, remove after the Electron SDK supporting gDM has been out for a while.
```

Discussion that led to this PR: jitsi/jitsi-meet-electron-sdk#512

## Motivation and Context

gDM support landed in `@jitsi/electron-sdk` 7.0.0 (Feb 2025), so the compatibility window the TODO asked for has passed.

Beyond the cleanup, the legacy path is actively broken on Wayland, which is now the default session on Ubuntu, Fedora and RHEL.

There, `desktopCapturer.getSources()` cannot enumerate silently. Every call goes through xdg-desktop-portal and shows a consent dialog. The user picks their source in the portal, then the Jitsi picker opens and asks them to pick again from a list containing only what they already chose. `DesktopPicker` also refreshes its thumbnails on a 2s interval, and each refresh triggers another portal prompt, so the OS dialog keeps reopening for as long as the picker is open. Some of our users concluded screen sharing was broken and stopped using it.

On the gDM path none of that happens. The portal is the only picker, and the selected source shares immediately, which is the same flow browser users already get.

Note the two removed error constants were exported, so this is technically breaking for anyone referencing them. They only ever described failures of the picker flow being removed here, so they cannot be raised any more. Happy to keep them as deprecated no-ops instead if you would rather avoid the break.

## How Has This Been Tested?

`tsc --noEmit` clean, `eslint` clean, 580/580 existing unit tests pass.

Verified end to end with a full local build: this branch packed and installed into `jitsi-meet` master (98de6219c, which pins lib-jitsi-meet at 48c54c20, the commit this branch is based on), then `make compile`, and the resulting `app.bundle.min.js`, `external_api.min.js`, `chunks/` and `lib-jitsi-meet.min.js` deployed together.

Client: Electron 44.0.0 with `@jitsi/electron-sdk` 10.0.4, on Ubuntu 26.04, GNOME Shell 50.1, Wayland, xdg-desktop-portal 1.21.1, PipeWire 1.6.2.

Result: clicking share opens the xdg-desktop-portal dialog once, and the selected source is shared immediately. No second picker, no repeated portal prompts, and re-sharing opens a fresh portal dialog so a different source can be chosen.

For comparison, on a released build (`jitsi-meet-web` 1.0.8384-1) with the legacy path active, both pickers appear, the source has to be selected twice, and the portal dialog reopens every 2 seconds while the Jitsi picker is open. Setting `electronUseGetDisplayMedia` on that same build produces the same good behaviour as this branch, which is what this PR makes unconditional.

Browser clients were unaffected, as expected, since they already used this code path.

## Screenshots or GIF (In case of UI changes):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
