### PR TITLE
fix: p2p video freeze false positive and unused p2p codec order

### DIFF
--- a/modules/connectivity/TrackStreamingStatus.spec.ts
+++ b/modules/connectivity/TrackStreamingStatus.spec.ts
@@ -430,6 +430,35 @@ describe('TrackStreamingStatusImpl._handleFramesDecodedUpdate', () => {
         expect(impl._lastFramesDecodedAt).toBe(1000);
     });
 
+    it('treats a counter that restarted as decoding rather than as frozen', () => {
+        // A long-running stream, then the decoder is re-created and its counter restarts from zero.
+        jasmine.clock().mockDate(new Date(1000));
+        impl._handleFramesDecodedUpdate({ framesDecoded: new Map([[SSRC, 20000]]) });
+
+        jasmine.clock().mockDate(new Date(2000));
+        impl._handleFramesDecodedUpdate({ framesDecoded: new Map([[SSRC, 5]]) });
+
+        expect(impl._lastFramesDecoded).toBe(5);
+        expect(impl._lastFramesDecodedAt).toBe(2000);
+        expect(impl._statsTrackFrozen).toBeFalse();
+    });
+
+    it('does not stay frozen while a restarted counter climbs back to its previous value', () => {
+        jasmine.clock().mockDate(new Date(0));
+        impl._handleFramesDecodedUpdate({ framesDecoded: new Map([[SSRC, 20000]]) });
+
+        // Nothing arrives for long enough to be declared frozen.
+        jasmine.clock().mockDate(new Date(DEFAULT_RTC_MUTE_TIMEOUT + 1));
+        impl._handleFramesDecodedUpdate({ framesDecoded: new Map([[SSRC, 20000]]) });
+        expect(impl._statsTrackFrozen).toBeTrue();
+
+        // The decoder comes back with a counter well below where the old one left off.
+        jasmine.clock().mockDate(new Date(DEFAULT_RTC_MUTE_TIMEOUT + 2000));
+        impl._handleFramesDecodedUpdate({ framesDecoded: new Map([[SSRC, 30]]) });
+
+        expect(impl._statsTrackFrozen).toBeFalse();
+    });
+
     it('records the first framesDecoded value and its timestamp', () => {
         jasmine.clock().mockDate(new Date(1000));
         const map = new Map([[SSRC, 50]]);

--- a/modules/connectivity/TrackStreamingStatus.ts
+++ b/modules/connectivity/TrackStreamingStatus.ts
@@ -146,14 +146,14 @@ export class TrackStreamingStatusImpl {
     _lastFramesDecoded: Nullable<number>;
 
     /**
-     * Timestamp (ms) of the last time framesDecoded was observed to have increased.
+     * Timestamp (ms) of the last time framesDecoded was observed to have changed.
      * Used to measure how long the track has been frozen.
      */
     _lastFramesDecodedAt: Nullable<number>;
 
     /**
      * True when the stats-based logic has concluded the video is currently frozen.
-     * Cleared when framesDecoded resumes advancing.
+     * Cleared when framesDecoded starts moving again.
      */
     _statsTrackFrozen: boolean;
 
@@ -421,9 +421,9 @@ export class TrackStreamingStatusImpl {
      * Used as a freeze-detection fallback on browsers where MediaStreamTrack mute/unmute events are
      * unreliable (Chrome >= M144, Firefox, Safari).
      *
-     * Detection logic: record the timestamp of the last framesDecoded increment. If the counter stops
-     * advancing for longer than the configured frozen timeout, declare the track frozen. Clear the frozen
-     * state as soon as frames start advancing again.
+     * Detection logic: record the timestamp of the last framesDecoded change. If the counter stops moving
+     * for longer than the configured frozen timeout, declare the track frozen. Clear the frozen state as
+     * soon as it moves again.
      *
      * @param data - The CONNECTION_STATS event payload.
      */
@@ -455,8 +455,9 @@ export class TrackStreamingStatusImpl {
             if (this._lastFramesDecodedAt === null) {
                 this._lastFramesDecodedAt = now;
             }
-        } else if (framesDecoded > (this._lastFramesDecoded ?? -1)) {
-            // Frames are advancing — track is healthy.
+        } else if (framesDecoded !== this._lastFramesDecoded) {
+            // The counter restarts from zero when the decoder is re-created on renegotiation, so a decrease
+            // means a restart rather than a stall.
             this._lastFramesDecodedAt = now;
             this._lastFramesDecoded = framesDecoded;
 

--- a/modules/qualitycontrol/CodecSelection.spec.ts
+++ b/modules/qualitycontrol/CodecSelection.spec.ts
@@ -403,4 +403,49 @@ describe('Codec Selection', () => {
             expect(jingleSession.setVideoCodecs).toHaveBeenCalledWith([ 'av1', 'vp9', 'vp8' ], 'vp9');
         });
     });
+
+    describe('When the session is p2p', () => {
+        let p2pSession;
+
+        beforeEach(() => {
+            options = {
+                jvb: {
+                    preferenceOrder: [ 'AV1', 'VP9', 'VP8' ],
+                    screenshareCodec: 'AV1'
+                },
+                p2p: {
+                    preferenceOrder: [ 'VP8', 'VP9' ],
+                    screenshareCodec: 'VP9'
+                }
+            };
+
+            p2pSession = new JingleSessionPC(
+                SID,
+                'peer1',
+                'peer2',
+                connection,
+                { },
+                { },
+                /* isP2P */ true,
+                /* isInitiator */ false);
+
+            p2pSession.initialize(
+                /* ChatRoom */ new MockChatRoom(),
+                /* RTC */ rtc,
+                /* Signaling layer */ conference._signalingLayer,
+                /* options */ { });
+
+            qualityController = new QualityController(conference, options);
+            spyOn(p2pSession, 'setVideoCodecs');
+        });
+
+        it('uses the p2p preference order and not the jvb one', () => {
+            participant1 = new MockParticipant('remote-1');
+            conference.addParticipant(participant1, [ 'vp9', 'vp8' ]);
+
+            qualityController.codecController.selectPreferredCodec(p2pSession);
+
+            expect(p2pSession.setVideoCodecs).toHaveBeenCalledWith([ 'vp8', 'vp9' ], 'vp9');
+        });
+    });
 });

--- a/modules/qualitycontrol/CodecSelection.ts
+++ b/modules/qualitycontrol/CodecSelection.ts
@@ -183,7 +183,8 @@ export class CodecSelection {
             return;
         }
 
-        let localPreferredCodecOrder = this.codecPreferenceOrder.jvb;
+        const connectionType = session.isP2P ? 'p2p' : 'jvb';
+        let localPreferredCodecOrder = this.codecPreferenceOrder[connectionType];
 
         // E2EE is curently supported only for VP8 codec.
         if (this.conference.isE2EEEnabled()) {
@@ -231,7 +232,7 @@ export class CodecSelection {
             return;
         }
 
-        session.setVideoCodecs(selectedCodecOrder, this.screenshareCodec?.jvb as CodecMimeType);
+        session.setVideoCodecs(selectedCodecOrder, this.screenshareCodec?.[connectionType] as CodecMimeType);
     }
 
     /**


### PR DESCRIPTION
Two unrelated p2p fixes found while investigating a video freeze. See the individual commits for details.

`npm test` 603 passing, up from 602.