### PR TITLE
fix: Tag the ICE restart answer on React Native, where lastElementChild does not exist

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -45,7 +45,7 @@ import Listenable from './modules/util/Listenable';
 import { isValidNumber, safeSubtract } from './modules/util/MathUtil';
 import RandomUtil from './modules/util/RandomUtil';
 import { getJitterDelay } from './modules/util/Retry';
-import { findAll, findFirst, getAttribute } from './modules/util/XMLUtils';
+import { findAll, findFirst, getAttribute, getFirstChildElement } from './modules/util/XMLUtils';
 import ComponentsVersions from './modules/version/ComponentsVersions';
 import JitsiVideoSIPGWSession from './modules/videosipgw/JitsiVideoSIPGWSession';
 import VideoSIPGW from './modules/videosipgw/VideoSIPGW';
@@ -2338,7 +2338,7 @@ export default class JitsiConference extends Listenable {
             this._pendingTranslationRequests.delete(id);
         }
 
-        const condition = findFirst(stanza, 'error')?.firstElementChild?.localName;
+        const condition = getFirstChildElement(findFirst(stanza, 'error'))?.localName;
         const error = (Object.values(JitsiAudioTranslationErrors) as string[]).includes(condition ?? '')
             ? condition as JitsiAudioTranslationErrors
             : JitsiAudioTranslationErrors.UNKNOWN;

