### PR TITLE
ref(chat): take message moderation from the room

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -4982,6 +4982,16 @@ export default class JitsiConference extends Listenable {
     }
 
     /**
+     * Returns <tt>true</tt> when the room handles message moderation and editing
+     * server side. Clients should only offer those actions when it does.
+     *
+     * @returns {boolean} whether the room applies message moderation.
+     */
+    public isMessageModerationSupported(): boolean {
+        return Boolean(this.room?.messageModerationSupported);
+    }
+
+    /**
      * Enables lobby by moderators
      *
      * @returns {Promise} resolves when lobby room is joined or rejects with the error.

--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -3198,6 +3198,21 @@ export default class JitsiConference extends Listenable {
     }
 
     /**
+     * Sends a correction of a message this participant sent earlier (XEP-0308).
+     *
+     * @param {string} messageId - The id of the message being corrected.
+     * @param {string} message - The new text.
+     * @param {string} [receiverId] - Set for a private message, the recipient.
+     * @param {boolean} [useFullJid=false] - Whether receiverId is a full jid.
+     */
+    public sendMessageCorrection(
+            messageId: string, message: string, receiverId?: string, useFullJid = false): void {
+        if (this.room) {
+            this.room.sendMessageCorrection(messageId, message, receiverId, useFullJid);
+        }
+    }
+
+    /**
    * Sends private text message to another participant of the conference.
    * @param {string} id - The ID of the participant to send a private message.
    * @param {string} message - The text message.

--- a/JitsiConferenceEventManager.ts
+++ b/JitsiConferenceEventManager.ts
@@ -423,6 +423,17 @@ export default class JitsiConferenceEventManager {
                     participantId, txt, ts, messageId, displayName, isVisitor, replyToId);
             });
 
+        chatRoom?.addListener(XMPPEvents.MESSAGE_CORRECTED,
+            (from: string, messageId: string, message: string, timestamp?: string) => {
+                conference.eventEmitter.emit(
+                    JitsiConferenceEvents.MESSAGE_CORRECTED,
+                    Strophe.getResourceFromJid(from),
+                    messageId,
+                    message,
+                    timestamp
+                );
+            });
+
         chatRoom?.addListener(XMPPEvents.MESSAGE_MODERATED,
             (messageId: string, reason?: string) => {
                 conference.eventEmitter.emit(

--- a/JitsiConferenceEventManager.ts
+++ b/JitsiConferenceEventManager.ts
@@ -338,6 +338,8 @@ export default class JitsiConferenceEventManager {
             JitsiConferenceEvents.MEMBERS_ONLY_CHANGED);
         this.chatRoomForwarder.forward(XMPPEvents.MUC_VISITORS_SUPPORTED_CHANGED,
             JitsiConferenceEvents.VISITORS_SUPPORTED_CHANGED);
+        this.chatRoomForwarder.forward(XMPPEvents.MUC_MESSAGE_MODERATION_SUPPORTED_CHANGED,
+            JitsiConferenceEvents.MESSAGE_MODERATION_SUPPORTED_CHANGED);
 
         chatRoom.addListener(XMPPEvents.MUC_MEMBER_JOINED,
             conference.onMemberJoined.bind(conference));
@@ -422,13 +424,10 @@ export default class JitsiConferenceEventManager {
             });
 
         chatRoom?.addListener(XMPPEvents.MESSAGE_MODERATED,
-            (messageId: string, moderatorJid?: string, reason?: string) => {
-                const moderatorId = moderatorJid ? Strophe.getResourceFromJid(moderatorJid) : undefined;
-
+            (messageId: string, reason?: string) => {
                 conference.eventEmitter.emit(
                     JitsiConferenceEvents.MESSAGE_MODERATED,
                     messageId,
-                    moderatorId,
                     reason
                 );
             });

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -296,9 +296,15 @@ export enum JitsiConferenceEvents {
     MEMBERS_ONLY_CHANGED = 'conference.membersOnlyChanged',
 
     /**
-     * Event fired when a chat message is moderated.
+     * Event fired when a chat message is moderated. The room is the authority for
+     * this, so the event carries only the message id and the optional reason.
      */
     MESSAGE_MODERATED = 'conference.message_moderated',
