### PR TITLE
fix(e2ee): pass empty frames through

### DIFF
--- a/modules/e2ee/Context.spec.ts
+++ b/modules/e2ee/Context.spec.ts
@@ -42,6 +42,19 @@ function makeAudioFrame() {
 }
 
 /**
+ * generates an empty audio frame, as produced by the opus encoder when DTX is enabled.
+ */
+function makeEmptyAudioFrame() {
+    return {
+        data: new ArrayBuffer(0),
+        type: undefined, // type is undefined for audio frames.
+        getMetadata: () => {
+            return { synchronizationSource: 123 };
+        }
+    };
+}
+
+/**
  * generates a dummy video frame
  */
 function makeVideoFrame() {
@@ -110,6 +123,58 @@ describe('E2EE Context', () => {
             };
 
             sender.encodeFunction(makeVideoFrame(), sendController);
+        });
+
+        it('passes an empty audio frame through', () => {
+            const enqueued = [];
+
+            sendController = {
+                enqueue: encodedFrame => enqueued.push(encodedFrame)
+            };
+
+            const frame = makeEmptyAudioFrame();
+
+            expect(() => sender.encodeFunction(frame, sendController)).not.toThrow();
+            expect(enqueued).toEqual([ frame ]);
+            expect(frame.data.byteLength).toEqual(0);
+        });
+
+        it('does not break the transform stream on an empty audio frame', async () => {
+            const transformStream = new TransformStream({
+                transform: sender.encodeFunction.bind(sender)
+            });
+            const writer = transformStream.writable.getWriter();
+            const reader = transformStream.readable.getReader();
+
+            // Not awaited, the writes only settle as the frames are read out of the stream.
+            writer.write(makeEmptyAudioFrame());
+            writer.write(makeAudioFrame());
+
+            // The empty frame is passed through unmodified.
+            expect((await reader.read()).value.data.byteLength).toEqual(0);
+
+            // The stream must still be usable for the frames that follow.
+            expect((await reader.read()).value.data.byteLength).toEqual(audioBytes.length + 30);
+        });
+    });
+
+    describe('decode function', () => {
+        beforeEach(async () => {
+            await receiver.setKey(key, 0);
+        });
+
+        it('passes an empty audio frame through', async () => {
+            const enqueued = [];
+
+            receiveController = {
+                enqueue: encodedFrame => enqueued.push(encodedFrame)
+            };
+
+            const frame = makeEmptyAudioFrame();
+
+            await receiver.decodeFunction(frame, receiveController);
+
+            expect(enqueued).toEqual([ frame ]);
         });
     });
 

--- a/modules/e2ee/Context.ts
+++ b/modules/e2ee/Context.ts
@@ -291,6 +291,14 @@ export class Context {
             return controller.enqueue(encodedFrame);
         }
 
+        // Opus emits empty frames when DTX is enabled. There is nothing to encrypt and the frame has no
+        // header to leave in the clear, so pass it through. Reading a header that is not there throws a
+        // RangeError, which errors the TransformStream and stops the pipeline for all the frames that
+        // follow.
+        if (encodedFrame.data.byteLength < UNENCRYPTED_BYTES[encodedFrame.type]) {
+            return controller.enqueue(encodedFrame);
+        }
+
         const keyIndex = this._currentKeyIndex;
         const currentKey = this._cryptoKeyRing[keyIndex] as ICryptoKeyData | false;
 
@@ -354,6 +362,12 @@ export class Context {
      */
     public async decodeFunction(encodedFrame: IEncodedFrame, controller: ITransformStreamDefaultController): Promise<void> {
         if (!this._enabled) {
+            return controller.enqueue(encodedFrame);
+        }
+
+        // Empty frames (opus DTX) are sent unencrypted, they carry no data. Pass them through, otherwise
+        // they are dropped here because there is no key index to read.
+        if (encodedFrame.data.byteLength < UNENCRYPTED_BYTES[encodedFrame.type]) {
             return controller.enqueue(encodedFrame);
         }
 


### PR DESCRIPTION
Opus emits empty frames when DTX is enabled (`audioQuality.enableOpusDtx`). `Context.encodeFunction` sliced the unencrypted header off such a frame:

```js
new Uint8Array(encodedFrame.data, 0, UNENCRYPTED_BYTES[encodedFrame.type]);
```

Audio leaves 1 byte (the opus TOC byte) in the clear, so on a zero-length frame this throws `RangeError: Invalid typed array length: 1`. The throw is synchronous and escapes the `transform` callback of the `TransformStream`, which errors the stream. The encode pipeline then stops for every frame that follows, and audio never recovers.

`decodeFunction` also dropped empty frames, because it read the key index from the last byte of an empty buffer and got `undefined`.

A frame shorter than its unencrypted header now passes through untouched. Such a frame carries no payload to encrypt.

Verified on a stage standalone with two clients, E2EE on and DTX on. Before: audio stops the moment E2EE turns on, and both clients log the `RangeError` at `encodeFunction`. After: audio keeps flowing and no error appears. With DTX off the stock client was unaffected, which confirms the trigger.