--- a/modules/util/XMLUtils.spec.ts
+++ b/modules/util/XMLUtils.spec.ts
@@ -1,4 +1,4 @@
-import { stripXMLInvalidChars } from './XMLUtils';
+import { getFirstChildElement, getLastChildElement, parseXML, stripXMLInvalidChars } from './XMLUtils';
 
 describe('stripXMLInvalidChars', () => {
     it('strips the XML-invalid C0 control characters', () => {
@@ -33,5 +33,54 @@ describe('stripXMLInvalidChars', () => {
 
     it('handles the empty string', () => {
         expect(stripXMLInvalidChars('')).toBe('');
+    });
+});
+
+describe('getFirstChildElement / getLastChildElement', () => {
+    // Text nodes between the elements, so that firstChild/lastChild are not elements.
+    const parent = parseXML(
+        '<parent> <first a="1"/> text <middle/> <transport ufrag="x"><fingerprint>abc</fingerprint></transport> tail '
+        + '</parent>').documentElement;
+
+    it('skip non-element nodes', () => {
+        expect(getFirstChildElement(parent)?.tagName).toBe('first');
+        expect(getLastChildElement(parent)?.tagName).toBe('transport');
+    });
+
+    it('filter by tag name', () => {
+        expect(getFirstChildElement(parent, 'middle')?.tagName).toBe('middle');
+        expect(getLastChildElement(parent, 'first')?.getAttribute('a')).toBe('1');
+        expect(getFirstChildElement(parent, 'nope')).toBeNull();
+        expect(getLastChildElement(parent, 'nope')).toBeNull();
+    });
+
+    it('only look at direct children', () => {
+        expect(getFirstChildElement(parent, 'fingerprint')).toBeNull();
+        expect(getLastChildElement(parent, 'fingerprint')).toBeNull();
+    });
+
+    it('return null for a missing node or a node with no element children', () => {
+        expect(getFirstChildElement(null)).toBeNull();
+        expect(getLastChildElement(undefined)).toBeNull();
+        const empty = parseXML('<parent> just text </parent>').documentElement;
+
+        expect(getFirstChildElement(empty)).toBeNull();
+        expect(getLastChildElement(empty)).toBeNull();
+    });
+
+    it('do not depend on the element-traversal accessors', () => {
+        // On React Native (xmldom) these do not exist; the helpers must work from childNodes alone.
+        const bare = Object.create(null);
+
+        bare.childNodes = [
+            { nodeType: 3 },
+            { nodeType: 1, tagName: 'a' },
+            { nodeType: 8 },
+            { nodeType: 1, tagName: 'b' },
+            { nodeType: 3 }
+        ];
+        expect(getFirstChildElement(bare as unknown as Node)?.tagName).toBe('a');
+        expect(getLastChildElement(bare as unknown as Node)?.tagName).toBe('b');
+        expect(getLastChildElement(bare as unknown as Node, 'a')?.tagName).toBe('a');
     });
 });

--- a/modules/util/XMLUtils.ts
+++ b/modules/util/XMLUtils.ts
@@ -115,6 +115,59 @@ export function getChildren(element: Element): Element[] {
 }
 
 /**
+ * Gets the first child of a node which is an element (optionally, which has a given tag name), skipping text and
+ * other non-element nodes.
+ *
+ * Use this instead of `firstElementChild`: on React Native the DOM is provided by xmldom, which implements
+ * `firstChild`/`childNodes` but not the element-traversal accessors (`firstElementChild`, `lastElementChild`, etc.).
+ *
+ * @param node - The parent node.
+ * @param tagName - If given, only an element with this tag name qualifies.
+ * @returns The first matching child element, or null.
+ */
+export function getFirstChildElement(node: Node | null | undefined, tagName?: string): Element | null {
+    if (!node) {
+        return null;
+    }
+    const childNodes = node.childNodes;
+
+    for (let i = 0; i < childNodes.length; i++) {
+        const child = childNodes[i];
+
+        if (child.nodeType === 1 && (tagName === undefined || (child as Element).tagName === tagName)) {
+            return child as Element;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Gets the last child of a node which is an element (optionally, which has a given tag name), skipping text and
+ * other non-element nodes. See {@link getFirstChildElement} for why this exists.
+ *
+ * @param node - The parent node.
+ * @param tagName - If given, only an element with this tag name qualifies.
+ * @returns The last matching child element, or null.
+ */
+export function getLastChildElement(node: Node | null | undefined, tagName?: string): Element | null {
+    if (!node) {
+        return null;
+    }
+    const childNodes = node.childNodes;
+
+    for (let i = childNodes.length - 1; i >= 0; i--) {
+        const child = childNodes[i];
+
+        if (child.nodeType === 1 && (tagName === undefined || (child as Element).tagName === tagName)) {
+            return child as Element;
+        }
+    }
+
+    return null;
+}
+
+/**
  * Checks if any elements match the selector within the given element.
  * @param element - The element or document to search within.
  * @param selector - CSS selector string.

--- a/modules/xmpp/JingleSessionPC.ts
+++ b/modules/xmpp/JingleSessionPC.ts
@@ -29,7 +29,7 @@ import SDPUtil from '../sdp/SDPUtil';
 import Statistics from '../statistics/statistics';
 import AsyncQueue, { ClearedQueueError } from '../util/AsyncQueue';
 import { TraceParentExtension } from '../util/OTel';
-import { exists, findAll, findFirst, getAttribute } from '../util/XMLUtils';
+import { exists, findAll, findFirst, getAttribute, getLastChildElement } from '../util/XMLUtils';
 
 import JingleSession from './JingleSession';
 import { JingleSessionState } from './JingleSessionState';
@@ -1329,10 +1329,11 @@ export default class JingleSessionPC extends JingleSession {
             localSDP.transportToJingle(idx, transportInfo);
 
             // transportToJingle() leaves the cursor back on <content>, so tag the <transport> it just appended
-            // directly rather than through the builder.
-            const transportEl = transportInfo.node?.lastElementChild;
+            // directly rather than through the builder. Not via lastElementChild: the xmldom DOM used on React
+            // Native does not implement it.
+            const transportEl = getLastChildElement(transportInfo.node, 'transport');
 
-            if (transportEl?.tagName === 'transport') {
+            if (transportEl) {
                 transportEl.setAttribute('ice-generation', String(generation));
             } else {
                 logger.warn(`${this} ${ICE_RESTART_LOG_PREFIX} gen=${generation}: could not tag the transport `

--- a/modules/xmpp/strophe.stream-management.ts
+++ b/modules/xmpp/strophe.stream-management.ts
@@ -2,6 +2,8 @@
 
 import { $build, Strophe } from 'strophe.js';
 
+import { getFirstChildElement } from '../util/XMLUtils';
+
 /**
 * StropheJS - Stream Management XEP-0198
 *
@@ -390,9 +392,8 @@ const streamManagement: IStreamManagementPlugin = {
 	},
 
 	_handleResumeFailed: function(elem: Element): boolean {
-		const error = elem && (
-			(elem.firstElementChild && (elem.firstElementChild as Element).tagName)
-			|| (elem.firstChild && (elem.firstChild as Element).tagName));
+		// Not firstElementChild: the xmldom DOM used on React Native does not implement it.
+		const error = getFirstChildElement(elem)?.tagName;
 
 		this._c._changeConnectStatus(Strophe.Status.ERROR, error, elem);
 		this._c._doDisconnect();

--- a/test-setup-polyfill.ts
+++ b/test-setup-polyfill.ts
@@ -1,13 +1,39 @@
 /**
- * Test setup file that overrides native querySelector/querySelectorAll implementations
- * with the polyfill from @jitsi/js-utils. This simulates a React Native environment
- * where native querySelector is not available.
+ * Test setup file that makes the browser's DOM look like the one lib-jitsi-meet gets on React Native, where
+ * jitsi-meet runs strophe on top of @xmldom/xmldom (react/features/mobile/polyfills/browser.js) rather than a
+ * browser DOM:
  *
- * This file is loaded by karma-polyfill.conf.js BEFORE any test specs, ensuring all
- * tests run with the polyfill active.
+ * - querySelector/querySelectorAll are replaced with the polyfill from @jitsi/js-utils, which is what the
+ *   mobile app installs.
+ * - The element-traversal accessors which xmldom does not implement (firstElementChild, lastElementChild,
+ *   childElementCount, nextElementSibling, previousElementSibling) are removed, so that code which relies on
+ *   them fails here the same way it fails on a device. xmldom does provide firstChild, lastChild, childNodes,
+ *   and the mobile app polyfills `children`, so those stay.
+ *
+ * This file is loaded by karma-polyfill.conf.js BEFORE any test specs, ensuring all tests run in this mode.
  */
 
 import { querySelector, querySelectorAll } from '@jitsi/js-utils/polyfills';
+
+/**
+ * Element APIs which @xmldom/xmldom (0.8.x, as used by jitsi-meet on React Native) does not implement and the
+ * mobile app does not polyfill. Code in lib-jitsi-meet must not rely on them.
+ */
+const ACCESSORS_MISSING_ON_REACT_NATIVE = [
+    'childElementCount',
+    'firstElementChild',
+    'lastElementChild',
+    'nextElementSibling',
+    'previousElementSibling'
+];
+
+for (const name of ACCESSORS_MISSING_ON_REACT_NATIVE) {
+    for (const proto of [ Element.prototype, Document.prototype, DocumentFragment.prototype ]) {
+        if (Object.prototype.hasOwnProperty.call(proto, name)) {
+            delete (proto as any)[name];
+        }
+    }
+}
 
 /**
  * Override Element.prototype methods with polyfill implementations.
@@ -37,5 +63,6 @@ Document.prototype.querySelectorAll = function(selectors: string): NodeListOf<El
 };
 
 // Log confirmation that polyfill is active.
-console.log('📱 querySelector/querySelectorAll polyfill is ACTIVE (React Native simulation mode)');
-console.log('   All tests will use the polyfill implementation from @jitsi/js-utils');
+console.log('📱 React Native DOM simulation mode is ACTIVE');
+console.log('   querySelector/querySelectorAll use the polyfill implementation from @jitsi/js-utils, and '
+    + `${ACCESSORS_MISSING_ON_REACT_NATIVE.join(', ')} are unavailable`);


### PR DESCRIPTION
## Problem

On React Native, jitsi-meet runs strophe on top of `@xmldom/xmldom` (see `react/features/mobile/polyfills/browser.js`), which implements `firstChild`/`lastChild`/`childNodes` but none of the element-traversal accessors: `firstElementChild`, `lastElementChild`, `childElementCount`, `nextElementSibling`, `previousElementSibling` are all `undefined` on 0.8.13.

`_sendIceRestartTransportInfo()` (#3083) locates the `<transport>` it just appended via `transportInfo.node?.lastElementChild`. On mobile that is `undefined`, so it logs "could not tag the transport with the ICE generation" and sends the transport-info **without** `ice-generation`. The bridge cannot tell that answer from an ordinary transport update, applies it to the established Agent, and the in-place restart is abandoned when the pending Agent times out. Observed on a `mobile-26.3` build against a bridge with in-place restart: two restarts in a row, both abandoned after 20 s, while jicofo had relayed the tagged offer correctly. (jitsi/jicofo#1313 now tags on the endpoint's behalf as a fallback; this fixes the endpoint side.)

## Fix

- `XMLUtils`: add `getFirstChildElement(node, tagName?)` / `getLastChildElement(node, tagName?)`, which walk `childNodes` and therefore work on both DOMs.
- Use them in `_sendIceRestartTransportInfo`, and at the two other `firstElementChild` call sites: the audio-translation error condition in `JitsiConference`, and `_handleResumeFailed` in stream management.

## Tests

- Unit tests for the new helpers, including one against a bare `childNodes`-only object.
- `test-setup-polyfill.ts` (the React Native simulation used by `npm run test:polyfill`) now also deletes the accessors xmldom lacks from `Element`/`Document`/`DocumentFragment`, so code that relies on them fails there the way it fails on a device. Without the fix, the existing test "signals the new local ICE credentials back tagged with the same generation" fails in that mode with `Expected null to be '7'`; with it, both suites pass 610/610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