+
+    /**
+     * Indicates whether the room handles message moderation and editing server side.
+     */
+    MESSAGE_MODERATION_SUPPORTED_CHANGED = 'conference.messageModerationSupported',
 
     /**
      * New text message was received.

--- a/JitsiConferenceEvents.ts
+++ b/JitsiConferenceEvents.ts
@@ -296,6 +296,13 @@ export enum JitsiConferenceEvents {
     MEMBERS_ONLY_CHANGED = 'conference.membersOnlyChanged',
 
     /**
+     * Event fired when the author corrects one of their chat messages (XEP-0308).
+     * Carries the sender, the id of the corrected message, the new text and the
+     * timestamp when the correction comes from the room history.
+     */
+    MESSAGE_CORRECTED = 'conference.message_corrected',
+
+    /**
      * Event fired when a chat message is moderated. The room is the authority for
      * this, so the event carries only the message id and the optional reason.
      */

--- a/modules/xmpp/ChatRoom.ts
+++ b/modules/xmpp/ChatRoom.ts
@@ -1249,6 +1249,62 @@ export default class ChatRoom extends Listenable {
      * @param {string} receiverId - The receiver if the message was private.
      * @param {boolean} useDirectJid - Whether receiverId is already a JID.
      */
+    /**
+     * Sends a correction of a previously sent message (XEP-0308). The correction is
+     * an ordinary message carrying the new body, plus a <replace/> naming the message
+     * it corrects, so it is archived and replayed to anyone joining later.
+     *
+     * @param {string} messageId - The id of the message being corrected.
+     * @param {string} message - The new text.
+     * @param {string} [receiverId] - Set for a private message, the recipient.
+     * @param {boolean} [useDirectJid=false] - Whether receiverId is a full jid.
+     */
+    public sendMessageCorrection(
+            messageId: string,
+            message: string,
+            receiverId?: string,
+            useDirectJid: boolean = false): void {
+
+        if (!messageId) {
+            logger.warn('sendMessageCorrection: no messageId provided');
+
+            return;
+        }
+
+        let msg;
+
+        if (receiverId) {
+            const targetJid = useDirectJid
+                ? receiverId
+                : `${this.roomjid}/${receiverId}`;
+
+            msg = $msg({
+                to: targetJid,
+                type: 'chat'
+            });
+        } else {
+            msg = $msg({
+                to: this.roomjid,
+                type: 'groupchat'
+            });
+        }
+
+        msg.c('body')
+        .t(stripXMLInvalidChars(message))
+        .up()
+        .c('replace', {
+            id: messageId,
+            xmlns: 'urn:xmpp:message-correct:0'
+        })
+        .up()
+        .c('store', {
+            xmlns: 'urn:xmpp:hints'
+        })
+        .up();
+
+        this.connection.send(msg);
+    }
+
     public sendMessageRetraction(
             messageId: string,
             receiverId?: string,
@@ -1617,6 +1673,24 @@ export default class ChatRoom extends Listenable {
                     return true;
                 }
             }
+        }
+
+        const replaceEl = findFirst(msg, ':scope>replace[*|xmlns="urn:xmpp:message-correct:0"]');
+
+        if (replaceEl) {
+            const correctedMessageId = getAttribute(replaceEl, 'id');
+            const newText = getText(findFirst(msg, ':scope>body'));
+
+            if (!correctedMessageId || !newText) {
+                logger.warn('MESSAGE_CORRECTED: missing corrected message id or body');
+
+                return true;
+            }
+
+            this.eventEmitter.emit(XMPPEvents.MESSAGE_CORRECTED,
+                from, correctedMessageId, newText, stamp);
+
+            return true;
         }
 
         const retractEl = findFirst(msg, ':scope>retract[*|xmlns="urn:xmpp:message-retract:1"]');

--- a/modules/xmpp/ChatRoom.ts
+++ b/modules/xmpp/ChatRoom.ts
@@ -265,6 +265,7 @@ export default class ChatRoom extends Listenable {
     public transcriptionStatus: string;
     public membersOnlyEnabled?: boolean;
     public visitorsSupported?: boolean;
+    public messageModerationSupported?: boolean;
 
     /* eslint-disable max-params */
 
@@ -637,6 +638,16 @@ export default class ChatRoom extends Listenable {
             if (visitorsSupported !== this.visitorsSupported) {
                 this.visitorsSupported = visitorsSupported;
                 this.eventEmitter.emit(XMPPEvents.MUC_VISITORS_SUPPORTED_CHANGED, visitorsSupported);
+            }
+
+            const messageModerationEl = findFirst(result,
+                ':scope>query>x[type="result"]>field[var="muc#roominfo_messageModerationEnabled"]>value');
+            const messageModerationSupported = getText(messageModerationEl) === '1';
+
+            if (messageModerationSupported !== this.messageModerationSupported) {
+                this.messageModerationSupported = messageModerationSupported;
+                this.eventEmitter.emit(
+                    XMPPEvents.MUC_MESSAGE_MODERATION_SUPPORTED_CHANGED, messageModerationSupported);
             }
 
             this.initialDiscoRoomInfoReceived = true;
@@ -1588,11 +1599,20 @@ export default class ChatRoom extends Listenable {
                 const retractEl = findFirst(moderatedEl, ':scope>retract[*|xmlns="urn:xmpp:message-retract:1"]');
 
                 if (retractEl) {
+                    // Moderation is applied by the room, which sends it from the bare room
+                    // jid. A stanza that still carries a resource is an occupant's own
+                    // request, relayed because the room is not handling moderation, and
+                    // there is nothing here that can stand in for the room's decision.
+                    if (Strophe.getResourceFromJid(from)) {
+                        logger.warn(`Ignoring message moderation relayed from an occupant: ${from}`);
+
+                        return true;
+                    }
+
                     const messageId = getAttribute(applyToEl, 'id');
-                    const moderator = getAttribute(moderatedEl, 'by');
                     const reason = getText(findFirst(moderatedEl, 'reason'));
 
-                    this.eventEmitter.emit(XMPPEvents.MESSAGE_MODERATED, messageId, moderator, reason);
+                    this.eventEmitter.emit(XMPPEvents.MESSAGE_MODERATED, messageId, reason);
 
                     return true;
                 }

--- a/service/xmpp/XMPPEvents.ts
+++ b/service/xmpp/XMPPEvents.ts
@@ -248,6 +248,10 @@ export enum XMPPEvents {
     // Designates an event indicating that a participant left the XMPP MUC.
     MUC_MEMBER_LEFT = 'xmpp.muc_member_left',
 
+    // Designates an event indicating that the MUC support for server side message
+    // moderation has changed.
+    MUC_MESSAGE_MODERATION_SUPPORTED_CHANGED = 'xmpp.muc_message_moderation_supported_changed',
+
     // Designates an event indicating that the MUC role of a participant has
     // changed.
     MUC_ROLE_CHANGED = 'xmpp.muc_role_changed',

--- a/service/xmpp/XMPPEvents.ts
+++ b/service/xmpp/XMPPEvents.ts
@@ -197,6 +197,11 @@ export enum XMPPEvents {
     MEETING_ID_SET = 'xmpp.meeting_id_set',
 
     /**
+     * Event fired when a message is corrected by its author (XEP-0308).
+     */
+    MESSAGE_CORRECTED = 'xmpp.message_corrected',
+
+    /**
      * Event fired when a message is moderated.
      */
     MESSAGE_MODERATED = 'xmpp.message_moderated',


### PR DESCRIPTION
Message moderation is applied by the room, which sends it from the bare room jid. This drops the `by` attribute in favour of that, and picks up the room info flag that tells a client whether the server handles these operations at all.

### Changes

- `MESSAGE_MODERATED` now carries only the message id and the reason. `by` came from the stanza payload rather than from the room, and nothing rendered it.
- A moderation stanza that still carries a resource is ignored. That is an occupant's own request, relayed because the room is not handling moderation, and there is nothing in it that can stand in for the room's decision. `MESSAGE_RETRACTED` already worked this way, forwarding the stanza's `from`.
- `discoRoomInfo` reads `muc#roominfo_messageModerationEnabled`, exposed as `MESSAGE_MODERATION_SUPPORTED_CHANGED` and `isMessageModerationSupported()`, following the same shape as `muc#roominfo_visitorsEnabled`.

### Pairs with

jitsi/jitsi-meet, which adds the prosody module that applies the moderation and advertises the flag, and hides the actions where it is absent. The module needs to be enabled on the MUC component before the jitsi-meet side ships, otherwise the edit and delete actions disappear.

### Testing

`npm run type-check` and eslint clean, 580 unit tests pass. Exercised end to end against a self-hosted deployment with a main and a visitor prosody: moderating, editing and retracting all reach participants and visitors, and moderation is ignored when the module is not loaded.